### PR TITLE
Do not install all CRDs into all cluster kinds

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -35,7 +35,7 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen \
 
 annotation="kubermatic.k8c.io/location"
 locationMap='{
-  "applicationdefinitions.apps.kubermatic.k8c.io": "master",
+  "applicationdefinitions.apps.kubermatic.k8c.io": "master,seed",
   "applicationinstallations.apps.kubermatic.k8c.io": "usercluster",
   "addonconfigs.kubermatic.k8c.io": "master",
   "addons.kubermatic.k8c.io": "seed",

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -33,7 +33,7 @@ go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   paths=./pkg/apis/... \
   output:crd:dir=./$CRD_DIR
 
-labelName="kubermatic.k8c.io/location"
+annotation="kubermatic.k8c.io/location"
 locationMap='{
   "applicationdefinitions.apps.kubermatic.k8c.io": "master",
   "applicationinstallations.apps.kubermatic.k8c.io": "usercluster",
@@ -67,7 +67,7 @@ locationMap='{
 }'
 
 failure=false
-echodate "Labeling CRDs"
+echodate "Annotating CRDs"
 
 for filename in $CRD_DIR/*.yaml; do
   crdName="$(yq4 '.metadata.name' "$filename")"
@@ -79,7 +79,7 @@ for filename in $CRD_DIR/*.yaml; do
     continue
   fi
 
-  yq4 --inplace ".metadata.labels.\"$labelName\" = \"$location\"" "$filename"
+  yq4 --inplace ".metadata.annotations.\"$annotation\" = \"$location\"" "$filename"
 done
 
 if $failure; then

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -24,9 +24,64 @@ CONTAINERIZE_IMAGE=golang:1.18.4 containerize ./hack/update-codegen.sh
 echodate "Running go generate"
 go generate ./pkg/...
 
+CRD_DIR=pkg/crd/k8c.io
+
 echodate "Generating openAPI v3 CRDs"
 go run sigs.k8s.io/controller-tools/cmd/controller-gen \
   crd \
   object:headerFile=./hack/boilerplate/ce/boilerplate.go.txt \
   paths=./pkg/apis/... \
-  output:crd:dir=./pkg/crd/k8c.io
+  output:crd:dir=./$CRD_DIR
+
+labelName="kubermatic.k8c.io/location"
+locationMap='{
+  "applicationdefinitions.apps.kubermatic.k8c.io": "master",
+  "applicationinstallations.apps.kubermatic.k8c.io": "usercluster",
+  "addonconfigs.kubermatic.k8c.io": "master",
+  "addons.kubermatic.k8c.io": "seed",
+  "admissionplugins.kubermatic.k8c.io": "master",
+  "alertmanagers.kubermatic.k8c.io": "seed",
+  "allowedregistries.kubermatic.k8c.io": "master",
+  "clusters.kubermatic.k8c.io": "seed",
+  "clustertemplateinstances.kubermatic.k8c.io": "seed",
+  "clustertemplates.kubermatic.k8c.io": "master,seed",
+  "constraints.kubermatic.k8c.io": "master,seed",
+  "constrainttemplates.kubermatic.k8c.io": "master,seed",
+  "etcdbackupconfigs.kubermatic.k8c.io": "seed",
+  "etcdrestores.kubermatic.k8c.io": "seed",
+  "externalclusters.kubermatic.k8c.io": "master",
+  "groupprojectbindings.kubermatic.k8c.io": "master",
+  "ipamallocations.kubermatic.k8c.io": "master",
+  "ipampools.kubermatic.k8c.io": "master",
+  "kubermaticconfigurations.kubermatic.k8c.io": "master,seed",
+  "kubermaticsettings.kubermatic.k8c.io": "master",
+  "mlaadminsettings.kubermatic.k8c.io": "seed",
+  "presets.kubermatic.k8c.io": "master",
+  "projects.kubermatic.k8c.io": "master,seed",
+  "resourcequotas.kubermatic.k8c.io": "master",
+  "rulegroups.kubermatic.k8c.io": "master",
+  "seeds.kubermatic.k8c.io": "master,seed",
+  "userprojectbindings.kubermatic.k8c.io": "master,seed",
+  "usersshkeys.kubermatic.k8c.io": "master",
+  "users.kubermatic.k8c.io": "master,seed"
+}'
+
+failure=false
+echodate "Labeling CRDs"
+
+for filename in $CRD_DIR/*.yaml; do
+  crdName="$(yq4 '.metadata.name' "$filename")"
+  location="$(echo "$locationMap" | jq -rc --arg key "$crdName" '.[$key]')"
+
+  if [ -z "$location" ]; then
+    echodate "Error: No location defined for CRD $crdName"
+    failure=true
+    continue
+  fi
+
+  yq4 --inplace ".metadata.labels.\"$labelName\" = \"$location\"" "$filename"
+done
+
+if $failure; then
+  exit 1
+fi

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -38,6 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	crdutil "k8c.io/kubermatic/v2/pkg/util/crd"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -388,7 +389,11 @@ func (r *Reconciler) reconcileCRDs(ctx context.Context, cfg *kubermaticv1.Kuberm
 			return fmt.Errorf("failed to list CRDs for API group %q in the operator: %w", group, err)
 		}
 
-		for i := range crds {
+		for i, crdObject := range crds {
+			if crdutil.SkipCRDOnCluster(&crdObject, crdutil.SeedCluster) {
+				continue
+			}
+
 			creators = append(creators, common.CRDCreator(&crds[i], log, r.versions))
 		}
 	}

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: applicationdefinitions.apps.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: apps.kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: applicationdefinitions.apps.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: apps.kubermatic.k8c.io
   names:
@@ -15,342 +17,239 @@ spec:
     singular: applicationdefinition
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ApplicationDefinition is the Schema for the applicationdefinitions
-          API.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ApplicationDefinitionSpec defines the desired state of ApplicationDefinition.
-            properties:
-              defaultValues:
-                description: DefaultValues describe overrides for manifest-rendering
-                  in UI when creating an application.
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-              description:
-                description: Description of the application. what is its purpose
-                type: string
-              method:
-                description: Method used to install the application
-                enum:
-                - helm
-                type: string
-              versions:
-                description: Available version for this application
-                items:
-                  properties:
-                    template:
-                      description: Template defines how application is installed (source
-                        provenance, Method...)
-                      properties:
-                        source:
-                          description: Defined how the source of the application (e.g
-                            Helm chart) is retrieved. Exactly one type of source must
-                            be defined.
-                          properties:
-                            git:
-                              description: Install application from a Git repository
-                              properties:
-                                credentials:
-                                  description: Credentials are optional and holds
-                                    the git credentials
-                                  properties:
-                                    method:
-                                      description: Authentication method. Either password
-                                        or token or ssh-key. if method is password
-                                        then username and password must be defined.
-                                        if method is token then token must be defined.
-                                        if method is ssh-key then ssh-key must be
-                                        defined.
-                                      enum:
-                                      - password
-                                      - token
-                                      - ssh-key
-                                      type: string
-                                    password:
-                                      description: Password holds the ref and key
-                                        in the secret for the Password credential.
-                                        The Secret must exist in the namespace where
-                                        KKP is installed (default is "kubermatic").
-                                        The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                        set to helm or git
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    sshKey:
-                                      description: SSHKey holds the ref and key in
-                                        the secret for the SshKey credential. The
-                                        Secret must exist in the namespace where KKP
-                                        is installed (default is "kubermatic"). The
-                                        Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                        set to helm or git
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    token:
-                                      description: Token holds the ref and key in
-                                        the secret for the token credential. The Secret
-                                        must exist in the namespace where KKP is installed
-                                        (default is "kubermatic"). The Secret must
-                                        be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                        set to helm or git
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    username:
-                                      description: Username holds the ref and key
-                                        in the secret for the username credential.
-                                        The Secret must exist in the namespace where
-                                        KKP is installed (default is "kubermatic").
-                                        The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                        set to helm or git
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  required:
-                                  - method
-                                  type: object
-                                path:
-                                  description: Path of the "source" in the repository.
-                                    default is repository root
-                                  type: string
-                                ref:
-                                  description: Git reference to checkout. For large
-                                    repositories, we recommend to either use Tag,
-                                    Branch or Branch+Commit. This allows a shallow
-                                    clone, which dramatically speeds up performance
-                                  properties:
-                                    branch:
-                                      description: Branch to checkout. Only the last
-                                        commit of the branch will be checkout in order
-                                        to reduce the amount of data to download.
-                                      type: string
-                                    commit:
-                                      description: "Commit SHA in a Branch to checkout.
-                                        \n It must be used in conjunction with branch
-                                        field."
-                                      pattern: ^[a-f0-9]{40}$
-                                      type: string
-                                    tag:
-                                      description: Tag to check out. It can not be
-                                        used in conjunction with commit or branch.
-                                      type: string
-                                  type: object
-                                remote:
-                                  description: URL to the repository. Can be HTTP(s)
-                                    (e.g. https://example.com/myrepo) or SSH (e.g.
-                                    git://example.com[:port]/path/to/repo.git/)
-                                  minLength: 1
-                                  type: string
-                              required:
-                              - ref
-                              - remote
-                              type: object
-                            helm:
-                              description: Install Application from a Helm repository
-                              properties:
-                                chartName:
-                                  description: Name of the Chart.
-                                  minLength: 1
-                                  type: string
-                                chartVersion:
-                                  description: Version of the Chart.
-                                  minLength: 1
-                                  type: string
-                                credentials:
-                                  description: Credentials are optional and hold the
-                                    ref to the secret with helm credentials. Either
-                                    username / Password or registryConfigFile can
-                                    be defined.
-                                  properties:
-                                    password:
-                                      description: Password holds the ref and key
-                                        in the secret for the Password credential.
-                                        The Secret must exist in the namespace where
-                                        KKP is installed (default is "kubermatic").
-                                        The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                        set to helm or git
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    registryConfigFile:
-                                      description: RegistryConfigFile holds the ref
-                                        and key in the secret for the registry credential
-                                        file. The value is dockercfg file that follows
-                                        the same format rules as ~/.docker/config.json
-                                        The The Secret must exist in the namespace
-                                        where KKP is installed (default is "kubermatic").
-                                        The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                        set to helm or git
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                    username:
-                                      description: Username holds the ref and key
-                                        in the secret for the username credential.
-                                        The Secret must exist in the namespace where
-                                        KKP is installed (default is "kubermatic").
-                                        The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                        set to helm or git
-                                      properties:
-                                        key:
-                                          description: The key of the secret to select
-                                            from.  Must be a valid secret key.
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More
-                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                            TODO: Add other useful fields. apiVersion,
-                                            kind, uid?'
-                                          type: string
-                                        optional:
-                                          description: Specify whether the Secret
-                                            or its key must be defined
-                                          type: boolean
-                                      required:
-                                      - key
-                                      type: object
-                                      x-kubernetes-map-type: atomic
-                                  type: object
-                                url:
-                                  description: URl of the helm repository. It can
-                                    be an HTTP(s) repository (e.g. https://localhost/myrepo)
-                                    or on OCI repository (e.g. oci://localhost:5000/myrepo).
-                                  pattern: ^(http|https|oci)://.+
-                                  type: string
-                              required:
-                              - chartName
-                              - chartVersion
-                              - url
-                              type: object
-                          type: object
-                      required:
-                      - source
-                      type: object
-                    version:
-                      description: Version of the application (e.g. v1.2.3)
-                      pattern: v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?
-                      type: string
-                  required:
-                  - template
-                  - version
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ApplicationDefinition is the Schema for the applicationdefinitions API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ApplicationDefinitionSpec defines the desired state of ApplicationDefinition.
+              properties:
+                defaultValues:
+                  description: DefaultValues describe overrides for manifest-rendering in UI when creating an application.
                   type: object
-                type: array
-            required:
-            - description
-            - method
-            - versions
-            type: object
-        type: object
-    served: true
-    storage: true
+                  x-kubernetes-preserve-unknown-fields: true
+                description:
+                  description: Description of the application. what is its purpose
+                  type: string
+                method:
+                  description: Method used to install the application
+                  enum:
+                    - helm
+                  type: string
+                versions:
+                  description: Available version for this application
+                  items:
+                    properties:
+                      template:
+                        description: Template defines how application is installed (source provenance, Method...)
+                        properties:
+                          source:
+                            description: Defined how the source of the application (e.g Helm chart) is retrieved. Exactly one type of source must be defined.
+                            properties:
+                              git:
+                                description: Install application from a Git repository
+                                properties:
+                                  credentials:
+                                    description: Credentials are optional and holds the git credentials
+                                    properties:
+                                      method:
+                                        description: Authentication method. Either password or token or ssh-key. if method is password then username and password must be defined. if method is token then token must be defined. if method is ssh-key then ssh-key must be defined.
+                                        enum:
+                                          - password
+                                          - token
+                                          - ssh-key
+                                        type: string
+                                      password:
+                                        description: Password holds the ref and key in the secret for the Password credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      sshKey:
+                                        description: SSHKey holds the ref and key in the secret for the SshKey credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      token:
+                                        description: Token holds the ref and key in the secret for the token credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      username:
+                                        description: Username holds the ref and key in the secret for the username credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                      - method
+                                    type: object
+                                  path:
+                                    description: Path of the "source" in the repository. default is repository root
+                                    type: string
+                                  ref:
+                                    description: Git reference to checkout. For large repositories, we recommend to either use Tag, Branch or Branch+Commit. This allows a shallow clone, which dramatically speeds up performance
+                                    properties:
+                                      branch:
+                                        description: Branch to checkout. Only the last commit of the branch will be checkout in order to reduce the amount of data to download.
+                                        type: string
+                                      commit:
+                                        description: "Commit SHA in a Branch to checkout. \n It must be used in conjunction with branch field."
+                                        pattern: ^[a-f0-9]{40}$
+                                        type: string
+                                      tag:
+                                        description: Tag to check out. It can not be used in conjunction with commit or branch.
+                                        type: string
+                                    type: object
+                                  remote:
+                                    description: URL to the repository. Can be HTTP(s) (e.g. https://example.com/myrepo) or SSH (e.g. git://example.com[:port]/path/to/repo.git/)
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - ref
+                                  - remote
+                                type: object
+                              helm:
+                                description: Install Application from a Helm repository
+                                properties:
+                                  chartName:
+                                    description: Name of the Chart.
+                                    minLength: 1
+                                    type: string
+                                  chartVersion:
+                                    description: Version of the Chart.
+                                    minLength: 1
+                                    type: string
+                                  credentials:
+                                    description: Credentials are optional and hold the ref to the secret with helm credentials. Either username / Password or registryConfigFile can be defined.
+                                    properties:
+                                      password:
+                                        description: Password holds the ref and key in the secret for the Password credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      registryConfigFile:
+                                        description: RegistryConfigFile holds the ref and key in the secret for the registry credential file. The value is dockercfg file that follows the same format rules as ~/.docker/config.json The The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      username:
+                                        description: Username holds the ref and key in the secret for the username credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                        properties:
+                                          key:
+                                            description: The key of the secret to select from.  Must be a valid secret key.
+                                            type: string
+                                          name:
+                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: Specify whether the Secret or its key must be defined
+                                            type: boolean
+                                        required:
+                                          - key
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    type: object
+                                  url:
+                                    description: URl of the helm repository. It can be an HTTP(s) repository (e.g. https://localhost/myrepo) or on OCI repository (e.g. oci://localhost:5000/myrepo).
+                                    pattern: ^(http|https|oci)://.+
+                                    type: string
+                                required:
+                                  - chartName
+                                  - chartVersion
+                                  - url
+                                type: object
+                            type: object
+                        required:
+                          - source
+                        type: object
+                      version:
+                        description: Version of the application (e.g. v1.2.3)
+                        pattern: v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?
+                        type: string
+                    required:
+                      - template
+                      - version
+                    type: object
+                  type: array
+              required:
+                - description
+                - method
+                - versions
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-    kubermatic.k8c.io/location: master
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: applicationdefinitions.apps.kubermatic.k8c.io
 spec:

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: applicationinstallations.apps.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: usercluster
 spec:
   group: apps.kubermatic.k8c.io
   names:
@@ -15,460 +17,342 @@ spec:
     singular: applicationinstallation
   scope: Namespaced
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: ApplicationInstallation describes a single installation of an
-          Application.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              applicationRef:
-                description: ApplicationRef is a reference to identify which Application
-                  should be deployed
-                properties:
-                  name:
-                    description: Name of the Application. Should be a valid lowercase
-                      RFC1123 domain name
-                    maxLength: 63
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                  version:
-                    description: Version of the Application. Must be a valid SemVer
-                      version
-                    pattern: v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?
-                    type: string
-                required:
-                - name
-                - version
-                type: object
-              namespace:
-                description: Namespace describe the desired state of the namespace
-                  where application will be created.
-                properties:
-                  annotations:
-                    additionalProperties:
-                      type: string
-                    description: 'Annotations of the namespace More info: http://kubernetes.io/docs/user-guide/annotations'
-                    type: object
-                  create:
-                    default: true
-                    description: Create defines whether the namespace should be created
-                      if it does not exist. Defaults to true
-                    type: boolean
-                  labels:
-                    additionalProperties:
-                      type: string
-                    description: 'Labels of the namespace More info: http://kubernetes.io/docs/user-guide/labels'
-                    type: object
-                  name:
-                    description: Name is the namespace to deploy the Application into.
-                      Should be a valid lowercase RFC1123 domain name
-                    maxLength: 63
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                required:
-                - create
-                - name
-                type: object
-              values:
-                description: Values describe overrides for manifest-rendering. It's
-                  a free yaml field.
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-            required:
-            - applicationRef
-            - namespace
-            type: object
-          status:
-            description: ApplicationInstallationStatus denotes status information
-              about an ApplicationInstallation.
-            properties:
-              applicationVersion:
-                description: ApplicationVersion contains information installing /
-                  removing application
-                properties:
-                  template:
-                    description: Template defines how application is installed (source
-                      provenance, Method...)
-                    properties:
-                      source:
-                        description: Defined how the source of the application (e.g
-                          Helm chart) is retrieved. Exactly one type of source must
-                          be defined.
-                        properties:
-                          git:
-                            description: Install application from a Git repository
-                            properties:
-                              credentials:
-                                description: Credentials are optional and holds the
-                                  git credentials
-                                properties:
-                                  method:
-                                    description: Authentication method. Either password
-                                      or token or ssh-key. if method is password then
-                                      username and password must be defined. if method
-                                      is token then token must be defined. if method
-                                      is ssh-key then ssh-key must be defined.
-                                    enum:
-                                    - password
-                                    - token
-                                    - ssh-key
-                                    type: string
-                                  password:
-                                    description: Password holds the ref and key in
-                                      the secret for the Password credential. The
-                                      Secret must exist in the namespace where KKP
-                                      is installed (default is "kubermatic"). The
-                                      Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                      set to helm or git
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  sshKey:
-                                    description: SSHKey holds the ref and key in the
-                                      secret for the SshKey credential. The Secret
-                                      must exist in the namespace where KKP is installed
-                                      (default is "kubermatic"). The Secret must be
-                                      annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                      set to helm or git
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  token:
-                                    description: Token holds the ref and key in the
-                                      secret for the token credential. The Secret
-                                      must exist in the namespace where KKP is installed
-                                      (default is "kubermatic"). The Secret must be
-                                      annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                      set to helm or git
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  username:
-                                    description: Username holds the ref and key in
-                                      the secret for the username credential. The
-                                      Secret must exist in the namespace where KKP
-                                      is installed (default is "kubermatic"). The
-                                      Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                      set to helm or git
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                required:
-                                - method
-                                type: object
-                              path:
-                                description: Path of the "source" in the repository.
-                                  default is repository root
-                                type: string
-                              ref:
-                                description: Git reference to checkout. For large
-                                  repositories, we recommend to either use Tag, Branch
-                                  or Branch+Commit. This allows a shallow clone, which
-                                  dramatically speeds up performance
-                                properties:
-                                  branch:
-                                    description: Branch to checkout. Only the last
-                                      commit of the branch will be checkout in order
-                                      to reduce the amount of data to download.
-                                    type: string
-                                  commit:
-                                    description: "Commit SHA in a Branch to checkout.
-                                      \n It must be used in conjunction with branch
-                                      field."
-                                    pattern: ^[a-f0-9]{40}$
-                                    type: string
-                                  tag:
-                                    description: Tag to check out. It can not be used
-                                      in conjunction with commit or branch.
-                                    type: string
-                                type: object
-                              remote:
-                                description: URL to the repository. Can be HTTP(s)
-                                  (e.g. https://example.com/myrepo) or SSH (e.g. git://example.com[:port]/path/to/repo.git/)
-                                minLength: 1
-                                type: string
-                            required:
-                            - ref
-                            - remote
-                            type: object
-                          helm:
-                            description: Install Application from a Helm repository
-                            properties:
-                              chartName:
-                                description: Name of the Chart.
-                                minLength: 1
-                                type: string
-                              chartVersion:
-                                description: Version of the Chart.
-                                minLength: 1
-                                type: string
-                              credentials:
-                                description: Credentials are optional and hold the
-                                  ref to the secret with helm credentials. Either
-                                  username / Password or registryConfigFile can be
-                                  defined.
-                                properties:
-                                  password:
-                                    description: Password holds the ref and key in
-                                      the secret for the Password credential. The
-                                      Secret must exist in the namespace where KKP
-                                      is installed (default is "kubermatic"). The
-                                      Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                      set to helm or git
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  registryConfigFile:
-                                    description: RegistryConfigFile holds the ref
-                                      and key in the secret for the registry credential
-                                      file. The value is dockercfg file that follows
-                                      the same format rules as ~/.docker/config.json
-                                      The The Secret must exist in the namespace where
-                                      KKP is installed (default is "kubermatic").
-                                      The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                      set to helm or git
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                  username:
-                                    description: Username holds the ref and key in
-                                      the secret for the username credential. The
-                                      Secret must exist in the namespace where KKP
-                                      is installed (default is "kubermatic"). The
-                                      Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:`
-                                      set to helm or git
-                                    properties:
-                                      key:
-                                        description: The key of the secret to select
-                                          from.  Must be a valid secret key.
-                                        type: string
-                                      name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
-                                        type: string
-                                      optional:
-                                        description: Specify whether the Secret or
-                                          its key must be defined
-                                        type: boolean
-                                    required:
-                                    - key
-                                    type: object
-                                    x-kubernetes-map-type: atomic
-                                type: object
-                              url:
-                                description: URl of the helm repository. It can be
-                                  an HTTP(s) repository (e.g. https://localhost/myrepo)
-                                  or on OCI repository (e.g. oci://localhost:5000/myrepo).
-                                pattern: ^(http|https|oci)://.+
-                                type: string
-                            required:
-                            - chartName
-                            - chartVersion
-                            - url
-                            type: object
-                        type: object
-                    required:
-                    - source
-                    type: object
-                  version:
-                    description: Version of the application (e.g. v1.2.3)
-                    pattern: v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?
-                    type: string
-                required:
-                - template
-                - version
-                type: object
-              conditions:
-                additionalProperties:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: ApplicationInstallation describes a single installation of an Application.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                applicationRef:
+                  description: ApplicationRef is a reference to identify which Application should be deployed
                   properties:
-                    lastHeartbeatTime:
-                      description: Last time we got an update on a given condition.
-                      format: date-time
+                    name:
+                      description: Name of the Application. Should be a valid lowercase RFC1123 domain name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
-                    lastTransitionTime:
-                      description: Last time the condition transit from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human readable message indicating details about
-                        last transition.
-                      type: string
-                    reason:
-                      description: (brief) reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
+                    version:
+                      description: Version of the Application. Must be a valid SemVer version
+                      pattern: v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?
                       type: string
                   required:
-                  - status
+                    - name
+                    - version
                   type: object
-                description: Conditions contains conditions an installation is in,
-                  its primary use case is status signaling between controllers or
-                  between controllers and the API
-                type: object
-              helmRelease:
-                description: HelmRelease holds the information about the helm release
-                  installed by this application. This field is only filled if template
-                  method is 'helm'.
-                properties:
-                  info:
-                    description: Info provides information about a release.
+                namespace:
+                  description: Namespace describe the desired state of the namespace where application will be created.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations of the namespace More info: http://kubernetes.io/docs/user-guide/annotations'
+                      type: object
+                    create:
+                      default: true
+                      description: Create defines whether the namespace should be created if it does not exist. Defaults to true
+                      type: boolean
+                    labels:
+                      additionalProperties:
+                        type: string
+                      description: 'Labels of the namespace More info: http://kubernetes.io/docs/user-guide/labels'
+                      type: object
+                    name:
+                      description: Name is the namespace to deploy the Application into. Should be a valid lowercase RFC1123 domain name
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                      type: string
+                  required:
+                    - create
+                    - name
+                  type: object
+                values:
+                  description: Values describe overrides for manifest-rendering. It's a free yaml field.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - applicationRef
+                - namespace
+              type: object
+            status:
+              description: ApplicationInstallationStatus denotes status information about an ApplicationInstallation.
+              properties:
+                applicationVersion:
+                  description: ApplicationVersion contains information installing / removing application
+                  properties:
+                    template:
+                      description: Template defines how application is installed (source provenance, Method...)
+                      properties:
+                        source:
+                          description: Defined how the source of the application (e.g Helm chart) is retrieved. Exactly one type of source must be defined.
+                          properties:
+                            git:
+                              description: Install application from a Git repository
+                              properties:
+                                credentials:
+                                  description: Credentials are optional and holds the git credentials
+                                  properties:
+                                    method:
+                                      description: Authentication method. Either password or token or ssh-key. if method is password then username and password must be defined. if method is token then token must be defined. if method is ssh-key then ssh-key must be defined.
+                                      enum:
+                                        - password
+                                        - token
+                                        - ssh-key
+                                      type: string
+                                    password:
+                                      description: Password holds the ref and key in the secret for the Password credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    sshKey:
+                                      description: SSHKey holds the ref and key in the secret for the SshKey credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    token:
+                                      description: Token holds the ref and key in the secret for the token credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    username:
+                                      description: Username holds the ref and key in the secret for the username credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                    - method
+                                  type: object
+                                path:
+                                  description: Path of the "source" in the repository. default is repository root
+                                  type: string
+                                ref:
+                                  description: Git reference to checkout. For large repositories, we recommend to either use Tag, Branch or Branch+Commit. This allows a shallow clone, which dramatically speeds up performance
+                                  properties:
+                                    branch:
+                                      description: Branch to checkout. Only the last commit of the branch will be checkout in order to reduce the amount of data to download.
+                                      type: string
+                                    commit:
+                                      description: "Commit SHA in a Branch to checkout. \n It must be used in conjunction with branch field."
+                                      pattern: ^[a-f0-9]{40}$
+                                      type: string
+                                    tag:
+                                      description: Tag to check out. It can not be used in conjunction with commit or branch.
+                                      type: string
+                                  type: object
+                                remote:
+                                  description: URL to the repository. Can be HTTP(s) (e.g. https://example.com/myrepo) or SSH (e.g. git://example.com[:port]/path/to/repo.git/)
+                                  minLength: 1
+                                  type: string
+                              required:
+                                - ref
+                                - remote
+                              type: object
+                            helm:
+                              description: Install Application from a Helm repository
+                              properties:
+                                chartName:
+                                  description: Name of the Chart.
+                                  minLength: 1
+                                  type: string
+                                chartVersion:
+                                  description: Version of the Chart.
+                                  minLength: 1
+                                  type: string
+                                credentials:
+                                  description: Credentials are optional and hold the ref to the secret with helm credentials. Either username / Password or registryConfigFile can be defined.
+                                  properties:
+                                    password:
+                                      description: Password holds the ref and key in the secret for the Password credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    registryConfigFile:
+                                      description: RegistryConfigFile holds the ref and key in the secret for the registry credential file. The value is dockercfg file that follows the same format rules as ~/.docker/config.json The The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    username:
+                                      description: Username holds the ref and key in the secret for the username credential. The Secret must exist in the namespace where KKP is installed (default is "kubermatic"). The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to helm or git
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      required:
+                                        - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                                url:
+                                  description: URl of the helm repository. It can be an HTTP(s) repository (e.g. https://localhost/myrepo) or on OCI repository (e.g. oci://localhost:5000/myrepo).
+                                  pattern: ^(http|https|oci)://.+
+                                  type: string
+                              required:
+                                - chartName
+                                - chartVersion
+                                - url
+                              type: object
+                          type: object
+                      required:
+                        - source
+                      type: object
+                    version:
+                      description: Version of the application (e.g. v1.2.3)
+                      pattern: v?([0-9]+)(\.[0-9]+)?(\.[0-9]+)?(-([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?(\+([0-9A-Za-z\-]+(\.[0-9A-Za-z\-]+)*))?
+                      type: string
+                  required:
+                    - template
+                    - version
+                  type: object
+                conditions:
+                  additionalProperties:
                     properties:
-                      deleted:
-                        description: Deleted tracks when this object was deleted.
+                      lastHeartbeatTime:
+                        description: Last time we got an update on a given condition.
                         format: date-time
                         type: string
-                      description:
-                        description: Description is human-friendly "log entry" about
-                          this release.
-                        type: string
-                      firstDeployed:
-                        description: FirstDeployed is when the release was first deployed.
+                      lastTransitionTime:
+                        description: Last time the condition transit from one status to another.
                         format: date-time
                         type: string
-                      lastDeployed:
-                        description: LastDeployed is when the release was last deployed.
-                        format: date-time
+                      message:
+                        description: Human readable message indicating details about last transition.
                         type: string
-                      notes:
-                        description: Notes is  the rendered templates/NOTES.txt if
-                          available.
+                      reason:
+                        description: (brief) reason for the condition's last transition.
                         type: string
                       status:
-                        description: Status is the current state of the release.
+                        description: Status of the condition, one of True, False, Unknown.
                         type: string
+                    required:
+                      - status
                     type: object
-                  name:
-                    description: Name is the name of the release.
-                    type: string
-                  version:
-                    description: Version is an int which represents the revision of
-                      the release.
-                    type: integer
-                type: object
-              method:
-                description: Method used to install the application
-                enum:
-                - helm
-                type: string
-            required:
-            - method
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  description: Conditions contains conditions an installation is in, its primary use case is status signaling between controllers or between controllers and the API
+                  type: object
+                helmRelease:
+                  description: HelmRelease holds the information about the helm release installed by this application. This field is only filled if template method is 'helm'.
+                  properties:
+                    info:
+                      description: Info provides information about a release.
+                      properties:
+                        deleted:
+                          description: Deleted tracks when this object was deleted.
+                          format: date-time
+                          type: string
+                        description:
+                          description: Description is human-friendly "log entry" about this release.
+                          type: string
+                        firstDeployed:
+                          description: FirstDeployed is when the release was first deployed.
+                          format: date-time
+                          type: string
+                        lastDeployed:
+                          description: LastDeployed is when the release was last deployed.
+                          format: date-time
+                          type: string
+                        notes:
+                          description: Notes is  the rendered templates/NOTES.txt if available.
+                          type: string
+                        status:
+                          description: Status is the current state of the release.
+                          type: string
+                      type: object
+                    name:
+                      description: Name is the name of the release.
+                      type: string
+                    version:
+                      description: Version is an int which represents the revision of the release.
+                      type: integer
+                  type: object
+                method:
+                  description: Method used to install the application
+                  enum:
+                    - helm
+                  type: string
+              required:
+                - method
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: usercluster
   creationTimestamp: null
   name: applicationinstallations.apps.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: usercluster
 spec:
   group: apps.kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: addonconfigs.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addonconfigs.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: addonconfigs.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,74 +17,62 @@ spec:
     singular: addonconfig
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: AddonConfig specifies addon configuration. Addons can be installed
-          without a matching AddonConfig, but they will be missing a logo, description
-          and the potentially necessary form fields in the KKP dashboard to make the
-          addon comfortable to use.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AddonConfigSpec specifies configuration of addon.
-            properties:
-              description:
-                description: Description of the configured addon, it will be displayed
-                  in the addon overview in the UI
-                type: string
-              formSpec:
-                description: Controls that can be set for configured addon
-                items:
-                  description: AddonFormControl specifies addon form control.
-                  properties:
-                    displayName:
-                      description: DisplayName is visible in the UI
-                      type: string
-                    helpText:
-                      description: HelpText is visible in the UI next to the control
-                      type: string
-                    internalName:
-                      description: InternalName is used internally to save in the
-                        addon object
-                      type: string
-                    required:
-                      description: Required indicates if the control has to be set
-                      type: boolean
-                    type:
-                      description: Type of displayed control
-                      type: string
-                  type: object
-                type: array
-              logo:
-                description: Logo of the configured addon, encoded in base64
-                type: string
-              logoFormat:
-                description: LogoFormat contains logo format of the configured addon,
-                  i.e. svg+xml
-                type: string
-              shortDescription:
-                description: ShortDescription of the configured addon that contains
-                  more detailed information about the addon, it will be displayed
-                  in the addon details view in the UI
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: AddonConfig specifies addon configuration. Addons can be installed without a matching AddonConfig, but they will be missing a logo, description and the potentially necessary form fields in the KKP dashboard to make the addon comfortable to use.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AddonConfigSpec specifies configuration of addon.
+              properties:
+                description:
+                  description: Description of the configured addon, it will be displayed in the addon overview in the UI
+                  type: string
+                formSpec:
+                  description: Controls that can be set for configured addon
+                  items:
+                    description: AddonFormControl specifies addon form control.
+                    properties:
+                      displayName:
+                        description: DisplayName is visible in the UI
+                        type: string
+                      helpText:
+                        description: HelpText is visible in the UI next to the control
+                        type: string
+                      internalName:
+                        description: InternalName is used internally to save in the addon object
+                        type: string
+                      required:
+                        description: Required indicates if the control has to be set
+                        type: boolean
+                      type:
+                        description: Type of displayed control
+                        type: string
+                    type: object
+                  type: array
+                logo:
+                  description: Logo of the configured addon, encoded in base64
+                  type: string
+                logoFormat:
+                  description: LogoFormat contains logo format of the configured addon, i.e. svg+xml
+                  type: string
+                shortDescription:
+                  description: ShortDescription of the configured addon that contains more detailed information about the addon, it will be displayed in the addon details view in the UI
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: seed
   creationTimestamp: null
   name: addons.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: addons.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,135 +17,104 @@ spec:
     singular: addon
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Addon specifies a cluster addon. Addons can be installed into
-          user clusters to provide additional manifests for CNIs, CSIs or other applications,
-          which makes addons a necessary component to create functioning user clusters.
-          Addon objects must be created inside cluster namespaces.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec describes the desired addon state.
-            properties:
-              cluster:
-                description: Cluster is the reference to the cluster the addon should
-                  be installed in
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              isDefault:
-                description: IsDefault indicates whether the addon is installed because
-                  it was configured in the default addon section in the KubermaticConfiguration.
-                  User-installed addons must not set this field to true, as extra
-                  default Addon objects (that are not in the KubermaticConfiguration)
-                  will be garbage-collected.
-                type: boolean
-              name:
-                description: Name defines the name of the addon to install
-                type: string
-              requiredResourceTypes:
-                description: RequiredResourceTypes allows to indicate that this addon
-                  needs some resource type before it can be installed. This can be
-                  used to indicate that a specific CRD and/or extension apiserver
-                  must be installed before this addon can be installed. The addon
-                  will not be installed until that resource is served.
-                items:
-                  description: GroupVersionKind unambiguously identifies a kind. It
-                    doesn't anonymously include GroupVersion to avoid automatic coercion.
-                    It doesn't use a GroupVersion to avoid custom marshalling.
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Addon specifies a cluster addon. Addons can be installed into user clusters to provide additional manifests for CNIs, CSIs or other applications, which makes addons a necessary component to create functioning user clusters. Addon objects must be created inside cluster namespaces.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec describes the desired addon state.
+              properties:
+                cluster:
+                  description: Cluster is the reference to the cluster the addon should be installed in
                   properties:
-                    group:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                       type: string
                     kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                       type: string
-                    version:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                       type: string
                   type: object
-                type: array
-              variables:
-                description: Variables is free form data to use for parsing the manifest
-                  templates
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
-            required:
-            - cluster
-            - name
-            type: object
-          status:
-            description: Status contrains information about the reconciliation status.
-            properties:
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastHeartbeatTime:
-                      description: Last time we got an update on a given condition.
-                      format: date-time
-                      type: string
-                    lastTransitionTime:
-                      description: Last time the condition transitioned from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
-                      type: string
-                  required:
-                  - lastHeartbeatTime
-                  - status
+                  x-kubernetes-map-type: atomic
+                isDefault:
+                  description: IsDefault indicates whether the addon is installed because it was configured in the default addon section in the KubermaticConfiguration. User-installed addons must not set this field to true, as extra default Addon objects (that are not in the KubermaticConfiguration) will be garbage-collected.
+                  type: boolean
+                name:
+                  description: Name defines the name of the addon to install
+                  type: string
+                requiredResourceTypes:
+                  description: RequiredResourceTypes allows to indicate that this addon needs some resource type before it can be installed. This can be used to indicate that a specific CRD and/or extension apiserver must be installed before this addon can be installed. The addon will not be installed until that resource is served.
+                  items:
+                    description: GroupVersionKind unambiguously identifies a kind. It doesn't anonymously include GroupVersion to avoid automatic coercion. It doesn't use a GroupVersion to avoid custom marshalling.
+                    properties:
+                      group:
+                        type: string
+                      kind:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  type: array
+                variables:
+                  description: Variables is free form data to use for parsing the manifest templates
                   type: object
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-preserve-unknown-fields: true
+              required:
+                - cluster
+                - name
+              type: object
+            status:
+              description: Status contrains information about the reconciliation status.
+              properties:
+                conditions:
+                  additionalProperties:
+                    properties:
+                      lastHeartbeatTime:
+                        description: Last time we got an update on a given condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transitioned from one status to another.
+                        format: date-time
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                    required:
+                      - lastHeartbeatTime
+                      - status
+                    type: object
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: admissionplugins.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_admissionplugins.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: admissionplugins.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,36 +17,30 @@ spec:
     singular: admissionplugin
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: AdmissionPlugin is the type representing a AdmissionPlugin.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AdmissionPluginSpec specifies admission plugin name and from
-              which k8s version is supported.
-            properties:
-              fromVersion:
-                description: FromVersion flag can be empty. It means the plugin fit
-                  to all k8s versions
-                type: string
-              pluginName:
-                type: string
-            required:
-            - pluginName
-            type: object
-        type: object
-    served: true
-    storage: true
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: AdmissionPlugin is the type representing a AdmissionPlugin.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AdmissionPluginSpec specifies admission plugin name and from which k8s version is supported.
+              properties:
+                fromVersion:
+                  description: FromVersion flag can be empty. It means the plugin fit to all k8s versions
+                  type: string
+                pluginName:
+                  type: string
+              required:
+                - pluginName
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: seed
   creationTimestamp: null
   name: alertmanagers.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_alertmanagers.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: alertmanagers.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,69 +17,57 @@ spec:
     singular: alertmanager
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              configSecret:
-                description: ConfigSecret refers to the Secret in the same namespace
-                  as the Alertmanager object, which contains configuration for this
-                  Alertmanager.
-                properties:
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                      TODO: Add other useful fields. apiVersion, kind, uid?'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-            required:
-            - configSecret
-            type: object
-          status:
-            description: AlertmanagerStatus stores status information about the AlertManager.
-            properties:
-              configStatus:
-                description: AlertmanagerConfigurationStatus stores status information
-                  about the AlertManager configuration.
-                properties:
-                  errorMessage:
-                    description: ErrorMessage contains a default error message in
-                      case the configuration could not be applied. Will be reset if
-                      the error was resolved and condition becomes True
-                    type: string
-                  lastUpdated:
-                    description: LastUpdated stores the last successful time when
-                      the configuration was successfully applied
-                    format: date-time
-                    type: string
-                  status:
-                    description: Status of whether the configuration was applied,
-                      one of True, False
-                    type: string
-                required:
-                - status
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                configSecret:
+                  description: ConfigSecret refers to the Secret in the same namespace as the Alertmanager object, which contains configuration for this Alertmanager.
+                  properties:
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+              required:
+                - configSecret
+              type: object
+            status:
+              description: AlertmanagerStatus stores status information about the AlertManager.
+              properties:
+                configStatus:
+                  description: AlertmanagerConfigurationStatus stores status information about the AlertManager configuration.
+                  properties:
+                    errorMessage:
+                      description: ErrorMessage contains a default error message in case the configuration could not be applied. Will be reset if the error was resolved and condition becomes True
+                      type: string
+                    lastUpdated:
+                      description: LastUpdated stores the last successful time when the configuration was successfully applied
+                      format: date-time
+                      type: string
+                    status:
+                      description: Status of whether the configuration was applied, one of True, False
+                      type: string
+                  required:
+                    - status
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: allowedregistries.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_allowedregistries.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: allowedregistries.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,46 +17,37 @@ spec:
     singular: allowedregistry
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - description: RegistryPrefix contains the prefix of the registry which will be
-        allowed. User clusters will be able to deploy only images which are prefixed
-        with one of the allowed image registry prefixes.
-      jsonPath: .spec.registryPrefix
-      name: RegistryPrefix
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: AllowedRegistry is the object representing an allowed registry.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: AllowedRegistrySpec specifies the data for allowed registry
-              spec.
-            properties:
-              registryPrefix:
-                description: RegistryPrefix contains the prefix of the registry which
-                  will be allowed. User clusters will be able to deploy only images
-                  which are prefixed with one of the allowed image registry prefixes.
-                type: string
-            required:
-            - registryPrefix
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - description: RegistryPrefix contains the prefix of the registry which will be allowed. User clusters will be able to deploy only images which are prefixed with one of the allowed image registry prefixes.
+          jsonPath: .spec.registryPrefix
+          name: RegistryPrefix
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: AllowedRegistry is the object representing an allowed registry.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AllowedRegistrySpec specifies the data for allowed registry spec.
+              properties:
+                registryPrefix:
+                  description: RegistryPrefix contains the prefix of the registry which will be allowed. User clusters will be able to deploy only images which are prefixed with one of the allowed image registry prefixes.
+                  type: string
+              required:
+                - registryPrefix
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: clusters.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,2685 +17,2031 @@ spec:
     singular: cluster
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.humanReadableName
-      name: HumanReadableName
-      type: string
-    - jsonPath: .status.userEmail
-      name: Owner
-      type: string
-    - jsonPath: .spec.version
-      name: Version
-      type: string
-    - jsonPath: .spec.cloud.providerName
-      name: Provider
-      type: string
-    - jsonPath: .spec.cloud.dc
-      name: Datacenter
-      type: string
-    - jsonPath: .status.phase
-      name: Phase
-      type: string
-    - jsonPath: .spec.pause
-      name: Paused
-      type: boolean
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Cluster represents a Kubermatic Kubernetes Platform user cluster.
-          Cluster objects exist on Seed clusters and each user cluster consists of
-          a namespace containing the Kubernetes control plane and additional pods
-          (like Prometheus or the machine-controller).
-        properties:
-          address:
-            description: Address contains the IPs/URLs to access the cluster control
-              plane. This field is optional and replaced by the identical struct in
-              the ClusterStatus. No code should rely on these fields anymore.
-            properties:
-              adminToken:
-                description: AdminToken is the token for the kubeconfig, the user
-                  can download
-                type: string
-              externalName:
-                description: ExternalName is the DNS name for this cluster
-                type: string
-              internalURL:
-                description: InternalName is the seed cluster internal absolute DNS
-                  name to the API server
-                type: string
-              ip:
-                description: IP is the external IP under which the apiserver is available
-                type: string
-              port:
-                description: Port is the port the API server listens on
-                format: int32
-                type: integer
-              url:
-                description: URL under which the Apiserver is available
-                type: string
-            type: object
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Spec describes the desired cluster state.
-            properties:
-              admissionPlugins:
-                description: A list of arbitrary admission plugin names that are passed
-                  to kube-apiserver. Must not include admission plugins that can be
-                  enabled via a separate setting.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.humanReadableName
+          name: HumanReadableName
+          type: string
+        - jsonPath: .status.userEmail
+          name: Owner
+          type: string
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .spec.cloud.providerName
+          name: Provider
+          type: string
+        - jsonPath: .spec.cloud.dc
+          name: Datacenter
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .spec.pause
+          name: Paused
+          type: boolean
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Cluster represents a Kubermatic Kubernetes Platform user cluster. Cluster objects exist on Seed clusters and each user cluster consists of a namespace containing the Kubernetes control plane and additional pods (like Prometheus or the machine-controller).
+          properties:
+            address:
+              description: Address contains the IPs/URLs to access the cluster control plane. This field is optional and replaced by the identical struct in the ClusterStatus. No code should rely on these fields anymore.
+              properties:
+                adminToken:
+                  description: AdminToken is the token for the kubeconfig, the user can download
                   type: string
-                type: array
-              applicationSettings:
-                description: 'Optional: ApplicationSettings contains the settings
-                  relative to the application feature.'
-                properties:
-                  cacheSize:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: CacheSize is the size of the cache used to download
-                      application's sources.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-              auditLogging:
-                description: 'Optional: AuditLogging configures Kubernetes API audit
-                  logging (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/)
-                  for the user cluster.'
-                properties:
-                  enabled:
-                    description: Enabled will enable or disable audit logging.
-                    type: boolean
-                  policyPreset:
-                    description: 'Optional: PolicyPreset can be set to utilize a pre-defined
-                      set of audit policy rules.'
-                    enum:
-                    - ""
-                    - metadata
-                    - recommended
-                    - minimal
+                externalName:
+                  description: ExternalName is the DNS name for this cluster
+                  type: string
+                internalURL:
+                  description: InternalName is the seed cluster internal absolute DNS name to the API server
+                  type: string
+                ip:
+                  description: IP is the external IP under which the apiserver is available
+                  type: string
+                port:
+                  description: Port is the port the API server listens on
+                  format: int32
+                  type: integer
+                url:
+                  description: URL under which the Apiserver is available
+                  type: string
+              type: object
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec describes the desired cluster state.
+              properties:
+                admissionPlugins:
+                  description: A list of arbitrary admission plugin names that are passed to kube-apiserver. Must not include admission plugins that can be enabled via a separate setting.
+                  items:
                     type: string
-                  sidecar:
-                    description: 'Optional: Configures the fluent-bit sidecar deployed
-                      alongside kube-apiserver.'
-                    properties:
-                      config:
-                        description: AuditSidecarConfiguration defines custom configuration
-                          for the fluent-bit sidecar deployed with a kube-apiserver.
-                          Also see https://docs.fluentbit.io/manual/v/1.8/administration/configuring-fluent-bit/configuration-file.
-                        properties:
-                          filters:
-                            items:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            type: array
-                          outputs:
-                            items:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            type: array
-                          service:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                type: object
-              cloud:
-                description: Cloud contains information regarding the cloud provider
-                  that is responsible for hosting the cluster's workload.
-                properties:
-                  alibaba:
-                    description: AlibabaCloudSpec specifies the access data to Alibaba.
-                    properties:
-                      accessKeyID:
-                        type: string
-                      accessKeySecret:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    type: object
-                  anexia:
-                    description: AnexiaCloudSpec specifies the access data to Anexia.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      token:
-                        type: string
-                    type: object
-                  aws:
-                    description: AWSCloudSpec specifies access data to Amazon Web
-                      Services.
-                    properties:
-                      accessKeyID:
-                        type: string
-                      assumeRoleARN:
-                        type: string
-                      assumeRoleExternalID:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      instanceProfileName:
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the security group to. Only applies
-                          if the security group is generated by KKP and not preexisting.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set, the node port range can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the security group to.
-                          Only applies if the security group is generated by KKP and
-                          not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      roleARN:
-                        description: The IAM role, the control plane will use. The
-                          control plane will perform an assume-role
-                        type: string
-                      routeTableID:
-                        type: string
-                      secretAccessKey:
-                        type: string
-                      securityGroupID:
-                        type: string
-                      vpcID:
-                        type: string
-                    required:
-                    - instanceProfileName
-                    - roleARN
-                    - routeTableID
-                    - securityGroupID
-                    - vpcID
-                    type: object
-                  azure:
-                    description: AzureCloudSpec defines cloud resource references
-                      for Microsoft Azure.
-                    properties:
-                      assignAvailabilitySet:
-                        description: 'Optional: AssignAvailabilitySet determines whether
-                          KKP creates and assigns an AvailabilitySet to machines.
-                          Defaults to `true` internally if not set.'
-                        type: boolean
-                      availabilitySet:
-                        description: An availability set that will be associated with
-                          nodes created for this cluster. If this field is set to
-                          empty string at cluster creation and `AssignAvailabilitySet`
-                          is set to `true`, a new availability set will be created
-                          and this field will be updated to the generated availability
-                          set's name.
-                        type: string
-                      clientID:
-                        description: ClientID is the service principal used to access
-                          Azure. Can be read from `credentialsReference` instead.
-                        type: string
-                      clientSecret:
-                        description: ClientSecret is the client secret corresponding
-                          to the given service principal. Can be read from `credentialsReference`
-                          instead.
-                        type: string
-                      credentialsReference:
-                        description: CredentialsReference allows referencing a `Secret`
-                          resource instead of passing secret data in this spec.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      loadBalancerSKU:
-                        description: Azure SKU for Load Balancers. Possible values
-                          are `basic` and `standard`.
-                        enum:
-                        - standard
-                        - basic
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the security group to. Only applies
-                          if the security group is generated by KKP and not preexisting.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set, the node port range can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the security group to.
-                          Only applies if the security group is generated by KKP and
-                          not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      resourceGroup:
-                        description: The resource group that will be used to look
-                          up and create resources for the cluster in. If set to empty
-                          string at cluster creation, a new resource group will be
-                          created and this field will be updated to the generated
-                          resource group's name.
-                        type: string
-                      routeTable:
-                        description: The name of a route table associated with the
-                          subnet referenced by `subnet`. If set to empty string at
-                          cluster creation, a new route table will be created and
-                          this field will be updated to the generated route table's
-                          name. If no subnet is defined at cluster creation, this
-                          field should be empty as well.
-                        type: string
-                      securityGroup:
-                        description: The name of a security group associated with
-                          the subnet referenced by `subnet`. If set to empty string
-                          at cluster creation, a new security group will be created
-                          and this field will be updated to the generated security
-                          group's name. If no subnet is defined at cluster creation,
-                          this field should be empty as well.
-                        type: string
-                      subnet:
-                        description: The name of a subnet in the VNet referenced by
-                          `vnet`. If set to empty string at cluster creation, a new
-                          subnet will be created and this field will be updated to
-                          the generated subnet's name. If no VNet is defined at cluster
-                          creation, this field should be empty as well.
-                        type: string
-                      subscriptionID:
-                        description: SubscriptionID is the Azure Subscription used
-                          for this cluster. Can be read from `credentialsReference`
-                          instead.
-                        type: string
-                      tenantID:
-                        description: TenantID is the Azure Active Directory Tenant
-                          used for this cluster. Can be read from `credentialsReference`
-                          instead.
-                        type: string
-                      vnet:
-                        description: The name of the VNet resource used for setting
-                          up networking in. If set to empty string at cluster creation,
-                          a new VNet will be created and this field will be updated
-                          to the generated VNet's name.
-                        type: string
-                      vnetResourceGroup:
-                        description: 'Optional: VNetResourceGroup optionally defines
-                          a second resource group that will be used for VNet related
-                          resources instead. If left empty, NO additional resource
-                          group will be created and all VNet related resources use
-                          the resource group defined by `resourceGroup`.'
-                        type: string
-                    required:
-                    - availabilitySet
-                    - loadBalancerSKU
-                    - resourceGroup
-                    - routeTable
-                    - securityGroup
-                    - subnet
-                    - vnet
-                    - vnetResourceGroup
-                    type: object
-                  bringyourown:
-                    description: BringYourOwnCloudSpec specifies access data for a
-                      bring your own cluster.
-                    type: object
-                  dc:
-                    description: DatacenterName states the name of a cloud provider
-                      "datacenter" (defined in `Seed` resources) this cluster should
-                      be deployed into.
-                    type: string
-                  digitalocean:
-                    description: DigitaloceanCloudSpec specifies access data to DigitalOcean.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      token:
-                        type: string
-                    type: object
-                  fake:
-                    description: FakeCloudSpec specifies access data for a fake cloud.
-                    properties:
-                      token:
-                        type: string
-                    type: object
-                  gcp:
-                    description: GCPCloudSpec specifies access data to GCP.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      network:
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the firewall rules to. If NodePortsAllowedIPRange
-                          nor NodePortsAllowedIPRanges is set, the node port range
-                          can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the firewall rules to.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      serviceAccount:
-                        description: The Google Service Account (JSON format), encoded
-                          with base64.
-                        type: string
-                      subnetwork:
-                        type: string
-                    required:
-                    - network
-                    - subnetwork
-                    type: object
-                  hetzner:
-                    description: HetznerCloudSpec specifies access data to hetzner
-                      cloud.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      network:
-                        description: Network is the pre-existing Hetzner network in
-                          which the machines are running. While machines can be in
-                          multiple networks, a single one must be chosen for the HCloud
-                          CCM to work. If this is empty, the network configured on
-                          the datacenter will be used.
-                        type: string
-                      token:
-                        description: Token is used to authenticate with the Hetzner
-                          cloud API.
-                        type: string
-                    type: object
-                  kubevirt:
-                    description: KubevirtCloudSpec specifies the access data to Kubevirt.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      csiKubeconfig:
-                        type: string
-                      infraStorageClasses:
-                        description: InfraStorageClasses is a list of storage classes
-                          from KubeVirt infra cluster that are used for initialization
-                          of user cluster storage classes by the CSI driver kubevirt
-                          (hot pluggable disks)
-                        items:
-                          type: string
-                        type: array
-                      kubeconfig:
-                        description: The cluster's kubeconfig file, encoded with base64.
-                        type: string
-                      preAllocatedDataVolumes:
-                        description: PreAllocatedDataVolumes holds list of preallocated
-                          DataVolumes which can be used as reference for DataVolume
-                          cloning.
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            size:
-                              type: string
-                            storageClass:
-                              type: string
-                            url:
-                              type: string
-                          required:
-                          - name
-                          - size
-                          - storageClass
-                          - url
-                          type: object
-                        type: array
-                    type: object
-                  nutanix:
-                    description: NutanixCloudSpec specifies the access data to Nutanix.
-                    properties:
-                      clusterName:
-                        description: ClusterName is the Nutanix cluster that this
-                          user cluster will be deployed to.
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      csi:
-                        description: NutanixCSIConfig for csi driver that connects
-                          to a prism element
-                        properties:
-                          endpoint:
-                            description: Prism Element Endpoint to access Nutanix
-                              Prism Element for csi driver
-                            type: string
-                          fstype:
-                            description: 'Optional: defaults to "xfs"'
-                            type: string
-                          password:
-                            description: Prism Element Password for csi driver
-                            type: string
-                          port:
-                            description: 'Optional: Port to use when connecting to
-                              the Nutanix Prism Element endpoint (defaults to 9440)'
-                            format: int32
-                            type: integer
-                          ssSegmentedIscsiNetwork:
-                            description: 'Optional: defaults to "false"'
-                            type: boolean
-                          storageContainer:
-                            description: 'Optional: defaults to "SelfServiceContainer"'
-                            type: string
-                          username:
-                            description: Prism Element Username for csi driver
-                            type: string
-                        required:
-                        - endpoint
-                        type: object
-                      password:
-                        type: string
-                      projectName:
-                        description: ProjectName is the project that this cluster
-                          is deployed into. If none is given, no project will be used.
-                        type: string
-                      proxyURL:
-                        type: string
-                      username:
-                        type: string
-                    required:
-                    - clusterName
-                    type: object
-                  openstack:
-                    description: OpenstackCloudSpec specifies access data to an OpenStack
-                      cloud.
-                    properties:
-                      applicationCredentialID:
-                        type: string
-                      applicationCredentialSecret:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      domain:
-                        type: string
-                      enableIngressHostname:
-                        description: Enable the `enable-ingress-hostname` cloud provider
-                          option on the Openstack CCM. Can only be used with the external
-                          CCM and might be deprecated and removed in future versions
-                          as it is considered a workaround for the PROXY protocol
-                          to preserve client IPs.
-                        type: boolean
-                      floatingIPPool:
-                        description: "FloatingIPPool holds the name of the public
-                          network The public network is reachable from the outside
-                          world and should provide the pool of IP addresses to choose
-                          from. \n When specified, all worker nodes will receive a
-                          public ip from this floating ip pool \n Note that the network
-                          is external if the \"External\" field is set to true"
-                        type: string
-                      ingressHostnameSuffix:
-                        description: Set a specific suffix for the hostnames used
-                          for the PROXY protocol workaround that is enabled by EnableIngressHostname.
-                          The suffix is set to `nip.io` by default. Can only be used
-                          with the external CCM and might be deprecated and removed
-                          in future versions as it is considered a workaround only.
-                        type: string
-                      ipv6SubnetID:
-                        description: IPv6SubnetID holds the ID of the subnet used
-                          for IPv6 networking. If not provided, a new subnet will
-                          be created if IPv6 is enabled.
-                        type: string
-                      ipv6SubnetPool:
-                        description: IPv6SubnetPool holds the name of the subnet pool
-                          used for creating new IPv6 subnets. If not provided, the
-                          default IPv6 subnet pool will be used.
-                        type: string
-                      network:
-                        description: "Network holds the name of the internal network
-                          When specified, all worker nodes will be attached to this
-                          network. If not specified, a network, subnet & router will
-                          be created \n Note that the network is internal if the \"External\"
-                          field is set to false"
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the security group to. Only applies
-                          if the security group is generated by KKP and not preexisting.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set, the node port range can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the security group to.
-                          Only applies if the security group is generated by KKP and
-                          not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      password:
-                        type: string
-                      project:
-                        description: project, formally known as tenant.
-                        type: string
-                      projectID:
-                        description: project id, formally known as tenantID.
-                        type: string
-                      routerID:
-                        type: string
-                      securityGroups:
-                        type: string
-                      subnetID:
-                        type: string
-                      token:
-                        description: Used internally during cluster creation
-                        type: string
-                      useOctavia:
-                        description: "Whether or not to use Octavia for LoadBalancer
-                          type of Service implementation instead of using Neutron-LBaaS.
-                          Attention:Openstack CCM use Octavia as default load balancer
-                          implementation since v1.17.0 \n Takes precedence over the
-                          'use_octavia' flag provided at datacenter level if both
-                          are specified."
-                        type: boolean
-                      useToken:
-                        type: boolean
-                      username:
-                        type: string
-                    required:
-                    - floatingIPPool
-                    - network
-                    - routerID
-                    - securityGroups
-                    - subnetID
-                    type: object
-                  packet:
-                    description: PacketCloudSpec specifies access data to a Packet
-                      cloud.
-                    properties:
-                      apiKey:
-                        type: string
-                      billingCycle:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      projectID:
-                        type: string
-                    required:
-                    - billingCycle
-                    type: object
-                  providerName:
-                    description: ProviderName is the name of the cloud provider used
-                      for this cluster. This must match the given provider spec (e.g.
-                      if the providerName is "aws", then the `aws` field must be set).
-                    type: string
-                  vmwareclouddirector:
-                    description: VMwareCloudDirectorCloudSpec specifies access data
-                      to VMware Cloud Director cloud.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      csi:
-                        description: Config for CSI driver
-                        properties:
-                          filesystem:
-                            description: Filesystem to use for named disks, defaults
-                              to "ext4"
-                            type: string
-                          storageProfile:
-                            description: The name of the storage profile to use for
-                              disks created by CSI driver
-                            type: string
-                        required:
-                        - storageProfile
-                        type: object
-                      organization:
-                        description: Organization is the name of organization to use.
-                        type: string
-                      ovdcNetwork:
-                        description: Network is the name of organizational virtual
-                          data center network that will be associated with the VMs
-                          and vApp.
-                        type: string
-                      password:
-                        description: Password is the VMware Cloud Director user password.
-                        type: string
-                      username:
-                        description: Username is the VMware Cloud Director user name.
-                        type: string
-                      vapp:
-                        description: VApp used for isolation of VMs and their associated
-                          network
-                        type: string
-                      vdc:
-                        description: VDC is the organizational virtual data center.
-                        type: string
-                    required:
-                    - csi
-                    - ovdcNetwork
-                    type: object
-                  vsphere:
-                    description: VSphereCloudSpec specifies access data to VSphere
-                      cloud.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      datastore:
-                        description: Datastore to be used for storing virtual machines
-                          and as a default for dynamic volume provisioning, it is
-                          mutually exclusive with DatastoreCluster.
-                        type: string
-                      datastoreCluster:
-                        description: DatastoreCluster to be used for storing virtual
-                          machines, it is mutually exclusive with Datastore.
-                        type: string
-                      folder:
-                        description: Folder is the folder to be used to group the
-                          provisioned virtual machines.
-                        type: string
-                      infraManagementUser:
-                        description: This user will be used for everything except
-                          cloud provider functionality
-                        properties:
-                          password:
-                            type: string
-                          username:
-                            type: string
-                        type: object
-                      password:
-                        description: Password is the vSphere user password.
-                        type: string
-                      resourcePool:
-                        description: ResourcePool is used to manage resources such
-                          as cpu and memory for vSphere virtual machines. The resource
-                          pool should be defined on vSphere cluster level.
-                        type: string
-                      storagePolicy:
-                        description: StoragePolicy to be used for storage provisioning
-                        type: string
-                      tagCategoryID:
-                        description: This is category for the machine deployment tags
-                        type: string
-                      username:
-                        description: Username is the vSphere user name.
-                        type: string
-                      vmNetName:
-                        description: VMNetName is the name of the vSphere network.
-                        type: string
-                    required:
-                    - infraManagementUser
-                    - storagePolicy
-                    - vmNetName
-                    type: object
-                required:
-                - dc
-                - providerName
-                type: object
-              clusterNetwork:
-                description: ClusterNetworkingConfig specifies the different networking
-                  parameters for a cluster.
-                properties:
-                  coreDNSReplicas:
-                    description: CoreDNSReplicas is the number of desired pods of
-                      user cluster coredns deployment.
-                    format: int32
-                    type: integer
-                  dnsDomain:
-                    description: Domain name for services.
-                    type: string
-                  ipFamily:
-                    description: 'Optional: IP family used for cluster networking.
-                      Supported values are "", "IPv4" or "IPv4+IPv6". Can be omitted
-                      / empty if pods and services network ranges are specified. In
-                      that case it defaults according to the IP families of the provided
-                      network ranges. If neither ipFamily nor pods & services network
-                      ranges are specified, defaults to "IPv4".'
-                    enum:
-                    - ""
-                    - IPv4
-                    - IPv4+IPv6
-                    type: string
-                  ipvs:
-                    description: IPVS defines kube-proxy ipvs configuration options
-                    properties:
-                      strictArp:
-                        default: true
-                        description: StrictArp configure arp_ignore and arp_announce
-                          to avoid answering ARP queries from kube-ipvs0 interface.
-                          defaults to true.
-                        type: boolean
-                    type: object
-                  konnectivityEnabled:
-                    description: KonnectivityEnabled enables konnectivity for controlplane
-                      to node network communication.
-                    type: boolean
-                  nodeCidrMaskSizeIPv4:
-                    description: NodeCIDRMaskSizeIPv4 is the mask size used to address
-                      the nodes within provided IPv4 Pods CIDR. It has to be larger
-                      than the provided IPv4 Pods CIDR. Defaults to 24.
-                    format: int32
-                    type: integer
-                  nodeCidrMaskSizeIPv6:
-                    description: NodeCIDRMaskSizeIPv6 is the mask size used to address
-                      the nodes within provided IPv6 Pods CIDR. It has to be larger
-                      than the provided IPv6 Pods CIDR. Defaults to 64.
-                    format: int32
-                    type: integer
-                  nodeLocalDNSCacheEnabled:
-                    default: true
-                    description: NodeLocalDNSCacheEnabled controls whether the NodeLocal
-                      DNS Cache feature is enabled. Defaults to true.
-                    type: boolean
-                  pods:
-                    description: The network ranges from which POD networks are allocated.
-                      It can contain one IPv4 and/or one IPv6 CIDR. If both address
-                      families are specified, the first one defines the primary address
-                      family.
-                    properties:
-                      cidrBlocks:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - cidrBlocks
-                    type: object
-                  proxyMode:
-                    default: ipvs
-                    description: ProxyMode defines the kube-proxy mode ("ipvs" / "iptables"
-                      / "ebpf"). Defaults to "ipvs". "ebpf" disables kube-proxy and
-                      requires CNI support.
-                    enum:
-                    - ipvs
-                    - iptables
-                    - ebpf
-                    type: string
-                  services:
-                    description: The network ranges from which service VIPs are allocated.
-                      It can contain one IPv4 and/or one IPv6 CIDR. If both address
-                      families are specified, the first one defines the primary address
-                      family.
-                    properties:
-                      cidrBlocks:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - cidrBlocks
-                    type: object
-                required:
-                - dnsDomain
-                - pods
-                - proxyMode
-                - services
-                type: object
-              cniPlugin:
-                description: CNIPluginSettings contains the spec of the CNI plugin
-                  used by the Cluster.
-                properties:
-                  type:
-                    description: Type is the CNI plugin type to be used.
-                    enum:
-                    - canal
-                    - cilium
-                    - none
-                    type: string
-                  version:
-                    description: Version defines the CNI plugin version to be used.
-                      This varies by chosen CNI plugin type.
-                    type: string
-                required:
-                - type
-                - version
-                type: object
-              componentsOverride:
-                description: 'Optional: Component specific overrides that allow customization
-                  of control plane components.'
-                properties:
-                  apiserver:
-                    description: Apiserver configures kube-apiserver settings.
-                    properties:
-                      endpointReconcilingDisabled:
-                        type: boolean
-                      nodePortRange:
-                        type: string
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  controllerManager:
-                    description: ControllerManager configures kube-controller-manager
-                      settings.
-                    properties:
-                      leaderElection:
-                        properties:
-                          leaseDurationSeconds:
-                            description: LeaseDurationSeconds is the duration in seconds
-                              that non-leader candidates will wait to force acquire
-                              leadership. This is measured against time of last observed
-                              ack.
-                            format: int32
-                            type: integer
-                          renewDeadlineSeconds:
-                            description: RenewDeadlineSeconds is the duration in seconds
-                              that the acting controlplane will retry refreshing leadership
-                              before giving up.
-                            format: int32
-                            type: integer
-                          retryPeriodSeconds:
-                            description: RetryPeriodSeconds is the duration in seconds
-                              the LeaderElector clients should wait between tries
-                              of actions.
-                            format: int32
-                            type: integer
-                        type: object
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  etcd:
-                    description: Etcd configures the etcd ring used to store Kubernetes
-                      data.
-                    properties:
-                      clusterSize:
-                        format: int32
-                        type: integer
-                      diskSize:
-                        anyOf:
+                  type: array
+                applicationSettings:
+                  description: 'Optional: ApplicationSettings contains the settings relative to the application feature.'
+                  properties:
+                    cacheSize:
+                      anyOf:
                         - type: integer
                         - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      storageClass:
-                        type: string
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  konnectivityProxy:
-                    description: KonnectivityProxy configures resources limits/requests
-                      for konnectivity-server sidecar.
-                    properties:
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  nodePortProxyEnvoy:
-                    description: NodePortProxyEnvoy configures the per-cluster nodeport-proxy-envoy
-                      that is deployed if the `LoadBalancer` expose strategy is used.
-                      This is not effective if a different expose strategy is configured.
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  prometheus:
-                    description: Prometheus configures the Prometheus instance deployed
-                      into the cluster control plane.
-                    properties:
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  scheduler:
-                    description: Scheduler configures kube-scheduler settings.
-                    properties:
-                      leaderElection:
-                        properties:
-                          leaseDurationSeconds:
-                            description: LeaseDurationSeconds is the duration in seconds
-                              that non-leader candidates will wait to force acquire
-                              leadership. This is measured against time of last observed
-                              ack.
-                            format: int32
-                            type: integer
-                          renewDeadlineSeconds:
-                            description: RenewDeadlineSeconds is the duration in seconds
-                              that the acting controlplane will retry refreshing leadership
-                              before giving up.
-                            format: int32
-                            type: integer
-                          retryPeriodSeconds:
-                            description: RetryPeriodSeconds is the duration in seconds
-                              the LeaderElector clients should wait between tries
-                              of actions.
-                            format: int32
-                            type: integer
-                        type: object
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                required:
-                - apiserver
-                - controllerManager
-                - etcd
-                - nodePortProxyEnvoy
-                - prometheus
-                - scheduler
-                type: object
-              containerRuntime:
-                default: containerd
-                description: ContainerRuntime to use, i.e. `docker` or `containerd`.
-                  By default `containerd` will be used.
-                enum:
-                - docker
-                - containerd
-                type: string
-              debugLog:
-                description: Enables more verbose logging in KKP's user-cluster-controller-manager.
-                type: boolean
-              enableOperatingSystemManager:
-                description: 'Optional: Enables operating-system-manager (OSM), which
-                  is responsible for creating and managing worker node configuration.
-                  This field is enabled(true) by default.'
-                type: boolean
-              enableUserSSHKeyAgent:
-                description: 'Optional: Deploys the UserSSHKeyAgent to the user cluster.
-                  This field is immutable. If enabled, the agent will be deployed
-                  and used to sync user ssh keys attached by users to the cluster.
-                  No SSH keys will be synced after node creation if this is disabled.'
-                type: boolean
-              encryptionConfiguration:
-                description: 'Optional: Configures encryption-at-rest for Kubernetes
-                  API data. This needs the `encryptionAtRest` feature gate.'
-                properties:
-                  enabled:
-                    description: Enables encryption-at-rest on this cluster.
-                    type: boolean
-                  resources:
-                    description: List of resources that will be stored encrypted in
-                      etcd.
-                    items:
+                      description: CacheSize is the size of the cache used to download application's sources.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                auditLogging:
+                  description: 'Optional: AuditLogging configures Kubernetes API audit logging (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) for the user cluster.'
+                  properties:
+                    enabled:
+                      description: Enabled will enable or disable audit logging.
+                      type: boolean
+                    policyPreset:
+                      description: 'Optional: PolicyPreset can be set to utilize a pre-defined set of audit policy rules.'
+                      enum:
+                        - ""
+                        - metadata
+                        - recommended
+                        - minimal
                       type: string
-                    minItems: 1
-                    type: array
-                  secretbox:
-                    description: 'Configuration for the `secretbox` static key encryption
-                      scheme as supported by Kubernetes. More info: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers'
-                    properties:
-                      keys:
-                        description: List of 'secretbox' encryption keys. The first
-                          element of this list is considered the "primary" key which
-                          will be used for encrypting data while writing it. Additional
-                          keys will be used for decrypting data while reading it,
-                          if keys higher in the list did not succeed in decrypting
-                          it.
-                        items:
-                          description: SecretboxKey stores a key or key reference
-                            for encrypting Kubernetes API data at rest with a static
-                            key.
+                    sidecar:
+                      description: 'Optional: Configures the fluent-bit sidecar deployed alongside kube-apiserver.'
+                      properties:
+                        config:
+                          description: AuditSidecarConfiguration defines custom configuration for the fluent-bit sidecar deployed with a kube-apiserver. Also see https://docs.fluentbit.io/manual/v/1.8/administration/configuring-fluent-bit/configuration-file.
                           properties:
-                            name:
-                              description: Identifier of a key, used in various places
-                                to refer to the key.
-                              type: string
-                            secretRef:
-                              description: Instead of passing the sensitive encryption
-                                key via the `value` field, a secret can be referenced.
-                                The key of the secret referenced here needs to hold
-                                a key equivalent to the `value` field.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
+                            filters:
+                              items:
+                                additionalProperties:
                                   type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                type: object
+                              type: array
+                            outputs:
+                              items:
+                                additionalProperties:
                                   type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
+                                type: object
+                              type: array
+                            service:
+                              additionalProperties:
+                                type: string
                               type: object
-                              x-kubernetes-map-type: atomic
-                            value:
-                              description: Value contains a 32-byte random key that
-                                is base64 encoded. This is the key used for encryption.
-                                Can be generated via `head -c 32 /dev/urandom | base64`,
-                                for example.
+                          type: object
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                cloud:
+                  description: Cloud contains information regarding the cloud provider that is responsible for hosting the cluster's workload.
+                  properties:
+                    alibaba:
+                      description: AlibabaCloudSpec specifies the access data to Alibaba.
+                      properties:
+                        accessKeyID:
+                          type: string
+                        accessKeySecret:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    anexia:
+                      description: AnexiaCloudSpec specifies the access data to Anexia.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        token:
+                          type: string
+                      type: object
+                    aws:
+                      description: AWSCloudSpec specifies access data to Amazon Web Services.
+                      properties:
+                        accessKeyID:
+                          type: string
+                        assumeRoleARN:
+                          type: string
+                        assumeRoleExternalID:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        instanceProfileName:
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        roleARN:
+                          description: The IAM role, the control plane will use. The control plane will perform an assume-role
+                          type: string
+                        routeTableID:
+                          type: string
+                        secretAccessKey:
+                          type: string
+                        securityGroupID:
+                          type: string
+                        vpcID:
+                          type: string
+                      required:
+                        - instanceProfileName
+                        - roleARN
+                        - routeTableID
+                        - securityGroupID
+                        - vpcID
+                      type: object
+                    azure:
+                      description: AzureCloudSpec defines cloud resource references for Microsoft Azure.
+                      properties:
+                        assignAvailabilitySet:
+                          description: 'Optional: AssignAvailabilitySet determines whether KKP creates and assigns an AvailabilitySet to machines. Defaults to `true` internally if not set.'
+                          type: boolean
+                        availabilitySet:
+                          description: An availability set that will be associated with nodes created for this cluster. If this field is set to empty string at cluster creation and `AssignAvailabilitySet` is set to `true`, a new availability set will be created and this field will be updated to the generated availability set's name.
+                          type: string
+                        clientID:
+                          description: ClientID is the service principal used to access Azure. Can be read from `credentialsReference` instead.
+                          type: string
+                        clientSecret:
+                          description: ClientSecret is the client secret corresponding to the given service principal. Can be read from `credentialsReference` instead.
+                          type: string
+                        credentialsReference:
+                          description: CredentialsReference allows referencing a `Secret` resource instead of passing secret data in this spec.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        loadBalancerSKU:
+                          description: Azure SKU for Load Balancers. Possible values are `basic` and `standard`.
+                          enum:
+                            - standard
+                            - basic
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        resourceGroup:
+                          description: The resource group that will be used to look up and create resources for the cluster in. If set to empty string at cluster creation, a new resource group will be created and this field will be updated to the generated resource group's name.
+                          type: string
+                        routeTable:
+                          description: The name of a route table associated with the subnet referenced by `subnet`. If set to empty string at cluster creation, a new route table will be created and this field will be updated to the generated route table's name. If no subnet is defined at cluster creation, this field should be empty as well.
+                          type: string
+                        securityGroup:
+                          description: The name of a security group associated with the subnet referenced by `subnet`. If set to empty string at cluster creation, a new security group will be created and this field will be updated to the generated security group's name. If no subnet is defined at cluster creation, this field should be empty as well.
+                          type: string
+                        subnet:
+                          description: The name of a subnet in the VNet referenced by `vnet`. If set to empty string at cluster creation, a new subnet will be created and this field will be updated to the generated subnet's name. If no VNet is defined at cluster creation, this field should be empty as well.
+                          type: string
+                        subscriptionID:
+                          description: SubscriptionID is the Azure Subscription used for this cluster. Can be read from `credentialsReference` instead.
+                          type: string
+                        tenantID:
+                          description: TenantID is the Azure Active Directory Tenant used for this cluster. Can be read from `credentialsReference` instead.
+                          type: string
+                        vnet:
+                          description: The name of the VNet resource used for setting up networking in. If set to empty string at cluster creation, a new VNet will be created and this field will be updated to the generated VNet's name.
+                          type: string
+                        vnetResourceGroup:
+                          description: 'Optional: VNetResourceGroup optionally defines a second resource group that will be used for VNet related resources instead. If left empty, NO additional resource group will be created and all VNet related resources use the resource group defined by `resourceGroup`.'
+                          type: string
+                      required:
+                        - availabilitySet
+                        - loadBalancerSKU
+                        - resourceGroup
+                        - routeTable
+                        - securityGroup
+                        - subnet
+                        - vnet
+                        - vnetResourceGroup
+                      type: object
+                    bringyourown:
+                      description: BringYourOwnCloudSpec specifies access data for a bring your own cluster.
+                      type: object
+                    dc:
+                      description: DatacenterName states the name of a cloud provider "datacenter" (defined in `Seed` resources) this cluster should be deployed into.
+                      type: string
+                    digitalocean:
+                      description: DigitaloceanCloudSpec specifies access data to DigitalOcean.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        token:
+                          type: string
+                      type: object
+                    fake:
+                      description: FakeCloudSpec specifies access data for a fake cloud.
+                      properties:
+                        token:
+                          type: string
+                      type: object
+                    gcp:
+                      description: GCPCloudSpec specifies access data to GCP.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        network:
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the firewall rules to. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the firewall rules to. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        serviceAccount:
+                          description: The Google Service Account (JSON format), encoded with base64.
+                          type: string
+                        subnetwork:
+                          type: string
+                      required:
+                        - network
+                        - subnetwork
+                      type: object
+                    hetzner:
+                      description: HetznerCloudSpec specifies access data to hetzner cloud.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        network:
+                          description: Network is the pre-existing Hetzner network in which the machines are running. While machines can be in multiple networks, a single one must be chosen for the HCloud CCM to work. If this is empty, the network configured on the datacenter will be used.
+                          type: string
+                        token:
+                          description: Token is used to authenticate with the Hetzner cloud API.
+                          type: string
+                      type: object
+                    kubevirt:
+                      description: KubevirtCloudSpec specifies the access data to Kubevirt.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csiKubeconfig:
+                          type: string
+                        infraStorageClasses:
+                          description: InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
+                          items:
+                            type: string
+                          type: array
+                        kubeconfig:
+                          description: The cluster's kubeconfig file, encoded with base64.
+                          type: string
+                        preAllocatedDataVolumes:
+                          description: PreAllocatedDataVolumes holds list of preallocated DataVolumes which can be used as reference for DataVolume cloning.
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              size:
+                                type: string
+                              storageClass:
+                                type: string
+                              url:
+                                type: string
+                            required:
+                              - name
+                              - size
+                              - storageClass
+                              - url
+                            type: object
+                          type: array
+                      type: object
+                    nutanix:
+                      description: NutanixCloudSpec specifies the access data to Nutanix.
+                      properties:
+                        clusterName:
+                          description: ClusterName is the Nutanix cluster that this user cluster will be deployed to.
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: NutanixCSIConfig for csi driver that connects to a prism element
+                          properties:
+                            endpoint:
+                              description: Prism Element Endpoint to access Nutanix Prism Element for csi driver
+                              type: string
+                            fstype:
+                              description: 'Optional: defaults to "xfs"'
+                              type: string
+                            password:
+                              description: Prism Element Password for csi driver
+                              type: string
+                            port:
+                              description: 'Optional: Port to use when connecting to the Nutanix Prism Element endpoint (defaults to 9440)'
+                              format: int32
+                              type: integer
+                            ssSegmentedIscsiNetwork:
+                              description: 'Optional: defaults to "false"'
+                              type: boolean
+                            storageContainer:
+                              description: 'Optional: defaults to "SelfServiceContainer"'
+                              type: string
+                            username:
+                              description: Prism Element Username for csi driver
                               type: string
                           required:
-                          - name
+                            - endpoint
                           type: object
-                        minItems: 1
-                        type: array
-                    required:
-                    - keys
-                    type: object
-                required:
-                - enabled
-                - resources
-                type: object
-              eventRateLimitConfig:
-                description: 'Optional: Configures the EventRateLimit admission plugin
-                  (if enabled via `useEventRateLimitAdmissionPlugin`) to create limits
-                  on Kubernetes event generation. The EventRateLimit plugin is capable
-                  of comparing and rate limiting incoming `Events` based on several
-                  configured buckets.'
-                properties:
-                  namespace:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                  server:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                  sourceAndObject:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                  user:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                type: object
-              exposeStrategy:
-                description: ExposeStrategy is the strategy used to expose a cluster
-                  control plane.
-                enum:
-                - NodePort
-                - LoadBalancer
-                - Tunneling
-                type: string
-              features:
-                additionalProperties:
-                  type: boolean
-                description: A map of optional or early-stage features that can be
-                  enabled for the user cluster. Some feature gates cannot be disabled
-                  after being enabled. The available feature gates vary based on KKP
-                  version, Kubernetes version and Seed configuration. Please consult
-                  the KKP documentation for specific feature gates.
-                type: object
-              humanReadableName:
-                description: HumanReadableName is the cluster name provided by the
-                  user.
-                type: string
-              imagePullSecret:
-                description: 'Optional: ImagePullSecret references a secret with container
-                  registry credentials. This is passed to the machine-controller which
-                  sets the registry credentials on node level.'
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              kubernetesDashboard:
-                description: KubernetesDashboard holds the configuration for the kubernetes-dashboard
-                  component.
-                properties:
-                  enabled:
-                    description: Controls whether kubernetes-dashboard is deployed
-                      to the user cluster or not. Enabled by default.
-                    type: boolean
-                type: object
-              machineNetworks:
-                items:
-                  description: MachineNetworkingConfig specifies the networking parameters
-                    used for IPAM.
-                  properties:
-                    cidr:
+                        password:
+                          type: string
+                        projectName:
+                          description: ProjectName is the project that this cluster is deployed into. If none is given, no project will be used.
+                          type: string
+                        proxyURL:
+                          type: string
+                        username:
+                          type: string
+                      required:
+                        - clusterName
+                      type: object
+                    openstack:
+                      description: OpenstackCloudSpec specifies access data to an OpenStack cloud.
+                      properties:
+                        applicationCredentialID:
+                          type: string
+                        applicationCredentialSecret:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        domain:
+                          type: string
+                        enableIngressHostname:
+                          description: Enable the `enable-ingress-hostname` cloud provider option on the Openstack CCM. Can only be used with the external CCM and might be deprecated and removed in future versions as it is considered a workaround for the PROXY protocol to preserve client IPs.
+                          type: boolean
+                        floatingIPPool:
+                          description: "FloatingIPPool holds the name of the public network The public network is reachable from the outside world and should provide the pool of IP addresses to choose from. \n When specified, all worker nodes will receive a public ip from this floating ip pool \n Note that the network is external if the \"External\" field is set to true"
+                          type: string
+                        ingressHostnameSuffix:
+                          description: Set a specific suffix for the hostnames used for the PROXY protocol workaround that is enabled by EnableIngressHostname. The suffix is set to `nip.io` by default. Can only be used with the external CCM and might be deprecated and removed in future versions as it is considered a workaround only.
+                          type: string
+                        ipv6SubnetID:
+                          description: IPv6SubnetID holds the ID of the subnet used for IPv6 networking. If not provided, a new subnet will be created if IPv6 is enabled.
+                          type: string
+                        ipv6SubnetPool:
+                          description: IPv6SubnetPool holds the name of the subnet pool used for creating new IPv6 subnets. If not provided, the default IPv6 subnet pool will be used.
+                          type: string
+                        network:
+                          description: "Network holds the name of the internal network When specified, all worker nodes will be attached to this network. If not specified, a network, subnet & router will be created \n Note that the network is internal if the \"External\" field is set to false"
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        password:
+                          type: string
+                        project:
+                          description: project, formally known as tenant.
+                          type: string
+                        projectID:
+                          description: project id, formally known as tenantID.
+                          type: string
+                        routerID:
+                          type: string
+                        securityGroups:
+                          type: string
+                        subnetID:
+                          type: string
+                        token:
+                          description: Used internally during cluster creation
+                          type: string
+                        useOctavia:
+                          description: "Whether or not to use Octavia for LoadBalancer type of Service implementation instead of using Neutron-LBaaS. Attention:Openstack CCM use Octavia as default load balancer implementation since v1.17.0 \n Takes precedence over the 'use_octavia' flag provided at datacenter level if both are specified."
+                          type: boolean
+                        useToken:
+                          type: boolean
+                        username:
+                          type: string
+                      required:
+                        - floatingIPPool
+                        - network
+                        - routerID
+                        - securityGroups
+                        - subnetID
+                      type: object
+                    packet:
+                      description: PacketCloudSpec specifies access data to a Packet cloud.
+                      properties:
+                        apiKey:
+                          type: string
+                        billingCycle:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        projectID:
+                          type: string
+                      required:
+                        - billingCycle
+                      type: object
+                    providerName:
+                      description: ProviderName is the name of the cloud provider used for this cluster. This must match the given provider spec (e.g. if the providerName is "aws", then the `aws` field must be set).
                       type: string
-                    dnsServers:
+                    vmwareclouddirector:
+                      description: VMwareCloudDirectorCloudSpec specifies access data to VMware Cloud Director cloud.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: Config for CSI driver
+                          properties:
+                            filesystem:
+                              description: Filesystem to use for named disks, defaults to "ext4"
+                              type: string
+                            storageProfile:
+                              description: The name of the storage profile to use for disks created by CSI driver
+                              type: string
+                          required:
+                            - storageProfile
+                          type: object
+                        organization:
+                          description: Organization is the name of organization to use.
+                          type: string
+                        ovdcNetwork:
+                          description: Network is the name of organizational virtual data center network that will be associated with the VMs and vApp.
+                          type: string
+                        password:
+                          description: Password is the VMware Cloud Director user password.
+                          type: string
+                        username:
+                          description: Username is the VMware Cloud Director user name.
+                          type: string
+                        vapp:
+                          description: VApp used for isolation of VMs and their associated network
+                          type: string
+                        vdc:
+                          description: VDC is the organizational virtual data center.
+                          type: string
+                      required:
+                        - csi
+                        - ovdcNetwork
+                      type: object
+                    vsphere:
+                      description: VSphereCloudSpec specifies access data to VSphere cloud.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        datastore:
+                          description: Datastore to be used for storing virtual machines and as a default for dynamic volume provisioning, it is mutually exclusive with DatastoreCluster.
+                          type: string
+                        datastoreCluster:
+                          description: DatastoreCluster to be used for storing virtual machines, it is mutually exclusive with Datastore.
+                          type: string
+                        folder:
+                          description: Folder is the folder to be used to group the provisioned virtual machines.
+                          type: string
+                        infraManagementUser:
+                          description: This user will be used for everything except cloud provider functionality
+                          properties:
+                            password:
+                              type: string
+                            username:
+                              type: string
+                          type: object
+                        password:
+                          description: Password is the vSphere user password.
+                          type: string
+                        resourcePool:
+                          description: ResourcePool is used to manage resources such as cpu and memory for vSphere virtual machines. The resource pool should be defined on vSphere cluster level.
+                          type: string
+                        storagePolicy:
+                          description: StoragePolicy to be used for storage provisioning
+                          type: string
+                        tagCategoryID:
+                          description: This is category for the machine deployment tags
+                          type: string
+                        username:
+                          description: Username is the vSphere user name.
+                          type: string
+                        vmNetName:
+                          description: VMNetName is the name of the vSphere network.
+                          type: string
+                      required:
+                        - infraManagementUser
+                        - storagePolicy
+                        - vmNetName
+                      type: object
+                  required:
+                    - dc
+                    - providerName
+                  type: object
+                clusterNetwork:
+                  description: ClusterNetworkingConfig specifies the different networking parameters for a cluster.
+                  properties:
+                    coreDNSReplicas:
+                      description: CoreDNSReplicas is the number of desired pods of user cluster coredns deployment.
+                      format: int32
+                      type: integer
+                    dnsDomain:
+                      description: Domain name for services.
+                      type: string
+                    ipFamily:
+                      description: 'Optional: IP family used for cluster networking. Supported values are "", "IPv4" or "IPv4+IPv6". Can be omitted / empty if pods and services network ranges are specified. In that case it defaults according to the IP families of the provided network ranges. If neither ipFamily nor pods & services network ranges are specified, defaults to "IPv4".'
+                      enum:
+                        - ""
+                        - IPv4
+                        - IPv4+IPv6
+                      type: string
+                    ipvs:
+                      description: IPVS defines kube-proxy ipvs configuration options
+                      properties:
+                        strictArp:
+                          default: true
+                          description: StrictArp configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface. defaults to true.
+                          type: boolean
+                      type: object
+                    konnectivityEnabled:
+                      description: KonnectivityEnabled enables konnectivity for controlplane to node network communication.
+                      type: boolean
+                    nodeCidrMaskSizeIPv4:
+                      description: NodeCIDRMaskSizeIPv4 is the mask size used to address the nodes within provided IPv4 Pods CIDR. It has to be larger than the provided IPv4 Pods CIDR. Defaults to 24.
+                      format: int32
+                      type: integer
+                    nodeCidrMaskSizeIPv6:
+                      description: NodeCIDRMaskSizeIPv6 is the mask size used to address the nodes within provided IPv6 Pods CIDR. It has to be larger than the provided IPv6 Pods CIDR. Defaults to 64.
+                      format: int32
+                      type: integer
+                    nodeLocalDNSCacheEnabled:
+                      default: true
+                      description: NodeLocalDNSCacheEnabled controls whether the NodeLocal DNS Cache feature is enabled. Defaults to true.
+                      type: boolean
+                    pods:
+                      description: The network ranges from which POD networks are allocated. It can contain one IPv4 and/or one IPv6 CIDR. If both address families are specified, the first one defines the primary address family.
+                      properties:
+                        cidrBlocks:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - cidrBlocks
+                      type: object
+                    proxyMode:
+                      default: ipvs
+                      description: ProxyMode defines the kube-proxy mode ("ipvs" / "iptables" / "ebpf"). Defaults to "ipvs". "ebpf" disables kube-proxy and requires CNI support.
+                      enum:
+                        - ipvs
+                        - iptables
+                        - ebpf
+                      type: string
+                    services:
+                      description: The network ranges from which service VIPs are allocated. It can contain one IPv4 and/or one IPv6 CIDR. If both address families are specified, the first one defines the primary address family.
+                      properties:
+                        cidrBlocks:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - cidrBlocks
+                      type: object
+                  required:
+                    - dnsDomain
+                    - pods
+                    - proxyMode
+                    - services
+                  type: object
+                cniPlugin:
+                  description: CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.
+                  properties:
+                    type:
+                      description: Type is the CNI plugin type to be used.
+                      enum:
+                        - canal
+                        - cilium
+                        - none
+                      type: string
+                    version:
+                      description: Version defines the CNI plugin version to be used. This varies by chosen CNI plugin type.
+                      type: string
+                  required:
+                    - type
+                    - version
+                  type: object
+                componentsOverride:
+                  description: 'Optional: Component specific overrides that allow customization of control plane components.'
+                  properties:
+                    apiserver:
+                      description: Apiserver configures kube-apiserver settings.
+                      properties:
+                        endpointReconcilingDisabled:
+                          type: boolean
+                        nodePortRange:
+                          type: string
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    controllerManager:
+                      description: ControllerManager configures kube-controller-manager settings.
+                      properties:
+                        leaderElection:
+                          properties:
+                            leaseDurationSeconds:
+                              description: LeaseDurationSeconds is the duration in seconds that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack.
+                              format: int32
+                              type: integer
+                            renewDeadlineSeconds:
+                              description: RenewDeadlineSeconds is the duration in seconds that the acting controlplane will retry refreshing leadership before giving up.
+                              format: int32
+                              type: integer
+                            retryPeriodSeconds:
+                              description: RetryPeriodSeconds is the duration in seconds the LeaderElector clients should wait between tries of actions.
+                              format: int32
+                              type: integer
+                          type: object
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    etcd:
+                      description: Etcd configures the etcd ring used to store Kubernetes data.
+                      properties:
+                        clusterSize:
+                          format: int32
+                          type: integer
+                        diskSize:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        storageClass:
+                          type: string
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    konnectivityProxy:
+                      description: KonnectivityProxy configures resources limits/requests for konnectivity-server sidecar.
+                      properties:
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    nodePortProxyEnvoy:
+                      description: NodePortProxyEnvoy configures the per-cluster nodeport-proxy-envoy that is deployed if the `LoadBalancer` expose strategy is used. This is not effective if a different expose strategy is configured.
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    prometheus:
+                      description: Prometheus configures the Prometheus instance deployed into the cluster control plane.
+                      properties:
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    scheduler:
+                      description: Scheduler configures kube-scheduler settings.
+                      properties:
+                        leaderElection:
+                          properties:
+                            leaseDurationSeconds:
+                              description: LeaseDurationSeconds is the duration in seconds that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack.
+                              format: int32
+                              type: integer
+                            renewDeadlineSeconds:
+                              description: RenewDeadlineSeconds is the duration in seconds that the acting controlplane will retry refreshing leadership before giving up.
+                              format: int32
+                              type: integer
+                            retryPeriodSeconds:
+                              description: RetryPeriodSeconds is the duration in seconds the LeaderElector clients should wait between tries of actions.
+                              format: int32
+                              type: integer
+                          type: object
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  required:
+                    - apiserver
+                    - controllerManager
+                    - etcd
+                    - nodePortProxyEnvoy
+                    - prometheus
+                    - scheduler
+                  type: object
+                containerRuntime:
+                  default: containerd
+                  description: ContainerRuntime to use, i.e. `docker` or `containerd`. By default `containerd` will be used.
+                  enum:
+                    - docker
+                    - containerd
+                  type: string
+                debugLog:
+                  description: Enables more verbose logging in KKP's user-cluster-controller-manager.
+                  type: boolean
+                enableOperatingSystemManager:
+                  description: 'Optional: Enables operating-system-manager (OSM), which is responsible for creating and managing worker node configuration. This field is enabled(true) by default.'
+                  type: boolean
+                enableUserSSHKeyAgent:
+                  description: 'Optional: Deploys the UserSSHKeyAgent to the user cluster. This field is immutable. If enabled, the agent will be deployed and used to sync user ssh keys attached by users to the cluster. No SSH keys will be synced after node creation if this is disabled.'
+                  type: boolean
+                encryptionConfiguration:
+                  description: 'Optional: Configures encryption-at-rest for Kubernetes API data. This needs the `encryptionAtRest` feature gate.'
+                  properties:
+                    enabled:
+                      description: Enables encryption-at-rest on this cluster.
+                      type: boolean
+                    resources:
+                      description: List of resources that will be stored encrypted in etcd.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    secretbox:
+                      description: 'Configuration for the `secretbox` static key encryption scheme as supported by Kubernetes. More info: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers'
+                      properties:
+                        keys:
+                          description: List of 'secretbox' encryption keys. The first element of this list is considered the "primary" key which will be used for encrypting data while writing it. Additional keys will be used for decrypting data while reading it, if keys higher in the list did not succeed in decrypting it.
+                          items:
+                            description: SecretboxKey stores a key or key reference for encrypting Kubernetes API data at rest with a static key.
+                            properties:
+                              name:
+                                description: Identifier of a key, used in various places to refer to the key.
+                                type: string
+                              secretRef:
+                                description: Instead of passing the sensitive encryption key via the `value` field, a secret can be referenced. The key of the secret referenced here needs to hold a key equivalent to the `value` field.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              value:
+                                description: Value contains a 32-byte random key that is base64 encoded. This is the key used for encryption. Can be generated via `head -c 32 /dev/urandom | base64`, for example.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          minItems: 1
+                          type: array
+                      required:
+                        - keys
+                      type: object
+                  required:
+                    - enabled
+                    - resources
+                  type: object
+                eventRateLimitConfig:
+                  description: 'Optional: Configures the EventRateLimit admission plugin (if enabled via `useEventRateLimitAdmissionPlugin`) to create limits on Kubernetes event generation. The EventRateLimit plugin is capable of comparing and rate limiting incoming `Events` based on several configured buckets.'
+                  properties:
+                    namespace:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                    server:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                    sourceAndObject:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                    user:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                  type: object
+                exposeStrategy:
+                  description: ExposeStrategy is the strategy used to expose a cluster control plane.
+                  enum:
+                    - NodePort
+                    - LoadBalancer
+                    - Tunneling
+                  type: string
+                features:
+                  additionalProperties:
+                    type: boolean
+                  description: A map of optional or early-stage features that can be enabled for the user cluster. Some feature gates cannot be disabled after being enabled. The available feature gates vary based on KKP version, Kubernetes version and Seed configuration. Please consult the KKP documentation for specific feature gates.
+                  type: object
+                humanReadableName:
+                  description: HumanReadableName is the cluster name provided by the user.
+                  type: string
+                imagePullSecret:
+                  description: 'Optional: ImagePullSecret references a secret with container registry credentials. This is passed to the machine-controller which sets the registry credentials on node level.'
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret name must be unique.
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                kubernetesDashboard:
+                  description: KubernetesDashboard holds the configuration for the kubernetes-dashboard component.
+                  properties:
+                    enabled:
+                      description: Controls whether kubernetes-dashboard is deployed to the user cluster or not. Enabled by default.
+                      type: boolean
+                  type: object
+                machineNetworks:
+                  items:
+                    description: MachineNetworkingConfig specifies the networking parameters used for IPAM.
+                    properties:
+                      cidr:
+                        type: string
+                      dnsServers:
+                        items:
+                          type: string
+                        type: array
+                      gateway:
+                        type: string
+                    required:
+                      - cidr
+                      - dnsServers
+                      - gateway
+                    type: object
+                  type: array
+                mla:
+                  description: 'Optional: MLA contains monitoring, logging and alerting related settings for the user cluster.'
+                  properties:
+                    loggingEnabled:
+                      description: LoggingEnabled is the flag for enabling logging in user cluster.
+                      type: boolean
+                    loggingResources:
+                      description: LoggingResources is the resource requirements for user cluster promtail.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    monitoringEnabled:
+                      description: MonitoringEnabled is the flag for enabling monitoring in user cluster.
+                      type: boolean
+                    monitoringReplicas:
+                      description: MonitoringReplicas is the number of desired pods of user cluster prometheus deployment.
+                      format: int32
+                      type: integer
+                    monitoringResources:
+                      description: MonitoringResources is the resource requirements for user cluster prometheus.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                oidc:
+                  properties:
+                    clientID:
+                      type: string
+                    clientSecret:
+                      type: string
+                    extraScopes:
+                      type: string
+                    groupsClaim:
+                      type: string
+                    issuerURL:
+                      type: string
+                    requiredClaim:
+                      type: string
+                    usernameClaim:
+                      type: string
+                  type: object
+                opaIntegration:
+                  description: 'Optional: OPAIntegration is a preview feature that enables OPA integration for the cluster. Enabling it causes OPA Gatekeeper and its resources to be deployed on the user cluster. By default it is disabled.'
+                  properties:
+                    auditResources:
+                      description: 'Optional: AuditResources is the resource requirements for user cluster gatekeeper audit.'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    controllerResources:
+                      description: 'Optional: ControllerResources is the resource requirements for user cluster gatekeeper controller.'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    enabled:
+                      description: Enables OPA Gatekeeper integration.
+                      type: boolean
+                    experimentalEnableMutation:
+                      description: 'Optional: Enables experimental mutation in Gatekeeper.'
+                      type: boolean
+                    webhookTimeoutSeconds:
+                      default: 10
+                      description: The timeout in seconds that is set for the Gatekeeper validating webhook admission review calls. Defaults to `10` (seconds).
+                      format: int32
+                      type: integer
+                  type: object
+                pause:
+                  default: false
+                  description: If this is set to true, the cluster will not be reconciled by KKP. This indicates that the user needs to do some action to resolve the pause.
+                  type: boolean
+                pauseReason:
+                  description: PauseReason is the reason why the cluster is not being managed. This field is for informational purpose only and can be set by a user or a controller to communicate the reason for pausing the cluster.
+                  type: string
+                podNodeSelectorAdmissionPluginConfig:
+                  additionalProperties:
+                    type: string
+                  description: 'Optional: Provides configuration for the PodNodeSelector admission plugin (needs plugin enabled via `usePodNodeSelectorAdmissionPlugin`). It''s used by the backend to create a configuration file for this plugin. The key:value from this map is converted to <namespace>:<node-selectors-labels> in the file. Use `clusterDefaultNodeSelector` as key to configure a default node selector.'
+                  type: object
+                serviceAccount:
+                  description: 'Optional: ServiceAccount contains service account related settings for the user cluster''s kube-apiserver.'
+                  properties:
+                    apiAudiences:
+                      description: APIAudiences are the Identifiers of the API If this is not specified, it will be set to a single element list containing the issuer URL
                       items:
                         type: string
                       type: array
-                    gateway:
+                    issuer:
+                      description: Issuer is the identifier of the service account token issuer If this is not specified, it will be set to the URL of apiserver by default
                       type: string
-                  required:
-                  - cidr
-                  - dnsServers
-                  - gateway
+                    tokenVolumeProjectionEnabled:
+                      type: boolean
                   type: object
-                type: array
-              mla:
-                description: 'Optional: MLA contains monitoring, logging and alerting
-                  related settings for the user cluster.'
-                properties:
-                  loggingEnabled:
-                    description: LoggingEnabled is the flag for enabling logging in
-                      user cluster.
-                    type: boolean
-                  loggingResources:
-                    description: LoggingResources is the resource requirements for
-                      user cluster promtail.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                  monitoringEnabled:
-                    description: MonitoringEnabled is the flag for enabling monitoring
-                      in user cluster.
-                    type: boolean
-                  monitoringReplicas:
-                    description: MonitoringReplicas is the number of desired pods
-                      of user cluster prometheus deployment.
-                    format: int32
-                    type: integer
-                  monitoringResources:
-                    description: MonitoringResources is the resource requirements
-                      for user cluster prometheus.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-              oidc:
-                properties:
-                  clientID:
-                    type: string
-                  clientSecret:
-                    type: string
-                  extraScopes:
-                    type: string
-                  groupsClaim:
-                    type: string
-                  issuerURL:
-                    type: string
-                  requiredClaim:
-                    type: string
-                  usernameClaim:
-                    type: string
-                type: object
-              opaIntegration:
-                description: 'Optional: OPAIntegration is a preview feature that enables
-                  OPA integration for the cluster. Enabling it causes OPA Gatekeeper
-                  and its resources to be deployed on the user cluster. By default
-                  it is disabled.'
-                properties:
-                  auditResources:
-                    description: 'Optional: AuditResources is the resource requirements
-                      for user cluster gatekeeper audit.'
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                  controllerResources:
-                    description: 'Optional: ControllerResources is the resource requirements
-                      for user cluster gatekeeper controller.'
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                  enabled:
-                    description: Enables OPA Gatekeeper integration.
-                    type: boolean
-                  experimentalEnableMutation:
-                    description: 'Optional: Enables experimental mutation in Gatekeeper.'
-                    type: boolean
-                  webhookTimeoutSeconds:
-                    default: 10
-                    description: The timeout in seconds that is set for the Gatekeeper
-                      validating webhook admission review calls. Defaults to `10`
-                      (seconds).
-                    format: int32
-                    type: integer
-                type: object
-              pause:
-                default: false
-                description: If this is set to true, the cluster will not be reconciled
-                  by KKP. This indicates that the user needs to do some action to
-                  resolve the pause.
-                type: boolean
-              pauseReason:
-                description: PauseReason is the reason why the cluster is not being
-                  managed. This field is for informational purpose only and can be
-                  set by a user or a controller to communicate the reason for pausing
-                  the cluster.
-                type: string
-              podNodeSelectorAdmissionPluginConfig:
-                additionalProperties:
-                  type: string
-                description: 'Optional: Provides configuration for the PodNodeSelector
-                  admission plugin (needs plugin enabled via `usePodNodeSelectorAdmissionPlugin`).
-                  It''s used by the backend to create a configuration file for this
-                  plugin. The key:value from this map is converted to <namespace>:<node-selectors-labels>
-                  in the file. Use `clusterDefaultNodeSelector` as key to configure
-                  a default node selector.'
-                type: object
-              serviceAccount:
-                description: 'Optional: ServiceAccount contains service account related
-                  settings for the user cluster''s kube-apiserver.'
-                properties:
-                  apiAudiences:
-                    description: APIAudiences are the Identifiers of the API If this
-                      is not specified, it will be set to a single element list containing
-                      the issuer URL
-                    items:
-                      type: string
-                    type: array
-                  issuer:
-                    description: Issuer is the identifier of the service account token
-                      issuer If this is not specified, it will be set to the URL of
-                      apiserver by default
-                    type: string
-                  tokenVolumeProjectionEnabled:
-                    type: boolean
-                type: object
-              updateWindow:
-                description: 'Optional: UpdateWindow configures automatic update systems
-                  to respect a maintenance window for applying OS updates to nodes.
-                  This is only respected on Flatcar nodes currently.'
-                properties:
-                  length:
-                    description: Sets the length of the update window beginning with
-                      the start time. This needs to be a valid duration as parsed
-                      by Go's time.ParseDuration (https://pkg.go.dev/time#ParseDuration),
-                      e.g. `2h`.
-                    type: string
-                  start:
-                    description: Sets the start time of the update window. This can
-                      be a time of day in 24h format, e.g. `22:30`, or a day of week
-                      plus a time of day, for example `Mon 21:00`. Only short names
-                      for week days are supported, i.e. `Mon`, `Tue`, `Wed`, `Thu`,
-                      `Fri`, `Sat` and `Sun`.
-                    type: string
-                type: object
-              useEventRateLimitAdmissionPlugin:
-                description: Enables the admission plugin `EventRateLimit`. Needs
-                  additional configuration via the `eventRateLimitConfig` field. This
-                  plugin is considered "alpha" by Kubernetes.
-                type: boolean
-              usePodNodeSelectorAdmissionPlugin:
-                description: Enables the admission plugin `PodNodeSelector`. Needs
-                  additional configuration via the `podNodeSelectorAdmissionPluginConfig`
-                  field.
-                type: boolean
-              usePodSecurityPolicyAdmissionPlugin:
-                description: Enables the admission plugin `PodSecurityPolicy`. This
-                  plugin is deprecated by Kubernetes.
-                type: boolean
-              version:
-                description: Version defines the wanted version of the control plane.
-                type: string
-            required:
-            - cloud
-            - clusterNetwork
-            - exposeStrategy
-            - humanReadableName
-            - version
-            type: object
-          status:
-            description: Status contains reconciliation information for the cluster.
-            properties:
-              address:
-                description: Address contains the IPs/URLs to access the cluster control
-                  plane.
-                properties:
-                  adminToken:
-                    description: AdminToken is the token for the kubeconfig, the user
-                      can download
-                    type: string
-                  externalName:
-                    description: ExternalName is the DNS name for this cluster
-                    type: string
-                  internalURL:
-                    description: InternalName is the seed cluster internal absolute
-                      DNS name to the API server
-                    type: string
-                  ip:
-                    description: IP is the external IP under which the apiserver is
-                      available
-                    type: string
-                  port:
-                    description: Port is the port the API server listens on
-                    format: int32
-                    type: integer
-                  url:
-                    description: URL under which the Apiserver is available
-                    type: string
-                type: object
-              cloudMigrationRevision:
-                description: CloudMigrationRevision describes the latest version of
-                  the migration that has been done It is used to avoid redundant and
-                  potentially costly migrations.
-                type: integer
-              conditions:
-                additionalProperties:
+                updateWindow:
+                  description: 'Optional: UpdateWindow configures automatic update systems to respect a maintenance window for applying OS updates to nodes. This is only respected on Flatcar nodes currently.'
                   properties:
-                    kubermaticVersion:
-                      description: KubermaticVersion current kubermatic version.
+                    length:
+                      description: Sets the length of the update window beginning with the start time. This needs to be a valid duration as parsed by Go's time.ParseDuration (https://pkg.go.dev/time#ParseDuration), e.g. `2h`.
                       type: string
-                    lastHeartbeatTime:
-                      description: Last time we got an update on a given condition.
-                      format: date-time
+                    start:
+                      description: Sets the start time of the update window. This can be a time of day in 24h format, e.g. `22:30`, or a day of week plus a time of day, for example `Mon 21:00`. Only short names for week days are supported, i.e. `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat` and `Sun`.
                       type: string
-                    lastTransitionTime:
-                      description: Last time the condition transit from one status
-                        to another.
-                      format: date-time
+                  type: object
+                useEventRateLimitAdmissionPlugin:
+                  description: Enables the admission plugin `EventRateLimit`. Needs additional configuration via the `eventRateLimitConfig` field. This plugin is considered "alpha" by Kubernetes.
+                  type: boolean
+                usePodNodeSelectorAdmissionPlugin:
+                  description: Enables the admission plugin `PodNodeSelector`. Needs additional configuration via the `podNodeSelectorAdmissionPluginConfig` field.
+                  type: boolean
+                usePodSecurityPolicyAdmissionPlugin:
+                  description: Enables the admission plugin `PodSecurityPolicy`. This plugin is deprecated by Kubernetes.
+                  type: boolean
+                version:
+                  description: Version defines the wanted version of the control plane.
+                  type: string
+              required:
+                - cloud
+                - clusterNetwork
+                - exposeStrategy
+                - humanReadableName
+                - version
+              type: object
+            status:
+              description: Status contains reconciliation information for the cluster.
+              properties:
+                address:
+                  description: Address contains the IPs/URLs to access the cluster control plane.
+                  properties:
+                    adminToken:
+                      description: AdminToken is the token for the kubeconfig, the user can download
                       type: string
-                    message:
-                      description: Human readable message indicating details about
-                        last transition.
+                    externalName:
+                      description: ExternalName is the DNS name for this cluster
                       type: string
-                    reason:
-                      description: (brief) reason for the condition's last transition.
+                    internalURL:
+                      description: InternalName is the seed cluster internal absolute DNS name to the API server
                       type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
+                    ip:
+                      description: IP is the external IP under which the apiserver is available
+                      type: string
+                    port:
+                      description: Port is the port the API server listens on
+                      format: int32
+                      type: integer
+                    url:
+                      description: URL under which the Apiserver is available
+                      type: string
+                  type: object
+                cloudMigrationRevision:
+                  description: CloudMigrationRevision describes the latest version of the migration that has been done It is used to avoid redundant and potentially costly migrations.
+                  type: integer
+                conditions:
+                  additionalProperties:
+                    properties:
+                      kubermaticVersion:
+                        description: KubermaticVersion current kubermatic version.
+                        type: string
+                      lastHeartbeatTime:
+                        description: Last time we got an update on a given condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transit from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: (brief) reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                    required:
+                      - kubermaticVersion
+                      - lastHeartbeatTime
+                      - status
+                    type: object
+                  description: Conditions contains conditions the cluster is in, its primary use case is status signaling between controllers or between controllers and the API.
+                  type: object
+                encryption:
+                  description: Encryption describes the status of the encryption-at-rest feature for encrypted data in etcd.
+                  properties:
+                    activeKey:
+                      description: The current "primary" key used to encrypt data written to etcd. Secondary keys that can be used for decryption (but not encryption) might be configured in the ClusterSpec.
+                      type: string
+                    encryptedResources:
+                      description: List of resources currently encrypted.
+                      items:
+                        type: string
+                      type: array
+                    phase:
+                      description: The current phase of the encryption process. Can be one of `Pending`, `Failed`, `Active` or `EncryptionNeeded`. The `encryption_controller` logic will process the cluster based on the current phase and issue necessary changes to make sure encryption on the cluster is active and updated with what the ClusterSpec defines.
+                      enum:
+                        - Pending
+                        - Failed
+                        - Active
+                        - EncryptionNeeded
                       type: string
                   required:
-                  - kubermaticVersion
-                  - lastHeartbeatTime
-                  - status
+                    - activeKey
+                    - encryptedResources
+                    - phase
                   type: object
-                description: Conditions contains conditions the cluster is in, its
-                  primary use case is status signaling between controllers or between
-                  controllers and the API.
-                type: object
-              encryption:
-                description: Encryption describes the status of the encryption-at-rest
-                  feature for encrypted data in etcd.
-                properties:
-                  activeKey:
-                    description: The current "primary" key used to encrypt data written
-                      to etcd. Secondary keys that can be used for decryption (but
-                      not encryption) might be configured in the ClusterSpec.
-                    type: string
-                  encryptedResources:
-                    description: List of resources currently encrypted.
-                    items:
-                      type: string
-                    type: array
-                  phase:
-                    description: The current phase of the encryption process. Can
-                      be one of `Pending`, `Failed`, `Active` or `EncryptionNeeded`.
-                      The `encryption_controller` logic will process the cluster based
-                      on the current phase and issue necessary changes to make sure
-                      encryption on the cluster is active and updated with what the
-                      ClusterSpec defines.
-                    enum:
-                    - Pending
-                    - Failed
-                    - Active
-                    - EncryptionNeeded
-                    type: string
-                required:
-                - activeKey
-                - encryptedResources
-                - phase
-                type: object
-              errorMessage:
-                description: ErrorMessage contains a default error message in case
-                  the controller encountered an error. Will be reset if the error
-                  was resolved.
-                type: string
-              errorReason:
-                description: ErrorReason contains a error reason in case the controller
-                  encountered an error. Will be reset if the error was resolved.
-                enum:
-                - InvalidConfiguration
-                - UnsupportedChange
-                - ReconcileError
-                type: string
-              extendedHealth:
-                description: ExtendedHealth exposes information about the current
-                  health state. Extends standard health status for new states.
-                properties:
-                  alertmanagerConfig:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  apiserver:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  applicationController:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  cloudProviderInfrastructure:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  controller:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  etcd:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  gatekeeperAudit:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  gatekeeperController:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  konnectivity:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  kubernetesDashboard:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  logging:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  machineController:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  mlaGateway:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  monitoring:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  openvpn:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  operatingSystemManager:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  scheduler:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                  userClusterControllerManager:
-                    enum:
-                    - HealthStatusDown
-                    - HealthStatusUp
-                    - HealthStatusProvisioning
-                    type: string
-                type: object
-              inheritedLabels:
-                additionalProperties:
+                errorMessage:
+                  description: ErrorMessage contains a default error message in case the controller encountered an error. Will be reset if the error was resolved.
                   type: string
-                description: InheritedLabels are labels the cluster inherited from
-                  the project. They are read-only for users.
-                type: object
-              lastProviderReconciliation:
-                description: LastProviderReconciliation is the time when the cloud
-                  provider resources were last fully reconciled (during normal cluster
-                  reconciliation, KKP does not re-check things like security groups,
-                  networks etc.).
-                format: date-time
-                type: string
-              lastUpdated:
-                format: date-time
-                type: string
-              namespaceName:
-                description: NamespaceName defines the namespace the control plane
-                  of this cluster is deployed in.
-                type: string
-              phase:
-                description: Phase is a description of the current cluster status,
-                  summarizing the various conditions, possible active updates etc.
-                  This field is for informational purpose only and no logic should
-                  be tied to the phase.
-                enum:
-                - Creating
-                - Updating
-                - Running
-                - Terminating
-                type: string
-              resourceUsage:
-                description: ResourceUsage shows the current usage of resources for
-                  the cluster.
-                properties:
-                  cpu:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: CPU holds the quantity of CPU. For the format, please
-                      check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  memory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Memory represents the quantity of RAM size. For the
-                      format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storage:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Storage represents the disk size. For the format,
-                      please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-              userEmail:
-                description: UserEmail contains the email of the owner of this cluster.
-                  During cluster creation only, this field will be used to bind the
-                  `cluster-admin` `ClusterRole` to a cluster owner.
-                type: string
-              userName:
-                description: 'Deprecated: UserName contains the name of the owner
-                  of this cluster. This field is not actively used and will be removed
-                  in the future.'
-                type: string
-              versions:
-                description: Versions contains information regarding the current and
-                  desired versions of the cluster control plane and worker nodes.
-                properties:
-                  apiserver:
-                    description: Apiserver is the currently desired version of the
-                      kube-apiserver. During upgrades across multiple minor versions
-                      (e.g. from 1.20 to 1.23), this will gradually be increased by
-                      the update-controller until the desired cluster version (spec.version)
-                      is reached.
+                errorReason:
+                  description: ErrorReason contains a error reason in case the controller encountered an error. Will be reset if the error was resolved.
+                  enum:
+                    - InvalidConfiguration
+                    - UnsupportedChange
+                    - ReconcileError
+                  type: string
+                extendedHealth:
+                  description: ExtendedHealth exposes information about the current health state. Extends standard health status for new states.
+                  properties:
+                    alertmanagerConfig:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    apiserver:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    applicationController:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    cloudProviderInfrastructure:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    controller:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    etcd:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    gatekeeperAudit:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    gatekeeperController:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    konnectivity:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    kubernetesDashboard:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    logging:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    machineController:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    mlaGateway:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    monitoring:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    openvpn:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    operatingSystemManager:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    scheduler:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                    userClusterControllerManager:
+                      enum:
+                        - HealthStatusDown
+                        - HealthStatusUp
+                        - HealthStatusProvisioning
+                      type: string
+                  type: object
+                inheritedLabels:
+                  additionalProperties:
                     type: string
-                  controlPlane:
-                    description: ControlPlane is the currently active cluster version.
-                      This can lag behind the apiserver version if an update is currently
-                      rolling out.
-                    type: string
-                  controllerManager:
-                    description: ControllerManager is the currently desired version
-                      of the kube-controller-manager. This field behaves the same
-                      as the apiserver field.
-                    type: string
-                  oldestNodeVersion:
-                    description: OldestNodeVersion is the oldest node version currently
-                      in use inside the cluster. This can be nil if there are no nodes.
-                      This field is primarily for speeding up reconciling, so that
-                      the controller doesn't have to re-fetch to the usercluster and
-                      query its node on every reconciliation.
-                    type: string
-                  scheduler:
-                    description: Scheduler is the currently desired version of the
-                      kube-scheduler. This field behaves the same as the apiserver
-                      field.
-                    type: string
-                required:
-                - apiserver
-                - controlPlane
-                - controllerManager
-                - scheduler
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  description: InheritedLabels are labels the cluster inherited from the project. They are read-only for users.
+                  type: object
+                lastProviderReconciliation:
+                  description: LastProviderReconciliation is the time when the cloud provider resources were last fully reconciled (during normal cluster reconciliation, KKP does not re-check things like security groups, networks etc.).
+                  format: date-time
+                  type: string
+                lastUpdated:
+                  format: date-time
+                  type: string
+                namespaceName:
+                  description: NamespaceName defines the namespace the control plane of this cluster is deployed in.
+                  type: string
+                phase:
+                  description: Phase is a description of the current cluster status, summarizing the various conditions, possible active updates etc. This field is for informational purpose only and no logic should be tied to the phase.
+                  enum:
+                    - Creating
+                    - Updating
+                    - Running
+                    - Terminating
+                  type: string
+                resourceUsage:
+                  description: ResourceUsage shows the current usage of resources for the cluster.
+                  properties:
+                    cpu:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: CPU holds the quantity of CPU. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    memory:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Memory represents the quantity of RAM size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storage:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Storage represents the disk size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                userEmail:
+                  description: UserEmail contains the email of the owner of this cluster. During cluster creation only, this field will be used to bind the `cluster-admin` `ClusterRole` to a cluster owner.
+                  type: string
+                userName:
+                  description: 'Deprecated: UserName contains the name of the owner of this cluster. This field is not actively used and will be removed in the future.'
+                  type: string
+                versions:
+                  description: Versions contains information regarding the current and desired versions of the cluster control plane and worker nodes.
+                  properties:
+                    apiserver:
+                      description: Apiserver is the currently desired version of the kube-apiserver. During upgrades across multiple minor versions (e.g. from 1.20 to 1.23), this will gradually be increased by the update-controller until the desired cluster version (spec.version) is reached.
+                      type: string
+                    controlPlane:
+                      description: ControlPlane is the currently active cluster version. This can lag behind the apiserver version if an update is currently rolling out.
+                      type: string
+                    controllerManager:
+                      description: ControllerManager is the currently desired version of the kube-controller-manager. This field behaves the same as the apiserver field.
+                      type: string
+                    oldestNodeVersion:
+                      description: OldestNodeVersion is the oldest node version currently in use inside the cluster. This can be nil if there are no nodes. This field is primarily for speeding up reconciling, so that the controller doesn't have to re-fetch to the usercluster and query its node on every reconciliation.
+                      type: string
+                    scheduler:
+                      description: Scheduler is the currently desired version of the kube-scheduler. This field behaves the same as the apiserver field.
+                      type: string
+                  required:
+                    - apiserver
+                    - controlPlane
+                    - controllerManager
+                    - scheduler
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: seed
   creationTimestamp: null
   name: clusters.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: clustertemplateinstances.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,57 +17,51 @@ spec:
     singular: clustertemplateinstance
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.projectID
-      name: ProjectID
-      type: string
-    - jsonPath: .spec.clusterTemplateID
-      name: ClusterTemplateID
-      type: string
-    - jsonPath: .spec.replicas
-      name: Replicas
-      type: integer
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ClusterTemplateInstance is the object representing a cluster
-          template instance.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterTemplateInstanceSpec specifies the data for cluster
-              instances.
-            properties:
-              clusterTemplateID:
-                type: string
-              clusterTemplateName:
-                type: string
-              projectID:
-                type: string
-              replicas:
-                format: int64
-                type: integer
-            required:
-            - clusterTemplateID
-            - clusterTemplateName
-            - projectID
-            - replicas
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.projectID
+          name: ProjectID
+          type: string
+        - jsonPath: .spec.clusterTemplateID
+          name: ClusterTemplateID
+          type: string
+        - jsonPath: .spec.replicas
+          name: Replicas
+          type: integer
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterTemplateInstance is the object representing a cluster template instance.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterTemplateInstanceSpec specifies the data for cluster instances.
+              properties:
+                clusterTemplateID:
+                  type: string
+                clusterTemplateName:
+                  type: string
+                projectID:
+                  type: string
+                replicas:
+                  format: int64
+                  type: integer
+              required:
+                - clusterTemplateID
+                - clusterTemplateName
+                - projectID
+                - replicas
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplateinstances.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: seed
   creationTimestamp: null
   name: clustertemplateinstances.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: clustertemplates.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: clustertemplates.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,2331 +17,1735 @@ spec:
     singular: clustertemplate
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.humanReadableName
-      name: HumanReadableName
-      type: string
-    - jsonPath: .spec.version
-      name: Version
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ClusterTemplate is the object representing a cluster template.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          clusterLabels:
-            additionalProperties:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.humanReadableName
+          name: HumanReadableName
+          type: string
+        - jsonPath: .spec.version
+          name: Version
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ClusterTemplate is the object representing a cluster template.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
               type: string
-            type: object
-          credential:
-            type: string
-          inheritedClusterLabels:
-            additionalProperties:
+            clusterLabels:
+              additionalProperties:
+                type: string
+              type: object
+            credential:
               type: string
-            type: object
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ClusterSpec describes the desired state of a user cluster.
-            properties:
-              admissionPlugins:
-                description: A list of arbitrary admission plugin names that are passed
-                  to kube-apiserver. Must not include admission plugins that can be
-                  enabled via a separate setting.
-                items:
-                  type: string
-                type: array
-              applicationSettings:
-                description: 'Optional: ApplicationSettings contains the settings
-                  relative to the application feature.'
-                properties:
-                  cacheSize:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: CacheSize is the size of the cache used to download
-                      application's sources.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-              auditLogging:
-                description: 'Optional: AuditLogging configures Kubernetes API audit
-                  logging (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/)
-                  for the user cluster.'
-                properties:
-                  enabled:
-                    description: Enabled will enable or disable audit logging.
-                    type: boolean
-                  policyPreset:
-                    description: 'Optional: PolicyPreset can be set to utilize a pre-defined
-                      set of audit policy rules.'
-                    enum:
-                    - ""
-                    - metadata
-                    - recommended
-                    - minimal
+            inheritedClusterLabels:
+              additionalProperties:
+                type: string
+              type: object
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ClusterSpec describes the desired state of a user cluster.
+              properties:
+                admissionPlugins:
+                  description: A list of arbitrary admission plugin names that are passed to kube-apiserver. Must not include admission plugins that can be enabled via a separate setting.
+                  items:
                     type: string
-                  sidecar:
-                    description: 'Optional: Configures the fluent-bit sidecar deployed
-                      alongside kube-apiserver.'
-                    properties:
-                      config:
-                        description: AuditSidecarConfiguration defines custom configuration
-                          for the fluent-bit sidecar deployed with a kube-apiserver.
-                          Also see https://docs.fluentbit.io/manual/v/1.8/administration/configuring-fluent-bit/configuration-file.
-                        properties:
-                          filters:
-                            items:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            type: array
-                          outputs:
-                            items:
-                              additionalProperties:
-                                type: string
-                              type: object
-                            type: array
-                          service:
-                            additionalProperties:
-                              type: string
-                            type: object
-                        type: object
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                type: object
-              cloud:
-                description: Cloud contains information regarding the cloud provider
-                  that is responsible for hosting the cluster's workload.
-                properties:
-                  alibaba:
-                    description: AlibabaCloudSpec specifies the access data to Alibaba.
-                    properties:
-                      accessKeyID:
-                        type: string
-                      accessKeySecret:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    type: object
-                  anexia:
-                    description: AnexiaCloudSpec specifies the access data to Anexia.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      token:
-                        type: string
-                    type: object
-                  aws:
-                    description: AWSCloudSpec specifies access data to Amazon Web
-                      Services.
-                    properties:
-                      accessKeyID:
-                        type: string
-                      assumeRoleARN:
-                        type: string
-                      assumeRoleExternalID:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      instanceProfileName:
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the security group to. Only applies
-                          if the security group is generated by KKP and not preexisting.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set, the node port range can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the security group to.
-                          Only applies if the security group is generated by KKP and
-                          not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      roleARN:
-                        description: The IAM role, the control plane will use. The
-                          control plane will perform an assume-role
-                        type: string
-                      routeTableID:
-                        type: string
-                      secretAccessKey:
-                        type: string
-                      securityGroupID:
-                        type: string
-                      vpcID:
-                        type: string
-                    required:
-                    - instanceProfileName
-                    - roleARN
-                    - routeTableID
-                    - securityGroupID
-                    - vpcID
-                    type: object
-                  azure:
-                    description: AzureCloudSpec defines cloud resource references
-                      for Microsoft Azure.
-                    properties:
-                      assignAvailabilitySet:
-                        description: 'Optional: AssignAvailabilitySet determines whether
-                          KKP creates and assigns an AvailabilitySet to machines.
-                          Defaults to `true` internally if not set.'
-                        type: boolean
-                      availabilitySet:
-                        description: An availability set that will be associated with
-                          nodes created for this cluster. If this field is set to
-                          empty string at cluster creation and `AssignAvailabilitySet`
-                          is set to `true`, a new availability set will be created
-                          and this field will be updated to the generated availability
-                          set's name.
-                        type: string
-                      clientID:
-                        description: ClientID is the service principal used to access
-                          Azure. Can be read from `credentialsReference` instead.
-                        type: string
-                      clientSecret:
-                        description: ClientSecret is the client secret corresponding
-                          to the given service principal. Can be read from `credentialsReference`
-                          instead.
-                        type: string
-                      credentialsReference:
-                        description: CredentialsReference allows referencing a `Secret`
-                          resource instead of passing secret data in this spec.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      loadBalancerSKU:
-                        description: Azure SKU for Load Balancers. Possible values
-                          are `basic` and `standard`.
-                        enum:
-                        - standard
-                        - basic
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the security group to. Only applies
-                          if the security group is generated by KKP and not preexisting.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set, the node port range can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the security group to.
-                          Only applies if the security group is generated by KKP and
-                          not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      resourceGroup:
-                        description: The resource group that will be used to look
-                          up and create resources for the cluster in. If set to empty
-                          string at cluster creation, a new resource group will be
-                          created and this field will be updated to the generated
-                          resource group's name.
-                        type: string
-                      routeTable:
-                        description: The name of a route table associated with the
-                          subnet referenced by `subnet`. If set to empty string at
-                          cluster creation, a new route table will be created and
-                          this field will be updated to the generated route table's
-                          name. If no subnet is defined at cluster creation, this
-                          field should be empty as well.
-                        type: string
-                      securityGroup:
-                        description: The name of a security group associated with
-                          the subnet referenced by `subnet`. If set to empty string
-                          at cluster creation, a new security group will be created
-                          and this field will be updated to the generated security
-                          group's name. If no subnet is defined at cluster creation,
-                          this field should be empty as well.
-                        type: string
-                      subnet:
-                        description: The name of a subnet in the VNet referenced by
-                          `vnet`. If set to empty string at cluster creation, a new
-                          subnet will be created and this field will be updated to
-                          the generated subnet's name. If no VNet is defined at cluster
-                          creation, this field should be empty as well.
-                        type: string
-                      subscriptionID:
-                        description: SubscriptionID is the Azure Subscription used
-                          for this cluster. Can be read from `credentialsReference`
-                          instead.
-                        type: string
-                      tenantID:
-                        description: TenantID is the Azure Active Directory Tenant
-                          used for this cluster. Can be read from `credentialsReference`
-                          instead.
-                        type: string
-                      vnet:
-                        description: The name of the VNet resource used for setting
-                          up networking in. If set to empty string at cluster creation,
-                          a new VNet will be created and this field will be updated
-                          to the generated VNet's name.
-                        type: string
-                      vnetResourceGroup:
-                        description: 'Optional: VNetResourceGroup optionally defines
-                          a second resource group that will be used for VNet related
-                          resources instead. If left empty, NO additional resource
-                          group will be created and all VNet related resources use
-                          the resource group defined by `resourceGroup`.'
-                        type: string
-                    required:
-                    - availabilitySet
-                    - loadBalancerSKU
-                    - resourceGroup
-                    - routeTable
-                    - securityGroup
-                    - subnet
-                    - vnet
-                    - vnetResourceGroup
-                    type: object
-                  bringyourown:
-                    description: BringYourOwnCloudSpec specifies access data for a
-                      bring your own cluster.
-                    type: object
-                  dc:
-                    description: DatacenterName states the name of a cloud provider
-                      "datacenter" (defined in `Seed` resources) this cluster should
-                      be deployed into.
-                    type: string
-                  digitalocean:
-                    description: DigitaloceanCloudSpec specifies access data to DigitalOcean.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      token:
-                        type: string
-                    type: object
-                  fake:
-                    description: FakeCloudSpec specifies access data for a fake cloud.
-                    properties:
-                      token:
-                        type: string
-                    type: object
-                  gcp:
-                    description: GCPCloudSpec specifies access data to GCP.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      network:
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the firewall rules to. If NodePortsAllowedIPRange
-                          nor NodePortsAllowedIPRanges is set, the node port range
-                          can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the firewall rules to.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      serviceAccount:
-                        description: The Google Service Account (JSON format), encoded
-                          with base64.
-                        type: string
-                      subnetwork:
-                        type: string
-                    required:
-                    - network
-                    - subnetwork
-                    type: object
-                  hetzner:
-                    description: HetznerCloudSpec specifies access data to hetzner
-                      cloud.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      network:
-                        description: Network is the pre-existing Hetzner network in
-                          which the machines are running. While machines can be in
-                          multiple networks, a single one must be chosen for the HCloud
-                          CCM to work. If this is empty, the network configured on
-                          the datacenter will be used.
-                        type: string
-                      token:
-                        description: Token is used to authenticate with the Hetzner
-                          cloud API.
-                        type: string
-                    type: object
-                  kubevirt:
-                    description: KubevirtCloudSpec specifies the access data to Kubevirt.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      csiKubeconfig:
-                        type: string
-                      infraStorageClasses:
-                        description: InfraStorageClasses is a list of storage classes
-                          from KubeVirt infra cluster that are used for initialization
-                          of user cluster storage classes by the CSI driver kubevirt
-                          (hot pluggable disks)
-                        items:
-                          type: string
-                        type: array
-                      kubeconfig:
-                        description: The cluster's kubeconfig file, encoded with base64.
-                        type: string
-                      preAllocatedDataVolumes:
-                        description: PreAllocatedDataVolumes holds list of preallocated
-                          DataVolumes which can be used as reference for DataVolume
-                          cloning.
-                        items:
-                          properties:
-                            name:
-                              type: string
-                            size:
-                              type: string
-                            storageClass:
-                              type: string
-                            url:
-                              type: string
-                          required:
-                          - name
-                          - size
-                          - storageClass
-                          - url
-                          type: object
-                        type: array
-                    type: object
-                  nutanix:
-                    description: NutanixCloudSpec specifies the access data to Nutanix.
-                    properties:
-                      clusterName:
-                        description: ClusterName is the Nutanix cluster that this
-                          user cluster will be deployed to.
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      csi:
-                        description: NutanixCSIConfig for csi driver that connects
-                          to a prism element
-                        properties:
-                          endpoint:
-                            description: Prism Element Endpoint to access Nutanix
-                              Prism Element for csi driver
-                            type: string
-                          fstype:
-                            description: 'Optional: defaults to "xfs"'
-                            type: string
-                          password:
-                            description: Prism Element Password for csi driver
-                            type: string
-                          port:
-                            description: 'Optional: Port to use when connecting to
-                              the Nutanix Prism Element endpoint (defaults to 9440)'
-                            format: int32
-                            type: integer
-                          ssSegmentedIscsiNetwork:
-                            description: 'Optional: defaults to "false"'
-                            type: boolean
-                          storageContainer:
-                            description: 'Optional: defaults to "SelfServiceContainer"'
-                            type: string
-                          username:
-                            description: Prism Element Username for csi driver
-                            type: string
-                        required:
-                        - endpoint
-                        type: object
-                      password:
-                        type: string
-                      projectName:
-                        description: ProjectName is the project that this cluster
-                          is deployed into. If none is given, no project will be used.
-                        type: string
-                      proxyURL:
-                        type: string
-                      username:
-                        type: string
-                    required:
-                    - clusterName
-                    type: object
-                  openstack:
-                    description: OpenstackCloudSpec specifies access data to an OpenStack
-                      cloud.
-                    properties:
-                      applicationCredentialID:
-                        type: string
-                      applicationCredentialSecret:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      domain:
-                        type: string
-                      enableIngressHostname:
-                        description: Enable the `enable-ingress-hostname` cloud provider
-                          option on the Openstack CCM. Can only be used with the external
-                          CCM and might be deprecated and removed in future versions
-                          as it is considered a workaround for the PROXY protocol
-                          to preserve client IPs.
-                        type: boolean
-                      floatingIPPool:
-                        description: "FloatingIPPool holds the name of the public
-                          network The public network is reachable from the outside
-                          world and should provide the pool of IP addresses to choose
-                          from. \n When specified, all worker nodes will receive a
-                          public ip from this floating ip pool \n Note that the network
-                          is external if the \"External\" field is set to true"
-                        type: string
-                      ingressHostnameSuffix:
-                        description: Set a specific suffix for the hostnames used
-                          for the PROXY protocol workaround that is enabled by EnableIngressHostname.
-                          The suffix is set to `nip.io` by default. Can only be used
-                          with the external CCM and might be deprecated and removed
-                          in future versions as it is considered a workaround only.
-                        type: string
-                      ipv6SubnetID:
-                        description: IPv6SubnetID holds the ID of the subnet used
-                          for IPv6 networking. If not provided, a new subnet will
-                          be created if IPv6 is enabled.
-                        type: string
-                      ipv6SubnetPool:
-                        description: IPv6SubnetPool holds the name of the subnet pool
-                          used for creating new IPv6 subnets. If not provided, the
-                          default IPv6 subnet pool will be used.
-                        type: string
-                      network:
-                        description: "Network holds the name of the internal network
-                          When specified, all worker nodes will be attached to this
-                          network. If not specified, a network, subnet & router will
-                          be created \n Note that the network is internal if the \"External\"
-                          field is set to false"
-                        type: string
-                      nodePortsAllowedIPRange:
-                        description: A CIDR range that will be used to allow access
-                          to the node port range in the security group to. Only applies
-                          if the security group is generated by KKP and not preexisting.
-                          If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set, the node port range can be accessed from anywhere.
-                        type: string
-                      nodePortsAllowedIPRanges:
-                        description: 'Optional: CIDR ranges that will be used to allow
-                          access to the node port range in the security group to.
-                          Only applies if the security group is generated by KKP and
-                          not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges
-                          is set,  the node port range can be accessed from anywhere.'
-                        properties:
-                          cidrBlocks:
-                            items:
-                              type: string
-                            type: array
-                        required:
-                        - cidrBlocks
-                        type: object
-                      password:
-                        type: string
-                      project:
-                        description: project, formally known as tenant.
-                        type: string
-                      projectID:
-                        description: project id, formally known as tenantID.
-                        type: string
-                      routerID:
-                        type: string
-                      securityGroups:
-                        type: string
-                      subnetID:
-                        type: string
-                      token:
-                        description: Used internally during cluster creation
-                        type: string
-                      useOctavia:
-                        description: "Whether or not to use Octavia for LoadBalancer
-                          type of Service implementation instead of using Neutron-LBaaS.
-                          Attention:Openstack CCM use Octavia as default load balancer
-                          implementation since v1.17.0 \n Takes precedence over the
-                          'use_octavia' flag provided at datacenter level if both
-                          are specified."
-                        type: boolean
-                      useToken:
-                        type: boolean
-                      username:
-                        type: string
-                    required:
-                    - floatingIPPool
-                    - network
-                    - routerID
-                    - securityGroups
-                    - subnetID
-                    type: object
-                  packet:
-                    description: PacketCloudSpec specifies access data to a Packet
-                      cloud.
-                    properties:
-                      apiKey:
-                        type: string
-                      billingCycle:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      projectID:
-                        type: string
-                    required:
-                    - billingCycle
-                    type: object
-                  providerName:
-                    description: ProviderName is the name of the cloud provider used
-                      for this cluster. This must match the given provider spec (e.g.
-                      if the providerName is "aws", then the `aws` field must be set).
-                    type: string
-                  vmwareclouddirector:
-                    description: VMwareCloudDirectorCloudSpec specifies access data
-                      to VMware Cloud Director cloud.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      csi:
-                        description: Config for CSI driver
-                        properties:
-                          filesystem:
-                            description: Filesystem to use for named disks, defaults
-                              to "ext4"
-                            type: string
-                          storageProfile:
-                            description: The name of the storage profile to use for
-                              disks created by CSI driver
-                            type: string
-                        required:
-                        - storageProfile
-                        type: object
-                      organization:
-                        description: Organization is the name of organization to use.
-                        type: string
-                      ovdcNetwork:
-                        description: Network is the name of organizational virtual
-                          data center network that will be associated with the VMs
-                          and vApp.
-                        type: string
-                      password:
-                        description: Password is the VMware Cloud Director user password.
-                        type: string
-                      username:
-                        description: Username is the VMware Cloud Director user name.
-                        type: string
-                      vapp:
-                        description: VApp used for isolation of VMs and their associated
-                          network
-                        type: string
-                      vdc:
-                        description: VDC is the organizational virtual data center.
-                        type: string
-                    required:
-                    - csi
-                    - ovdcNetwork
-                    type: object
-                  vsphere:
-                    description: VSphereCloudSpec specifies access data to VSphere
-                      cloud.
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      datastore:
-                        description: Datastore to be used for storing virtual machines
-                          and as a default for dynamic volume provisioning, it is
-                          mutually exclusive with DatastoreCluster.
-                        type: string
-                      datastoreCluster:
-                        description: DatastoreCluster to be used for storing virtual
-                          machines, it is mutually exclusive with Datastore.
-                        type: string
-                      folder:
-                        description: Folder is the folder to be used to group the
-                          provisioned virtual machines.
-                        type: string
-                      infraManagementUser:
-                        description: This user will be used for everything except
-                          cloud provider functionality
-                        properties:
-                          password:
-                            type: string
-                          username:
-                            type: string
-                        type: object
-                      password:
-                        description: Password is the vSphere user password.
-                        type: string
-                      resourcePool:
-                        description: ResourcePool is used to manage resources such
-                          as cpu and memory for vSphere virtual machines. The resource
-                          pool should be defined on vSphere cluster level.
-                        type: string
-                      storagePolicy:
-                        description: StoragePolicy to be used for storage provisioning
-                        type: string
-                      tagCategoryID:
-                        description: This is category for the machine deployment tags
-                        type: string
-                      username:
-                        description: Username is the vSphere user name.
-                        type: string
-                      vmNetName:
-                        description: VMNetName is the name of the vSphere network.
-                        type: string
-                    required:
-                    - infraManagementUser
-                    - storagePolicy
-                    - vmNetName
-                    type: object
-                required:
-                - dc
-                - providerName
-                type: object
-              clusterNetwork:
-                description: ClusterNetworkingConfig specifies the different networking
-                  parameters for a cluster.
-                properties:
-                  coreDNSReplicas:
-                    description: CoreDNSReplicas is the number of desired pods of
-                      user cluster coredns deployment.
-                    format: int32
-                    type: integer
-                  dnsDomain:
-                    description: Domain name for services.
-                    type: string
-                  ipFamily:
-                    description: 'Optional: IP family used for cluster networking.
-                      Supported values are "", "IPv4" or "IPv4+IPv6". Can be omitted
-                      / empty if pods and services network ranges are specified. In
-                      that case it defaults according to the IP families of the provided
-                      network ranges. If neither ipFamily nor pods & services network
-                      ranges are specified, defaults to "IPv4".'
-                    enum:
-                    - ""
-                    - IPv4
-                    - IPv4+IPv6
-                    type: string
-                  ipvs:
-                    description: IPVS defines kube-proxy ipvs configuration options
-                    properties:
-                      strictArp:
-                        default: true
-                        description: StrictArp configure arp_ignore and arp_announce
-                          to avoid answering ARP queries from kube-ipvs0 interface.
-                          defaults to true.
-                        type: boolean
-                    type: object
-                  konnectivityEnabled:
-                    description: KonnectivityEnabled enables konnectivity for controlplane
-                      to node network communication.
-                    type: boolean
-                  nodeCidrMaskSizeIPv4:
-                    description: NodeCIDRMaskSizeIPv4 is the mask size used to address
-                      the nodes within provided IPv4 Pods CIDR. It has to be larger
-                      than the provided IPv4 Pods CIDR. Defaults to 24.
-                    format: int32
-                    type: integer
-                  nodeCidrMaskSizeIPv6:
-                    description: NodeCIDRMaskSizeIPv6 is the mask size used to address
-                      the nodes within provided IPv6 Pods CIDR. It has to be larger
-                      than the provided IPv6 Pods CIDR. Defaults to 64.
-                    format: int32
-                    type: integer
-                  nodeLocalDNSCacheEnabled:
-                    default: true
-                    description: NodeLocalDNSCacheEnabled controls whether the NodeLocal
-                      DNS Cache feature is enabled. Defaults to true.
-                    type: boolean
-                  pods:
-                    description: The network ranges from which POD networks are allocated.
-                      It can contain one IPv4 and/or one IPv6 CIDR. If both address
-                      families are specified, the first one defines the primary address
-                      family.
-                    properties:
-                      cidrBlocks:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - cidrBlocks
-                    type: object
-                  proxyMode:
-                    default: ipvs
-                    description: ProxyMode defines the kube-proxy mode ("ipvs" / "iptables"
-                      / "ebpf"). Defaults to "ipvs". "ebpf" disables kube-proxy and
-                      requires CNI support.
-                    enum:
-                    - ipvs
-                    - iptables
-                    - ebpf
-                    type: string
-                  services:
-                    description: The network ranges from which service VIPs are allocated.
-                      It can contain one IPv4 and/or one IPv6 CIDR. If both address
-                      families are specified, the first one defines the primary address
-                      family.
-                    properties:
-                      cidrBlocks:
-                        items:
-                          type: string
-                        type: array
-                    required:
-                    - cidrBlocks
-                    type: object
-                required:
-                - dnsDomain
-                - pods
-                - proxyMode
-                - services
-                type: object
-              cniPlugin:
-                description: CNIPluginSettings contains the spec of the CNI plugin
-                  used by the Cluster.
-                properties:
-                  type:
-                    description: Type is the CNI plugin type to be used.
-                    enum:
-                    - canal
-                    - cilium
-                    - none
-                    type: string
-                  version:
-                    description: Version defines the CNI plugin version to be used.
-                      This varies by chosen CNI plugin type.
-                    type: string
-                required:
-                - type
-                - version
-                type: object
-              componentsOverride:
-                description: 'Optional: Component specific overrides that allow customization
-                  of control plane components.'
-                properties:
-                  apiserver:
-                    description: Apiserver configures kube-apiserver settings.
-                    properties:
-                      endpointReconcilingDisabled:
-                        type: boolean
-                      nodePortRange:
-                        type: string
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  controllerManager:
-                    description: ControllerManager configures kube-controller-manager
-                      settings.
-                    properties:
-                      leaderElection:
-                        properties:
-                          leaseDurationSeconds:
-                            description: LeaseDurationSeconds is the duration in seconds
-                              that non-leader candidates will wait to force acquire
-                              leadership. This is measured against time of last observed
-                              ack.
-                            format: int32
-                            type: integer
-                          renewDeadlineSeconds:
-                            description: RenewDeadlineSeconds is the duration in seconds
-                              that the acting controlplane will retry refreshing leadership
-                              before giving up.
-                            format: int32
-                            type: integer
-                          retryPeriodSeconds:
-                            description: RetryPeriodSeconds is the duration in seconds
-                              the LeaderElector clients should wait between tries
-                              of actions.
-                            format: int32
-                            type: integer
-                        type: object
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  etcd:
-                    description: Etcd configures the etcd ring used to store Kubernetes
-                      data.
-                    properties:
-                      clusterSize:
-                        format: int32
-                        type: integer
-                      diskSize:
-                        anyOf:
+                  type: array
+                applicationSettings:
+                  description: 'Optional: ApplicationSettings contains the settings relative to the application feature.'
+                  properties:
+                    cacheSize:
+                      anyOf:
                         - type: integer
                         - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      storageClass:
-                        type: string
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  konnectivityProxy:
-                    description: KonnectivityProxy configures resources limits/requests
-                      for konnectivity-server sidecar.
-                    properties:
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  nodePortProxyEnvoy:
-                    description: NodePortProxyEnvoy configures the per-cluster nodeport-proxy-envoy
-                      that is deployed if the `LoadBalancer` expose strategy is used.
-                      This is not effective if a different expose strategy is configured.
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  prometheus:
-                    description: Prometheus configures the Prometheus instance deployed
-                      into the cluster control plane.
-                    properties:
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  scheduler:
-                    description: Scheduler configures kube-scheduler settings.
-                    properties:
-                      leaderElection:
-                        properties:
-                          leaseDurationSeconds:
-                            description: LeaseDurationSeconds is the duration in seconds
-                              that non-leader candidates will wait to force acquire
-                              leadership. This is measured against time of last observed
-                              ack.
-                            format: int32
-                            type: integer
-                          renewDeadlineSeconds:
-                            description: RenewDeadlineSeconds is the duration in seconds
-                              that the acting controlplane will retry refreshing leadership
-                              before giving up.
-                            format: int32
-                            type: integer
-                          retryPeriodSeconds:
-                            description: RetryPeriodSeconds is the duration in seconds
-                              the LeaderElector clients should wait between tries
-                              of actions.
-                            format: int32
-                            type: integer
-                        type: object
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                required:
-                - apiserver
-                - controllerManager
-                - etcd
-                - nodePortProxyEnvoy
-                - prometheus
-                - scheduler
-                type: object
-              containerRuntime:
-                default: containerd
-                description: ContainerRuntime to use, i.e. `docker` or `containerd`.
-                  By default `containerd` will be used.
-                enum:
-                - docker
-                - containerd
-                type: string
-              debugLog:
-                description: Enables more verbose logging in KKP's user-cluster-controller-manager.
-                type: boolean
-              enableOperatingSystemManager:
-                description: 'Optional: Enables operating-system-manager (OSM), which
-                  is responsible for creating and managing worker node configuration.
-                  This field is enabled(true) by default.'
-                type: boolean
-              enableUserSSHKeyAgent:
-                description: 'Optional: Deploys the UserSSHKeyAgent to the user cluster.
-                  This field is immutable. If enabled, the agent will be deployed
-                  and used to sync user ssh keys attached by users to the cluster.
-                  No SSH keys will be synced after node creation if this is disabled.'
-                type: boolean
-              encryptionConfiguration:
-                description: 'Optional: Configures encryption-at-rest for Kubernetes
-                  API data. This needs the `encryptionAtRest` feature gate.'
-                properties:
-                  enabled:
-                    description: Enables encryption-at-rest on this cluster.
-                    type: boolean
-                  resources:
-                    description: List of resources that will be stored encrypted in
-                      etcd.
-                    items:
+                      description: CacheSize is the size of the cache used to download application's sources.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                auditLogging:
+                  description: 'Optional: AuditLogging configures Kubernetes API audit logging (https://kubernetes.io/docs/tasks/debug-application-cluster/audit/) for the user cluster.'
+                  properties:
+                    enabled:
+                      description: Enabled will enable or disable audit logging.
+                      type: boolean
+                    policyPreset:
+                      description: 'Optional: PolicyPreset can be set to utilize a pre-defined set of audit policy rules.'
+                      enum:
+                        - ""
+                        - metadata
+                        - recommended
+                        - minimal
                       type: string
-                    minItems: 1
-                    type: array
-                  secretbox:
-                    description: 'Configuration for the `secretbox` static key encryption
-                      scheme as supported by Kubernetes. More info: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers'
-                    properties:
-                      keys:
-                        description: List of 'secretbox' encryption keys. The first
-                          element of this list is considered the "primary" key which
-                          will be used for encrypting data while writing it. Additional
-                          keys will be used for decrypting data while reading it,
-                          if keys higher in the list did not succeed in decrypting
-                          it.
-                        items:
-                          description: SecretboxKey stores a key or key reference
-                            for encrypting Kubernetes API data at rest with a static
-                            key.
+                    sidecar:
+                      description: 'Optional: Configures the fluent-bit sidecar deployed alongside kube-apiserver.'
+                      properties:
+                        config:
+                          description: AuditSidecarConfiguration defines custom configuration for the fluent-bit sidecar deployed with a kube-apiserver. Also see https://docs.fluentbit.io/manual/v/1.8/administration/configuring-fluent-bit/configuration-file.
                           properties:
-                            name:
-                              description: Identifier of a key, used in various places
-                                to refer to the key.
-                              type: string
-                            secretRef:
-                              description: Instead of passing the sensitive encryption
-                                key via the `value` field, a secret can be referenced.
-                                The key of the secret referenced here needs to hold
-                                a key equivalent to the `value` field.
-                              properties:
-                                key:
-                                  description: The key of the secret to select from.  Must
-                                    be a valid secret key.
+                            filters:
+                              items:
+                                additionalProperties:
                                   type: string
-                                name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                    TODO: Add other useful fields. apiVersion, kind,
-                                    uid?'
+                                type: object
+                              type: array
+                            outputs:
+                              items:
+                                additionalProperties:
                                   type: string
-                                optional:
-                                  description: Specify whether the Secret or its key
-                                    must be defined
-                                  type: boolean
-                              required:
-                              - key
+                                type: object
+                              type: array
+                            service:
+                              additionalProperties:
+                                type: string
                               type: object
-                              x-kubernetes-map-type: atomic
-                            value:
-                              description: Value contains a 32-byte random key that
-                                is base64 encoded. This is the key used for encryption.
-                                Can be generated via `head -c 32 /dev/urandom | base64`,
-                                for example.
+                          type: object
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                cloud:
+                  description: Cloud contains information regarding the cloud provider that is responsible for hosting the cluster's workload.
+                  properties:
+                    alibaba:
+                      description: AlibabaCloudSpec specifies the access data to Alibaba.
+                      properties:
+                        accessKeyID:
+                          type: string
+                        accessKeySecret:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    anexia:
+                      description: AnexiaCloudSpec specifies the access data to Anexia.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        token:
+                          type: string
+                      type: object
+                    aws:
+                      description: AWSCloudSpec specifies access data to Amazon Web Services.
+                      properties:
+                        accessKeyID:
+                          type: string
+                        assumeRoleARN:
+                          type: string
+                        assumeRoleExternalID:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        instanceProfileName:
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        roleARN:
+                          description: The IAM role, the control plane will use. The control plane will perform an assume-role
+                          type: string
+                        routeTableID:
+                          type: string
+                        secretAccessKey:
+                          type: string
+                        securityGroupID:
+                          type: string
+                        vpcID:
+                          type: string
+                      required:
+                        - instanceProfileName
+                        - roleARN
+                        - routeTableID
+                        - securityGroupID
+                        - vpcID
+                      type: object
+                    azure:
+                      description: AzureCloudSpec defines cloud resource references for Microsoft Azure.
+                      properties:
+                        assignAvailabilitySet:
+                          description: 'Optional: AssignAvailabilitySet determines whether KKP creates and assigns an AvailabilitySet to machines. Defaults to `true` internally if not set.'
+                          type: boolean
+                        availabilitySet:
+                          description: An availability set that will be associated with nodes created for this cluster. If this field is set to empty string at cluster creation and `AssignAvailabilitySet` is set to `true`, a new availability set will be created and this field will be updated to the generated availability set's name.
+                          type: string
+                        clientID:
+                          description: ClientID is the service principal used to access Azure. Can be read from `credentialsReference` instead.
+                          type: string
+                        clientSecret:
+                          description: ClientSecret is the client secret corresponding to the given service principal. Can be read from `credentialsReference` instead.
+                          type: string
+                        credentialsReference:
+                          description: CredentialsReference allows referencing a `Secret` resource instead of passing secret data in this spec.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        loadBalancerSKU:
+                          description: Azure SKU for Load Balancers. Possible values are `basic` and `standard`.
+                          enum:
+                            - standard
+                            - basic
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        resourceGroup:
+                          description: The resource group that will be used to look up and create resources for the cluster in. If set to empty string at cluster creation, a new resource group will be created and this field will be updated to the generated resource group's name.
+                          type: string
+                        routeTable:
+                          description: The name of a route table associated with the subnet referenced by `subnet`. If set to empty string at cluster creation, a new route table will be created and this field will be updated to the generated route table's name. If no subnet is defined at cluster creation, this field should be empty as well.
+                          type: string
+                        securityGroup:
+                          description: The name of a security group associated with the subnet referenced by `subnet`. If set to empty string at cluster creation, a new security group will be created and this field will be updated to the generated security group's name. If no subnet is defined at cluster creation, this field should be empty as well.
+                          type: string
+                        subnet:
+                          description: The name of a subnet in the VNet referenced by `vnet`. If set to empty string at cluster creation, a new subnet will be created and this field will be updated to the generated subnet's name. If no VNet is defined at cluster creation, this field should be empty as well.
+                          type: string
+                        subscriptionID:
+                          description: SubscriptionID is the Azure Subscription used for this cluster. Can be read from `credentialsReference` instead.
+                          type: string
+                        tenantID:
+                          description: TenantID is the Azure Active Directory Tenant used for this cluster. Can be read from `credentialsReference` instead.
+                          type: string
+                        vnet:
+                          description: The name of the VNet resource used for setting up networking in. If set to empty string at cluster creation, a new VNet will be created and this field will be updated to the generated VNet's name.
+                          type: string
+                        vnetResourceGroup:
+                          description: 'Optional: VNetResourceGroup optionally defines a second resource group that will be used for VNet related resources instead. If left empty, NO additional resource group will be created and all VNet related resources use the resource group defined by `resourceGroup`.'
+                          type: string
+                      required:
+                        - availabilitySet
+                        - loadBalancerSKU
+                        - resourceGroup
+                        - routeTable
+                        - securityGroup
+                        - subnet
+                        - vnet
+                        - vnetResourceGroup
+                      type: object
+                    bringyourown:
+                      description: BringYourOwnCloudSpec specifies access data for a bring your own cluster.
+                      type: object
+                    dc:
+                      description: DatacenterName states the name of a cloud provider "datacenter" (defined in `Seed` resources) this cluster should be deployed into.
+                      type: string
+                    digitalocean:
+                      description: DigitaloceanCloudSpec specifies access data to DigitalOcean.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        token:
+                          type: string
+                      type: object
+                    fake:
+                      description: FakeCloudSpec specifies access data for a fake cloud.
+                      properties:
+                        token:
+                          type: string
+                      type: object
+                    gcp:
+                      description: GCPCloudSpec specifies access data to GCP.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        network:
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the firewall rules to. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the firewall rules to. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        serviceAccount:
+                          description: The Google Service Account (JSON format), encoded with base64.
+                          type: string
+                        subnetwork:
+                          type: string
+                      required:
+                        - network
+                        - subnetwork
+                      type: object
+                    hetzner:
+                      description: HetznerCloudSpec specifies access data to hetzner cloud.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        network:
+                          description: Network is the pre-existing Hetzner network in which the machines are running. While machines can be in multiple networks, a single one must be chosen for the HCloud CCM to work. If this is empty, the network configured on the datacenter will be used.
+                          type: string
+                        token:
+                          description: Token is used to authenticate with the Hetzner cloud API.
+                          type: string
+                      type: object
+                    kubevirt:
+                      description: KubevirtCloudSpec specifies the access data to Kubevirt.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csiKubeconfig:
+                          type: string
+                        infraStorageClasses:
+                          description: InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
+                          items:
+                            type: string
+                          type: array
+                        kubeconfig:
+                          description: The cluster's kubeconfig file, encoded with base64.
+                          type: string
+                        preAllocatedDataVolumes:
+                          description: PreAllocatedDataVolumes holds list of preallocated DataVolumes which can be used as reference for DataVolume cloning.
+                          items:
+                            properties:
+                              name:
+                                type: string
+                              size:
+                                type: string
+                              storageClass:
+                                type: string
+                              url:
+                                type: string
+                            required:
+                              - name
+                              - size
+                              - storageClass
+                              - url
+                            type: object
+                          type: array
+                      type: object
+                    nutanix:
+                      description: NutanixCloudSpec specifies the access data to Nutanix.
+                      properties:
+                        clusterName:
+                          description: ClusterName is the Nutanix cluster that this user cluster will be deployed to.
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: NutanixCSIConfig for csi driver that connects to a prism element
+                          properties:
+                            endpoint:
+                              description: Prism Element Endpoint to access Nutanix Prism Element for csi driver
+                              type: string
+                            fstype:
+                              description: 'Optional: defaults to "xfs"'
+                              type: string
+                            password:
+                              description: Prism Element Password for csi driver
+                              type: string
+                            port:
+                              description: 'Optional: Port to use when connecting to the Nutanix Prism Element endpoint (defaults to 9440)'
+                              format: int32
+                              type: integer
+                            ssSegmentedIscsiNetwork:
+                              description: 'Optional: defaults to "false"'
+                              type: boolean
+                            storageContainer:
+                              description: 'Optional: defaults to "SelfServiceContainer"'
+                              type: string
+                            username:
+                              description: Prism Element Username for csi driver
                               type: string
                           required:
-                          - name
+                            - endpoint
                           type: object
-                        minItems: 1
-                        type: array
-                    required:
-                    - keys
-                    type: object
-                required:
-                - enabled
-                - resources
-                type: object
-              eventRateLimitConfig:
-                description: 'Optional: Configures the EventRateLimit admission plugin
-                  (if enabled via `useEventRateLimitAdmissionPlugin`) to create limits
-                  on Kubernetes event generation. The EventRateLimit plugin is capable
-                  of comparing and rate limiting incoming `Events` based on several
-                  configured buckets.'
-                properties:
-                  namespace:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                  server:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                  sourceAndObject:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                  user:
-                    properties:
-                      burst:
-                        format: int32
-                        type: integer
-                      cacheSize:
-                        format: int32
-                        type: integer
-                      qps:
-                        format: int32
-                        type: integer
-                    required:
-                    - burst
-                    - qps
-                    type: object
-                type: object
-              exposeStrategy:
-                description: ExposeStrategy is the strategy used to expose a cluster
-                  control plane.
-                enum:
-                - NodePort
-                - LoadBalancer
-                - Tunneling
-                type: string
-              features:
-                additionalProperties:
-                  type: boolean
-                description: A map of optional or early-stage features that can be
-                  enabled for the user cluster. Some feature gates cannot be disabled
-                  after being enabled. The available feature gates vary based on KKP
-                  version, Kubernetes version and Seed configuration. Please consult
-                  the KKP documentation for specific feature gates.
-                type: object
-              humanReadableName:
-                description: HumanReadableName is the cluster name provided by the
-                  user.
-                type: string
-              imagePullSecret:
-                description: 'Optional: ImagePullSecret references a secret with container
-                  registry credentials. This is passed to the machine-controller which
-                  sets the registry credentials on node level.'
-                properties:
-                  name:
-                    description: name is unique within a namespace to reference a
-                      secret resource.
-                    type: string
-                  namespace:
-                    description: namespace defines the space within which the secret
-                      name must be unique.
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              kubernetesDashboard:
-                description: KubernetesDashboard holds the configuration for the kubernetes-dashboard
-                  component.
-                properties:
-                  enabled:
-                    description: Controls whether kubernetes-dashboard is deployed
-                      to the user cluster or not. Enabled by default.
-                    type: boolean
-                type: object
-              machineNetworks:
-                items:
-                  description: MachineNetworkingConfig specifies the networking parameters
-                    used for IPAM.
-                  properties:
-                    cidr:
+                        password:
+                          type: string
+                        projectName:
+                          description: ProjectName is the project that this cluster is deployed into. If none is given, no project will be used.
+                          type: string
+                        proxyURL:
+                          type: string
+                        username:
+                          type: string
+                      required:
+                        - clusterName
+                      type: object
+                    openstack:
+                      description: OpenstackCloudSpec specifies access data to an OpenStack cloud.
+                      properties:
+                        applicationCredentialID:
+                          type: string
+                        applicationCredentialSecret:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        domain:
+                          type: string
+                        enableIngressHostname:
+                          description: Enable the `enable-ingress-hostname` cloud provider option on the Openstack CCM. Can only be used with the external CCM and might be deprecated and removed in future versions as it is considered a workaround for the PROXY protocol to preserve client IPs.
+                          type: boolean
+                        floatingIPPool:
+                          description: "FloatingIPPool holds the name of the public network The public network is reachable from the outside world and should provide the pool of IP addresses to choose from. \n When specified, all worker nodes will receive a public ip from this floating ip pool \n Note that the network is external if the \"External\" field is set to true"
+                          type: string
+                        ingressHostnameSuffix:
+                          description: Set a specific suffix for the hostnames used for the PROXY protocol workaround that is enabled by EnableIngressHostname. The suffix is set to `nip.io` by default. Can only be used with the external CCM and might be deprecated and removed in future versions as it is considered a workaround only.
+                          type: string
+                        ipv6SubnetID:
+                          description: IPv6SubnetID holds the ID of the subnet used for IPv6 networking. If not provided, a new subnet will be created if IPv6 is enabled.
+                          type: string
+                        ipv6SubnetPool:
+                          description: IPv6SubnetPool holds the name of the subnet pool used for creating new IPv6 subnets. If not provided, the default IPv6 subnet pool will be used.
+                          type: string
+                        network:
+                          description: "Network holds the name of the internal network When specified, all worker nodes will be attached to this network. If not specified, a network, subnet & router will be created \n Note that the network is internal if the \"External\" field is set to false"
+                          type: string
+                        nodePortsAllowedIPRange:
+                          description: A CIDR range that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set, the node port range can be accessed from anywhere.
+                          type: string
+                        nodePortsAllowedIPRanges:
+                          description: 'Optional: CIDR ranges that will be used to allow access to the node port range in the security group to. Only applies if the security group is generated by KKP and not preexisting. If NodePortsAllowedIPRange nor NodePortsAllowedIPRanges is set,  the node port range can be accessed from anywhere.'
+                          properties:
+                            cidrBlocks:
+                              items:
+                                type: string
+                              type: array
+                          required:
+                            - cidrBlocks
+                          type: object
+                        password:
+                          type: string
+                        project:
+                          description: project, formally known as tenant.
+                          type: string
+                        projectID:
+                          description: project id, formally known as tenantID.
+                          type: string
+                        routerID:
+                          type: string
+                        securityGroups:
+                          type: string
+                        subnetID:
+                          type: string
+                        token:
+                          description: Used internally during cluster creation
+                          type: string
+                        useOctavia:
+                          description: "Whether or not to use Octavia for LoadBalancer type of Service implementation instead of using Neutron-LBaaS. Attention:Openstack CCM use Octavia as default load balancer implementation since v1.17.0 \n Takes precedence over the 'use_octavia' flag provided at datacenter level if both are specified."
+                          type: boolean
+                        useToken:
+                          type: boolean
+                        username:
+                          type: string
+                      required:
+                        - floatingIPPool
+                        - network
+                        - routerID
+                        - securityGroups
+                        - subnetID
+                      type: object
+                    packet:
+                      description: PacketCloudSpec specifies access data to a Packet cloud.
+                      properties:
+                        apiKey:
+                          type: string
+                        billingCycle:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        projectID:
+                          type: string
+                      required:
+                        - billingCycle
+                      type: object
+                    providerName:
+                      description: ProviderName is the name of the cloud provider used for this cluster. This must match the given provider spec (e.g. if the providerName is "aws", then the `aws` field must be set).
                       type: string
-                    dnsServers:
+                    vmwareclouddirector:
+                      description: VMwareCloudDirectorCloudSpec specifies access data to VMware Cloud Director cloud.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: Config for CSI driver
+                          properties:
+                            filesystem:
+                              description: Filesystem to use for named disks, defaults to "ext4"
+                              type: string
+                            storageProfile:
+                              description: The name of the storage profile to use for disks created by CSI driver
+                              type: string
+                          required:
+                            - storageProfile
+                          type: object
+                        organization:
+                          description: Organization is the name of organization to use.
+                          type: string
+                        ovdcNetwork:
+                          description: Network is the name of organizational virtual data center network that will be associated with the VMs and vApp.
+                          type: string
+                        password:
+                          description: Password is the VMware Cloud Director user password.
+                          type: string
+                        username:
+                          description: Username is the VMware Cloud Director user name.
+                          type: string
+                        vapp:
+                          description: VApp used for isolation of VMs and their associated network
+                          type: string
+                        vdc:
+                          description: VDC is the organizational virtual data center.
+                          type: string
+                      required:
+                        - csi
+                        - ovdcNetwork
+                      type: object
+                    vsphere:
+                      description: VSphereCloudSpec specifies access data to VSphere cloud.
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        datastore:
+                          description: Datastore to be used for storing virtual machines and as a default for dynamic volume provisioning, it is mutually exclusive with DatastoreCluster.
+                          type: string
+                        datastoreCluster:
+                          description: DatastoreCluster to be used for storing virtual machines, it is mutually exclusive with Datastore.
+                          type: string
+                        folder:
+                          description: Folder is the folder to be used to group the provisioned virtual machines.
+                          type: string
+                        infraManagementUser:
+                          description: This user will be used for everything except cloud provider functionality
+                          properties:
+                            password:
+                              type: string
+                            username:
+                              type: string
+                          type: object
+                        password:
+                          description: Password is the vSphere user password.
+                          type: string
+                        resourcePool:
+                          description: ResourcePool is used to manage resources such as cpu and memory for vSphere virtual machines. The resource pool should be defined on vSphere cluster level.
+                          type: string
+                        storagePolicy:
+                          description: StoragePolicy to be used for storage provisioning
+                          type: string
+                        tagCategoryID:
+                          description: This is category for the machine deployment tags
+                          type: string
+                        username:
+                          description: Username is the vSphere user name.
+                          type: string
+                        vmNetName:
+                          description: VMNetName is the name of the vSphere network.
+                          type: string
+                      required:
+                        - infraManagementUser
+                        - storagePolicy
+                        - vmNetName
+                      type: object
+                  required:
+                    - dc
+                    - providerName
+                  type: object
+                clusterNetwork:
+                  description: ClusterNetworkingConfig specifies the different networking parameters for a cluster.
+                  properties:
+                    coreDNSReplicas:
+                      description: CoreDNSReplicas is the number of desired pods of user cluster coredns deployment.
+                      format: int32
+                      type: integer
+                    dnsDomain:
+                      description: Domain name for services.
+                      type: string
+                    ipFamily:
+                      description: 'Optional: IP family used for cluster networking. Supported values are "", "IPv4" or "IPv4+IPv6". Can be omitted / empty if pods and services network ranges are specified. In that case it defaults according to the IP families of the provided network ranges. If neither ipFamily nor pods & services network ranges are specified, defaults to "IPv4".'
+                      enum:
+                        - ""
+                        - IPv4
+                        - IPv4+IPv6
+                      type: string
+                    ipvs:
+                      description: IPVS defines kube-proxy ipvs configuration options
+                      properties:
+                        strictArp:
+                          default: true
+                          description: StrictArp configure arp_ignore and arp_announce to avoid answering ARP queries from kube-ipvs0 interface. defaults to true.
+                          type: boolean
+                      type: object
+                    konnectivityEnabled:
+                      description: KonnectivityEnabled enables konnectivity for controlplane to node network communication.
+                      type: boolean
+                    nodeCidrMaskSizeIPv4:
+                      description: NodeCIDRMaskSizeIPv4 is the mask size used to address the nodes within provided IPv4 Pods CIDR. It has to be larger than the provided IPv4 Pods CIDR. Defaults to 24.
+                      format: int32
+                      type: integer
+                    nodeCidrMaskSizeIPv6:
+                      description: NodeCIDRMaskSizeIPv6 is the mask size used to address the nodes within provided IPv6 Pods CIDR. It has to be larger than the provided IPv6 Pods CIDR. Defaults to 64.
+                      format: int32
+                      type: integer
+                    nodeLocalDNSCacheEnabled:
+                      default: true
+                      description: NodeLocalDNSCacheEnabled controls whether the NodeLocal DNS Cache feature is enabled. Defaults to true.
+                      type: boolean
+                    pods:
+                      description: The network ranges from which POD networks are allocated. It can contain one IPv4 and/or one IPv6 CIDR. If both address families are specified, the first one defines the primary address family.
+                      properties:
+                        cidrBlocks:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - cidrBlocks
+                      type: object
+                    proxyMode:
+                      default: ipvs
+                      description: ProxyMode defines the kube-proxy mode ("ipvs" / "iptables" / "ebpf"). Defaults to "ipvs". "ebpf" disables kube-proxy and requires CNI support.
+                      enum:
+                        - ipvs
+                        - iptables
+                        - ebpf
+                      type: string
+                    services:
+                      description: The network ranges from which service VIPs are allocated. It can contain one IPv4 and/or one IPv6 CIDR. If both address families are specified, the first one defines the primary address family.
+                      properties:
+                        cidrBlocks:
+                          items:
+                            type: string
+                          type: array
+                      required:
+                        - cidrBlocks
+                      type: object
+                  required:
+                    - dnsDomain
+                    - pods
+                    - proxyMode
+                    - services
+                  type: object
+                cniPlugin:
+                  description: CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.
+                  properties:
+                    type:
+                      description: Type is the CNI plugin type to be used.
+                      enum:
+                        - canal
+                        - cilium
+                        - none
+                      type: string
+                    version:
+                      description: Version defines the CNI plugin version to be used. This varies by chosen CNI plugin type.
+                      type: string
+                  required:
+                    - type
+                    - version
+                  type: object
+                componentsOverride:
+                  description: 'Optional: Component specific overrides that allow customization of control plane components.'
+                  properties:
+                    apiserver:
+                      description: Apiserver configures kube-apiserver settings.
+                      properties:
+                        endpointReconcilingDisabled:
+                          type: boolean
+                        nodePortRange:
+                          type: string
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    controllerManager:
+                      description: ControllerManager configures kube-controller-manager settings.
+                      properties:
+                        leaderElection:
+                          properties:
+                            leaseDurationSeconds:
+                              description: LeaseDurationSeconds is the duration in seconds that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack.
+                              format: int32
+                              type: integer
+                            renewDeadlineSeconds:
+                              description: RenewDeadlineSeconds is the duration in seconds that the acting controlplane will retry refreshing leadership before giving up.
+                              format: int32
+                              type: integer
+                            retryPeriodSeconds:
+                              description: RetryPeriodSeconds is the duration in seconds the LeaderElector clients should wait between tries of actions.
+                              format: int32
+                              type: integer
+                          type: object
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    etcd:
+                      description: Etcd configures the etcd ring used to store Kubernetes data.
+                      properties:
+                        clusterSize:
+                          format: int32
+                          type: integer
+                        diskSize:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        storageClass:
+                          type: string
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    konnectivityProxy:
+                      description: KonnectivityProxy configures resources limits/requests for konnectivity-server sidecar.
+                      properties:
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    nodePortProxyEnvoy:
+                      description: NodePortProxyEnvoy configures the per-cluster nodeport-proxy-envoy that is deployed if the `LoadBalancer` expose strategy is used. This is not effective if a different expose strategy is configured.
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    prometheus:
+                      description: Prometheus configures the Prometheus instance deployed into the cluster control plane.
+                      properties:
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    scheduler:
+                      description: Scheduler configures kube-scheduler settings.
+                      properties:
+                        leaderElection:
+                          properties:
+                            leaseDurationSeconds:
+                              description: LeaseDurationSeconds is the duration in seconds that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack.
+                              format: int32
+                              type: integer
+                            renewDeadlineSeconds:
+                              description: RenewDeadlineSeconds is the duration in seconds that the acting controlplane will retry refreshing leadership before giving up.
+                              format: int32
+                              type: integer
+                            retryPeriodSeconds:
+                              description: RetryPeriodSeconds is the duration in seconds the LeaderElector clients should wait between tries of actions.
+                              format: int32
+                              type: integer
+                          type: object
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                  required:
+                    - apiserver
+                    - controllerManager
+                    - etcd
+                    - nodePortProxyEnvoy
+                    - prometheus
+                    - scheduler
+                  type: object
+                containerRuntime:
+                  default: containerd
+                  description: ContainerRuntime to use, i.e. `docker` or `containerd`. By default `containerd` will be used.
+                  enum:
+                    - docker
+                    - containerd
+                  type: string
+                debugLog:
+                  description: Enables more verbose logging in KKP's user-cluster-controller-manager.
+                  type: boolean
+                enableOperatingSystemManager:
+                  description: 'Optional: Enables operating-system-manager (OSM), which is responsible for creating and managing worker node configuration. This field is enabled(true) by default.'
+                  type: boolean
+                enableUserSSHKeyAgent:
+                  description: 'Optional: Deploys the UserSSHKeyAgent to the user cluster. This field is immutable. If enabled, the agent will be deployed and used to sync user ssh keys attached by users to the cluster. No SSH keys will be synced after node creation if this is disabled.'
+                  type: boolean
+                encryptionConfiguration:
+                  description: 'Optional: Configures encryption-at-rest for Kubernetes API data. This needs the `encryptionAtRest` feature gate.'
+                  properties:
+                    enabled:
+                      description: Enables encryption-at-rest on this cluster.
+                      type: boolean
+                    resources:
+                      description: List of resources that will be stored encrypted in etcd.
+                      items:
+                        type: string
+                      minItems: 1
+                      type: array
+                    secretbox:
+                      description: 'Configuration for the `secretbox` static key encryption scheme as supported by Kubernetes. More info: https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/#providers'
+                      properties:
+                        keys:
+                          description: List of 'secretbox' encryption keys. The first element of this list is considered the "primary" key which will be used for encrypting data while writing it. Additional keys will be used for decrypting data while reading it, if keys higher in the list did not succeed in decrypting it.
+                          items:
+                            description: SecretboxKey stores a key or key reference for encrypting Kubernetes API data at rest with a static key.
+                            properties:
+                              name:
+                                description: Identifier of a key, used in various places to refer to the key.
+                                type: string
+                              secretRef:
+                                description: Instead of passing the sensitive encryption key via the `value` field, a secret can be referenced. The key of the secret referenced here needs to hold a key equivalent to the `value` field.
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              value:
+                                description: Value contains a 32-byte random key that is base64 encoded. This is the key used for encryption. Can be generated via `head -c 32 /dev/urandom | base64`, for example.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          minItems: 1
+                          type: array
+                      required:
+                        - keys
+                      type: object
+                  required:
+                    - enabled
+                    - resources
+                  type: object
+                eventRateLimitConfig:
+                  description: 'Optional: Configures the EventRateLimit admission plugin (if enabled via `useEventRateLimitAdmissionPlugin`) to create limits on Kubernetes event generation. The EventRateLimit plugin is capable of comparing and rate limiting incoming `Events` based on several configured buckets.'
+                  properties:
+                    namespace:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                    server:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                    sourceAndObject:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                    user:
+                      properties:
+                        burst:
+                          format: int32
+                          type: integer
+                        cacheSize:
+                          format: int32
+                          type: integer
+                        qps:
+                          format: int32
+                          type: integer
+                      required:
+                        - burst
+                        - qps
+                      type: object
+                  type: object
+                exposeStrategy:
+                  description: ExposeStrategy is the strategy used to expose a cluster control plane.
+                  enum:
+                    - NodePort
+                    - LoadBalancer
+                    - Tunneling
+                  type: string
+                features:
+                  additionalProperties:
+                    type: boolean
+                  description: A map of optional or early-stage features that can be enabled for the user cluster. Some feature gates cannot be disabled after being enabled. The available feature gates vary based on KKP version, Kubernetes version and Seed configuration. Please consult the KKP documentation for specific feature gates.
+                  type: object
+                humanReadableName:
+                  description: HumanReadableName is the cluster name provided by the user.
+                  type: string
+                imagePullSecret:
+                  description: 'Optional: ImagePullSecret references a secret with container registry credentials. This is passed to the machine-controller which sets the registry credentials on node level.'
+                  properties:
+                    name:
+                      description: name is unique within a namespace to reference a secret resource.
+                      type: string
+                    namespace:
+                      description: namespace defines the space within which the secret name must be unique.
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                kubernetesDashboard:
+                  description: KubernetesDashboard holds the configuration for the kubernetes-dashboard component.
+                  properties:
+                    enabled:
+                      description: Controls whether kubernetes-dashboard is deployed to the user cluster or not. Enabled by default.
+                      type: boolean
+                  type: object
+                machineNetworks:
+                  items:
+                    description: MachineNetworkingConfig specifies the networking parameters used for IPAM.
+                    properties:
+                      cidr:
+                        type: string
+                      dnsServers:
+                        items:
+                          type: string
+                        type: array
+                      gateway:
+                        type: string
+                    required:
+                      - cidr
+                      - dnsServers
+                      - gateway
+                    type: object
+                  type: array
+                mla:
+                  description: 'Optional: MLA contains monitoring, logging and alerting related settings for the user cluster.'
+                  properties:
+                    loggingEnabled:
+                      description: LoggingEnabled is the flag for enabling logging in user cluster.
+                      type: boolean
+                    loggingResources:
+                      description: LoggingResources is the resource requirements for user cluster promtail.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    monitoringEnabled:
+                      description: MonitoringEnabled is the flag for enabling monitoring in user cluster.
+                      type: boolean
+                    monitoringReplicas:
+                      description: MonitoringReplicas is the number of desired pods of user cluster prometheus deployment.
+                      format: int32
+                      type: integer
+                    monitoringResources:
+                      description: MonitoringResources is the resource requirements for user cluster prometheus.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                oidc:
+                  properties:
+                    clientID:
+                      type: string
+                    clientSecret:
+                      type: string
+                    extraScopes:
+                      type: string
+                    groupsClaim:
+                      type: string
+                    issuerURL:
+                      type: string
+                    requiredClaim:
+                      type: string
+                    usernameClaim:
+                      type: string
+                  type: object
+                opaIntegration:
+                  description: 'Optional: OPAIntegration is a preview feature that enables OPA integration for the cluster. Enabling it causes OPA Gatekeeper and its resources to be deployed on the user cluster. By default it is disabled.'
+                  properties:
+                    auditResources:
+                      description: 'Optional: AuditResources is the resource requirements for user cluster gatekeeper audit.'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    controllerResources:
+                      description: 'Optional: ControllerResources is the resource requirements for user cluster gatekeeper controller.'
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                    enabled:
+                      description: Enables OPA Gatekeeper integration.
+                      type: boolean
+                    experimentalEnableMutation:
+                      description: 'Optional: Enables experimental mutation in Gatekeeper.'
+                      type: boolean
+                    webhookTimeoutSeconds:
+                      default: 10
+                      description: The timeout in seconds that is set for the Gatekeeper validating webhook admission review calls. Defaults to `10` (seconds).
+                      format: int32
+                      type: integer
+                  type: object
+                pause:
+                  default: false
+                  description: If this is set to true, the cluster will not be reconciled by KKP. This indicates that the user needs to do some action to resolve the pause.
+                  type: boolean
+                pauseReason:
+                  description: PauseReason is the reason why the cluster is not being managed. This field is for informational purpose only and can be set by a user or a controller to communicate the reason for pausing the cluster.
+                  type: string
+                podNodeSelectorAdmissionPluginConfig:
+                  additionalProperties:
+                    type: string
+                  description: 'Optional: Provides configuration for the PodNodeSelector admission plugin (needs plugin enabled via `usePodNodeSelectorAdmissionPlugin`). It''s used by the backend to create a configuration file for this plugin. The key:value from this map is converted to <namespace>:<node-selectors-labels> in the file. Use `clusterDefaultNodeSelector` as key to configure a default node selector.'
+                  type: object
+                serviceAccount:
+                  description: 'Optional: ServiceAccount contains service account related settings for the user cluster''s kube-apiserver.'
+                  properties:
+                    apiAudiences:
+                      description: APIAudiences are the Identifiers of the API If this is not specified, it will be set to a single element list containing the issuer URL
                       items:
                         type: string
                       type: array
-                    gateway:
+                    issuer:
+                      description: Issuer is the identifier of the service account token issuer If this is not specified, it will be set to the URL of apiserver by default
                       type: string
-                  required:
-                  - cidr
-                  - dnsServers
-                  - gateway
+                    tokenVolumeProjectionEnabled:
+                      type: boolean
                   type: object
-                type: array
-              mla:
-                description: 'Optional: MLA contains monitoring, logging and alerting
-                  related settings for the user cluster.'
-                properties:
-                  loggingEnabled:
-                    description: LoggingEnabled is the flag for enabling logging in
-                      user cluster.
-                    type: boolean
-                  loggingResources:
-                    description: LoggingResources is the resource requirements for
-                      user cluster promtail.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                  monitoringEnabled:
-                    description: MonitoringEnabled is the flag for enabling monitoring
-                      in user cluster.
-                    type: boolean
-                  monitoringReplicas:
-                    description: MonitoringReplicas is the number of desired pods
-                      of user cluster prometheus deployment.
-                    format: int32
-                    type: integer
-                  monitoringResources:
-                    description: MonitoringResources is the resource requirements
-                      for user cluster prometheus.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-              oidc:
-                properties:
-                  clientID:
-                    type: string
-                  clientSecret:
-                    type: string
-                  extraScopes:
-                    type: string
-                  groupsClaim:
-                    type: string
-                  issuerURL:
-                    type: string
-                  requiredClaim:
-                    type: string
-                  usernameClaim:
-                    type: string
-                type: object
-              opaIntegration:
-                description: 'Optional: OPAIntegration is a preview feature that enables
-                  OPA integration for the cluster. Enabling it causes OPA Gatekeeper
-                  and its resources to be deployed on the user cluster. By default
-                  it is disabled.'
-                properties:
-                  auditResources:
-                    description: 'Optional: AuditResources is the resource requirements
-                      for user cluster gatekeeper audit.'
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                  controllerResources:
-                    description: 'Optional: ControllerResources is the resource requirements
-                      for user cluster gatekeeper controller.'
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                  enabled:
-                    description: Enables OPA Gatekeeper integration.
-                    type: boolean
-                  experimentalEnableMutation:
-                    description: 'Optional: Enables experimental mutation in Gatekeeper.'
-                    type: boolean
-                  webhookTimeoutSeconds:
-                    default: 10
-                    description: The timeout in seconds that is set for the Gatekeeper
-                      validating webhook admission review calls. Defaults to `10`
-                      (seconds).
-                    format: int32
-                    type: integer
-                type: object
-              pause:
-                default: false
-                description: If this is set to true, the cluster will not be reconciled
-                  by KKP. This indicates that the user needs to do some action to
-                  resolve the pause.
-                type: boolean
-              pauseReason:
-                description: PauseReason is the reason why the cluster is not being
-                  managed. This field is for informational purpose only and can be
-                  set by a user or a controller to communicate the reason for pausing
-                  the cluster.
-                type: string
-              podNodeSelectorAdmissionPluginConfig:
-                additionalProperties:
-                  type: string
-                description: 'Optional: Provides configuration for the PodNodeSelector
-                  admission plugin (needs plugin enabled via `usePodNodeSelectorAdmissionPlugin`).
-                  It''s used by the backend to create a configuration file for this
-                  plugin. The key:value from this map is converted to <namespace>:<node-selectors-labels>
-                  in the file. Use `clusterDefaultNodeSelector` as key to configure
-                  a default node selector.'
-                type: object
-              serviceAccount:
-                description: 'Optional: ServiceAccount contains service account related
-                  settings for the user cluster''s kube-apiserver.'
-                properties:
-                  apiAudiences:
-                    description: APIAudiences are the Identifiers of the API If this
-                      is not specified, it will be set to a single element list containing
-                      the issuer URL
-                    items:
+                updateWindow:
+                  description: 'Optional: UpdateWindow configures automatic update systems to respect a maintenance window for applying OS updates to nodes. This is only respected on Flatcar nodes currently.'
+                  properties:
+                    length:
+                      description: Sets the length of the update window beginning with the start time. This needs to be a valid duration as parsed by Go's time.ParseDuration (https://pkg.go.dev/time#ParseDuration), e.g. `2h`.
                       type: string
-                    type: array
-                  issuer:
-                    description: Issuer is the identifier of the service account token
-                      issuer If this is not specified, it will be set to the URL of
-                      apiserver by default
-                    type: string
-                  tokenVolumeProjectionEnabled:
-                    type: boolean
-                type: object
-              updateWindow:
-                description: 'Optional: UpdateWindow configures automatic update systems
-                  to respect a maintenance window for applying OS updates to nodes.
-                  This is only respected on Flatcar nodes currently.'
-                properties:
-                  length:
-                    description: Sets the length of the update window beginning with
-                      the start time. This needs to be a valid duration as parsed
-                      by Go's time.ParseDuration (https://pkg.go.dev/time#ParseDuration),
-                      e.g. `2h`.
-                    type: string
-                  start:
-                    description: Sets the start time of the update window. This can
-                      be a time of day in 24h format, e.g. `22:30`, or a day of week
-                      plus a time of day, for example `Mon 21:00`. Only short names
-                      for week days are supported, i.e. `Mon`, `Tue`, `Wed`, `Thu`,
-                      `Fri`, `Sat` and `Sun`.
-                    type: string
-                type: object
-              useEventRateLimitAdmissionPlugin:
-                description: Enables the admission plugin `EventRateLimit`. Needs
-                  additional configuration via the `eventRateLimitConfig` field. This
-                  plugin is considered "alpha" by Kubernetes.
-                type: boolean
-              usePodNodeSelectorAdmissionPlugin:
-                description: Enables the admission plugin `PodNodeSelector`. Needs
-                  additional configuration via the `podNodeSelectorAdmissionPluginConfig`
-                  field.
-                type: boolean
-              usePodSecurityPolicyAdmissionPlugin:
-                description: Enables the admission plugin `PodSecurityPolicy`. This
-                  plugin is deprecated by Kubernetes.
-                type: boolean
-              version:
-                description: Version defines the wanted version of the control plane.
-                type: string
-            required:
-            - cloud
-            - clusterNetwork
-            - exposeStrategy
-            - humanReadableName
-            - version
-            type: object
-          userSSHKeys:
-            items:
-              description: ClusterTemplateSSHKey is the object for holding SSH key.
-              properties:
-                id:
-                  description: ID is the name of the UserSSHKey object that is supposed
-                    to be assigned to any ClusterTemplateInstance created based on
-                    this template.
-                  type: string
-                name:
-                  description: Name is the human readable SSH key name.
+                    start:
+                      description: Sets the start time of the update window. This can be a time of day in 24h format, e.g. `22:30`, or a day of week plus a time of day, for example `Mon 21:00`. Only short names for week days are supported, i.e. `Mon`, `Tue`, `Wed`, `Thu`, `Fri`, `Sat` and `Sun`.
+                      type: string
+                  type: object
+                useEventRateLimitAdmissionPlugin:
+                  description: Enables the admission plugin `EventRateLimit`. Needs additional configuration via the `eventRateLimitConfig` field. This plugin is considered "alpha" by Kubernetes.
+                  type: boolean
+                usePodNodeSelectorAdmissionPlugin:
+                  description: Enables the admission plugin `PodNodeSelector`. Needs additional configuration via the `podNodeSelectorAdmissionPluginConfig` field.
+                  type: boolean
+                usePodSecurityPolicyAdmissionPlugin:
+                  description: Enables the admission plugin `PodSecurityPolicy`. This plugin is deprecated by Kubernetes.
+                  type: boolean
+                version:
+                  description: Version defines the wanted version of the control plane.
                   type: string
               required:
-              - id
-              - name
+                - cloud
+                - clusterNetwork
+                - exposeStrategy
+                - humanReadableName
+                - version
               type: object
-            type: array
-        required:
-        - credential
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+            userSSHKeys:
+              items:
+                description: ClusterTemplateSSHKey is the object for holding SSH key.
+                properties:
+                  id:
+                    description: ID is the name of the UserSSHKey object that is supposed to be assigned to any ClusterTemplateInstance created based on this template.
+                    type: string
+                  name:
+                    description: Name is the human readable SSH key name.
+                    type: string
+                required:
+                  - id
+                  - name
+                type: object
+              type: array
+          required:
+            - credential
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: constraints.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,242 +17,175 @@ spec:
     singular: constraint
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Constraint specifies a kubermatic wrapper for the gatekeeper
-          constraints.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ConstraintSpec specifies the data for the constraint.
-            properties:
-              constraintType:
-                description: ConstraintType specifies the type of gatekeeper constraint
-                  that the constraint applies to
-                type: string
-              disabled:
-                description: Disabled  is the flag for disabling OPA constraints
-                type: boolean
-              match:
-                description: Match contains the constraint to resource matching data
-                properties:
-                  excludedNamespaces:
-                    description: ExcludedNamespaces is a list of namespace names.
-                      If defined, a constraint will only apply to resources not in
-                      a listed namespace.
-                    items:
-                      type: string
-                    type: array
-                  kinds:
-                    description: Kinds accepts a list of objects with apiGroups and
-                      kinds fields that list the groups/kinds of objects to which
-                      the constraint will apply. If multiple groups/kinds objects
-                      are specified, only one match is needed for the resource to
-                      be in scope
-                    items:
-                      description: Kind specifies the resource Kind and APIGroup.
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Constraint specifies a kubermatic wrapper for the gatekeeper constraints.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConstraintSpec specifies the data for the constraint.
+              properties:
+                constraintType:
+                  description: ConstraintType specifies the type of gatekeeper constraint that the constraint applies to
+                  type: string
+                disabled:
+                  description: Disabled  is the flag for disabling OPA constraints
+                  type: boolean
+                match:
+                  description: Match contains the constraint to resource matching data
+                  properties:
+                    excludedNamespaces:
+                      description: ExcludedNamespaces is a list of namespace names. If defined, a constraint will only apply to resources not in a listed namespace.
+                      items:
+                        type: string
+                      type: array
+                    kinds:
+                      description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the constraint will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope
+                      items:
+                        description: Kind specifies the resource Kind and APIGroup.
+                        properties:
+                          apiGroups:
+                            description: APIGroups specifies the APIGroups of the resources
+                            items:
+                              type: string
+                            type: array
+                          kinds:
+                            description: Kinds specifies the kinds of the resources
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    labelSelector:
+                      description: LabelSelector is a standard Kubernetes label selector.
                       properties:
-                        apiGroups:
-                          description: APIGroups specifies the APIGroups of the resources
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                           items:
-                            type: string
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
                           type: array
-                        kinds:
-                          description: Kinds specifies the kinds of the resources
-                          items:
+                        matchLabels:
+                          additionalProperties:
                             type: string
-                          type: array
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
                       type: object
-                    type: array
-                  labelSelector:
-                    description: LabelSelector is a standard Kubernetes label selector.
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
+                      x-kubernetes-map-type: atomic
+                    namespaceSelector:
+                      description: NamespaceSelector  is a standard Kubernetes namespace selector. If defined, make sure to add Namespaces to your configs.config.gatekeeper.sh object to ensure namespaces are synced into OPA
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
                                 type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
-                          type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  namespaceSelector:
-                    description: NamespaceSelector  is a standard Kubernetes namespace
-                      selector. If defined, make sure to add Namespaces to your configs.config.gatekeeper.sh
-                      object to ensure namespaces are synced into OPA
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                 type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  namespaces:
-                    description: Namespaces is a list of namespace names. If defined,
-                      a constraint will only apply to resources in a listed namespace.
-                    items:
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    namespaces:
+                      description: Namespaces is a list of namespace names. If defined, a constraint will only apply to resources in a listed namespace.
+                      items:
+                        type: string
+                      type: array
+                    scope:
+                      description: Scope accepts *, Cluster, or Namespaced which determines if cluster-scoped and/or namesapced-scoped resources are selected. (defaults to *)
                       type: string
-                    type: array
-                  scope:
-                    description: Scope accepts *, Cluster, or Namespaced which determines
-                      if cluster-scoped and/or namesapced-scoped resources are selected.
-                      (defaults to *)
-                    type: string
-                type: object
-              parameters:
-                description: "Parameters specifies the parameters used by the constraint
-                  template REGO. It supports both the legacy rawJSON parameters, in
-                  which all the parameters are set in a JSON string, and regular parameters
-                  like in Gatekeeper Constraints. If rawJSON is set, during constraint
-                  syncing to the user cluster, the other parameters are ignored Example
-                  with rawJSON parameters: \n parameters: rawJSON: '{\"labels\":[\"gatekeeper\"]}'
-                  \n And with regular parameters: \n parameters: labels: [\"gatekeeper\"]"
-                x-kubernetes-preserve-unknown-fields: true
-              selector:
-                description: Selector specifies the cluster selection filters
-                properties:
-                  labelSelector:
-                    description: LabelSelector selects the Clusters to which the Constraint
-                      applies based on their labels
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
-                          properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
-                              type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
-                              items:
+                  type: object
+                parameters:
+                  description: "Parameters specifies the parameters used by the constraint template REGO. It supports both the legacy rawJSON parameters, in which all the parameters are set in a JSON string, and regular parameters like in Gatekeeper Constraints. If rawJSON is set, during constraint syncing to the user cluster, the other parameters are ignored Example with rawJSON parameters: \n parameters: rawJSON: '{\"labels\":[\"gatekeeper\"]}' \n And with regular parameters: \n parameters: labels: [\"gatekeeper\"]"
+                  x-kubernetes-preserve-unknown-fields: true
+                selector:
+                  description: Selector specifies the cluster selection filters
+                  properties:
+                    labelSelector:
+                      description: LabelSelector selects the Clusters to which the Constraint applies based on their labels
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
                                 type: string
-                              type: array
-                          required:
-                          - key
-                          - operator
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  providers:
-                    description: Providers is a list of cloud providers to which the
-                      Constraint applies to. Empty means all providers are selected.
-                    items:
-                      type: string
-                    type: array
-                type: object
-            required:
-            - constraintType
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    providers:
+                      description: Providers is a list of cloud providers to which the Constraint applies to. Empty means all providers are selected.
+                      items:
+                        type: string
+                      type: array
+                  type: object
+              required:
+                - constraintType
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: constraints.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: constrainttemplates.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,131 +17,107 @@ spec:
     singular: constrainttemplate
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ConstraintTemplate is the object representing a kubermatic wrapper
-          for a gatekeeper constraint template.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ConstraintTemplateSpec is the object representing the gatekeeper
-              constraint template spec and kubermatic related spec.
-            properties:
-              crd:
-                properties:
-                  spec:
-                    properties:
-                      names:
-                        properties:
-                          kind:
-                            type: string
-                          shortNames:
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      validation:
-                        default:
-                          legacySchema: false
-                        properties:
-                          legacySchema:
-                            default: false
-                            type: boolean
-                          openAPIV3Schema:
-                            type: object
-                            x-kubernetes-preserve-unknown-fields: true
-                        type: object
-                    type: object
-                type: object
-              selector:
-                description: ConstraintTemplateSelector is the object holding the
-                  cluster selection filters.
-                properties:
-                  labelSelector:
-                    description: LabelSelector selects the Clusters to which the Constraint
-                      Template applies based on their labels
-                    properties:
-                      matchExpressions:
-                        description: matchExpressions is a list of label selector
-                          requirements. The requirements are ANDed.
-                        items:
-                          description: A label selector requirement is a selector
-                            that contains values, a key, and an operator that relates
-                            the key and values.
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ConstraintTemplate is the object representing a kubermatic wrapper for a gatekeeper constraint template.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ConstraintTemplateSpec is the object representing the gatekeeper constraint template spec and kubermatic related spec.
+              properties:
+                crd:
+                  properties:
+                    spec:
+                      properties:
+                        names:
                           properties:
-                            key:
-                              description: key is the label key that the selector
-                                applies to.
+                            kind:
                               type: string
-                            operator:
-                              description: operator represents a key's relationship
-                                to a set of values. Valid operators are In, NotIn,
-                                Exists and DoesNotExist.
-                              type: string
-                            values:
-                              description: values is an array of string values. If
-                                the operator is In or NotIn, the values array must
-                                be non-empty. If the operator is Exists or DoesNotExist,
-                                the values array must be empty. This array is replaced
-                                during a strategic merge patch.
+                            shortNames:
                               items:
                                 type: string
                               type: array
-                          required:
-                          - key
-                          - operator
                           type: object
-                        type: array
-                      matchLabels:
-                        additionalProperties:
-                          type: string
-                        description: matchLabels is a map of {key,value} pairs. A
-                          single {key,value} in the matchLabels map is equivalent
-                          to an element of matchExpressions, whose key field is "key",
-                          the operator is "In", and the values array contains only
-                          "value". The requirements are ANDed.
-                        type: object
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  providers:
-                    description: Providers is a list of cloud providers to which the
-                      Constraint Template applies to. Empty means all providers are
-                      selected.
-                    items:
-                      type: string
-                    type: array
-                type: object
-              targets:
-                items:
+                        validation:
+                          default:
+                            legacySchema: false
+                          properties:
+                            legacySchema:
+                              default: false
+                              type: boolean
+                            openAPIV3Schema:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                          type: object
+                      type: object
+                  type: object
+                selector:
+                  description: ConstraintTemplateSelector is the object holding the cluster selection filters.
                   properties:
-                    libs:
+                    labelSelector:
+                      description: LabelSelector selects the Clusters to which the Constraint Template applies based on their labels
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    providers:
+                      description: Providers is a list of cloud providers to which the Constraint Template applies to. Empty means all providers are selected.
                       items:
                         type: string
                       type: array
-                    rego:
-                      type: string
-                    target:
-                      type: string
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                targets:
+                  items:
+                    properties:
+                      libs:
+                        items:
+                          type: string
+                        type: array
+                      rego:
+                        type: string
+                      target:
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_constrainttemplates.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: constrainttemplates.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: etcdbackupconfigs.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,167 +17,139 @@ spec:
     singular: etcdbackupconfig
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: EtcdBackupConfig specifies a add-on.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: EtcdBackupConfigSpec specifies details of an etcd backup.
-            properties:
-              cluster:
-                description: Cluster is the reference to the cluster whose etcd will
-                  be backed up
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              destination:
-                description: Destination indicates where the backup will be stored.
-                  The destination name must correspond to a destination in the cluster's
-                  Seed.Spec.EtcdBackupRestore.
-                type: string
-              keep:
-                description: Keep is the number of backups to keep around before deleting
-                  the oldest one If not set, defaults to DefaultKeptBackupsCount.
-                  Only used if Schedule is set.
-                type: integer
-              name:
-                description: Name defines the name of the backup The name of the backup
-                  file in S3 will be <cluster>-<backup name> If a schedule is set
-                  (see below), -<timestamp> will be appended.
-                type: string
-              schedule:
-                description: Schedule is a cron expression defining when to perform
-                  the backup. If not set, the backup is performed exactly once, immediately.
-                type: string
-            required:
-            - cluster
-            - destination
-            - name
-            type: object
-          status:
-            properties:
-              cleanupRunning:
-                description: If the controller was configured with a cleanupContainer,
-                  CleanupRunning keeps track of the corresponding job
-                type: boolean
-              conditions:
-                additionalProperties:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EtcdBackupConfig specifies a add-on.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: EtcdBackupConfigSpec specifies details of an etcd backup.
+              properties:
+                cluster:
+                  description: Cluster is the reference to the cluster whose etcd will be backed up
                   properties:
-                    lastHeartbeatTime:
-                      description: Last time we got an update on a given condition.
-                      format: date-time
+                    apiVersion:
+                      description: API version of the referent.
                       type: string
-                    lastTransitionTime:
-                      description: Last time the condition transit from one status
-                        to another.
-                      format: date-time
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
                       type: string
-                    message:
-                      description: Human readable message indicating details about
-                        last transition.
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                       type: string
-                    reason:
-                      description: (brief) reason for the condition's last transition.
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                       type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                       type: string
-                  required:
-                  - lastHeartbeatTime
-                  - status
-                  type: object
-                description: Conditions contains conditions of the EtcdBackupConfig
-                type: object
-              currentBackups:
-                description: CurrentBackups tracks the creation and deletion progress
-                  of all backups managed by the EtcdBackupConfig
-                items:
-                  properties:
-                    backupFinishedTime:
-                      format: date-time
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
-                    backupMessage:
-                      type: string
-                    backupName:
-                      type: string
-                    backupPhase:
-                      type: string
-                    backupStartTime:
-                      format: date-time
-                      type: string
-                    deleteFinishedTime:
-                      format: date-time
-                      type: string
-                    deleteJobName:
-                      type: string
-                    deleteMessage:
-                      type: string
-                    deletePhase:
-                      type: string
-                    deleteStartTime:
-                      format: date-time
-                      type: string
-                    jobName:
-                      type: string
-                    scheduledTime:
-                      description: ScheduledTime will always be set when the BackupStatus
-                        is created, so it'll never be nil
-                      format: date-time
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                       type: string
                   type: object
-                type: array
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  x-kubernetes-map-type: atomic
+                destination:
+                  description: Destination indicates where the backup will be stored. The destination name must correspond to a destination in the cluster's Seed.Spec.EtcdBackupRestore.
+                  type: string
+                keep:
+                  description: Keep is the number of backups to keep around before deleting the oldest one If not set, defaults to DefaultKeptBackupsCount. Only used if Schedule is set.
+                  type: integer
+                name:
+                  description: Name defines the name of the backup The name of the backup file in S3 will be <cluster>-<backup name> If a schedule is set (see below), -<timestamp> will be appended.
+                  type: string
+                schedule:
+                  description: Schedule is a cron expression defining when to perform the backup. If not set, the backup is performed exactly once, immediately.
+                  type: string
+              required:
+                - cluster
+                - destination
+                - name
+              type: object
+            status:
+              properties:
+                cleanupRunning:
+                  description: If the controller was configured with a cleanupContainer, CleanupRunning keeps track of the corresponding job
+                  type: boolean
+                conditions:
+                  additionalProperties:
+                    properties:
+                      lastHeartbeatTime:
+                        description: Last time we got an update on a given condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transit from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: (brief) reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                    required:
+                      - lastHeartbeatTime
+                      - status
+                    type: object
+                  description: Conditions contains conditions of the EtcdBackupConfig
+                  type: object
+                currentBackups:
+                  description: CurrentBackups tracks the creation and deletion progress of all backups managed by the EtcdBackupConfig
+                  items:
+                    properties:
+                      backupFinishedTime:
+                        format: date-time
+                        type: string
+                      backupMessage:
+                        type: string
+                      backupName:
+                        type: string
+                      backupPhase:
+                        type: string
+                      backupStartTime:
+                        format: date-time
+                        type: string
+                      deleteFinishedTime:
+                        format: date-time
+                        type: string
+                      deleteJobName:
+                        type: string
+                      deleteMessage:
+                        type: string
+                      deletePhase:
+                        type: string
+                      deleteStartTime:
+                        format: date-time
+                        type: string
+                      jobName:
+                        type: string
+                      scheduledTime:
+                        description: ScheduledTime will always be set when the BackupStatus is created, so it'll never be nil
+                        format: date-time
+                        type: string
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdbackupconfigs.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: seed
   creationTimestamp: null
   name: etcdbackupconfigs.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: seed
   creationTimestamp: null
   name: etcdrestores.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: etcdrestores.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,113 +17,89 @@ spec:
     singular: etcdrestore
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.phase
-      name: Phase
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: EtcdRestore specifies a add-on.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: EtcdRestoreSpec specifies details of an etcd restore.
-            properties:
-              backupDownloadCredentialsSecret:
-                description: BackupDownloadCredentialsSecret is the name of a secret
-                  in the cluster-xxx namespace containing credentials needed to download
-                  the backup
-                type: string
-              backupName:
-                description: BackupName is the name of the backup to restore from
-                type: string
-              cluster:
-                description: Cluster is the reference to the cluster whose etcd will
-                  be backed up
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              destination:
-                description: Destination indicates where the backup was stored. The
-                  destination name should correspond to a destination in the cluster's
-                  Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination
-                  configured in Seed.Spec.BackupRestore
-                type: string
-              name:
-                description: Name defines the name of the restore The name of the
-                  restore file in S3 will be <cluster>-<restore name> If a schedule
-                  is set (see below), -<timestamp> will be appended.
-                type: string
-            required:
-            - backupName
-            - cluster
-            - name
-            type: object
-          status:
-            properties:
-              phase:
-                description: EtcdRestorePhase represents the lifecycle phase of an
-                  EtcdRestore.
-                enum:
-                - Started
-                - StsRebuilding
-                - Completed
-                type: string
-              restoreTime:
-                format: date-time
-                type: string
-            required:
-            - phase
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: EtcdRestore specifies a add-on.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: EtcdRestoreSpec specifies details of an etcd restore.
+              properties:
+                backupDownloadCredentialsSecret:
+                  description: BackupDownloadCredentialsSecret is the name of a secret in the cluster-xxx namespace containing credentials needed to download the backup
+                  type: string
+                backupName:
+                  description: BackupName is the name of the backup to restore from
+                  type: string
+                cluster:
+                  description: Cluster is the reference to the cluster whose etcd will be backed up
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                destination:
+                  description: Destination indicates where the backup was stored. The destination name should correspond to a destination in the cluster's Seed.Spec.EtcdBackupRestore. If empty, it will use the legacy destination configured in Seed.Spec.BackupRestore
+                  type: string
+                name:
+                  description: Name defines the name of the restore The name of the restore file in S3 will be <cluster>-<restore name> If a schedule is set (see below), -<timestamp> will be appended.
+                  type: string
+              required:
+                - backupName
+                - cluster
+                - name
+              type: object
+            status:
+              properties:
+                phase:
+                  description: EtcdRestorePhase represents the lifecycle phase of an EtcdRestore.
+                  enum:
+                    - Started
+                    - StsRebuilding
+                    - Completed
+                  type: string
+                restoreTime:
+                  format: date-time
+                  type: string
+              required:
+                - phase
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: externalclusters.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: externalclusters.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,453 +17,345 @@ spec:
     singular: externalcluster
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.humanReadableName
-      name: HumanReadableName
-      type: string
-    - jsonPath: .spec.cloudSpec.providerName
-      name: Provider
-      type: string
-    - jsonPath: .spec.pause
-      name: Paused
-      type: boolean
-    - jsonPath: .status.condition.phase
-      name: Phase
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ExternalCluster is the object representing an external kubernetes
-          cluster.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ExternalClusterSpec specifies the data for a new external
-              kubernetes cluster.
-            properties:
-              cloudSpec:
-                description: CloudSpec contains provider specific fields
-                properties:
-                  aks:
-                    properties:
-                      clientID:
-                        type: string
-                      clientSecret:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      name:
-                        type: string
-                      resourceGroup:
-                        type: string
-                      subscriptionID:
-                        type: string
-                      tenantID:
-                        type: string
-                    required:
-                    - clientID
-                    - clientSecret
-                    - credentialsReference
-                    - name
-                    - resourceGroup
-                    - subscriptionID
-                    - tenantID
-                    type: object
-                  bringyourown:
-                    type: object
-                  eks:
-                    properties:
-                      accessKeyID:
-                        type: string
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      name:
-                        type: string
-                      region:
-                        type: string
-                      secretAccessKey:
-                        type: string
-                    required:
-                    - accessKeyID
-                    - name
-                    - region
-                    - secretAccessKey
-                    type: object
-                  gke:
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      name:
-                        type: string
-                      serviceAccount:
-                        type: string
-                      zone:
-                        type: string
-                    required:
-                    - name
-                    - serviceAccount
-                    type: object
-                  kubeone:
-                    properties:
-                      credentialsReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      manifestReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                      providerName:
-                        description: ProviderName is the name of the cloud provider
-                          used, one of "aws", "azure", "digitalocean", "gcp", "hetzner",
-                          "nutanix", "openstack", "packet", "vsphere" KubeOne natively-supported
-                          providers
-                        type: string
-                      sshReference:
-                        description: GlobalObjectKeySelector is needed as we can not
-                          use v1.SecretKeySelector because it is not cross namespace.
-                        properties:
-                          apiVersion:
-                            description: API version of the referent.
-                            type: string
-                          fieldPath:
-                            description: 'If referring to a piece of an object instead
-                              of an entire object, this string should contain a valid
-                              JSON/Go field access statement, such as desiredState.manifest.containers[2].
-                              For example, if the object reference is to a container
-                              within a pod, this would take on a value like: "spec.containers{name}"
-                              (where "name" refers to the name of the container that
-                              triggered the event) or if no container name is specified
-                              "spec.containers[2]" (container with index 2 in this
-                              pod). This syntax is chosen only to have some well-defined
-                              way of referencing a part of an object. TODO: this design
-                              is not final and this field is subject to change in
-                              the future.'
-                            type: string
-                          key:
-                            type: string
-                          kind:
-                            description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                            type: string
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          namespace:
-                            description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                            type: string
-                          resourceVersion:
-                            description: 'Specific resourceVersion to which this reference
-                              is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                            type: string
-                          uid:
-                            description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                            type: string
-                        type: object
-                        x-kubernetes-map-type: atomic
-                    required:
-                    - credentialsReference
-                    - manifestReference
+    - additionalPrinterColumns:
+        - jsonPath: .spec.humanReadableName
+          name: HumanReadableName
+          type: string
+        - jsonPath: .spec.cloudSpec.providerName
+          name: Provider
+          type: string
+        - jsonPath: .spec.pause
+          name: Paused
+          type: boolean
+        - jsonPath: .status.condition.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ExternalCluster is the object representing an external kubernetes cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ExternalClusterSpec specifies the data for a new external kubernetes cluster.
+              properties:
+                cloudSpec:
+                  description: CloudSpec contains provider specific fields
+                  properties:
+                    aks:
+                      properties:
+                        clientID:
+                          type: string
+                        clientSecret:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          type: string
+                        resourceGroup:
+                          type: string
+                        subscriptionID:
+                          type: string
+                        tenantID:
+                          type: string
+                      required:
+                        - clientID
+                        - clientSecret
+                        - credentialsReference
+                        - name
+                        - resourceGroup
+                        - subscriptionID
+                        - tenantID
+                      type: object
+                    bringyourown:
+                      type: object
+                    eks:
+                      properties:
+                        accessKeyID:
+                          type: string
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          type: string
+                        region:
+                          type: string
+                        secretAccessKey:
+                          type: string
+                      required:
+                        - accessKeyID
+                        - name
+                        - region
+                        - secretAccessKey
+                      type: object
+                    gke:
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        name:
+                          type: string
+                        serviceAccount:
+                          type: string
+                        zone:
+                          type: string
+                      required:
+                        - name
+                        - serviceAccount
+                      type: object
+                    kubeone:
+                      properties:
+                        credentialsReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        manifestReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        providerName:
+                          description: ProviderName is the name of the cloud provider used, one of "aws", "azure", "digitalocean", "gcp", "hetzner", "nutanix", "openstack", "packet", "vsphere" KubeOne natively-supported providers
+                          type: string
+                        sshReference:
+                          description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
+                          properties:
+                            apiVersion:
+                              description: API version of the referent.
+                              type: string
+                            fieldPath:
+                              description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                              type: string
+                            key:
+                              type: string
+                            kind:
+                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            namespace:
+                              description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                              type: string
+                            resourceVersion:
+                              description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                              type: string
+                            uid:
+                              description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                        - credentialsReference
+                        - manifestReference
+                        - providerName
+                        - sshReference
+                      type: object
+                    providerName:
+                      description: ExternalClusterProvider is the identifier for the cloud provider that hosts the external cluster control plane.
+                      enum:
+                        - aks
+                        - bringyourown
+                        - eks
+                        - gke
+                        - kubeone
+                      type: string
+                  required:
                     - providerName
-                    - sshReference
-                    type: object
-                  providerName:
-                    description: ExternalClusterProvider is the identifier for the
-                      cloud provider that hosts the external cluster control plane.
-                    enum:
-                    - aks
-                    - bringyourown
-                    - eks
-                    - gke
-                    - kubeone
-                    type: string
-                required:
-                - providerName
-                type: object
-              humanReadableName:
-                description: HumanReadableName is the cluster name provided by the
-                  user
-                type: string
-              kubeconfigReference:
-                description: KubeconfigReference is reference to cluster Kubeconfig
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  key:
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              pause:
-                description: If this is set to true, the cluster will not be reconciled
-                  by KKP. This indicates that the user needs to do some action to
-                  resolve the pause.
-                type: boolean
-              pauseReason:
-                description: PauseReason is the reason why the cluster is not being
-                  managed. This field is for informational purpose only and can be
-                  set by a user or a controller to communicate the reason for pausing
-                  the cluster.
-                type: string
-            required:
-            - cloudSpec
-            - humanReadableName
-            - pause
-            type: object
-          status:
-            description: ExternalClusterStatus denotes status information about an
-              ExternalCluster.
-            properties:
-              condition:
-                description: Conditions contains conditions an externalcluster is
-                  in, its primary use case is status signaling for controller
-                properties:
-                  message:
-                    description: Human readable message indicating details about last
-                      transition.
-                    type: string
-                  phase:
-                    type: string
-                required:
-                - phase
-                type: object
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                  type: object
+                humanReadableName:
+                  description: HumanReadableName is the cluster name provided by the user
+                  type: string
+                kubeconfigReference:
+                  description: KubeconfigReference is reference to cluster Kubeconfig
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    key:
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                pause:
+                  description: If this is set to true, the cluster will not be reconciled by KKP. This indicates that the user needs to do some action to resolve the pause.
+                  type: boolean
+                pauseReason:
+                  description: PauseReason is the reason why the cluster is not being managed. This field is for informational purpose only and can be set by a user or a controller to communicate the reason for pausing the cluster.
+                  type: string
+              required:
+                - cloudSpec
+                - humanReadableName
+                - pause
+              type: object
+            status:
+              description: ExternalClusterStatus denotes status information about an ExternalCluster.
+              properties:
+                condition:
+                  description: Conditions contains conditions an externalcluster is in, its primary use case is status signaling for controller
+                  properties:
+                    message:
+                      description: Human readable message indicating details about last transition.
+                      type: string
+                    phase:
+                      type: string
+                  required:
+                    - phase
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: groupprojectbindings.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,67 +17,56 @@ spec:
     singular: groupprojectbinding
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.projectID
-      name: ProjectID
-      type: string
-    - jsonPath: .spec.group
-      name: Group
-      type: string
-    - jsonPath: .spec.role
-      name: Role
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: GroupProjectBinding specifies a binding between a group and a
-          project This resource is used by the user management to manipulate member
-          groups of the given project.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: GroupProjectBindingSpec specifies an oidc group binding to
-              a project.
-            properties:
-              group:
-                description: Group is the group name that is bound to the given project.
-                type: string
-              projectID:
-                description: ProjectID is the ID of the target project. Should be
-                  a valid lowercase RFC1123 domain name
-                maxLength: 63
-                pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                type: string
-              role:
-                description: 'Role is the user''s role within the project, determining
-                  their permissions. Possible roles are: "viewers" - allowed to get/list
-                  project resources "editors" - allowed to edit all project resources
-                  "owners" - same as editors, but also can manage users in the project'
-                enum:
-                - viewers
-                - editors
-                - owners
-                type: string
-            required:
-            - group
-            - projectID
-            - role
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.projectID
+          name: ProjectID
+          type: string
+        - jsonPath: .spec.group
+          name: Group
+          type: string
+        - jsonPath: .spec.role
+          name: Role
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: GroupProjectBinding specifies a binding between a group and a project This resource is used by the user management to manipulate member groups of the given project.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: GroupProjectBindingSpec specifies an oidc group binding to a project.
+              properties:
+                group:
+                  description: Group is the group name that is bound to the given project.
+                  type: string
+                projectID:
+                  description: ProjectID is the ID of the target project. Should be a valid lowercase RFC1123 domain name
+                  maxLength: 63
+                  pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                  type: string
+                role:
+                  description: 'Role is the user''s role within the project, determining their permissions. Possible roles are: "viewers" - allowed to get/list project resources "editors" - allowed to edit all project resources "owners" - same as editors, but also can manage users in the project'
+                  enum:
+                    - viewers
+                    - editors
+                    - owners
+                  type: string
+              required:
+                - group
+                - projectID
+                - role
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_groupprojectbindings.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: groupprojectbindings.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: ipamallocations.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,57 +17,49 @@ spec:
     singular: ipamallocation
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: IPAMAllocation is the object representing an allocation from
-          an IPAMPool made for a particular KKP user cluster.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPAMAllocationSpec specifies an allocation from an IPAMPool
-              made for a particular KKP user cluster.
-            properties:
-              addresses:
-                description: Addresses are the IP address ranges that are being used
-                  for the allocation. Set when "type=range".
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: IPAMAllocation is the object representing an allocation from an IPAMPool made for a particular KKP user cluster.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPAMAllocationSpec specifies an allocation from an IPAMPool made for a particular KKP user cluster.
+              properties:
+                addresses:
+                  description: Addresses are the IP address ranges that are being used for the allocation. Set when "type=range".
+                  items:
+                    type: string
+                  type: array
+                cidr:
+                  description: CIDR is the CIDR that is being used for the allocation. Set when "type=prefix".
+                  pattern: ((^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))/([0-9]|[1-2][0-9]|3[0-2])$)|(^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))/([0-9]|[0-9][0-9]|1[0-1][0-9]|12[0-8])$))
                   type: string
-                type: array
-              cidr:
-                description: CIDR is the CIDR that is being used for the allocation.
-                  Set when "type=prefix".
-                pattern: ((^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))/([0-9]|[1-2][0-9]|3[0-2])$)|(^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))/([0-9]|[0-9][0-9]|1[0-1][0-9]|12[0-8])$))
-                type: string
-              dc:
-                description: DC is the datacenter of the allocation.
-                type: string
-              type:
-                description: Type is the allocation type that is being used.
-                enum:
-                - prefix
-                - range
-                type: string
-            required:
-            - dc
-            - type
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                dc:
+                  description: DC is the datacenter of the allocation.
+                  type: string
+                type:
+                  description: Type is the allocation type that is being used.
+                  enum:
+                    - prefix
+                    - range
+                  type: string
+              required:
+                - dc
+                - type
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_ipamallocations.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: ipamallocations.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: ipampools.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_ipampools.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: ipampools.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,69 +17,59 @@ spec:
     singular: ipampool
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: IPAMPool is the object representing Multi-Cluster IP Address
-          Management (IPAM) configuration for KKP user clusters.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: IPAMPoolSpec specifies the  Multi-Cluster IP Address Management
-              (IPAM) configuration for KKP user clusters.
-            properties:
-              datacenters:
-                additionalProperties:
-                  description: IPAMPoolDatacenterSettings contains IPAM Pool configuration
-                    for a datacenter.
-                  properties:
-                    allocationPrefix:
-                      description: AllocationPrefix is the prefix for the allocation.
-                        Used when "type=prefix".
-                      maximum: 128
-                      minimum: 1
-                      type: integer
-                    allocationRange:
-                      description: AllocationRange is the range for the allocation.
-                        Used when "type=range".
-                      minimum: 1
-                      type: integer
-                    poolCidr:
-                      description: PoolCIDR is the pool CIDR to be used for the allocation.
-                      pattern: ((^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))/([0-9]|[1-2][0-9]|3[0-2])$)|(^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))/([0-9]|[0-9][0-9]|1[0-1][0-9]|12[0-8])$))
-                      type: string
-                    type:
-                      description: Type is the allocation type to be used.
-                      enum:
-                      - prefix
-                      - range
-                      type: string
-                  required:
-                  - poolCidr
-                  - type
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: IPAMPool is the object representing Multi-Cluster IP Address Management (IPAM) configuration for KKP user clusters.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: IPAMPoolSpec specifies the  Multi-Cluster IP Address Management (IPAM) configuration for KKP user clusters.
+              properties:
+                datacenters:
+                  additionalProperties:
+                    description: IPAMPoolDatacenterSettings contains IPAM Pool configuration for a datacenter.
+                    properties:
+                      allocationPrefix:
+                        description: AllocationPrefix is the prefix for the allocation. Used when "type=prefix".
+                        maximum: 128
+                        minimum: 1
+                        type: integer
+                      allocationRange:
+                        description: AllocationRange is the range for the allocation. Used when "type=range".
+                        minimum: 1
+                        type: integer
+                      poolCidr:
+                        description: PoolCIDR is the pool CIDR to be used for the allocation.
+                        pattern: ((^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))/([0-9]|[1-2][0-9]|3[0-2])$)|(^(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:))/([0-9]|[0-9][0-9]|1[0-1][0-9]|12[0-8])$))
+                        type: string
+                      type:
+                        description: Type is the allocation type to be used.
+                        enum:
+                          - prefix
+                          - range
+                        type: string
+                    required:
+                      - poolCidr
+                      - type
+                    type: object
+                  description: Datacenters contains a map of datacenters (DCs) for the allocation.
                   type: object
-                description: Datacenters contains a map of datacenters (DCs) for the
-                  allocation.
-                type: object
-            required:
-            - datacenters
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+              required:
+                - datacenters
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: kubermaticconfigurations.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,828 +17,624 @@ spec:
     singular: kubermaticconfiguration
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: KubermaticConfiguration is the configuration required for running
-          Kubermatic.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: KubermaticConfigurationSpec is the spec for a Kubermatic
-              installation.
-            properties:
-              api:
-                description: API configures the frontend REST API used by the dashboard.
-                properties:
-                  accessibleAddons:
-                    description: AccessibleAddons is a list of addons that should
-                      be enabled in the API.
-                    items:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: KubermaticConfiguration is the configuration required for running Kubermatic.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: KubermaticConfigurationSpec is the spec for a Kubermatic installation.
+              properties:
+                api:
+                  description: API configures the frontend REST API used by the dashboard.
+                  properties:
+                    accessibleAddons:
+                      description: AccessibleAddons is a list of addons that should be enabled in the API.
+                      items:
+                        type: string
+                      type: array
+                    debugLog:
+                      description: DebugLog enables more verbose logging.
+                      type: boolean
+                    dockerRepository:
+                      description: DockerRepository is the repository containing the Kubermatic REST API image.
                       type: string
-                    type: array
-                  debugLog:
-                    description: DebugLog enables more verbose logging.
-                    type: boolean
-                  dockerRepository:
-                    description: DockerRepository is the repository containing the
-                      Kubermatic REST API image.
-                    type: string
-                  pprofEndpoint:
-                    description: PProfEndpoint controls the port the API should listen
-                      on to provide pprof data. This port is never exposed from the
-                      container and only available via port-forwardings.
-                    type: string
-                  replicas:
-                    description: Replicas sets the number of pod replicas for the
-                      API deployment.
-                    format: int32
-                    type: integer
-                  resources:
-                    description: Resources describes the requested and maximum allowed
-                      CPU/memory usage.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-              auth:
-                description: Auth defines keys and URLs for Dex. These must be defined
-                  unless the HeadlessInstallation feature gate is set, which will
-                  disable the UI/API and its need for an OIDC provider entirely.
-                properties:
-                  clientID:
-                    type: string
-                  issuerClientID:
-                    type: string
-                  issuerClientSecret:
-                    type: string
-                  issuerCookieKey:
-                    type: string
-                  issuerRedirectURL:
-                    type: string
-                  serviceAccountKey:
-                    type: string
-                  skipTokenIssuerTLSVerify:
-                    type: boolean
-                  tokenIssuer:
-                    type: string
-                type: object
-              caBundle:
-                description: CABundle references a ConfigMap in the same namespace
-                  as the KubermaticConfiguration. This ConfigMap must contain a ca-bundle.pem
-                  with PEM-encoded certificates. This bundle automatically synchronized
-                  into each seed and each usercluster. APIGroup and Kind are currently
-                  ignored.
-                properties:
-                  apiGroup:
-                    description: APIGroup is the group for the resource being referenced.
-                      If APIGroup is not specified, the specified Kind must be in
-                      the core API group. For any other third-party types, APIGroup
-                      is required.
-                    type: string
-                  kind:
-                    description: Kind is the type of resource being referenced
-                    type: string
-                  name:
-                    description: Name is the name of resource being referenced
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-                x-kubernetes-map-type: atomic
-              exposeStrategy:
-                description: 'ExposeStrategy is the strategy to expose the cluster
-                  with. Note: The `seed_dns_overwrite` setting of a Seed''s datacenter
-                  doesn''t have any effect if this is set to LoadBalancerStrategy.'
-                enum:
-                - NodePort
-                - LoadBalancer
-                - Tunneling
-                type: string
-              featureGates:
-                additionalProperties:
-                  type: boolean
-                description: FeatureGates are used to optionally enable certain features.
-                type: object
-              imagePullSecret:
-                description: ImagePullSecret is used to authenticate against Docker
-                  registries.
-                type: string
-              ingress:
-                description: Ingress contains settings for making the API and UI accessible
-                  remotely.
-                properties:
-                  certificateIssuer:
-                    description: CertificateIssuer is the name of a cert-manager Issuer
-                      or ClusterIssuer (default) that will be used to acquire the
-                      certificate for the configured domain. To use a namespaced Issuer,
-                      set the Kind to "Issuer" and manually create the matching Issuer
-                      in Kubermatic's namespace. Setting an empty name disables the
-                      automatic creation of certificates and disables the TLS settings
-                      on the Kubermatic Ingress.
-                    properties:
-                      apiGroup:
-                        description: APIGroup is the group for the resource being
-                          referenced. If APIGroup is not specified, the specified
-                          Kind must be in the core API group. For any other third-party
-                          types, APIGroup is required.
-                        type: string
-                      kind:
-                        description: Kind is the type of resource being referenced
-                        type: string
-                      name:
-                        description: Name is the name of resource being referenced
-                        type: string
-                    required:
+                    pprofEndpoint:
+                      description: PProfEndpoint controls the port the API should listen on to provide pprof data. This port is never exposed from the container and only available via port-forwardings.
+                      type: string
+                    replicas:
+                      description: Replicas sets the number of pod replicas for the API deployment.
+                      format: int32
+                      type: integer
+                    resources:
+                      description: Resources describes the requested and maximum allowed CPU/memory usage.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                auth:
+                  description: Auth defines keys and URLs for Dex. These must be defined unless the HeadlessInstallation feature gate is set, which will disable the UI/API and its need for an OIDC provider entirely.
+                  properties:
+                    clientID:
+                      type: string
+                    issuerClientID:
+                      type: string
+                    issuerClientSecret:
+                      type: string
+                    issuerCookieKey:
+                      type: string
+                    issuerRedirectURL:
+                      type: string
+                    serviceAccountKey:
+                      type: string
+                    skipTokenIssuerTLSVerify:
+                      type: boolean
+                    tokenIssuer:
+                      type: string
+                  type: object
+                caBundle:
+                  description: CABundle references a ConfigMap in the same namespace as the KubermaticConfiguration. This ConfigMap must contain a ca-bundle.pem with PEM-encoded certificates. This bundle automatically synchronized into each seed and each usercluster. APIGroup and Kind are currently ignored.
+                  properties:
+                    apiGroup:
+                      description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                      type: string
+                    kind:
+                      description: Kind is the type of resource being referenced
+                      type: string
+                    name:
+                      description: Name is the name of resource being referenced
+                      type: string
+                  required:
                     - kind
                     - name
-                    type: object
-                    x-kubernetes-map-type: atomic
-                  className:
-                    description: ClassName is the Ingress resource's class name, used
-                      for selecting the appropriate ingress controller.
-                    type: string
-                  disable:
-                    description: Disable will prevent an Ingress from being created
-                      at all. This is mostly useful during testing. If the Ingress
-                      is disabled, the CertificateIssuer setting can also be left
-                      empty, as no Certificate resource will be created.
+                  type: object
+                  x-kubernetes-map-type: atomic
+                exposeStrategy:
+                  description: 'ExposeStrategy is the strategy to expose the cluster with. Note: The `seed_dns_overwrite` setting of a Seed''s datacenter doesn''t have any effect if this is set to LoadBalancerStrategy.'
+                  enum:
+                    - NodePort
+                    - LoadBalancer
+                    - Tunneling
+                  type: string
+                featureGates:
+                  additionalProperties:
                     type: boolean
-                  domain:
-                    description: Domain is the base domain where the dashboard shall
-                      be available. Even with a disabled Ingress, this must always
-                      be a valid hostname.
-                    type: string
-                required:
-                - domain
-                type: object
-              masterController:
-                description: MasterController configures the master-controller-manager.
-                properties:
-                  debugLog:
-                    description: DebugLog enables more verbose logging.
-                    type: boolean
-                  dockerRepository:
-                    description: DockerRepository is the repository containing the
-                      Kubermatic master-controller-manager image.
-                    type: string
-                  pprofEndpoint:
-                    description: PProfEndpoint controls the port the master-controller-manager
-                      should listen on to provide pprof data. This port is never exposed
-                      from the container and only available via port-forwardings.
-                    type: string
-                  projectsMigrator:
-                    description: ProjectsMigrator configures the migrator for user
-                      projects.
-                    properties:
-                      dryRun:
-                        description: DryRun makes the migrator only log the actions
-                          it would take.
-                        type: boolean
-                    type: object
-                  replicas:
-                    description: Replicas sets the number of pod replicas for the
-                      master-controller-manager.
-                    format: int32
-                    type: integer
-                  resources:
-                    description: Resources describes the requested and maximum allowed
-                      CPU/memory usage.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-              proxy:
-                description: Proxy allows to configure Kubermatic to use proxies to
-                  talk to the world outside of its cluster.
-                properties:
-                  http:
-                    description: HTTP is the full URL to the proxy to use for plaintext
-                      HTTP connections, e.g. "http://internalproxy.example.com:8080".
-                    type: string
-                  https:
-                    description: HTTPS is the full URL to the proxy to use for encrypted
-                      HTTPS connections, e.g. "http://secureinternalproxy.example.com:8080".
-                    type: string
-                  noProxy:
-                    description: 'NoProxy is a comma-separated list of hostnames /
-                      network masks for which no proxy shall be used. If you make
-                      use of proxies, this list should contain all local and cluster-internal
-                      domains and networks, e.g. "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,mydomain".
-                      The operator will always prepend the following elements to this
-                      list if proxying is configured (i.e. HTTP/HTTPS are not empty):
-                      "127.0.0.1/8", "localhost", ".local", ".local.", "kubernetes",
-                      ".default", ".svc"'
-                    type: string
-                type: object
-              seedController:
-                description: SeedController configures the seed-controller-manager.
-                properties:
-                  backupCleanupContainer:
-                    description: BackupCleanupContainer is the container used for
-                      removing expired backups from the storage location. This container
-                      is only relevant when the old, deprecated backup controllers
-                      are enabled.
-                    type: string
-                  backupDeleteContainer:
-                    description: BackupDeleteContainer is the container used for deleting
-                      etcd snapshots from a backup location. This container is only
-                      relevant when the new backup/restore controllers are enabled.
-                    type: string
-                  backupStoreContainer:
-                    description: BackupStoreContainer is the container used for shipping
-                      etcd snapshots to a backup location.
-                    type: string
-                  debugLog:
-                    description: DebugLog enables more verbose logging.
-                    type: boolean
-                  dockerRepository:
-                    description: DockerRepository is the repository containing the
-                      Kubermatic seed-controller-manager image.
-                    type: string
-                  maximumParallelReconciles:
-                    description: MaximumParallelReconciles limits the number of cluster
-                      reconciliations that are active at any given time.
-                    type: integer
-                  pprofEndpoint:
-                    description: PProfEndpoint controls the port the seed-controller-manager
-                      should listen on to provide pprof data. This port is never exposed
-                      from the container and only available via port-forwardings.
-                    type: string
-                  replicas:
-                    description: Replicas sets the number of pod replicas for the
-                      seed-controller-manager.
-                    format: int32
-                    type: integer
-                  resources:
-                    description: Resources describes the requested and maximum allowed
-                      CPU/memory usage.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-              ui:
-                description: UI configures the dashboard.
-                properties:
-                  config:
-                    description: Config sets flags for various dashboard features.
-                    type: string
-                  dockerRepository:
-                    description: DockerRepository is the repository containing the
-                      Kubermatic dashboard image.
-                    type: string
-                  dockerTag:
-                    description: DockerTag is used to overwrite the dashboard Docker
-                      image tag and is only for development purposes. This field must
-                      not be set in production environments. ---
-                    type: string
-                  replicas:
-                    description: Replicas sets the number of pod replicas for the
-                      UI deployment.
-                    format: int32
-                    type: integer
-                  resources:
-                    description: Resources describes the requested and maximum allowed
-                      CPU/memory usage.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-              userCluster:
-                description: UserCluster configures various aspects of the user-created
-                  clusters.
-                properties:
-                  addons:
-                    description: Addons controls the optional additions installed
-                      into each user cluster.
-                    properties:
-                      default:
-                        description: Default is the list of addons to be installed
-                          by default into each cluster. Mutually exclusive with "defaultManifests".
-                        items:
+                  description: FeatureGates are used to optionally enable certain features.
+                  type: object
+                imagePullSecret:
+                  description: ImagePullSecret is used to authenticate against Docker registries.
+                  type: string
+                ingress:
+                  description: Ingress contains settings for making the API and UI accessible remotely.
+                  properties:
+                    certificateIssuer:
+                      description: CertificateIssuer is the name of a cert-manager Issuer or ClusterIssuer (default) that will be used to acquire the certificate for the configured domain. To use a namespaced Issuer, set the Kind to "Issuer" and manually create the matching Issuer in Kubermatic's namespace. Setting an empty name disables the automatic creation of certificates and disables the TLS settings on the Kubermatic Ingress.
+                      properties:
+                        apiGroup:
+                          description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
                           type: string
-                        type: array
-                      defaultManifests:
-                        description: DefaultManifests is a list of addon manifests
-                          to install into all clusters. Mutually exclusive with "default".
-                        type: string
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the Docker image containing the possible addon manifests.
-                        type: string
-                      dockerTagSuffix:
-                        description: DockerTagSuffix is appended to the tag used for
-                          referring to the addons image. If left empty, the tag will
-                          be the KKP version (e.g. "v2.15.0"), with a suffix it becomes
-                          "v2.15.0-SUFFIX".
-                        type: string
-                    type: object
-                  apiserverReplicas:
-                    description: APIServerReplicas configures the replica count for
-                      the API-Server deployment inside user clusters.
-                    format: int32
-                    type: integer
-                  disableApiserverEndpointReconciling:
-                    description: DisableAPIServerEndpointReconciling can be used to
-                      toggle the `--endpoint-reconciler-type` flag for the Kubernetes
-                      API server.
-                    type: boolean
-                  dnatControllerDockerRepository:
-                    description: DNATControllerDockerRepository is the repository
-                      containing the dnat-controller image.
-                    type: string
-                  etcdLauncherDockerRepository:
-                    description: EtcdLauncherDockerRepository is the repository containing
-                      the Kubermatic etcd-launcher image.
-                    type: string
-                  etcdVolumeSize:
-                    description: EtcdVolumeSize configures the volume size to use
-                      for each etcd pod inside user clusters.
-                    type: string
-                  kubermaticDockerRepository:
-                    description: KubermaticDockerRepository is the repository containing
-                      the Kubermatic user-cluster-controller-manager image.
-                    type: string
-                  machineController:
-                    description: MachineController configures the Machine Controller
-                    properties:
-                      imageRepository:
-                        description: ImageRepository is used to override the Machine
-                          Controller image repository. It is only for development,
-                          tests and PoC purposes. This field must not be set in production
-                          environments.
-                        type: string
-                      imageTag:
-                        description: ImageTag is used to override the Machine Controller
-                          image. It is only for development, tests and PoC purposes.
-                          This field must not be set in production environments.
-                        type: string
-                    type: object
-                  monitoring:
-                    description: Monitoring can be used to fine-tune to in-cluster
-                      Prometheus.
-                    properties:
-                      customRules:
-                        description: CustomRules can be used to inject custom recording
-                          and alerting rules. This field must be a YAML-formatted
-                          string with a `group` element at its root, as documented
-                          on https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/.
-                          This value is treated as a Go template, which allows to
-                          inject dynamic values like the internal cluster address
-                          or the cluster ID. Refer to pkg/resources/prometheus and
-                          the documentation for more information on the available
-                          fields.
-                        type: string
-                      customScrapingConfigs:
-                        description: CustomScrapingConfigs can be used to inject custom
-                          scraping rules. This must be a YAML-formatted string containing
-                          an array of scrape configurations as documented on https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config.
-                          This value is treated as a Go template, which allows to
-                          inject dynamic values like the internal cluster address
-                          or the cluster ID. Refer to pkg/resources/prometheus and
-                          the documentation for more information on the available
-                          fields.
-                        type: string
-                      disableDefaultRules:
-                        description: DisableDefaultRules disables the recording and
-                          alerting rules.
-                        type: boolean
-                      disableDefaultScrapingConfigs:
-                        description: DisableDefaultScrapingConfigs disables the default
-                          scraping targets.
-                        type: boolean
-                      scrapeAnnotationPrefix:
-                        description: ScrapeAnnotationPrefix (if set) is used to make
-                          the in-cluster Prometheus scrape pods inside the user clusters.
-                        type: string
-                    type: object
-                  nodePortRange:
-                    description: NodePortRange is the port range for user clusters
-                      - this must match the NodePort range of the seed cluster.
-                    type: string
-                  operatingSystemManager:
-                    description: OperatingSystemManager configures the image repo
-                      and the tag version for osm deployment.
-                    properties:
-                      imageRepository:
-                        description: ImageRepository is used to override the OperatingSystemManager
-                          image repository. It is recommended to use this field only
-                          for development, tests and PoC purposes. For production
-                          environments. it is not recommended, to use this field due
-                          to compatibility with the overall KKP stack.
-                        type: string
-                      imageTag:
-                        description: ImageTag is used to override the OperatingSystemManager
-                          image. It is recommended to use this field only for development,
-                          tests and PoC purposes. For production environments. it
-                          is not recommended, to use this field due to compatibility
-                          with the overall KKP stack.
-                        type: string
-                    type: object
-                  overwriteRegistry:
-                    description: OverwriteRegistry specifies a custom Docker registry
-                      which will be used for all images used for user clusters (user
-                      cluster control plane + addons). This also applies to the KubermaticDockerRepository
-                      and DNATControllerDockerRepository fields.
-                    type: string
-                type: object
-              versions:
-                description: Versions configures the available and default Kubernetes
-                  versions and updates.
-                properties:
-                  default:
-                    description: Default is the default version to offer users.
-                    type: string
-                  externalClusters:
-                    additionalProperties:
-                      description: ExternalClusterProviderVersioningConfiguration
-                        configures the available and default Kubernetes versions for
-                        ExternalCluster Providers.
+                        kind:
+                          description: Kind is the type of resource being referenced
+                          type: string
+                        name:
+                          description: Name is the name of resource being referenced
+                          type: string
+                      required:
+                        - kind
+                        - name
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    className:
+                      description: ClassName is the Ingress resource's class name, used for selecting the appropriate ingress controller.
+                      type: string
+                    disable:
+                      description: Disable will prevent an Ingress from being created at all. This is mostly useful during testing. If the Ingress is disabled, the CertificateIssuer setting can also be left empty, as no Certificate resource will be created.
+                      type: boolean
+                    domain:
+                      description: Domain is the base domain where the dashboard shall be available. Even with a disabled Ingress, this must always be a valid hostname.
+                      type: string
+                  required:
+                    - domain
+                  type: object
+                masterController:
+                  description: MasterController configures the master-controller-manager.
+                  properties:
+                    debugLog:
+                      description: DebugLog enables more verbose logging.
+                      type: boolean
+                    dockerRepository:
+                      description: DockerRepository is the repository containing the Kubermatic master-controller-manager image.
+                      type: string
+                    pprofEndpoint:
+                      description: PProfEndpoint controls the port the master-controller-manager should listen on to provide pprof data. This port is never exposed from the container and only available via port-forwardings.
+                      type: string
+                    projectsMigrator:
+                      description: ProjectsMigrator configures the migrator for user projects.
+                      properties:
+                        dryRun:
+                          description: DryRun makes the migrator only log the actions it would take.
+                          type: boolean
+                      type: object
+                    replicas:
+                      description: Replicas sets the number of pod replicas for the master-controller-manager.
+                      format: int32
+                      type: integer
+                    resources:
+                      description: Resources describes the requested and maximum allowed CPU/memory usage.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                proxy:
+                  description: Proxy allows to configure Kubermatic to use proxies to talk to the world outside of its cluster.
+                  properties:
+                    http:
+                      description: HTTP is the full URL to the proxy to use for plaintext HTTP connections, e.g. "http://internalproxy.example.com:8080".
+                      type: string
+                    https:
+                      description: HTTPS is the full URL to the proxy to use for encrypted HTTPS connections, e.g. "http://secureinternalproxy.example.com:8080".
+                      type: string
+                    noProxy:
+                      description: 'NoProxy is a comma-separated list of hostnames / network masks for which no proxy shall be used. If you make use of proxies, this list should contain all local and cluster-internal domains and networks, e.g. "10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,mydomain". The operator will always prepend the following elements to this list if proxying is configured (i.e. HTTP/HTTPS are not empty): "127.0.0.1/8", "localhost", ".local", ".local.", "kubernetes", ".default", ".svc"'
+                      type: string
+                  type: object
+                seedController:
+                  description: SeedController configures the seed-controller-manager.
+                  properties:
+                    backupCleanupContainer:
+                      description: BackupCleanupContainer is the container used for removing expired backups from the storage location. This container is only relevant when the old, deprecated backup controllers are enabled.
+                      type: string
+                    backupDeleteContainer:
+                      description: BackupDeleteContainer is the container used for deleting etcd snapshots from a backup location. This container is only relevant when the new backup/restore controllers are enabled.
+                      type: string
+                    backupStoreContainer:
+                      description: BackupStoreContainer is the container used for shipping etcd snapshots to a backup location.
+                      type: string
+                    debugLog:
+                      description: DebugLog enables more verbose logging.
+                      type: boolean
+                    dockerRepository:
+                      description: DockerRepository is the repository containing the Kubermatic seed-controller-manager image.
+                      type: string
+                    maximumParallelReconciles:
+                      description: MaximumParallelReconciles limits the number of cluster reconciliations that are active at any given time.
+                      type: integer
+                    pprofEndpoint:
+                      description: PProfEndpoint controls the port the seed-controller-manager should listen on to provide pprof data. This port is never exposed from the container and only available via port-forwardings.
+                      type: string
+                    replicas:
+                      description: Replicas sets the number of pod replicas for the seed-controller-manager.
+                      format: int32
+                      type: integer
+                    resources:
+                      description: Resources describes the requested and maximum allowed CPU/memory usage.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                ui:
+                  description: UI configures the dashboard.
+                  properties:
+                    config:
+                      description: Config sets flags for various dashboard features.
+                      type: string
+                    dockerRepository:
+                      description: DockerRepository is the repository containing the Kubermatic dashboard image.
+                      type: string
+                    dockerTag:
+                      description: DockerTag is used to overwrite the dashboard Docker image tag and is only for development purposes. This field must not be set in production environments. ---
+                      type: string
+                    replicas:
+                      description: Replicas sets the number of pod replicas for the UI deployment.
+                      format: int32
+                      type: integer
+                    resources:
+                      description: Resources describes the requested and maximum allowed CPU/memory usage.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+                userCluster:
+                  description: UserCluster configures various aspects of the user-created clusters.
+                  properties:
+                    addons:
+                      description: Addons controls the optional additions installed into each user cluster.
                       properties:
                         default:
-                          description: Default is the default version to offer users.
-                          type: string
-                        updates:
-                          description: Updates is a list of available upgrades.
+                          description: Default is the list of addons to be installed by default into each cluster. Mutually exclusive with "defaultManifests".
                           items:
-                            description: Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version
-                              struct so it can be used in our API.
                             type: string
                           type: array
-                        versions:
-                          description: Versions lists the available versions.
-                          items:
-                            description: Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version
-                              struct so it can be used in our API.
-                            type: string
-                          type: array
-                      type: object
-                    description: ExternalClusters contains the available and default
-                      Kubernetes versions and updates for ExternalClusters.
-                    type: object
-                  providerIncompatibilities:
-                    description: ProviderIncompatibilities lists all the Kubernetes
-                      version incompatibilities
-                    items:
-                      description: Incompatibility represents a version incompatibility
-                        for a user cluster.
-                      properties:
-                        condition:
-                          description: Condition is the cluster or datacenter condition
-                            that must be met to block a specific version
-                          enum:
-                          - always
-                          - externalCloudProvider
-                          - nonAMD64WithCanalAndIPVS
+                        defaultManifests:
+                          description: DefaultManifests is a list of addon manifests to install into all clusters. Mutually exclusive with "default".
                           type: string
-                        operation:
-                          description: Operation is the operation triggering the compatibility
-                            check (CREATE or UPDATE)
-                          enum:
-                          - CREATE
-                          - UPGRADE
-                          - SUPPORT
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the Docker image containing the possible addon manifests.
                           type: string
-                        provider:
-                          description: Provider to which to apply the compatibility
-                            check. Empty string matches all providers
-                          enum:
-                          - digitalocean
-                          - hetzner
-                          - azure
-                          - vsphere
-                          - aws
-                          - openstack
-                          - packet
-                          - gcp
-                          - kubevirt
-                          - nutanix
-                          - alibaba
-                          - anexia
-                          - fake
-                          - vmwareclouddirector
-                          type: string
-                        version:
-                          description: Version is the Kubernetes version that must
-                            be checked. Wildcards are allowed, e.g. "1.22.*".
+                        dockerTagSuffix:
+                          description: DockerTagSuffix is appended to the tag used for referring to the addons image. If left empty, the tag will be the KKP version (e.g. "v2.15.0"), with a suffix it becomes "v2.15.0-SUFFIX".
                           type: string
                       type: object
-                    type: array
-                  updates:
-                    description: 'Updates is a list of available and automatic upgrades.
-                      All ''to'' versions must be configured in the version list for
-                      this orchestrator. Each update may optionally be configured
-                      to be ''automatic: true'', in which case the controlplane of
-                      all clusters whose version matches the ''from'' directive will
-                      get updated to the ''to'' version. If automatic is enabled,
-                      the ''to'' version must be a version and not a version range.
-                      Also, updates may set ''automaticNodeUpdate: true'', in which
-                      case Nodes will get updates as well. ''automaticNodeUpdate:
-                      true'' implies ''automatic: true'' as well, because Nodes may
-                      not have a newer version than the controlplane.'
-                    items:
-                      description: Update represents an update option for a user cluster.
-                      properties:
-                        automatic:
-                          description: Automatic controls whether this update is executed
-                            automatically for the control plane of all matching user
-                            clusters. ---
-                          type: boolean
-                        automaticNodeUpdate:
-                          description: Automatic controls whether this update is executed
-                            automatically for the worker nodes of all matching user
-                            clusters. ---
-                          type: boolean
-                        from:
-                          description: From is the version from which an update is
-                            allowed. Wildcards are allowed, e.g. "1.18.*".
-                          type: string
-                        to:
-                          description: To is the version to which an update is allowed.
-                            Must be a valid version if `automatic` is set to true,
-                            e.g. "1.20.13". Can be a wildcard otherwise, e.g. "1.20.*".
-                          type: string
-                      type: object
-                    type: array
-                  versions:
-                    description: Versions lists the available versions.
-                    items:
-                      description: Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version
-                        struct so it can be used in our API.
+                    apiserverReplicas:
+                      description: APIServerReplicas configures the replica count for the API-Server deployment inside user clusters.
+                      format: int32
+                      type: integer
+                    disableApiserverEndpointReconciling:
+                      description: DisableAPIServerEndpointReconciling can be used to toggle the `--endpoint-reconciler-type` flag for the Kubernetes API server.
+                      type: boolean
+                    dnatControllerDockerRepository:
+                      description: DNATControllerDockerRepository is the repository containing the dnat-controller image.
                       type: string
-                    type: array
-                type: object
-              verticalPodAutoscaler:
-                description: VerticalPodAutoscaler configures the Kubernetes VPA integration.
-                properties:
-                  admissionController:
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
+                    etcdLauncherDockerRepository:
+                      description: EtcdLauncherDockerRepository is the repository containing the Kubermatic etcd-launcher image.
+                      type: string
+                    etcdVolumeSize:
+                      description: EtcdVolumeSize configures the volume size to use for each etcd pod inside user clusters.
+                      type: string
+                    kubermaticDockerRepository:
+                      description: KubermaticDockerRepository is the repository containing the Kubermatic user-cluster-controller-manager image.
+                      type: string
+                    machineController:
+                      description: MachineController configures the Machine Controller
+                      properties:
+                        imageRepository:
+                          description: ImageRepository is used to override the Machine Controller image repository. It is only for development, tests and PoC purposes. This field must not be set in production environments.
+                          type: string
+                        imageTag:
+                          description: ImageTag is used to override the Machine Controller image. It is only for development, tests and PoC purposes. This field must not be set in production environments.
+                          type: string
+                      type: object
+                    monitoring:
+                      description: Monitoring can be used to fine-tune to in-cluster Prometheus.
+                      properties:
+                        customRules:
+                          description: CustomRules can be used to inject custom recording and alerting rules. This field must be a YAML-formatted string with a `group` element at its root, as documented on https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/. This value is treated as a Go template, which allows to inject dynamic values like the internal cluster address or the cluster ID. Refer to pkg/resources/prometheus and the documentation for more information on the available fields.
+                          type: string
+                        customScrapingConfigs:
+                          description: CustomScrapingConfigs can be used to inject custom scraping rules. This must be a YAML-formatted string containing an array of scrape configurations as documented on https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config. This value is treated as a Go template, which allows to inject dynamic values like the internal cluster address or the cluster ID. Refer to pkg/resources/prometheus and the documentation for more information on the available fields.
+                          type: string
+                        disableDefaultRules:
+                          description: DisableDefaultRules disables the recording and alerting rules.
+                          type: boolean
+                        disableDefaultScrapingConfigs:
+                          description: DisableDefaultScrapingConfigs disables the default scraping targets.
+                          type: boolean
+                        scrapeAnnotationPrefix:
+                          description: ScrapeAnnotationPrefix (if set) is used to make the in-cluster Prometheus scrape pods inside the user clusters.
+                          type: string
+                      type: object
+                    nodePortRange:
+                      description: NodePortRange is the port range for user clusters - this must match the NodePort range of the seed cluster.
+                      type: string
+                    operatingSystemManager:
+                      description: OperatingSystemManager configures the image repo and the tag version for osm deployment.
+                      properties:
+                        imageRepository:
+                          description: ImageRepository is used to override the OperatingSystemManager image repository. It is recommended to use this field only for development, tests and PoC purposes. For production environments. it is not recommended, to use this field due to compatibility with the overall KKP stack.
+                          type: string
+                        imageTag:
+                          description: ImageTag is used to override the OperatingSystemManager image. It is recommended to use this field only for development, tests and PoC purposes. For production environments. it is not recommended, to use this field due to compatibility with the overall KKP stack.
+                          type: string
+                      type: object
+                    overwriteRegistry:
+                      description: OverwriteRegistry specifies a custom Docker registry which will be used for all images used for user clusters (user cluster control plane + addons). This also applies to the KubermaticDockerRepository and DNATControllerDockerRepository fields.
+                      type: string
+                  type: object
+                versions:
+                  description: Versions configures the available and default Kubernetes versions and updates.
+                  properties:
+                    default:
+                      description: Default is the default version to offer users.
+                      type: string
+                    externalClusters:
+                      additionalProperties:
+                        description: ExternalClusterProviderVersioningConfiguration configures the available and default Kubernetes versions for ExternalCluster Providers.
                         properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
+                          default:
+                            description: Default is the default version to offer users.
+                            type: string
+                          updates:
+                            description: Updates is a list of available upgrades.
+                            items:
+                              description: Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version struct so it can be used in our API.
+                              type: string
+                            type: array
+                          versions:
+                            description: Versions lists the available versions.
+                            items:
+                              description: Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version struct so it can be used in our API.
+                              type: string
+                            type: array
                         type: object
-                    type: object
-                  recommender:
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
+                      description: ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
+                      type: object
+                    providerIncompatibilities:
+                      description: ProviderIncompatibilities lists all the Kubernetes version incompatibilities
+                      items:
+                        description: Incompatibility represents a version incompatibility for a user cluster.
                         properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
+                          condition:
+                            description: Condition is the cluster or datacenter condition that must be met to block a specific version
+                            enum:
+                              - always
+                              - externalCloudProvider
+                              - nonAMD64WithCanalAndIPVS
+                            type: string
+                          operation:
+                            description: Operation is the operation triggering the compatibility check (CREATE or UPDATE)
+                            enum:
+                              - CREATE
+                              - UPGRADE
+                              - SUPPORT
+                            type: string
+                          provider:
+                            description: Provider to which to apply the compatibility check. Empty string matches all providers
+                            enum:
+                              - digitalocean
+                              - hetzner
+                              - azure
+                              - vsphere
+                              - aws
+                              - openstack
+                              - packet
+                              - gcp
+                              - kubevirt
+                              - nutanix
+                              - alibaba
+                              - anexia
+                              - fake
+                              - vmwareclouddirector
+                            type: string
+                          version:
+                            description: Version is the Kubernetes version that must be checked. Wildcards are allowed, e.g. "1.22.*".
+                            type: string
                         type: object
-                    type: object
-                  updater:
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
+                      type: array
+                    updates:
+                      description: 'Updates is a list of available and automatic upgrades. All ''to'' versions must be configured in the version list for this orchestrator. Each update may optionally be configured to be ''automatic: true'', in which case the controlplane of all clusters whose version matches the ''from'' directive will get updated to the ''to'' version. If automatic is enabled, the ''to'' version must be a version and not a version range. Also, updates may set ''automaticNodeUpdate: true'', in which case Nodes will get updates as well. ''automaticNodeUpdate: true'' implies ''automatic: true'' as well, because Nodes may not have a newer version than the controlplane.'
+                      items:
+                        description: Update represents an update option for a user cluster.
                         properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
+                          automatic:
+                            description: Automatic controls whether this update is executed automatically for the control plane of all matching user clusters. ---
+                            type: boolean
+                          automaticNodeUpdate:
+                            description: Automatic controls whether this update is executed automatically for the worker nodes of all matching user clusters. ---
+                            type: boolean
+                          from:
+                            description: From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
+                            type: string
+                          to:
+                            description: To is the version to which an update is allowed. Must be a valid version if `automatic` is set to true, e.g. "1.20.13". Can be a wildcard otherwise, e.g. "1.20.*".
+                            type: string
+                        type: object
+                      type: array
+                    versions:
+                      description: Versions lists the available versions.
+                      items:
+                        description: Semver is a type that encapsulates github.com/Masterminds/semver/v3.Version struct so it can be used in our API.
+                        type: string
+                      type: array
+                  type: object
+                verticalPodAutoscaler:
+                  description: VerticalPodAutoscaler configures the Kubernetes VPA integration.
+                  properties:
+                    admissionController:
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    recommender:
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    updater:
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                webhook:
+                  description: Webhook configures the webhook.
+                  properties:
+                    debugLog:
+                      description: DebugLog enables more verbose logging.
+                      type: boolean
+                    dockerRepository:
+                      description: DockerRepository is the repository containing the Kubermatic webhook image.
+                      type: string
+                    pprofEndpoint:
+                      description: PProfEndpoint controls the port the webhook should listen on to provide pprof data. This port is never exposed from the container and only available via port-forwardings.
+                      type: string
+                    replicas:
+                      description: Replicas sets the number of pod replicas for the webhook.
+                      format: int32
+                      type: integer
+                    resources:
+                      description: Resources describes the requested and maximum allowed CPU/memory usage.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            anyOf:
                               - type: integer
                               - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
                               - type: integer
                               - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                type: object
-              webhook:
-                description: Webhook configures the webhook.
-                properties:
-                  debugLog:
-                    description: DebugLog enables more verbose logging.
-                    type: boolean
-                  dockerRepository:
-                    description: DockerRepository is the repository containing the
-                      Kubermatic webhook image.
-                    type: string
-                  pprofEndpoint:
-                    description: PProfEndpoint controls the port the webhook should
-                      listen on to provide pprof data. This port is never exposed
-                      from the container and only available via port-forwardings.
-                    type: string
-                  replicas:
-                    description: Replicas sets the number of pod replicas for the
-                      webhook.
-                    format: int32
-                    type: integer
-                  resources:
-                    description: Resources describes the requested and maximum allowed
-                      CPU/memory usage.
-                    properties:
-                      limits:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Limits describes the maximum amount of compute
-                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                      requests:
-                        additionalProperties:
-                          anyOf:
-                          - type: integer
-                          - type: string
-                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                          x-kubernetes-int-or-string: true
-                        description: 'Requests describes the minimum amount of compute
-                          resources required. If Requests is omitted for a container,
-                          it defaults to Limits if that is explicitly specified, otherwise
-                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                        type: object
-                    type: object
-                type: object
-            type: object
-          status:
-            description: KubermaticConfigurationStatus stores status information about
-              a KubermaticConfiguration.
-            properties:
-              kubermaticEdition:
-                description: KubermaticEdition current Kubermatic Edition , i.e. Community
-                  Edition or Enterprise Edition.
-                type: string
-              kubermaticVersion:
-                description: KubermaticVersion current Kubermatic Version.
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                          type: object
+                      type: object
+                  type: object
+              type: object
+            status:
+              description: KubermaticConfigurationStatus stores status information about a KubermaticConfiguration.
+              properties:
+                kubermaticEdition:
+                  description: KubermaticEdition current Kubermatic Edition , i.e. Community Edition or Enterprise Edition.
+                  type: string
+                kubermaticVersion:
+                  description: KubermaticVersion current Kubermatic Version.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: kubermaticconfigurations.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: kubermaticsettings.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: kubermaticsettings.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,157 +17,140 @@ spec:
     singular: kubermaticsetting
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: KubermaticSetting is the type representing a KubermaticSetting.
-          These settings affect the KKP dashboard and are not relevant when using
-          the Kube API on the master/seed clusters directly.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              cleanupOptions:
-                description: CleanupOptions control what happens when a cluster is
-                  deleted via the dashboard.
-                properties:
-                  enabled:
-                    description: Enable checkboxes that allow the user to ask for
-                      LoadBalancers and PVCs to be deleted in order to not leave potentially
-                      expensive resources behind.
-                    type: boolean
-                  enforced:
-                    description: If enforced is set to true, the cleanup of LoadBalancers
-                      and PVCs is enforced.
-                    type: boolean
-                type: object
-              customLinks:
-                description: CustomLinks are additional links that can be shown the
-                  dashboard's footer.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: KubermaticSetting is the type representing a KubermaticSetting. These settings affect the KKP dashboard and are not relevant when using the Kube API on the master/seed clusters directly.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                cleanupOptions:
+                  description: CleanupOptions control what happens when a cluster is deleted via the dashboard.
                   properties:
-                    icon:
-                      type: string
-                    label:
-                      type: string
-                    location:
-                      type: string
-                    url:
-                      type: string
-                  required:
-                  - icon
-                  - label
-                  - location
-                  - url
+                    enabled:
+                      description: Enable checkboxes that allow the user to ask for LoadBalancers and PVCs to be deleted in order to not leave potentially expensive resources behind.
+                      type: boolean
+                    enforced:
+                      description: If enforced is set to true, the cleanup of LoadBalancers and PVCs is enforced.
+                      type: boolean
                   type: object
-                type: array
-              defaultNodeCount:
-                description: DefaultNodeCount is the default number of replicas for
-                  the initial MachineDeployment.
-                type: integer
-              displayAPIDocs:
-                description: DisplayDemoInfo controls whether a a link to the KKP
-                  API documentation is shown in the footer.
-                type: boolean
-              displayDemoInfo:
-                description: DisplayDemoInfo controls whether a "Demo System" hint
-                  is shown in the footer.
-                type: boolean
-              displayTermsOfService:
-                description: DisplayDemoInfo controls whether a a link to TOS is shown
-                  in the footer.
-                type: boolean
-              enableDashboard:
-                description: EnableDashboard enables the link to the Kubernetes dashboard
-                  for a user cluster.
-                type: boolean
-              enableExternalClusterImport:
-                type: boolean
-              enableOIDCKubeconfig:
-                type: boolean
-              machineDeploymentVMResourceQuota:
-                properties:
-                  enableGPU:
-                    type: boolean
-                  maxCPU:
-                    description: Maximal number of vCPU
-                    type: integer
-                  maxRAM:
-                    description: Maximum RAM size in GB
-                    type: integer
-                  minCPU:
-                    description: Minimal number of vCPU
-                    type: integer
-                  minRAM:
-                    description: Minimal RAM size in GB
-                    type: integer
-                required:
-                - enableGPU
-                - maxCPU
-                - maxRAM
-                - minCPU
-                - minRAM
-                type: object
-              mlaAlertmanagerPrefix:
-                type: string
-              mlaGrafanaPrefix:
-                type: string
-              mlaOptions:
-                properties:
-                  loggingEnabled:
-                    type: boolean
-                  loggingEnforced:
-                    type: boolean
-                  monitoringEnabled:
-                    type: boolean
-                  monitoringEnforced:
-                    type: boolean
-                type: object
-              opaOptions:
-                properties:
-                  enabled:
-                    type: boolean
-                  enforced:
-                    type: boolean
-                type: object
-              restrictProjectCreation:
-                type: boolean
-              userProjectsLimit:
-                description: UserProjectsLimit is the maximum number of projects a
-                  user can create.
-                format: int64
-                type: integer
-            required:
-            - customLinks
-            - defaultNodeCount
-            - displayAPIDocs
-            - displayDemoInfo
-            - displayTermsOfService
-            - enableDashboard
-            - enableExternalClusterImport
-            - enableOIDCKubeconfig
-            - machineDeploymentVMResourceQuota
-            - mlaAlertmanagerPrefix
-            - mlaGrafanaPrefix
-            - restrictProjectCreation
-            - userProjectsLimit
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                customLinks:
+                  description: CustomLinks are additional links that can be shown the dashboard's footer.
+                  items:
+                    properties:
+                      icon:
+                        type: string
+                      label:
+                        type: string
+                      location:
+                        type: string
+                      url:
+                        type: string
+                    required:
+                      - icon
+                      - label
+                      - location
+                      - url
+                    type: object
+                  type: array
+                defaultNodeCount:
+                  description: DefaultNodeCount is the default number of replicas for the initial MachineDeployment.
+                  type: integer
+                displayAPIDocs:
+                  description: DisplayDemoInfo controls whether a a link to the KKP API documentation is shown in the footer.
+                  type: boolean
+                displayDemoInfo:
+                  description: DisplayDemoInfo controls whether a "Demo System" hint is shown in the footer.
+                  type: boolean
+                displayTermsOfService:
+                  description: DisplayDemoInfo controls whether a a link to TOS is shown in the footer.
+                  type: boolean
+                enableDashboard:
+                  description: EnableDashboard enables the link to the Kubernetes dashboard for a user cluster.
+                  type: boolean
+                enableExternalClusterImport:
+                  type: boolean
+                enableOIDCKubeconfig:
+                  type: boolean
+                machineDeploymentVMResourceQuota:
+                  properties:
+                    enableGPU:
+                      type: boolean
+                    maxCPU:
+                      description: Maximal number of vCPU
+                      type: integer
+                    maxRAM:
+                      description: Maximum RAM size in GB
+                      type: integer
+                    minCPU:
+                      description: Minimal number of vCPU
+                      type: integer
+                    minRAM:
+                      description: Minimal RAM size in GB
+                      type: integer
+                  required:
+                    - enableGPU
+                    - maxCPU
+                    - maxRAM
+                    - minCPU
+                    - minRAM
+                  type: object
+                mlaAlertmanagerPrefix:
+                  type: string
+                mlaGrafanaPrefix:
+                  type: string
+                mlaOptions:
+                  properties:
+                    loggingEnabled:
+                      type: boolean
+                    loggingEnforced:
+                      type: boolean
+                    monitoringEnabled:
+                      type: boolean
+                    monitoringEnforced:
+                      type: boolean
+                  type: object
+                opaOptions:
+                  properties:
+                    enabled:
+                      type: boolean
+                    enforced:
+                      type: boolean
+                  type: object
+                restrictProjectCreation:
+                  type: boolean
+                userProjectsLimit:
+                  description: UserProjectsLimit is the maximum number of projects a user can create.
+                  format: int64
+                  type: integer
+              required:
+                - customLinks
+                - defaultNodeCount
+                - displayAPIDocs
+                - displayDemoInfo
+                - displayTermsOfService
+                - enableDashboard
+                - enableExternalClusterImport
+                - enableOIDCKubeconfig
+                - machineDeploymentVMResourceQuota
+                - mlaAlertmanagerPrefix
+                - mlaGrafanaPrefix
+                - restrictProjectCreation
+                - userProjectsLimit
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: mlaadminsettings.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,110 +17,89 @@ spec:
     singular: mlaadminsetting
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: MLAAdminSetting is the object representing cluster-specific administrator
-          settings for KKP user cluster MLA (monitoring, logging & alerting) stack.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: MLAAdminSettingSpec specifies the cluster-specific administrator
-              settings for KKP user cluster MLA (monitoring, logging & alerting) stack.
-            properties:
-              clusterName:
-                description: ClusterName is the name of the user cluster whose MLA
-                  settings are defined in this object.
-                type: string
-              loggingRateLimits:
-                description: LoggingRateLimits contains rate-limiting configuration
-                  logging in the user cluster.
-                properties:
-                  ingestionBurstSize:
-                    description: IngestionBurstSize represents ingestion burst size
-                      in number of requests (nginx `burst`).
-                    format: int32
-                    type: integer
-                  ingestionRate:
-                    description: IngestionRate represents ingestion rate limit in
-                      requests per second (nginx `rate` in `r/s`).
-                    format: int32
-                    type: integer
-                  queryBurstSize:
-                    description: QueryBurstSize represents query burst size in number
-                      of requests (nginx `burst`).
-                    format: int32
-                    type: integer
-                  queryRate:
-                    description: QueryRate represents query request rate limit per
-                      second (nginx `rate` in `r/s`).
-                    format: int32
-                    type: integer
-                type: object
-              monitoringRateLimits:
-                description: MonitoringRateLimits contains rate-limiting configuration
-                  for monitoring in the user cluster.
-                properties:
-                  ingestionBurstSize:
-                    description: IngestionBurstSize represents ingestion burst size
-                      in samples per second (Cortex `ingestion_burst_size`).
-                    format: int32
-                    type: integer
-                  ingestionRate:
-                    description: IngestionRate represents the ingestion rate limit
-                      in samples per second (Cortex `ingestion_rate`).
-                    format: int32
-                    type: integer
-                  maxSamplesPerQuery:
-                    description: MaxSamplesPerQuery represents maximum number of samples
-                      during a query (Cortex `max_samples_per_query`).
-                    format: int32
-                    type: integer
-                  maxSeriesPerMetric:
-                    description: MaxSeriesPerMetric represents maximum number of series
-                      per metric (Cortex `max_series_per_metric`).
-                    format: int32
-                    type: integer
-                  maxSeriesPerQuery:
-                    description: MaxSeriesPerQuery represents maximum number of timeseries
-                      during a query (Cortex `max_series_per_query`).
-                    format: int32
-                    type: integer
-                  maxSeriesTotal:
-                    description: MaxSeriesTotal represents maximum number of series
-                      per this user cluster (Cortex `max_series_per_user`).
-                    format: int32
-                    type: integer
-                  queryBurstSize:
-                    description: QueryBurstSize represents query burst size in number
-                      of requests (nginx `burst`).
-                    format: int32
-                    type: integer
-                  queryRate:
-                    description: QueryRate represents  query request rate limit per
-                      second (nginx `rate` in `r/s`).
-                    format: int32
-                    type: integer
-                type: object
-            required:
-            - clusterName
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: MLAAdminSetting is the object representing cluster-specific administrator settings for KKP user cluster MLA (monitoring, logging & alerting) stack.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: MLAAdminSettingSpec specifies the cluster-specific administrator settings for KKP user cluster MLA (monitoring, logging & alerting) stack.
+              properties:
+                clusterName:
+                  description: ClusterName is the name of the user cluster whose MLA settings are defined in this object.
+                  type: string
+                loggingRateLimits:
+                  description: LoggingRateLimits contains rate-limiting configuration logging in the user cluster.
+                  properties:
+                    ingestionBurstSize:
+                      description: IngestionBurstSize represents ingestion burst size in number of requests (nginx `burst`).
+                      format: int32
+                      type: integer
+                    ingestionRate:
+                      description: IngestionRate represents ingestion rate limit in requests per second (nginx `rate` in `r/s`).
+                      format: int32
+                      type: integer
+                    queryBurstSize:
+                      description: QueryBurstSize represents query burst size in number of requests (nginx `burst`).
+                      format: int32
+                      type: integer
+                    queryRate:
+                      description: QueryRate represents query request rate limit per second (nginx `rate` in `r/s`).
+                      format: int32
+                      type: integer
+                  type: object
+                monitoringRateLimits:
+                  description: MonitoringRateLimits contains rate-limiting configuration for monitoring in the user cluster.
+                  properties:
+                    ingestionBurstSize:
+                      description: IngestionBurstSize represents ingestion burst size in samples per second (Cortex `ingestion_burst_size`).
+                      format: int32
+                      type: integer
+                    ingestionRate:
+                      description: IngestionRate represents the ingestion rate limit in samples per second (Cortex `ingestion_rate`).
+                      format: int32
+                      type: integer
+                    maxSamplesPerQuery:
+                      description: MaxSamplesPerQuery represents maximum number of samples during a query (Cortex `max_samples_per_query`).
+                      format: int32
+                      type: integer
+                    maxSeriesPerMetric:
+                      description: MaxSeriesPerMetric represents maximum number of series per metric (Cortex `max_series_per_metric`).
+                      format: int32
+                      type: integer
+                    maxSeriesPerQuery:
+                      description: MaxSeriesPerQuery represents maximum number of timeseries during a query (Cortex `max_series_per_query`).
+                      format: int32
+                      type: integer
+                    maxSeriesTotal:
+                      description: MaxSeriesTotal represents maximum number of series per this user cluster (Cortex `max_series_per_user`).
+                      format: int32
+                      type: integer
+                    queryBurstSize:
+                      description: QueryBurstSize represents query burst size in number of requests (nginx `burst`).
+                      format: int32
+                      type: integer
+                    queryRate:
+                      description: QueryRate represents  query request rate limit per second (nginx `rate` in `r/s`).
+                      format: int32
+                      type: integer
+                  type: object
+              required:
+                - clusterName
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_mlaadminsettings.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: seed
   creationTimestamp: null
   name: mlaadminsettings.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: presets.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: presets.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,477 +17,416 @@ spec:
     singular: preset
   scope: Cluster
   versions:
-  - name: v1
-    schema:
-      openAPIV3Schema:
-        description: Presets are preconfigured cloud provider credentials that can
-          be applied to new clusters. This frees end users from having to know the
-          actual credentials used for their clusters.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: Presets specifies default presets for supported providers.
-            properties:
-              aks:
-                properties:
-                  clientID:
-                    type: string
-                  clientSecret:
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  subscriptionID:
-                    type: string
-                  tenantID:
-                    type: string
-                required:
-                - clientID
-                - clientSecret
-                - subscriptionID
-                - tenantID
-                type: object
-              alibaba:
-                properties:
-                  accessKeyID:
-                    description: Access Key ID to authenticate against Alibaba.
-                    type: string
-                  accessKeySecret:
-                    description: Access Key Secret to authenticate against Alibaba.
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                required:
-                - accessKeyID
-                - accessKeySecret
-                type: object
-              anexia:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  token:
-                    description: Token is used to authenticate with the Anexia API.
-                    type: string
-                required:
-                - token
-                type: object
-              aws:
-                properties:
-                  accessKeyID:
-                    description: Access Key ID to authenticate against AWS.
-                    type: string
-                  assumeRoleARN:
-                    type: string
-                  assumeRoleExternalID:
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  instanceProfileName:
-                    description: Instance profile to use. This can be configured,
-                      but if left empty will be automatically filled in during reconciliation.
-                    type: string
-                  roleARN:
-                    description: ARN to use. This can be configured, but if left empty
-                      will be automatically filled in during reconciliation.
-                    type: string
-                  routeTableID:
-                    description: Route table to use. This can be configured, but if
-                      left empty will be automatically filled in during reconciliation.
-                    type: string
-                  secretAccessKey:
-                    description: Secret Access Key to authenticate against AWS.
-                    type: string
-                  securityGroupID:
-                    description: Security group to use. This can be configured, but
-                      if left empty will be automatically filled in during reconciliation.
-                    type: string
-                  vpcID:
-                    description: AWS VPC to use. Must be configured.
-                    type: string
-                required:
-                - accessKeyID
-                - secretAccessKey
-                type: object
-              azure:
-                properties:
-                  clientID:
-                    type: string
-                  clientSecret:
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  loadBalancerSKU:
-                    description: LoadBalancerSKU sets the LB type that will be used
-                      for the Azure cluster, possible values are "basic" and "standard",
-                      if empty, "basic" will be used
-                    enum:
-                    - standard
-                    - basic
-                    type: string
-                  resourceGroup:
-                    type: string
-                  routeTable:
-                    type: string
-                  securityGroup:
-                    type: string
-                  subnet:
-                    type: string
-                  subscriptionID:
-                    type: string
-                  tenantID:
-                    type: string
-                  vnet:
-                    type: string
-                  vnetResourceGroup:
-                    type: string
-                required:
-                - clientID
-                - clientSecret
-                - loadBalancerSKU
-                - subscriptionID
-                - tenantID
-                type: object
-              digitalocean:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  token:
-                    description: Token is used to authenticate with the DigitalOcean
-                      API.
-                    type: string
-                required:
-                - token
-                type: object
-              eks:
-                properties:
-                  accessKeyID:
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  region:
-                    type: string
-                  secretAccessKey:
-                    type: string
-                required:
-                - accessKeyID
-                - region
-                - secretAccessKey
-                type: object
-              enabled:
-                description: Only enabled presets will be available in the KKP dashboard.
-                type: boolean
-              fake:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  token:
-                    type: string
-                required:
-                - token
-                type: object
-              gcp:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  network:
-                    type: string
-                  serviceAccount:
-                    type: string
-                  subnetwork:
-                    type: string
-                required:
-                - serviceAccount
-                type: object
-              gke:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  serviceAccount:
-                    type: string
-                required:
-                - serviceAccount
-                type: object
-              hetzner:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  network:
-                    description: Network is the pre-existing Hetzner network in which
-                      the machines are running. While machines can be in multiple
-                      networks, a single one must be chosen for the HCloud CCM to
-                      work. If this is empty, the network configured on the datacenter
-                      will be used.
-                    type: string
-                  token:
-                    description: Token is used to authenticate with the Hetzner API.
-                    type: string
-                required:
-                - token
-                type: object
-              kubevirt:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  kubeconfig:
-                    type: string
-                required:
-                - kubeconfig
-                type: object
-              nutanix:
-                properties:
-                  clusterName:
-                    description: ClusterName is the Nutanix cluster to deploy resources
-                      and nodes to.
-                    type: string
-                  csiEndpoint:
-                    description: CSIEndpoint to access Nutanix Prism Element for csi
-                      driver
-                    type: string
-                  csiPassword:
-                    description: Prism Element Password for csi driver
-                    type: string
-                  csiPort:
-                    description: CSIPort to use when connecting to the Nutanix Prism
-                      Element endpoint (defaults to 9440)
-                    format: int32
-                    type: integer
-                  csiUsername:
-                    description: Prism Element Username for csi driver
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  password:
-                    description: Password is the password corresponding to the provided
-                      user.
-                    type: string
-                  projectName:
-                    description: ProjectName is the optional Nutanix project to use.
-                      If none is given, no project will be used.
-                    type: string
-                  proxyURL:
-                    description: ProxyURL is used to optionally configure a HTTP proxy
-                      to access Nutanix Prism Central.
-                    type: string
-                  username:
-                    description: Username is the username to access the Nutanix Prism
-                      Central API.
-                    type: string
-                required:
-                - clusterName
-                - password
-                - username
-                type: object
-              openstack:
-                properties:
-                  applicationCredentialID:
-                    type: string
-                  applicationCredentialSecret:
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  domain:
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  floatingIPPool:
-                    type: string
-                  network:
-                    type: string
-                  password:
-                    type: string
-                  project:
-                    type: string
-                  projectID:
-                    type: string
-                  routerID:
-                    type: string
-                  securityGroups:
-                    type: string
-                  subnetID:
-                    type: string
-                  useToken:
-                    type: boolean
-                  username:
-                    type: string
-                required:
-                - domain
-                type: object
-              packet:
-                properties:
-                  apiKey:
-                    type: string
-                  billingCycle:
-                    type: string
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  projectID:
-                    type: string
-                required:
-                - apiKey
-                - projectID
-                type: object
-              requiredEmails:
-                description: RequiredEmails is a list of e-mail addresses that this
-                  presets should be restricted to. Each item in the list can be either
-                  a full e-mail address or just a domain name. This restriction is
-                  only enforced in the KKP API.
-                items:
-                  type: string
-                type: array
-              vmwareclouddirector:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  organization:
-                    type: string
-                  ovdcNetwork:
-                    type: string
-                  password:
-                    type: string
-                  username:
-                    type: string
-                  vdc:
-                    type: string
-                required:
-                - organization
-                - ovdcNetwork
-                - password
-                - username
-                - vdc
-                type: object
-              vsphere:
-                properties:
-                  datacenter:
-                    description: If datacenter is set, this preset is only applicable
-                      to the configured datacenter.
-                    type: string
-                  datastore:
-                    type: string
-                  datastoreCluster:
-                    type: string
-                  enabled:
-                    description: Only enabled presets will be available in the KKP
-                      dashboard.
-                    type: boolean
-                  password:
-                    type: string
-                  resourcePool:
-                    type: string
-                  username:
-                    type: string
-                  vmNetName:
-                    type: string
-                required:
-                - password
-                - username
-                type: object
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: Presets are preconfigured cloud provider credentials that can be applied to new clusters. This frees end users from having to know the actual credentials used for their clusters.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Presets specifies default presets for supported providers.
+              properties:
+                aks:
+                  properties:
+                    clientID:
+                      type: string
+                    clientSecret:
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    subscriptionID:
+                      type: string
+                    tenantID:
+                      type: string
+                  required:
+                    - clientID
+                    - clientSecret
+                    - subscriptionID
+                    - tenantID
+                  type: object
+                alibaba:
+                  properties:
+                    accessKeyID:
+                      description: Access Key ID to authenticate against Alibaba.
+                      type: string
+                    accessKeySecret:
+                      description: Access Key Secret to authenticate against Alibaba.
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                  required:
+                    - accessKeyID
+                    - accessKeySecret
+                  type: object
+                anexia:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    token:
+                      description: Token is used to authenticate with the Anexia API.
+                      type: string
+                  required:
+                    - token
+                  type: object
+                aws:
+                  properties:
+                    accessKeyID:
+                      description: Access Key ID to authenticate against AWS.
+                      type: string
+                    assumeRoleARN:
+                      type: string
+                    assumeRoleExternalID:
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    instanceProfileName:
+                      description: Instance profile to use. This can be configured, but if left empty will be automatically filled in during reconciliation.
+                      type: string
+                    roleARN:
+                      description: ARN to use. This can be configured, but if left empty will be automatically filled in during reconciliation.
+                      type: string
+                    routeTableID:
+                      description: Route table to use. This can be configured, but if left empty will be automatically filled in during reconciliation.
+                      type: string
+                    secretAccessKey:
+                      description: Secret Access Key to authenticate against AWS.
+                      type: string
+                    securityGroupID:
+                      description: Security group to use. This can be configured, but if left empty will be automatically filled in during reconciliation.
+                      type: string
+                    vpcID:
+                      description: AWS VPC to use. Must be configured.
+                      type: string
+                  required:
+                    - accessKeyID
+                    - secretAccessKey
+                  type: object
+                azure:
+                  properties:
+                    clientID:
+                      type: string
+                    clientSecret:
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    loadBalancerSKU:
+                      description: LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used
+                      enum:
+                        - standard
+                        - basic
+                      type: string
+                    resourceGroup:
+                      type: string
+                    routeTable:
+                      type: string
+                    securityGroup:
+                      type: string
+                    subnet:
+                      type: string
+                    subscriptionID:
+                      type: string
+                    tenantID:
+                      type: string
+                    vnet:
+                      type: string
+                    vnetResourceGroup:
+                      type: string
+                  required:
+                    - clientID
+                    - clientSecret
+                    - loadBalancerSKU
+                    - subscriptionID
+                    - tenantID
+                  type: object
+                digitalocean:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    token:
+                      description: Token is used to authenticate with the DigitalOcean API.
+                      type: string
+                  required:
+                    - token
+                  type: object
+                eks:
+                  properties:
+                    accessKeyID:
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    region:
+                      type: string
+                    secretAccessKey:
+                      type: string
+                  required:
+                    - accessKeyID
+                    - region
+                    - secretAccessKey
+                  type: object
+                enabled:
+                  description: Only enabled presets will be available in the KKP dashboard.
+                  type: boolean
+                fake:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    token:
+                      type: string
+                  required:
+                    - token
+                  type: object
+                gcp:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    network:
+                      type: string
+                    serviceAccount:
+                      type: string
+                    subnetwork:
+                      type: string
+                  required:
+                    - serviceAccount
+                  type: object
+                gke:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    serviceAccount:
+                      type: string
+                  required:
+                    - serviceAccount
+                  type: object
+                hetzner:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    network:
+                      description: Network is the pre-existing Hetzner network in which the machines are running. While machines can be in multiple networks, a single one must be chosen for the HCloud CCM to work. If this is empty, the network configured on the datacenter will be used.
+                      type: string
+                    token:
+                      description: Token is used to authenticate with the Hetzner API.
+                      type: string
+                  required:
+                    - token
+                  type: object
+                kubevirt:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    kubeconfig:
+                      type: string
+                  required:
+                    - kubeconfig
+                  type: object
+                nutanix:
+                  properties:
+                    clusterName:
+                      description: ClusterName is the Nutanix cluster to deploy resources and nodes to.
+                      type: string
+                    csiEndpoint:
+                      description: CSIEndpoint to access Nutanix Prism Element for csi driver
+                      type: string
+                    csiPassword:
+                      description: Prism Element Password for csi driver
+                      type: string
+                    csiPort:
+                      description: CSIPort to use when connecting to the Nutanix Prism Element endpoint (defaults to 9440)
+                      format: int32
+                      type: integer
+                    csiUsername:
+                      description: Prism Element Username for csi driver
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    password:
+                      description: Password is the password corresponding to the provided user.
+                      type: string
+                    projectName:
+                      description: ProjectName is the optional Nutanix project to use. If none is given, no project will be used.
+                      type: string
+                    proxyURL:
+                      description: ProxyURL is used to optionally configure a HTTP proxy to access Nutanix Prism Central.
+                      type: string
+                    username:
+                      description: Username is the username to access the Nutanix Prism Central API.
+                      type: string
+                  required:
+                    - clusterName
+                    - password
+                    - username
+                  type: object
+                openstack:
+                  properties:
+                    applicationCredentialID:
+                      type: string
+                    applicationCredentialSecret:
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    domain:
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    floatingIPPool:
+                      type: string
+                    network:
+                      type: string
+                    password:
+                      type: string
+                    project:
+                      type: string
+                    projectID:
+                      type: string
+                    routerID:
+                      type: string
+                    securityGroups:
+                      type: string
+                    subnetID:
+                      type: string
+                    useToken:
+                      type: boolean
+                    username:
+                      type: string
+                  required:
+                    - domain
+                  type: object
+                packet:
+                  properties:
+                    apiKey:
+                      type: string
+                    billingCycle:
+                      type: string
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    projectID:
+                      type: string
+                  required:
+                    - apiKey
+                    - projectID
+                  type: object
+                requiredEmails:
+                  description: RequiredEmails is a list of e-mail addresses that this presets should be restricted to. Each item in the list can be either a full e-mail address or just a domain name. This restriction is only enforced in the KKP API.
+                  items:
+                    type: string
+                  type: array
+                vmwareclouddirector:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    organization:
+                      type: string
+                    ovdcNetwork:
+                      type: string
+                    password:
+                      type: string
+                    username:
+                      type: string
+                    vdc:
+                      type: string
+                  required:
+                    - organization
+                    - ovdcNetwork
+                    - password
+                    - username
+                    - vdc
+                  type: object
+                vsphere:
+                  properties:
+                    datacenter:
+                      description: If datacenter is set, this preset is only applicable to the configured datacenter.
+                      type: string
+                    datastore:
+                      type: string
+                    datastoreCluster:
+                      type: string
+                    enabled:
+                      description: Only enabled presets will be available in the KKP dashboard.
+                      type: boolean
+                    password:
+                      type: string
+                    resourcePool:
+                      type: string
+                    username:
+                      type: string
+                    vmNetName:
+                      type: string
+                  required:
+                    - password
+                    - username
+                  type: object
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_projects.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_projects.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: projects.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,61 +17,53 @@ spec:
     singular: project
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.name
-      name: HumanReadableName
-      type: string
-    - jsonPath: .status.phase
-      name: Status
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Project is the type describing a project. A project is a collection
-          of SSH keys, clusters and members. Members are assigned by creating UserProjectBinding
-          objects.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ProjectSpec is a specification of a project.
-            properties:
-              name:
-                description: Name is the human-readable name given to the project.
-                type: string
-            required:
-            - name
-            type: object
-          status:
-            description: ProjectStatus represents the current status of a project.
-            properties:
-              phase:
-                description: Phase describes the project phase. New projects are in
-                  the `Inactive` phase; after being reconciled they move to `Active`
-                  and during deletion they are `Terminating`.
-                enum:
-                - Active
-                - Inactive
-                - Terminating
-                type: string
-            required:
-            - phase
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.name
+          name: HumanReadableName
+          type: string
+        - jsonPath: .status.phase
+          name: Status
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Project is the type describing a project. A project is a collection of SSH keys, clusters and members. Members are assigned by creating UserProjectBinding objects.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ProjectSpec is a specification of a project.
+              properties:
+                name:
+                  description: Name is the human-readable name given to the project.
+                  type: string
+              required:
+                - name
+              type: object
+            status:
+              description: ProjectStatus represents the current status of a project.
+              properties:
+                phase:
+                  description: Phase describes the project phase. New projects are in the `Inactive` phase; after being reconciled they move to `Active` and during deletion they are `Terminating`.
+                  enum:
+                    - Active
+                    - Inactive
+                    - Terminating
+                  type: string
+              required:
+                - phase
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_projects.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_projects.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: projects.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: resourcequotas.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,153 +17,133 @@ spec:
     singular: resourcequota
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    - jsonPath: .spec.subject.name
-      name: Subject Name
-      type: string
-    - jsonPath: .spec.subject.kind
-      name: Subject Kind
-      type: string
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: ResourceQuota specifies the amount of cluster resources a project
-          can use.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: ResourceQuotaSpec describes the desired state of a resource
-              quota.
-            properties:
-              quota:
-                description: Quota specifies the current maximum allowed usage of
-                  resources.
-                properties:
-                  cpu:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: CPU holds the quantity of CPU. For the format, please
-                      check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  memory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Memory represents the quantity of RAM size. For the
-                      format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storage:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Storage represents the disk size. For the format,
-                      please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-              subject:
-                description: Subject specifies to which entity the quota applies to.
-                properties:
-                  kind:
-                    default: project
-                    description: Kind of the quota subject. For now the only possible
-                      kind is project.
-                    enum:
-                    - project
-                    type: string
-                  name:
-                    description: Name of the quota subject.
-                    type: string
-                required:
-                - kind
-                - name
-                type: object
-            required:
-            - quota
-            - subject
-            type: object
-          status:
-            description: ResourceQuotaStatus describes the current state of a resource
-              quota.
-            properties:
-              globalUsage:
-                description: GlobalUsage is holds the current usage of resources for
-                  all seeds.
-                properties:
-                  cpu:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: CPU holds the quantity of CPU. For the format, please
-                      check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  memory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Memory represents the quantity of RAM size. For the
-                      format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storage:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Storage represents the disk size. For the format,
-                      please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-              localUsage:
-                description: LocalUsage is holds the current usage of resources for
-                  the local seed.
-                properties:
-                  cpu:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: CPU holds the quantity of CPU. For the format, please
-                      check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  memory:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Memory represents the quantity of RAM size. For the
-                      format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                  storage:
-                    anyOf:
-                    - type: integer
-                    - type: string
-                    description: Storage represents the disk size. For the format,
-                      please check k8s.io/apimachinery/pkg/api/resource.Quantity.
-                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                    x-kubernetes-int-or-string: true
-                type: object
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        - jsonPath: .spec.subject.name
+          name: Subject Name
+          type: string
+        - jsonPath: .spec.subject.kind
+          name: Subject Kind
+          type: string
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: ResourceQuota specifies the amount of cluster resources a project can use.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: ResourceQuotaSpec describes the desired state of a resource quota.
+              properties:
+                quota:
+                  description: Quota specifies the current maximum allowed usage of resources.
+                  properties:
+                    cpu:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: CPU holds the quantity of CPU. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    memory:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Memory represents the quantity of RAM size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storage:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Storage represents the disk size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                subject:
+                  description: Subject specifies to which entity the quota applies to.
+                  properties:
+                    kind:
+                      default: project
+                      description: Kind of the quota subject. For now the only possible kind is project.
+                      enum:
+                        - project
+                      type: string
+                    name:
+                      description: Name of the quota subject.
+                      type: string
+                  required:
+                    - kind
+                    - name
+                  type: object
+              required:
+                - quota
+                - subject
+              type: object
+            status:
+              description: ResourceQuotaStatus describes the current state of a resource quota.
+              properties:
+                globalUsage:
+                  description: GlobalUsage is holds the current usage of resources for all seeds.
+                  properties:
+                    cpu:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: CPU holds the quantity of CPU. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    memory:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Memory represents the quantity of RAM size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storage:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Storage represents the disk size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+                localUsage:
+                  description: LocalUsage is holds the current usage of resources for the local seed.
+                  properties:
+                    cpu:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: CPU holds the quantity of CPU. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    memory:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Memory represents the quantity of RAM size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    storage:
+                      anyOf:
+                        - type: integer
+                        - type: string
+                      description: Storage represents the disk size. For the format, please check k8s.io/apimachinery/pkg/api/resource.Quantity.
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                  type: object
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_resourcequotas.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: resourcequotas.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: rulegroups.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,86 +17,69 @@ spec:
     singular: rulegroup
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              cluster:
-                description: Cluster is the reference to the cluster the ruleGroup
-                  should be created in. All fields except for the name are ignored.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              data:
-                description: 'Data contains the RuleGroup data. Ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group'
-                format: byte
-                type: string
-              isDefault:
-                description: IsDefault indicates whether the ruleGroup is default
-                type: boolean
-              ruleGroupType:
-                description: RuleGroupType is the type of this ruleGroup applies to.
-                  It can be `Metrics` or `Logs`.
-                enum:
-                - Metrics
-                - Logs
-                type: string
-            required:
-            - cluster
-            - data
-            - ruleGroupType
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                cluster:
+                  description: Cluster is the reference to the cluster the ruleGroup should be created in. All fields except for the name are ignored.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                data:
+                  description: 'Data contains the RuleGroup data. Ref: https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/#rule_group'
+                  format: byte
+                  type: string
+                isDefault:
+                  description: IsDefault indicates whether the ruleGroup is default
+                  type: boolean
+                ruleGroupType:
+                  description: RuleGroupType is the type of this ruleGroup applies to. It can be `Metrics` or `Logs`.
+                  enum:
+                    - Metrics
+                    - Logs
+                  type: string
+              required:
+                - cluster
+                - data
+                - ruleGroupType
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: rulegroups.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: seeds.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: seeds.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,1452 +17,1074 @@ spec:
     singular: seed
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.clusters
-      name: Clusters
-      type: integer
-    - jsonPath: .spec.location
-      name: Location
-      type: string
-    - jsonPath: .status.versions.kubermatic
-      name: KKP Version
-      type: string
-    - jsonPath: .status.versions.cluster
-      name: Cluster Version
-      type: string
-    - jsonPath: .status.phase
-      name: Phase
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: Seed is the type representing a Seed cluster. Seed clusters host
-          the the control planes for KKP user clusters.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: The spec for a seed cluster.
-            properties:
-              country:
-                description: 'Optional: Country of the seed as ISO-3166 two-letter
-                  code, e.g. DE or UK. For informational purposes in the Kubermatic
-                  dashboard only.'
-                type: string
-              datacenters:
-                additionalProperties:
-                  properties:
-                    country:
-                      description: 'Optional: Country of the seed as ISO-3166 two-letter
-                        code, e.g. DE or UK. For informational purposes in the Kubermatic
-                        dashboard only.'
-                      type: string
-                    location:
-                      description: 'Optional: Detailed location of the cluster, like
-                        "Hamburg" or "Datacenter 7". For informational purposes in
-                        the Kubermatic dashboard only.'
-                      type: string
-                    node:
-                      description: Node holds node-specific settings, like e.g. HTTP
-                        proxy, Docker registries and the like. Proxy settings are
-                        inherited from the seed if not specified here.
-                      properties:
-                        containerdRegistryMirrors:
-                          description: 'Optional: ContainerdRegistryMirrors configure
-                            registry mirrors endpoints. Can be used multiple times
-                            to specify multiple mirrors.'
-                          properties:
-                            registries:
-                              additionalProperties:
-                                description: ContainerdRegistry defines endpoints
-                                  and security for given container registry.
+    - additionalPrinterColumns:
+        - jsonPath: .status.clusters
+          name: Clusters
+          type: integer
+        - jsonPath: .spec.location
+          name: Location
+          type: string
+        - jsonPath: .status.versions.kubermatic
+          name: KKP Version
+          type: string
+        - jsonPath: .status.versions.cluster
+          name: Cluster Version
+          type: string
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: Seed is the type representing a Seed cluster. Seed clusters host the the control planes for KKP user clusters.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: The spec for a seed cluster.
+              properties:
+                country:
+                  description: 'Optional: Country of the seed as ISO-3166 two-letter code, e.g. DE or UK. For informational purposes in the Kubermatic dashboard only.'
+                  type: string
+                datacenters:
+                  additionalProperties:
+                    properties:
+                      country:
+                        description: 'Optional: Country of the seed as ISO-3166 two-letter code, e.g. DE or UK. For informational purposes in the Kubermatic dashboard only.'
+                        type: string
+                      location:
+                        description: 'Optional: Detailed location of the cluster, like "Hamburg" or "Datacenter 7". For informational purposes in the Kubermatic dashboard only.'
+                        type: string
+                      node:
+                        description: Node holds node-specific settings, like e.g. HTTP proxy, Docker registries and the like. Proxy settings are inherited from the seed if not specified here.
+                        properties:
+                          containerdRegistryMirrors:
+                            description: 'Optional: ContainerdRegistryMirrors configure registry mirrors endpoints. Can be used multiple times to specify multiple mirrors.'
+                            properties:
+                              registries:
+                                additionalProperties:
+                                  description: ContainerdRegistry defines endpoints and security for given container registry.
+                                  properties:
+                                    mirrors:
+                                      description: List of registry mirrors to use
+                                      items:
+                                        type: string
+                                      type: array
+                                  type: object
+                                description: A map of registries to use to render configs and mirrors for containerd registries
+                                type: object
+                            type: object
+                          httpProxy:
+                            description: 'Optional: If set, this proxy will be configured for both HTTP and HTTPS.'
+                            type: string
+                          insecureRegistries:
+                            description: 'Optional: These image registries will be configured as insecure on the container runtime.'
+                            items:
+                              type: string
+                            type: array
+                          noProxy:
+                            description: 'Optional: If set this will be set as NO_PROXY environment variable on the node; The value must be a comma-separated list of domains for which no proxy should be used, e.g. "*.example.com,internal.dev". Note that the in-cluster apiserver URL will be automatically prepended to this value.'
+                            type: string
+                          pauseImage:
+                            description: 'Optional: Translates to --pod-infra-container-image on the kubelet. If not set, the kubelet will default it.'
+                            type: string
+                          registryMirrors:
+                            description: 'Optional: These image registries will be configured as registry mirrors on the container runtime.'
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      spec:
+                        description: Spec describes the cloud provider settings used to manage resources in this datacenter. Exactly one cloud provider must be defined.
+                        properties:
+                          alibaba:
+                            description: DatacenterSpecAlibaba describes a alibaba datacenter.
+                            properties:
+                              region:
+                                description: Region to use, for a full list of regions see https://www.alibabacloud.com/help/doc-detail/40654.htm
+                                type: string
+                            required:
+                              - region
+                            type: object
+                          anexia:
+                            description: DatacenterSpecAnexia describes a anexia datacenter.
+                            properties:
+                              locationID:
+                                description: LocationID the location of the region
+                                type: string
+                            required:
+                              - locationID
+                            type: object
+                          aws:
+                            description: DatacenterSpecAWS describes an AWS datacenter.
+                            properties:
+                              images:
+                                additionalProperties:
+                                  type: string
+                                description: List of AMIs to use for a given operating system. This gets defaulted by querying for the latest AMI for the given distribution when machines are created, so under normal circumstances it is not necessary to define the AMIs statically.
+                                type: object
+                              region:
+                                description: The AWS region to use, e.g. "us-east-1". For a list of available regions, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
+                                type: string
+                            required:
+                              - region
+                            type: object
+                          azure:
+                            description: DatacenterSpecAzure describes an Azure cloud datacenter.
+                            properties:
+                              location:
+                                description: Region to use, for example "westeurope". A list of available regions can be found at https://azure.microsoft.com/en-us/global-infrastructure/locations/
+                                type: string
+                            required:
+                              - location
+                            type: object
+                          bringyourown:
+                            description: BringYourOwn contains settings for clusters using manually created nodes via kubeadm.
+                            type: object
+                          digitalocean:
+                            description: DatacenterSpecDigitalocean describes a DigitalOcean datacenter.
+                            properties:
+                              region:
+                                description: Datacenter location, e.g. "ams3". A list of existing datacenters can be found at https://www.digitalocean.com/docs/platform/availability-matrix/
+                                type: string
+                            required:
+                              - region
+                            type: object
+                          enforceAuditLogging:
+                            description: EnforceAuditLogging enforces audit logging on every cluster within the DC, ignoring cluster-specific settings.
+                            type: boolean
+                          enforcePodSecurityPolicy:
+                            description: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC, ignoring cluster-specific settings
+                            type: boolean
+                          fake:
+                            description: DatacenterSpecFake describes a fake datacenter.
+                            properties:
+                              fakeProperty:
+                                type: string
+                            type: object
+                          gcp:
+                            description: DatacenterSpecGCP describes a GCP datacenter.
+                            properties:
+                              region:
+                                description: Region to use, for example "europe-west3", for a full list of regions see https://cloud.google.com/compute/docs/regions-zones/
+                                type: string
+                              regional:
+                                description: 'Optional: Regional clusters spread their resources across multiple availability zones. Refer to the official documentation for more details on this: https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters'
+                                type: boolean
+                              zoneSuffixes:
+                                description: List of enabled zones, for example [a, c]. See the link above for the available zones in your chosen region.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - region
+                              - zoneSuffixes
+                            type: object
+                          hetzner:
+                            description: DatacenterSpecHetzner describes a Hetzner cloud datacenter.
+                            properties:
+                              datacenter:
+                                description: Datacenter location, e.g. "nbg1-dc3". A list of existing datacenters can be found at https://docs.hetzner.com/general/others/data-centers-and-connection/
+                                type: string
+                              location:
+                                description: 'Optional: Detailed location of the datacenter, like "Hamburg" or "Datacenter 7". For informational purposes only.'
+                                type: string
+                              network:
+                                description: Network is the pre-existing Hetzner network in which the machines are running. While machines can be in multiple networks, a single one must be chosen for the HCloud CCM to work.
+                                type: string
+                            required:
+                              - datacenter
+                              - network
+                            type: object
+                          kubevirt:
+                            description: DatacenterSpecKubevirt describes a kubevirt datacenter.
+                            properties:
+                              dnsConfig:
+                                description: DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                                 properties:
-                                  mirrors:
-                                    description: List of registry mirrors to use
+                                  nameservers:
+                                    description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
+                                    items:
+                                      type: string
+                                    type: array
+                                  options:
+                                    description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
+                                    items:
+                                      description: PodDNSConfigOption defines DNS resolver options of a pod.
+                                      properties:
+                                        name:
+                                          description: Required.
+                                          type: string
+                                        value:
+                                          type: string
+                                      type: object
+                                    type: array
+                                  searches:
+                                    description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                     items:
                                       type: string
                                     type: array
                                 type: object
-                              description: A map of registries to use to render configs
-                                and mirrors for containerd registries
+                              dnsPolicy:
+                                default: ClusterFirst
+                                description: DNSPolicy represents the dns policy for the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy.
+                                enum:
+                                  - ClusterFirstWithHostNet
+                                  - ClusterFirst
+                                  - Default
+                                  - None
+                                type: string
+                            type: object
+                          nutanix:
+                            description: Nutanix is experimental and unsupported
+                            properties:
+                              allowInsecure:
+                                description: 'Optional: AllowInsecure allows to disable the TLS certificate check against the endpoint (defaults to false)'
+                                type: boolean
+                              endpoint:
+                                description: Endpoint to use for accessing Nutanix Prism Central. No protocol or port should be passed, for example "nutanix.example.com" or "10.0.0.1"
+                                type: string
+                              images:
+                                additionalProperties:
+                                  type: string
+                                description: Images to use for each supported operating system
+                                type: object
+                              port:
+                                description: 'Optional: Port to use when connecting to the Nutanix Prism Central endpoint (defaults to 9440)'
+                                format: int32
+                                type: integer
+                            required:
+                              - endpoint
+                              - images
+                            type: object
+                          openstack:
+                            description: DatacenterSpecOpenstack describes an OpenStack datacenter.
+                            properties:
+                              authURL:
+                                type: string
+                              availabilityZone:
+                                type: string
+                              dnsServers:
+                                description: Used for automatic network creation
+                                items:
+                                  type: string
+                                type: array
+                              enabledFlavors:
+                                description: 'Optional: List of enabled flavors for the given datacenter'
+                                items:
+                                  type: string
+                                type: array
+                              enforceFloatingIP:
+                                description: Optional
+                                type: boolean
+                              ignoreVolumeAZ:
+                                description: Optional
+                                type: boolean
+                              images:
+                                additionalProperties:
+                                  type: string
+                                description: Images to use for each supported operating system.
+                                type: object
+                              ipv6Enabled:
+                                description: 'Optional: defines if the IPv6 is enabled for the datacenter'
+                                type: boolean
+                              manageSecurityGroups:
+                                description: 'Optional: Gets mapped to the "manage-security-groups" setting in the cloud config. This setting defaults to true.'
+                                type: boolean
+                              nodeSizeRequirements:
+                                properties:
+                                  minimumMemory:
+                                    description: MinimumMemory is the minimum required amount of memory, measured in MB
+                                    type: integer
+                                  minimumVCPUs:
+                                    description: VCPUs is the minimum required amount of (virtual) CPUs
+                                    type: integer
+                                required:
+                                  - minimumMemory
+                                  - minimumVCPUs
+                                type: object
+                              region:
+                                type: string
+                              trustDevicePath:
+                                description: 'Optional: Gets mapped to the "trust-device-path" setting in the cloud config. This setting defaults to false.'
+                                type: boolean
+                              useOctavia:
+                                description: 'Optional: Gets mapped to the "use-octavia" setting in the cloud config. use-octavia is enabled by default in CCM since v1.17.0, and disabled by default with the in-tree cloud provider.'
+                                type: boolean
+                            required:
+                              - authURL
+                              - availabilityZone
+                              - dnsServers
+                              - images
+                              - nodeSizeRequirements
+                              - region
+                            type: object
+                          packet:
+                            description: DatacenterSpecPacket describes a Packet datacenter.
+                            properties:
+                              facilities:
+                                description: The list of enabled facilities, for example "ams1", for a full list of available facilities see https://metal.equinix.com/developers/docs/locations/facilities/
+                                items:
+                                  type: string
+                                type: array
+                              metro:
+                                description: Metros are facilities that are grouped together geographically and share capacity and networking features, see https://metal.equinix.com/developers/docs/locations/metros/
+                                type: string
+                            type: object
+                          providerReconciliationInterval:
+                            description: ProviderReconciliationInterval is the time that must have passed since a Cluster's status.lastProviderReconciliation to make the cliuster controller perform an in-depth provider reconciliation, where for example missing security groups will be reconciled. Setting this too low can cause rate limits by the cloud provider, setting this too high means that *if* a resource at a cloud provider is removed/changed outside of KKP, it will take this long to fix it.
+                            type: string
+                          requiredEmails:
+                            description: 'Optional: When defined, only users with an e-mail address on the given domains can make use of this datacenter. You can define multiple domains, e.g. "example.com", one of which must match the email domain exactly (i.e. "example.com" will not match "user@test.example.com").'
+                            items:
+                              type: string
+                            type: array
+                          vmwareclouddirector:
+                            properties:
+                              allowInsecure:
+                                description: If set to true, disables the TLS certificate check against the endpoint.
+                                type: boolean
+                              catalog:
+                                description: The default catalog which contains the VM templates.
+                                type: string
+                              storageProfile:
+                                description: The name of the storage profile to use for disks attached to the VMs.
+                                type: string
+                              templates:
+                                additionalProperties:
+                                  type: string
+                                description: A list of VM templates to use for a given operating system. You must define at least one template.
+                                type: object
+                              url:
+                                description: Endpoint URL to use, including protocol, for example "https://vclouddirector.example.com".
+                                type: string
+                            required:
+                              - templates
+                              - url
+                            type: object
+                          vsphere:
+                            description: DatacenterSpecVSphere describes a vSphere datacenter.
+                            properties:
+                              allowInsecure:
+                                description: If set to true, disables the TLS certificate check against the endpoint.
+                                type: boolean
+                              cluster:
+                                description: The name of the vSphere cluster to use. Used for out-of-tree CSI Driver.
+                                type: string
+                              datacenter:
+                                description: The name of the datacenter to use.
+                                type: string
+                              datastore:
+                                description: The default Datastore to be used for provisioning volumes using storage classes/dynamic provisioning and for storing virtual machine files in case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
+                                type: string
+                              endpoint:
+                                description: Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
+                                type: string
+                              infraManagementUser:
+                                description: 'Optional: Infra management user is the user that will be used for everything except the cloud provider functionality, which will still use the credentials passed in via the Kubermatic dashboard/API.'
+                                properties:
+                                  password:
+                                    type: string
+                                  username:
+                                    type: string
+                                type: object
+                              ipv6Enabled:
+                                description: 'Optional: defines if the IPv6 is enabled for the datacenter'
+                                type: boolean
+                              rootPath:
+                                description: 'Optional: The root path for cluster specific VM folders. Each cluster gets its own folder below the root folder. Must be the FQDN (for example "/datacenter-1/vm/all-kubermatic-vms-in-here") and defaults to the root VM folder: "/datacenter-1/vm"'
+                                type: string
+                              storagePolicy:
+                                description: The name of the storage policy to use for the storage class created in the user cluster.
+                                type: string
+                              templates:
+                                additionalProperties:
+                                  type: string
+                                description: 'A list of VM templates to use for a given operating system. You must define at least one template. See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation'
+                                type: object
+                            required:
+                              - cluster
+                              - datacenter
+                              - datastore
+                              - endpoint
+                              - templates
+                            type: object
+                        type: object
+                    required:
+                      - spec
+                    type: object
+                  description: Datacenters contains a map of the possible datacenters (DCs) in this seed. Each DC must have a globally unique identifier (i.e. names must be unique across all seeds).
+                  type: object
+                defaultClusterTemplate:
+                  description: DefaultClusterTemplate is the name of a cluster template of scope "seed" that is used to default all new created clusters
+                  type: string
+                defaultComponentSettings:
+                  description: 'DefaultComponentSettings are default values to set for newly created clusters. Deprecated: Use DefaultClusterTemplate instead.'
+                  properties:
+                    apiserver:
+                      description: Apiserver configures kube-apiserver settings.
+                      properties:
+                        endpointReconcilingDisabled:
+                          type: boolean
+                        nodePortRange:
+                          type: string
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
                           type: object
-                        httpProxy:
-                          description: 'Optional: If set, this proxy will be configured
-                            for both HTTP and HTTPS.'
-                          type: string
-                        insecureRegistries:
-                          description: 'Optional: These image registries will be configured
-                            as insecure on the container runtime.'
+                        tolerations:
                           items:
-                            type: string
-                          type: array
-                        noProxy:
-                          description: 'Optional: If set this will be set as NO_PROXY
-                            environment variable on the node; The value must be a
-                            comma-separated list of domains for which no proxy should
-                            be used, e.g. "*.example.com,internal.dev". Note that
-                            the in-cluster apiserver URL will be automatically prepended
-                            to this value.'
-                          type: string
-                        pauseImage:
-                          description: 'Optional: Translates to --pod-infra-container-image
-                            on the kubelet. If not set, the kubelet will default it.'
-                          type: string
-                        registryMirrors:
-                          description: 'Optional: These image registries will be configured
-                            as registry mirrors on the container runtime.'
-                          items:
-                            type: string
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
                           type: array
                       type: object
-                    spec:
-                      description: Spec describes the cloud provider settings used
-                        to manage resources in this datacenter. Exactly one cloud
-                        provider must be defined.
+                    controllerManager:
+                      description: ControllerManager configures kube-controller-manager settings.
                       properties:
-                        alibaba:
-                          description: DatacenterSpecAlibaba describes a alibaba datacenter.
+                        leaderElection:
                           properties:
-                            region:
-                              description: Region to use, for a full list of regions
-                                see https://www.alibabacloud.com/help/doc-detail/40654.htm
-                              type: string
-                          required:
-                          - region
-                          type: object
-                        anexia:
-                          description: DatacenterSpecAnexia describes a anexia datacenter.
-                          properties:
-                            locationID:
-                              description: LocationID the location of the region
-                              type: string
-                          required:
-                          - locationID
-                          type: object
-                        aws:
-                          description: DatacenterSpecAWS describes an AWS datacenter.
-                          properties:
-                            images:
-                              additionalProperties:
-                                type: string
-                              description: List of AMIs to use for a given operating
-                                system. This gets defaulted by querying for the latest
-                                AMI for the given distribution when machines are created,
-                                so under normal circumstances it is not necessary
-                                to define the AMIs statically.
-                              type: object
-                            region:
-                              description: The AWS region to use, e.g. "us-east-1".
-                                For a list of available regions, see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
-                              type: string
-                          required:
-                          - region
-                          type: object
-                        azure:
-                          description: DatacenterSpecAzure describes an Azure cloud
-                            datacenter.
-                          properties:
-                            location:
-                              description: Region to use, for example "westeurope".
-                                A list of available regions can be found at https://azure.microsoft.com/en-us/global-infrastructure/locations/
-                              type: string
-                          required:
-                          - location
-                          type: object
-                        bringyourown:
-                          description: BringYourOwn contains settings for clusters
-                            using manually created nodes via kubeadm.
-                          type: object
-                        digitalocean:
-                          description: DatacenterSpecDigitalocean describes a DigitalOcean
-                            datacenter.
-                          properties:
-                            region:
-                              description: Datacenter location, e.g. "ams3". A list
-                                of existing datacenters can be found at https://www.digitalocean.com/docs/platform/availability-matrix/
-                              type: string
-                          required:
-                          - region
-                          type: object
-                        enforceAuditLogging:
-                          description: EnforceAuditLogging enforces audit logging
-                            on every cluster within the DC, ignoring cluster-specific
-                            settings.
-                          type: boolean
-                        enforcePodSecurityPolicy:
-                          description: EnforcePodSecurityPolicy enforces pod security
-                            policy plugin on every clusters within the DC, ignoring
-                            cluster-specific settings
-                          type: boolean
-                        fake:
-                          description: DatacenterSpecFake describes a fake datacenter.
-                          properties:
-                            fakeProperty:
-                              type: string
-                          type: object
-                        gcp:
-                          description: DatacenterSpecGCP describes a GCP datacenter.
-                          properties:
-                            region:
-                              description: Region to use, for example "europe-west3",
-                                for a full list of regions see https://cloud.google.com/compute/docs/regions-zones/
-                              type: string
-                            regional:
-                              description: 'Optional: Regional clusters spread their
-                                resources across multiple availability zones. Refer
-                                to the official documentation for more details on
-                                this: https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters'
-                              type: boolean
-                            zoneSuffixes:
-                              description: List of enabled zones, for example [a,
-                                c]. See the link above for the available zones in
-                                your chosen region.
-                              items:
-                                type: string
-                              type: array
-                          required:
-                          - region
-                          - zoneSuffixes
-                          type: object
-                        hetzner:
-                          description: DatacenterSpecHetzner describes a Hetzner cloud
-                            datacenter.
-                          properties:
-                            datacenter:
-                              description: Datacenter location, e.g. "nbg1-dc3". A
-                                list of existing datacenters can be found at https://docs.hetzner.com/general/others/data-centers-and-connection/
-                              type: string
-                            location:
-                              description: 'Optional: Detailed location of the datacenter,
-                                like "Hamburg" or "Datacenter 7". For informational
-                                purposes only.'
-                              type: string
-                            network:
-                              description: Network is the pre-existing Hetzner network
-                                in which the machines are running. While machines
-                                can be in multiple networks, a single one must be
-                                chosen for the HCloud CCM to work.
-                              type: string
-                          required:
-                          - datacenter
-                          - network
-                          type: object
-                        kubevirt:
-                          description: DatacenterSpecKubevirt describes a kubevirt
-                            datacenter.
-                          properties:
-                            dnsConfig:
-                              description: DNSConfig represents the DNS parameters
-                                of a pod. Parameters specified here will be merged
-                                to the generated DNS configuration based on DNSPolicy.
-                              properties:
-                                nameservers:
-                                  description: A list of DNS name server IP addresses.
-                                    This will be appended to the base nameservers
-                                    generated from DNSPolicy. Duplicated nameservers
-                                    will be removed.
-                                  items:
-                                    type: string
-                                  type: array
-                                options:
-                                  description: A list of DNS resolver options. This
-                                    will be merged with the base options generated
-                                    from DNSPolicy. Duplicated entries will be removed.
-                                    Resolution options given in Options will override
-                                    those that appear in the base DNSPolicy.
-                                  items:
-                                    description: PodDNSConfigOption defines DNS resolver
-                                      options of a pod.
-                                    properties:
-                                      name:
-                                        description: Required.
-                                        type: string
-                                      value:
-                                        type: string
-                                    type: object
-                                  type: array
-                                searches:
-                                  description: A list of DNS search domains for host-name
-                                    lookup. This will be appended to the base search
-                                    paths generated from DNSPolicy. Duplicated search
-                                    paths will be removed.
-                                  items:
-                                    type: string
-                                  type: array
-                              type: object
-                            dnsPolicy:
-                              default: ClusterFirst
-                              description: DNSPolicy represents the dns policy for
-                                the pod. Valid values are 'ClusterFirstWithHostNet',
-                                'ClusterFirst', 'Default' or 'None'. Defaults to "ClusterFirst".
-                                DNS parameters given in DNSConfig will be merged with
-                                the policy selected with DNSPolicy.
-                              enum:
-                              - ClusterFirstWithHostNet
-                              - ClusterFirst
-                              - Default
-                              - None
-                              type: string
-                          type: object
-                        nutanix:
-                          description: Nutanix is experimental and unsupported
-                          properties:
-                            allowInsecure:
-                              description: 'Optional: AllowInsecure allows to disable
-                                the TLS certificate check against the endpoint (defaults
-                                to false)'
-                              type: boolean
-                            endpoint:
-                              description: Endpoint to use for accessing Nutanix Prism
-                                Central. No protocol or port should be passed, for
-                                example "nutanix.example.com" or "10.0.0.1"
-                              type: string
-                            images:
-                              additionalProperties:
-                                type: string
-                              description: Images to use for each supported operating
-                                system
-                              type: object
-                            port:
-                              description: 'Optional: Port to use when connecting
-                                to the Nutanix Prism Central endpoint (defaults to
-                                9440)'
+                            leaseDurationSeconds:
+                              description: LeaseDurationSeconds is the duration in seconds that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack.
                               format: int32
                               type: integer
-                          required:
-                          - endpoint
-                          - images
+                            renewDeadlineSeconds:
+                              description: RenewDeadlineSeconds is the duration in seconds that the acting controlplane will retry refreshing leadership before giving up.
+                              format: int32
+                              type: integer
+                            retryPeriodSeconds:
+                              description: RetryPeriodSeconds is the duration in seconds the LeaderElector clients should wait between tries of actions.
+                              format: int32
+                              type: integer
                           type: object
-                        openstack:
-                          description: DatacenterSpecOpenstack describes an OpenStack
-                            datacenter.
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
                           properties:
-                            authURL:
-                              type: string
-                            availabilityZone:
-                              type: string
-                            dnsServers:
-                              description: Used for automatic network creation
-                              items:
-                                type: string
-                              type: array
-                            enabledFlavors:
-                              description: 'Optional: List of enabled flavors for
-                                the given datacenter'
-                              items:
-                                type: string
-                              type: array
-                            enforceFloatingIP:
-                              description: Optional
-                              type: boolean
-                            ignoreVolumeAZ:
-                              description: Optional
-                              type: boolean
-                            images:
+                            limits:
                               additionalProperties:
-                                type: string
-                              description: Images to use for each supported operating
-                                system.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
-                            ipv6Enabled:
-                              description: 'Optional: defines if the IPv6 is enabled
-                                for the datacenter'
-                              type: boolean
-                            manageSecurityGroups:
-                              description: 'Optional: Gets mapped to the "manage-security-groups"
-                                setting in the cloud config. This setting defaults
-                                to true.'
-                              type: boolean
-                            nodeSizeRequirements:
-                              properties:
-                                minimumMemory:
-                                  description: MinimumMemory is the minimum required
-                                    amount of memory, measured in MB
-                                  type: integer
-                                minimumVCPUs:
-                                  description: VCPUs is the minimum required amount
-                                    of (virtual) CPUs
-                                  type: integer
-                              required:
-                              - minimumMemory
-                              - minimumVCPUs
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
-                            region:
-                              type: string
-                            trustDevicePath:
-                              description: 'Optional: Gets mapped to the "trust-device-path"
-                                setting in the cloud config. This setting defaults
-                                to false.'
-                              type: boolean
-                            useOctavia:
-                              description: 'Optional: Gets mapped to the "use-octavia"
-                                setting in the cloud config. use-octavia is enabled
-                                by default in CCM since v1.17.0, and disabled by default
-                                with the in-tree cloud provider.'
-                              type: boolean
-                          required:
-                          - authURL
-                          - availabilityZone
-                          - dnsServers
-                          - images
-                          - nodeSizeRequirements
-                          - region
                           type: object
-                        packet:
-                          description: DatacenterSpecPacket describes a Packet datacenter.
-                          properties:
-                            facilities:
-                              description: The list of enabled facilities, for example
-                                "ams1", for a full list of available facilities see
-                                https://metal.equinix.com/developers/docs/locations/facilities/
-                              items:
-                                type: string
-                              type: array
-                            metro:
-                              description: Metros are facilities that are grouped
-                                together geographically and share capacity and networking
-                                features, see https://metal.equinix.com/developers/docs/locations/metros/
-                              type: string
-                          type: object
-                        providerReconciliationInterval:
-                          description: ProviderReconciliationInterval is the time
-                            that must have passed since a Cluster's status.lastProviderReconciliation
-                            to make the cliuster controller perform an in-depth provider
-                            reconciliation, where for example missing security groups
-                            will be reconciled. Setting this too low can cause rate
-                            limits by the cloud provider, setting this too high means
-                            that *if* a resource at a cloud provider is removed/changed
-                            outside of KKP, it will take this long to fix it.
-                          type: string
-                        requiredEmails:
-                          description: 'Optional: When defined, only users with an
-                            e-mail address on the given domains can make use of this
-                            datacenter. You can define multiple domains, e.g. "example.com",
-                            one of which must match the email domain exactly (i.e.
-                            "example.com" will not match "user@test.example.com").'
+                        tolerations:
                           items:
-                            type: string
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
                           type: array
-                        vmwareclouddirector:
+                      type: object
+                    etcd:
+                      description: Etcd configures the etcd ring used to store Kubernetes data.
+                      properties:
+                        clusterSize:
+                          format: int32
+                          type: integer
+                        diskSize:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
                           properties:
-                            allowInsecure:
-                              description: If set to true, disables the TLS certificate
-                                check against the endpoint.
-                              type: boolean
-                            catalog:
-                              description: The default catalog which contains the
-                                VM templates.
-                              type: string
-                            storageProfile:
-                              description: The name of the storage profile to use
-                                for disks attached to the VMs.
-                              type: string
-                            templates:
+                            limits:
                               additionalProperties:
-                                type: string
-                              description: A list of VM templates to use for a given
-                                operating system. You must define at least one template.
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
-                            url:
-                              description: Endpoint URL to use, including protocol,
-                                for example "https://vclouddirector.example.com".
-                              type: string
-                          required:
-                          - templates
-                          - url
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
                           type: object
-                        vsphere:
-                          description: DatacenterSpecVSphere describes a vSphere datacenter.
+                        storageClass:
+                          type: string
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    konnectivityProxy:
+                      description: KonnectivityProxy configures resources limits/requests for konnectivity-server sidecar.
+                      properties:
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
                           properties:
-                            allowInsecure:
-                              description: If set to true, disables the TLS certificate
-                                check against the endpoint.
-                              type: boolean
-                            cluster:
-                              description: The name of the vSphere cluster to use.
-                                Used for out-of-tree CSI Driver.
-                              type: string
-                            datacenter:
-                              description: The name of the datacenter to use.
-                              type: string
-                            datastore:
-                              description: The default Datastore to be used for provisioning
-                                volumes using storage classes/dynamic provisioning
-                                and for storing virtual machine files in case no `Datastore`
-                                or `DatastoreCluster` is provided at Cluster level.
-                              type: string
-                            endpoint:
-                              description: Endpoint URL to use, including protocol,
-                                for example "https://vcenter.example.com".
-                              type: string
-                            infraManagementUser:
-                              description: 'Optional: Infra management user is the
-                                user that will be used for everything except the cloud
-                                provider functionality, which will still use the credentials
-                                passed in via the Kubermatic dashboard/API.'
-                              properties:
-                                password:
-                                  type: string
-                                username:
-                                  type: string
-                              type: object
-                            ipv6Enabled:
-                              description: 'Optional: defines if the IPv6 is enabled
-                                for the datacenter'
-                              type: boolean
-                            rootPath:
-                              description: 'Optional: The root path for cluster specific
-                                VM folders. Each cluster gets its own folder below
-                                the root folder. Must be the FQDN (for example "/datacenter-1/vm/all-kubermatic-vms-in-here")
-                                and defaults to the root VM folder: "/datacenter-1/vm"'
-                              type: string
-                            storagePolicy:
-                              description: The name of the storage policy to use for
-                                the storage class created in the user cluster.
-                              type: string
-                            templates:
+                            limits:
                               additionalProperties:
-                                type: string
-                              description: 'A list of VM templates to use for a given
-                                operating system. You must define at least one template.
-                                See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation'
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                               type: object
-                          required:
-                          - cluster
-                          - datacenter
-                          - datastore
-                          - endpoint
-                          - templates
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
                           type: object
+                      type: object
+                    nodePortProxyEnvoy:
+                      description: NodePortProxyEnvoy configures the per-cluster nodeport-proxy-envoy that is deployed if the `LoadBalancer` expose strategy is used. This is not effective if a different expose strategy is configured.
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    prometheus:
+                      description: Prometheus configures the Prometheus instance deployed into the cluster control plane.
+                      properties:
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    scheduler:
+                      description: Scheduler configures kube-scheduler settings.
+                      properties:
+                        leaderElection:
+                          properties:
+                            leaseDurationSeconds:
+                              description: LeaseDurationSeconds is the duration in seconds that non-leader candidates will wait to force acquire leadership. This is measured against time of last observed ack.
+                              format: int32
+                              type: integer
+                            renewDeadlineSeconds:
+                              description: RenewDeadlineSeconds is the duration in seconds that the acting controlplane will retry refreshing leadership before giving up.
+                              format: int32
+                              type: integer
+                            retryPeriodSeconds:
+                              description: RetryPeriodSeconds is the duration in seconds the LeaderElector clients should wait between tries of actions.
+                              format: int32
+                              type: integer
+                          type: object
+                        replicas:
+                          format: int32
+                          type: integer
+                        resources:
+                          description: ResourceRequirements describes the compute resource requirements.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                        tolerations:
+                          items:
+                            description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
+                            properties:
+                              effect:
+                                description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                                type: string
+                              key:
+                                description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                                type: string
+                              operator:
+                                description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
+                                type: string
+                              tolerationSeconds:
+                                description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
+                                format: int64
+                                type: integer
+                              value:
+                                description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
+                                type: string
+                            type: object
+                          type: array
                       type: object
                   required:
-                  - spec
+                    - apiserver
+                    - controllerManager
+                    - etcd
+                    - nodePortProxyEnvoy
+                    - prometheus
+                    - scheduler
                   type: object
-                description: Datacenters contains a map of the possible datacenters
-                  (DCs) in this seed. Each DC must have a globally unique identifier
-                  (i.e. names must be unique across all seeds).
-                type: object
-              defaultClusterTemplate:
-                description: DefaultClusterTemplate is the name of a cluster template
-                  of scope "seed" that is used to default all new created clusters
-                type: string
-              defaultComponentSettings:
-                description: 'DefaultComponentSettings are default values to set for
-                  newly created clusters. Deprecated: Use DefaultClusterTemplate instead.'
-                properties:
-                  apiserver:
-                    description: Apiserver configures kube-apiserver settings.
-                    properties:
-                      endpointReconcilingDisabled:
-                        type: boolean
-                      nodePortRange:
-                        type: string
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  controllerManager:
-                    description: ControllerManager configures kube-controller-manager
-                      settings.
-                    properties:
-                      leaderElection:
-                        properties:
-                          leaseDurationSeconds:
-                            description: LeaseDurationSeconds is the duration in seconds
-                              that non-leader candidates will wait to force acquire
-                              leadership. This is measured against time of last observed
-                              ack.
-                            format: int32
-                            type: integer
-                          renewDeadlineSeconds:
-                            description: RenewDeadlineSeconds is the duration in seconds
-                              that the acting controlplane will retry refreshing leadership
-                              before giving up.
-                            format: int32
-                            type: integer
-                          retryPeriodSeconds:
-                            description: RetryPeriodSeconds is the duration in seconds
-                              the LeaderElector clients should wait between tries
-                              of actions.
-                            format: int32
-                            type: integer
-                        type: object
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  etcd:
-                    description: Etcd configures the etcd ring used to store Kubernetes
-                      data.
-                    properties:
-                      clusterSize:
-                        format: int32
-                        type: integer
-                      diskSize:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      storageClass:
-                        type: string
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                  konnectivityProxy:
-                    description: KonnectivityProxy configures resources limits/requests
-                      for konnectivity-server sidecar.
-                    properties:
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  nodePortProxyEnvoy:
-                    description: NodePortProxyEnvoy configures the per-cluster nodeport-proxy-envoy
-                      that is deployed if the `LoadBalancer` expose strategy is used.
-                      This is not effective if a different expose strategy is configured.
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  prometheus:
-                    description: Prometheus configures the Prometheus instance deployed
-                      into the cluster control plane.
-                    properties:
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  scheduler:
-                    description: Scheduler configures kube-scheduler settings.
-                    properties:
-                      leaderElection:
-                        properties:
-                          leaseDurationSeconds:
-                            description: LeaseDurationSeconds is the duration in seconds
-                              that non-leader candidates will wait to force acquire
-                              leadership. This is measured against time of last observed
-                              ack.
-                            format: int32
-                            type: integer
-                          renewDeadlineSeconds:
-                            description: RenewDeadlineSeconds is the duration in seconds
-                              that the acting controlplane will retry refreshing leadership
-                              before giving up.
-                            format: int32
-                            type: integer
-                          retryPeriodSeconds:
-                            description: RetryPeriodSeconds is the duration in seconds
-                              the LeaderElector clients should wait between tries
-                              of actions.
-                            format: int32
-                            type: integer
-                        type: object
-                      replicas:
-                        format: int32
-                        type: integer
-                      resources:
-                        description: ResourceRequirements describes the compute resource
-                          requirements.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                      tolerations:
-                        items:
-                          description: The pod this Toleration is attached to tolerates
-                            any taint that matches the triple <key,value,effect> using
-                            the matching operator <operator>.
-                          properties:
-                            effect:
-                              description: Effect indicates the taint effect to match.
-                                Empty means match all taint effects. When specified,
-                                allowed values are NoSchedule, PreferNoSchedule and
-                                NoExecute.
-                              type: string
-                            key:
-                              description: Key is the taint key that the toleration
-                                applies to. Empty means match all taint keys. If the
-                                key is empty, operator must be Exists; this combination
-                                means to match all values and all keys.
-                              type: string
-                            operator:
-                              description: Operator represents a key's relationship
-                                to the value. Valid operators are Exists and Equal.
-                                Defaults to Equal. Exists is equivalent to wildcard
-                                for value, so that a pod can tolerate all taints of
-                                a particular category.
-                              type: string
-                            tolerationSeconds:
-                              description: TolerationSeconds represents the period
-                                of time the toleration (which must be of effect NoExecute,
-                                otherwise this field is ignored) tolerates the taint.
-                                By default, it is not set, which means tolerate the
-                                taint forever (do not evict). Zero and negative values
-                                will be treated as 0 (evict immediately) by the system.
-                              format: int64
-                              type: integer
-                            value:
-                              description: Value is the taint value the toleration
-                                matches to. If the operator is Exists, the value should
-                                be empty, otherwise just a regular string.
-                              type: string
-                          type: object
-                        type: array
-                    type: object
-                required:
-                - apiserver
-                - controllerManager
-                - etcd
-                - nodePortProxyEnvoy
-                - prometheus
-                - scheduler
-                type: object
-              etcdBackupRestore:
-                description: EtcdBackupRestore holds the configuration of the automatic
-                  etcd backup restores for the Seed; if this is set, the new backup/restore
-                  controllers are enabled for this Seed.
-                properties:
-                  defaultDestination:
-                    description: DefaultDestination marks the default destination
-                      that will be used for the default etcd backup config which is
-                      created for every user cluster. Has to correspond to a destination
-                      in Destinations. If removed, it removes the related default
-                      etcd backup configs.
-                    maxLength: 63
-                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-                    type: string
-                  destinations:
-                    additionalProperties:
-                      description: BackupDestination defines the bucket name and endpoint
-                        as a backup destination, and holds reference to the credentials
-                        secret.
-                      properties:
-                        bucketName:
-                          description: BucketName is the bucket name to use for backup
-                            and restore.
-                          type: string
-                        credentials:
-                          description: Credentials hold the ref to the secret with
-                            backup credentials
-                          properties:
-                            name:
-                              description: name is unique within a namespace to reference
-                                a secret resource.
-                              type: string
-                            namespace:
-                              description: namespace defines the space within which
-                                the secret name must be unique.
-                              type: string
-                          type: object
-                          x-kubernetes-map-type: atomic
-                        endpoint:
-                          description: Endpoint is the API endpoint to use for backup
-                            and restore.
-                          type: string
-                      required:
-                      - bucketName
-                      - endpoint
-                      type: object
-                    description: Destinations stores all the possible destinations
-                      where the backups for the Seed can be stored. If not empty,
-                      it enables automatic backup and restore for the seed.
-                    type: object
-                required:
-                - defaultDestination
-                type: object
-              exposeStrategy:
-                description: 'Optional: ExposeStrategy explicitly sets the expose
-                  strategy for this seed cluster, if not set, the default provided
-                  by the master is used.'
-                enum:
-                - NodePort
-                - LoadBalancer
-                - Tunneling
-                type: string
-              kubeconfig:
-                description: A reference to the Kubeconfig of this cluster. The Kubeconfig
-                  must have cluster-admin privileges. This field is mandatory for
-                  every seed, even if there are no datacenters defined yet.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
-                    type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              location:
-                description: 'Optional: Detailed location of the cluster, like "Hamburg"
-                  or "Datacenter 7". For informational purposes in the Kubermatic
-                  dashboard only.'
-                type: string
-              metering:
-                description: Metering configures the metering tool on user clusters
-                  across the seed.
-                properties:
-                  enabled:
-                    type: boolean
-                  reports:
-                    additionalProperties:
-                      properties:
-                        interval:
-                          default: 7
-                          description: Interval defines the number of days consulted
-                            in the metering report.
-                          format: int32
-                          minimum: 1
-                          type: integer
-                        retention:
-                          description: Retention defines a number of days after which
-                            reports are queued for removal. If not set, reports are
-                            kept forever. Please note that this functionality works
-                            only for object storage that supports an object lifecycle
-                            management mechanism.
-                          format: int32
-                          minimum: 1
-                          type: integer
-                        schedule:
-                          default: 0 1 * * 6
-                          description: Schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.
-                            Please take a note that Schedule is responsible only for
-                            setting the time when a report generation mechanism kicks
-                            off. The Interval MUST be set independently.
-                          type: string
-                        type:
-                          default:
-                          - cluster
-                          - namespace
-                          description: Types of reports to generate. Available report
-                            types are cluster and namespace. By default, all types
-                            of reports are generated.
-                          items:
-                            type: string
-                          type: array
-                      type: object
-                    default:
-                      weekly:
-                        interval: 7
-                        schedule: 0 1 * * 6
-                    description: ReportConfigurations is a map of report configuration
-                      definitions.
-                    type: object
-                  storageClassName:
-                    description: StorageClassName is the name of the storage class
-                      that the metering prometheus instance uses to store metric data
-                      for reporting.
-                    type: string
-                  storageSize:
-                    description: StorageSize is the size of the storage class. Default
-                      value is 100Gi.
-                    type: string
-                required:
-                - enabled
-                - storageClassName
-                - storageSize
-                type: object
-              mla:
-                description: 'Optional: MLA allows configuring seed level MLA (Monitoring,
-                  Logging & Alerting) stack settings.'
-                properties:
-                  userClusterMLAEnabled:
-                    description: 'Optional: UserClusterMLAEnabled controls whether
-                      the user cluster MLA (Monitoring, Logging & Alerting) stack
-                      is enabled in the seed.'
-                    type: boolean
-                type: object
-              nodeportProxy:
-                description: NodeportProxy can be used to configure the NodePort proxy
-                  service that is responsible for making user-cluster control planes
-                  accessible from the outside.
-                properties:
-                  annotations:
-                    additionalProperties:
+                etcdBackupRestore:
+                  description: EtcdBackupRestore holds the configuration of the automatic etcd backup restores for the Seed; if this is set, the new backup/restore controllers are enabled for this Seed.
+                  properties:
+                    defaultDestination:
+                      description: DefaultDestination marks the default destination that will be used for the default etcd backup config which is created for every user cluster. Has to correspond to a destination in Destinations. If removed, it removes the related default etcd backup configs.
+                      maxLength: 63
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                       type: string
-                    description: 'Annotations are used to further tweak the LoadBalancer
-                      integration with the cloud provider where the seed cluster is
-                      running. Deprecated: Use .envoy.loadBalancerService.annotations
-                      instead.'
-                    type: object
-                  disable:
-                    description: Disable will prevent the Kubermatic Operator from
-                      creating a nodeport-proxy setup on the seed cluster. This should
-                      only be used if a suitable replacement is installed (like the
-                      nodeport-proxy Helm chart).
-                    type: boolean
-                  envoy:
-                    description: Envoy configures the Envoy application itself.
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      loadBalancerService:
+                    destinations:
+                      additionalProperties:
+                        description: BackupDestination defines the bucket name and endpoint as a backup destination, and holds reference to the credentials secret.
                         properties:
-                          annotations:
-                            additionalProperties:
-                              type: string
-                            description: Annotations are used to further tweak the
-                              LoadBalancer integration with the cloud provider.
+                          bucketName:
+                            description: BucketName is the bucket name to use for backup and restore.
+                            type: string
+                          credentials:
+                            description: Credentials hold the ref to the secret with backup credentials
+                            properties:
+                              name:
+                                description: name is unique within a namespace to reference a secret resource.
+                                type: string
+                              namespace:
+                                description: namespace defines the space within which the secret name must be unique.
+                                type: string
                             type: object
-                          sourceRanges:
-                            description: 'SourceRanges will restrict loadbalancer
-                              service to IP ranges specified using CIDR notation like
-                              172.25.0.0/16. This field will be ignored if the cloud-provider
-                              does not support the feature. More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                            x-kubernetes-map-type: atomic
+                          endpoint:
+                            description: Endpoint is the API endpoint to use for backup and restore.
+                            type: string
+                        required:
+                          - bucketName
+                          - endpoint
+                        type: object
+                      description: Destinations stores all the possible destinations where the backups for the Seed can be stored. If not empty, it enables automatic backup and restore for the seed.
+                      type: object
+                  required:
+                    - defaultDestination
+                  type: object
+                exposeStrategy:
+                  description: 'Optional: ExposeStrategy explicitly sets the expose strategy for this seed cluster, if not set, the default provided by the master is used.'
+                  enum:
+                    - NodePort
+                    - LoadBalancer
+                    - Tunneling
+                  type: string
+                kubeconfig:
+                  description: A reference to the Kubeconfig of this cluster. The Kubeconfig must have cluster-admin privileges. This field is mandatory for every seed, even if there are no datacenters defined yet.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                location:
+                  description: 'Optional: Detailed location of the cluster, like "Hamburg" or "Datacenter 7". For informational purposes in the Kubermatic dashboard only.'
+                  type: string
+                metering:
+                  description: Metering configures the metering tool on user clusters across the seed.
+                  properties:
+                    enabled:
+                      type: boolean
+                    reports:
+                      additionalProperties:
+                        properties:
+                          interval:
+                            default: 7
+                            description: Interval defines the number of days consulted in the metering report.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          retention:
+                            description: Retention defines a number of days after which reports are queued for removal. If not set, reports are kept forever. Please note that this functionality works only for object storage that supports an object lifecycle management mechanism.
+                            format: int32
+                            minimum: 1
+                            type: integer
+                          schedule:
+                            default: 0 1 * * 6
+                            description: Schedule in Cron format, see https://en.wikipedia.org/wiki/Cron. Please take a note that Schedule is responsible only for setting the time when a report generation mechanism kicks off. The Interval MUST be set independently.
+                            type: string
+                          type:
+                            default:
+                              - cluster
+                              - namespace
+                            description: Types of reports to generate. Available report types are cluster and namespace. By default, all types of reports are generated.
                             items:
-                              pattern: ^((\d{1,3}\.){3}\d{1,3}\/([0-9]|[1-2][0-9]|3[0-2]))$
                               type: string
                             type: array
                         type: object
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  envoyManager:
-                    description: EnvoyManager configures the Kubermatic-internal Envoy
-                      manager.
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                  updater:
-                    description: Updater configures the component responsible for
-                      updating the LoadBalancer service.
-                    properties:
-                      dockerRepository:
-                        description: DockerRepository is the repository containing
-                          the component's image.
-                        type: string
-                      resources:
-                        description: Resources describes the requested and maximum
-                          allowed CPU/memory usage.
-                        properties:
-                          limits:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                              resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                          requests:
-                            additionalProperties:
-                              anyOf:
-                              - type: integer
-                              - type: string
-                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                              x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of
-                              compute resources required. If Requests is omitted for
-                              a container, it defaults to Limits if that is explicitly
-                              specified, otherwise to an implementation-defined value.
-                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                            type: object
-                        type: object
-                    type: object
-                type: object
-              proxySettings:
-                description: 'Optional: ProxySettings can be used to configure HTTP
-                  proxy settings on the worker nodes in user clusters. However, proxy
-                  settings on nodes take precedence.'
-                properties:
-                  httpProxy:
-                    description: 'Optional: If set, this proxy will be configured
-                      for both HTTP and HTTPS.'
-                    type: string
-                  noProxy:
-                    description: 'Optional: If set this will be set as NO_PROXY environment
-                      variable on the node; The value must be a comma-separated list
-                      of domains for which no proxy should be used, e.g. "*.example.com,internal.dev".
-                      Note that the in-cluster apiserver URL will be automatically
-                      prepended to this value.'
-                    type: string
-                type: object
-              seedDNSOverwrite:
-                description: 'Optional: This can be used to override the DNS name
-                  used for this seed. By default the seed name is used.'
-                type: string
-            required:
-            - kubeconfig
-            type: object
-          status:
-            description: SeedStatus contains runtime information regarding the seed.
-            properties:
-              clusters:
-                default: 0
-                description: Clusters is the total number of user clusters that exist
-                  on this seed.
-                minimum: 0
-                type: integer
-              conditions:
-                additionalProperties:
-                  properties:
-                    lastHeartbeatTime:
-                      description: Last time we got an update on a given condition.
-                      format: date-time
+                      default:
+                        weekly:
+                          interval: 7
+                          schedule: 0 1 * * 6
+                      description: ReportConfigurations is a map of report configuration definitions.
+                      type: object
+                    storageClassName:
+                      description: StorageClassName is the name of the storage class that the metering prometheus instance uses to store metric data for reporting.
                       type: string
-                    lastTransitionTime:
-                      description: Last time the condition transit from one status
-                        to another.
-                      format: date-time
-                      type: string
-                    message:
-                      description: Human readable message indicating details about
-                        last transition.
-                      type: string
-                    reason:
-                      description: (brief) reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: Status of the condition, one of True, False, Unknown.
+                    storageSize:
+                      description: StorageSize is the size of the storage class. Default value is 100Gi.
                       type: string
                   required:
-                  - lastHeartbeatTime
-                  - status
+                    - enabled
+                    - storageClassName
+                    - storageSize
                   type: object
-                description: Conditions contains conditions the seed is in, its primary
-                  use case is status signaling between controllers or between controllers
-                  and the API.
-                type: object
-              phase:
-                description: Phase contains a human readable text to indicate the
-                  seed cluster status. No logic should be tied to this field, as its
-                  content can change in between KKP releases.
-                enum:
-                - ""
-                - Healthy
-                - Unhealthy
-                - Invalid
-                - Terminating
-                - Paused
-                type: string
-              versions:
-                description: Versions contains information regarding versions of components
-                  in the cluster and the cluster itself.
-                properties:
-                  cluster:
-                    description: Cluster is the Kubernetes version of the cluster's
-                      control plane.
-                    type: string
-                  kubermatic:
-                    description: Kubermatic is the version of the currently deployed
-                      KKP components. Note that a permanent version skew between master
-                      and seed is not supported and KKP setups should never run for
-                      longer times with a skew between the clusters.
-                    type: string
-                type: object
-            required:
-            - clusters
-            type: object
-        required:
-        - spec
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                mla:
+                  description: 'Optional: MLA allows configuring seed level MLA (Monitoring, Logging & Alerting) stack settings.'
+                  properties:
+                    userClusterMLAEnabled:
+                      description: 'Optional: UserClusterMLAEnabled controls whether the user cluster MLA (Monitoring, Logging & Alerting) stack is enabled in the seed.'
+                      type: boolean
+                  type: object
+                nodeportProxy:
+                  description: NodeportProxy can be used to configure the NodePort proxy service that is responsible for making user-cluster control planes accessible from the outside.
+                  properties:
+                    annotations:
+                      additionalProperties:
+                        type: string
+                      description: 'Annotations are used to further tweak the LoadBalancer integration with the cloud provider where the seed cluster is running. Deprecated: Use .envoy.loadBalancerService.annotations instead.'
+                      type: object
+                    disable:
+                      description: Disable will prevent the Kubermatic Operator from creating a nodeport-proxy setup on the seed cluster. This should only be used if a suitable replacement is installed (like the nodeport-proxy Helm chart).
+                      type: boolean
+                    envoy:
+                      description: Envoy configures the Envoy application itself.
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        loadBalancerService:
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: Annotations are used to further tweak the LoadBalancer integration with the cloud provider.
+                              type: object
+                            sourceRanges:
+                              description: 'SourceRanges will restrict loadbalancer service to IP ranges specified using CIDR notation like 172.25.0.0/16. This field will be ignored if the cloud-provider does not support the feature. More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/'
+                              items:
+                                pattern: ^((\d{1,3}\.){3}\d{1,3}\/([0-9]|[1-2][0-9]|3[0-2]))$
+                                type: string
+                              type: array
+                          type: object
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    envoyManager:
+                      description: EnvoyManager configures the Kubermatic-internal Envoy manager.
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                    updater:
+                      description: Updater configures the component responsible for updating the LoadBalancer service.
+                      properties:
+                        dockerRepository:
+                          description: DockerRepository is the repository containing the component's image.
+                          type: string
+                        resources:
+                          description: Resources describes the requested and maximum allowed CPU/memory usage.
+                          properties:
+                            limits:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                            requests:
+                              additionalProperties:
+                                anyOf:
+                                  - type: integer
+                                  - type: string
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              type: object
+                          type: object
+                      type: object
+                  type: object
+                proxySettings:
+                  description: 'Optional: ProxySettings can be used to configure HTTP proxy settings on the worker nodes in user clusters. However, proxy settings on nodes take precedence.'
+                  properties:
+                    httpProxy:
+                      description: 'Optional: If set, this proxy will be configured for both HTTP and HTTPS.'
+                      type: string
+                    noProxy:
+                      description: 'Optional: If set this will be set as NO_PROXY environment variable on the node; The value must be a comma-separated list of domains for which no proxy should be used, e.g. "*.example.com,internal.dev". Note that the in-cluster apiserver URL will be automatically prepended to this value.'
+                      type: string
+                  type: object
+                seedDNSOverwrite:
+                  description: 'Optional: This can be used to override the DNS name used for this seed. By default the seed name is used.'
+                  type: string
+              required:
+                - kubeconfig
+              type: object
+            status:
+              description: SeedStatus contains runtime information regarding the seed.
+              properties:
+                clusters:
+                  default: 0
+                  description: Clusters is the total number of user clusters that exist on this seed.
+                  minimum: 0
+                  type: integer
+                conditions:
+                  additionalProperties:
+                    properties:
+                      lastHeartbeatTime:
+                        description: Last time we got an update on a given condition.
+                        format: date-time
+                        type: string
+                      lastTransitionTime:
+                        description: Last time the condition transit from one status to another.
+                        format: date-time
+                        type: string
+                      message:
+                        description: Human readable message indicating details about last transition.
+                        type: string
+                      reason:
+                        description: (brief) reason for the condition's last transition.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                    required:
+                      - lastHeartbeatTime
+                      - status
+                    type: object
+                  description: Conditions contains conditions the seed is in, its primary use case is status signaling between controllers or between controllers and the API.
+                  type: object
+                phase:
+                  description: Phase contains a human readable text to indicate the seed cluster status. No logic should be tied to this field, as its content can change in between KKP releases.
+                  enum:
+                    - ""
+                    - Healthy
+                    - Unhealthy
+                    - Invalid
+                    - Terminating
+                    - Paused
+                  type: string
+                versions:
+                  description: Versions contains information regarding versions of components in the cluster and the cluster itself.
+                  properties:
+                    cluster:
+                      description: Cluster is the Kubernetes version of the cluster's control plane.
+                      type: string
+                    kubermatic:
+                      description: Kubermatic is the version of the currently deployed KKP components. Note that a permanent version skew between master and seed is not supported and KKP setups should never run for longer times with a skew between the clusters.
+                      type: string
+                  type: object
+              required:
+                - clusters
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: userprojectbindings.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_userprojectbindings.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: userprojectbindings.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,59 +17,50 @@ spec:
     singular: userprojectbinding
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.projectID
-      name: ProjectID
-      type: string
-    - jsonPath: .spec.group
-      name: Group
-      type: string
-    - jsonPath: .spec.userEmail
-      name: UserEmail
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: UserProjectBinding specifies a binding between a user and a project
-          This resource is used by the user management to manipulate members of the
-          given project.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: UserProjectBindingSpec specifies a user.
-            properties:
-              group:
-                description: Group is the user's group, determining their permissions
-                  within the project. Must be one of `owners`, `editors`, `viewers`
-                  or `projectmanagers`.
-                type: string
-              projectID:
-                description: ProjectID is the name of the target project.
-                type: string
-              userEmail:
-                description: UserEmail is the email of the user that is bound to the
-                  given project.
-                type: string
-            required:
-            - group
-            - projectID
-            - userEmail
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+    - additionalPrinterColumns:
+        - jsonPath: .spec.projectID
+          name: ProjectID
+          type: string
+        - jsonPath: .spec.group
+          name: Group
+          type: string
+        - jsonPath: .spec.userEmail
+          name: UserEmail
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: UserProjectBinding specifies a binding between a user and a project This resource is used by the user management to manipulate members of the given project.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: UserProjectBindingSpec specifies a user.
+              properties:
+                group:
+                  description: Group is the user's group, determining their permissions within the project. Must be one of `owners`, `editors`, `viewers` or `projectmanagers`.
+                  type: string
+                projectID:
+                  description: ProjectID is the name of the target project.
+                  type: string
+                userEmail:
+                  description: UserEmail is the email of the user that is bound to the given project.
+                  type: string
+              required:
+                - group
+                - projectID
+                - userEmail
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: users.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: users.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master,seed
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,145 +17,118 @@ spec:
     singular: user
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.email
-      name: Email
-      type: string
-    - jsonPath: .spec.name
-      name: HumanReadableName
-      type: string
-    - jsonPath: .spec.admin
-      name: Admin
-      type: boolean
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: User specifies a KKP user. Users can be either humans or KKP
-          service accounts.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: UserSpec specifies a user.
-            properties:
-              admin:
-                default: false
-                description: IsAdmin defines whether this user is an administrator
-                  with additional permissions. Admins can for example see all projects
-                  and clusters in the KKP dashboard.
-                type: boolean
-              email:
-                description: Email is the email address of this user. Emails must
-                  be globally unique across all KKP users.
-                type: string
-              groups:
-                description: Groups holds the information to which groups the user
-                  belongs to. Set automatically when logging in to the KKP API, and
-                  used by the KKP API.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.email
+          name: Email
+          type: string
+        - jsonPath: .spec.name
+          name: HumanReadableName
+          type: string
+        - jsonPath: .spec.admin
+          name: Admin
+          type: boolean
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: User specifies a KKP user. Users can be either humans or KKP service accounts.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: UserSpec specifies a user.
+              properties:
+                admin:
+                  default: false
+                  description: IsAdmin defines whether this user is an administrator with additional permissions. Admins can for example see all projects and clusters in the KKP dashboard.
+                  type: boolean
+                email:
+                  description: Email is the email address of this user. Emails must be globally unique across all KKP users.
                   type: string
-                type: array
-              id:
-                description: 'ID is an unnused legacy field. Deprecated: do not set
-                  this field anymore.'
-                type: string
-              invalidTokensReference:
-                description: InvalidTokensReference is a reference to a Secret that
-                  contains invalidated login tokens. The tokens are used to provide
-                  a safe logout mechanism.
-                properties:
-                  apiVersion:
-                    description: API version of the referent.
+                groups:
+                  description: Groups holds the information to which groups the user belongs to. Set automatically when logging in to the KKP API, and used by the KKP API.
+                  items:
                     type: string
-                  fieldPath:
-                    description: 'If referring to a piece of an object instead of
-                      an entire object, this string should contain a valid JSON/Go
-                      field access statement, such as desiredState.manifest.containers[2].
-                      For example, if the object reference is to a container within
-                      a pod, this would take on a value like: "spec.containers{name}"
-                      (where "name" refers to the name of the container that triggered
-                      the event) or if no container name is specified "spec.containers[2]"
-                      (container with index 2 in this pod). This syntax is chosen
-                      only to have some well-defined way of referencing a part of
-                      an object. TODO: this design is not final and this field is
-                      subject to change in the future.'
-                    type: string
-                  key:
-                    type: string
-                  kind:
-                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                    type: string
-                  name:
-                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                    type: string
-                  namespace:
-                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                    type: string
-                  resourceVersion:
-                    description: 'Specific resourceVersion to which this reference
-                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                    type: string
-                  uid:
-                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                    type: string
-                type: object
-                x-kubernetes-map-type: atomic
-              name:
-                description: Name is the full name of this user.
-                type: string
-              project:
-                description: Project is the name of the project that this service
-                  account user is tied to. This field is only applicable to service
-                  accounts and regular users must not set this field.
-                type: string
-              settings:
-                description: Settings contains both user-configurable and system-owned
-                  configuration for the KKP dashboard.
-                properties:
-                  collapseSidenav:
-                    type: boolean
-                  displayAllProjectsForAdmin:
-                    type: boolean
-                  itemsPerPage:
-                    type: integer
-                  lastSeenChangelogVersion:
-                    type: string
-                  selectProjectTableView:
-                    type: boolean
-                  selectedProjectID:
-                    type: string
-                  selectedTheme:
-                    type: string
-                  useClustersView:
-                    type: boolean
-                type: object
-            required:
-            - admin
-            - email
-            - name
-            type: object
-          status:
-            description: UserStatus stores status information about a user.
-            properties:
-              lastSeen:
-                format: date-time
-                type: string
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: array
+                id:
+                  description: 'ID is an unnused legacy field. Deprecated: do not set this field anymore.'
+                  type: string
+                invalidTokensReference:
+                  description: InvalidTokensReference is a reference to a Secret that contains invalidated login tokens. The tokens are used to provide a safe logout mechanism.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    key:
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                name:
+                  description: Name is the full name of this user.
+                  type: string
+                project:
+                  description: Project is the name of the project that this service account user is tied to. This field is only applicable to service accounts and regular users must not set this field.
+                  type: string
+                settings:
+                  description: Settings contains both user-configurable and system-owned configuration for the KKP dashboard.
+                  properties:
+                    collapseSidenav:
+                      type: boolean
+                    displayAllProjectsForAdmin:
+                      type: boolean
+                    itemsPerPage:
+                      type: integer
+                    lastSeenChangelogVersion:
+                      type: string
+                    selectProjectTableView:
+                      type: boolean
+                    selectedProjectID:
+                      type: string
+                    selectedTheme:
+                      type: string
+                    useClustersView:
+                      type: boolean
+                  type: object
+              required:
+                - admin
+                - email
+                - name
+              type: object
+            status:
+              description: UserStatus stores status information about a user.
+              properties:
+                lastSeen:
+                  format: date-time
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -6,6 +6,8 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: usersshkeys.kubermatic.k8c.io
+  labels:
+    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:
@@ -15,72 +17,64 @@ spec:
     singular: usersshkey
   scope: Cluster
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.name
-      name: HumanReadableName
-      type: string
-    - jsonPath: .spec.owner
-      name: Owner
-      type: string
-    - jsonPath: .spec.project
-      name: Project
-      type: string
-    - jsonPath: .spec.fingerprint
-      name: Fingerprint
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
-    schema:
-      openAPIV3Schema:
-        description: UserSSHKey specifies a users UserSSHKey.
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            properties:
-              clusters:
-                description: Clusters is the list of cluster names that this SSH key
-                  is assigned to.
-                items:
+    - additionalPrinterColumns:
+        - jsonPath: .spec.name
+          name: HumanReadableName
+          type: string
+        - jsonPath: .spec.owner
+          name: Owner
+          type: string
+        - jsonPath: .spec.project
+          name: Project
+          type: string
+        - jsonPath: .spec.fingerprint
+          name: Fingerprint
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1
+      schema:
+        openAPIV3Schema:
+          description: UserSSHKey specifies a users UserSSHKey.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              properties:
+                clusters:
+                  description: Clusters is the list of cluster names that this SSH key is assigned to.
+                  items:
+                    type: string
+                  type: array
+                fingerprint:
+                  description: Fingerprint is calculated server-side based on the supplied public key and doesn't need to be set by clients.
                   type: string
-                type: array
-              fingerprint:
-                description: Fingerprint is calculated server-side based on the supplied
-                  public key and doesn't need to be set by clients.
-                type: string
-              name:
-                description: Name is the human readable name for this SSH key.
-                type: string
-              owner:
-                description: 'Owner is the name of the User object that owns this
-                  SSH key. Deprecated: This field is not used anymore.'
-                type: string
-              project:
-                description: Project is the name of the Project object that this SSH
-                  key belongs to. This field is immutable.
-                type: string
-              publicKey:
-                description: PublicKey is the SSH public key.
-                type: string
-            required:
-            - clusters
-            - name
-            - project
-            - publicKey
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources: {}
+                name:
+                  description: Name is the human readable name for this SSH key.
+                  type: string
+                owner:
+                  description: 'Owner is the name of the User object that owns this SSH key. Deprecated: This field is not used anymore.'
+                  type: string
+                project:
+                  description: Project is the name of the Project object that this SSH key belongs to. This field is immutable.
+                  type: string
+                publicKey:
+                  description: PublicKey is the SSH public key.
+                  type: string
+              required:
+                - clusters
+                - name
+                - project
+                - publicKey
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources: {}

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_usersshkeys.yaml
@@ -4,10 +4,9 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
+    kubermatic.k8c.io/location: master
   creationTimestamp: null
   name: usersshkeys.kubermatic.k8c.io
-  labels:
-    kubermatic.k8c.io/location: master
 spec:
   group: kubermatic.k8c.io
   names:

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/install/util"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/crd"
 
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -98,7 +99,7 @@ func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctr
 		}
 	} else {
 		sublogger.Info("Deploying Custom Resource Definitions…")
-		if err := util.DeployCRDs(ctx, kubeClient, sublogger, filepath.Join(chartDir, "crd"), nil); err != nil {
+		if err := util.DeployCRDs(ctx, kubeClient, sublogger, filepath.Join(chartDir, "crd"), nil, crd.MasterCluster); err != nil {
 			return fmt.Errorf("failed to deploy CRDs: %w", err)
 		}
 	}
@@ -243,7 +244,7 @@ func migrateCertManagerV2(
 
 	// step 6: install new CRDs
 	logger.Info("Deploying new Custom Resource Definitions…")
-	if err := util.DeployCRDs(ctx, kubeClient, logger, filepath.Join(chart.Directory, "crd"), nil); err != nil {
+	if err := util.DeployCRDs(ctx, kubeClient, logger, filepath.Join(chart.Directory, "crd"), nil, crd.MasterCluster); err != nil {
 		return fmt.Errorf("failed to deploy CRDs: %w", err)
 	}
 

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -32,6 +32,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/install/stack/common"
 	"k8c.io/kubermatic/v2/pkg/install/util"
 	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/util/crd"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
 
 	corev1 "k8s.io/api/core/v1"
@@ -301,17 +302,17 @@ func (*MasterStack) InstallKubermaticCRDs(ctx context.Context, client ctrlruntim
 	}
 
 	// install KKP CRDs
-	if err := util.DeployCRDs(ctx, client, logger, filepath.Join(crdDirectory, "k8c.io"), &opt.Versions); err != nil {
+	if err := util.DeployCRDs(ctx, client, logger, filepath.Join(crdDirectory, "k8c.io"), &opt.Versions, crd.MasterCluster); err != nil {
 		return err
 	}
 
 	// install VPA CRDs
-	if err := util.DeployCRDs(ctx, client, logger, filepath.Join(crdDirectory, "k8s.io"), nil); err != nil {
+	if err := util.DeployCRDs(ctx, client, logger, filepath.Join(crdDirectory, "k8s.io"), nil, crd.MasterCluster); err != nil {
 		return err
 	}
 
 	// install OSM CRDs
-	if err := util.DeployCRDs(ctx, client, logger, filepath.Join(crdDirectory, "operatingsystemmanager.k8c.io"), nil); err != nil {
+	if err := util.DeployCRDs(ctx, client, logger, filepath.Join(crdDirectory, "operatingsystemmanager.k8c.io"), nil, crd.MasterCluster); err != nil {
 		return err
 	}
 

--- a/pkg/install/util/crd.go
+++ b/pkg/install/util/crd.go
@@ -35,29 +35,36 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func DeployCRDs(ctx context.Context, kubeClient ctrlruntimeclient.Client, log logrus.FieldLogger, directory string, versions *kubermaticversion.Versions) error {
+func DeployCRDs(ctx context.Context, kubeClient ctrlruntimeclient.Client, log logrus.FieldLogger, directory string, versions *kubermaticversion.Versions, kind crd.ClusterKind) error {
 	crds, err := crd.LoadFromDirectory(directory)
 	if err != nil {
 		return fmt.Errorf("failed to load CRDs: %w", err)
 	}
 
-	for _, crd := range crds {
-		log.WithField("name", crd.GetName()).Debug("Creating CRD…")
+	for _, crdObject := range crds {
+		logger := log.WithField("name", crdObject.GetName())
+
+		if crd.SkipCRDOnCluster(crdObject, kind) {
+			logger.Debug("Skipping CRD")
+			continue
+		}
+
+		logger.Debug("Creating CRD…")
 
 		if versions != nil {
 			// inject the current KKP version, so the operator and other controllers
 			// can react to the changed CRDs (the seed-operator will do the same when
 			// updating CRDs on seed clusters)
-			annotations := crd.GetAnnotations()
+			annotations := crdObject.GetAnnotations()
 			if annotations == nil {
 				annotations = map[string]string{}
 			}
 			annotations[resources.VersionLabel] = versions.KubermaticCommit
-			crd.SetAnnotations(annotations)
+			crdObject.SetAnnotations(annotations)
 		}
 
-		if err := DeployCRD(ctx, kubeClient, crd); err != nil {
-			return fmt.Errorf("failed to deploy CRD %s: %w", crd.GetName(), err)
+		if err := DeployCRD(ctx, kubeClient, crdObject); err != nil {
+			return fmt.Errorf("failed to deploy CRD %s: %w", crdObject.GetName(), err)
 		}
 	}
 

--- a/pkg/install/util/crd.go
+++ b/pkg/install/util/crd.go
@@ -69,9 +69,13 @@ func DeployCRDs(ctx context.Context, kubeClient ctrlruntimeclient.Client, log lo
 	}
 
 	// wait for CRDs to be established
-	for _, crd := range crds {
-		if err := WaitForReadyCRD(ctx, kubeClient, crd.GetName(), 30*time.Second); err != nil {
-			return fmt.Errorf("failed to wait for CRD %s to have Established=True condition: %w", crd.GetName(), err)
+	for _, crdObject := range crds {
+		if crd.SkipCRDOnCluster(crdObject, kind) {
+			continue
+		}
+
+		if err := WaitForReadyCRD(ctx, kubeClient, crdObject.GetName(), 30*time.Second); err != nil {
+			return fmt.Errorf("failed to wait for CRD %s to have Established=True condition: %w", crdObject.GetName(), err)
 		}
 	}
 

--- a/pkg/util/crd/crd.go
+++ b/pkg/util/crd/crd.go
@@ -22,9 +22,11 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	yamlutil "k8s.io/apimachinery/pkg/util/yaml"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -83,4 +85,26 @@ func LoadFromFile(filename string) ([]ctrlruntimeclient.Object, error) {
 	}
 
 	return crds, nil
+}
+
+type ClusterKind string
+
+const (
+	MasterCluster ClusterKind = "master"
+	SeedCluster   ClusterKind = "seed"
+
+	// LocationLabel is the label on CRD object that contains a comma separated list
+	// of cluster kinds where this CRD should be installed into.
+	LocationLabel = "kubermatic.k8c.io/location"
+)
+
+func SkipCRDOnCluster(crd ctrlruntimeclient.Object, kind ClusterKind) bool {
+	locationLabel := crd.GetLabels()[LocationLabel]
+
+	// only filter out if a label exists
+	if locationLabel == "" {
+		return false
+	}
+
+	return !sets.NewString(strings.Split(locationLabel, ",")...).Has(string(kind))
 }

--- a/pkg/util/crd/crd.go
+++ b/pkg/util/crd/crd.go
@@ -93,18 +93,18 @@ const (
 	MasterCluster ClusterKind = "master"
 	SeedCluster   ClusterKind = "seed"
 
-	// LocationLabel is the label on CRD object that contains a comma separated list
+	// LocationAnnotation is the annotation on CRD object that contains a comma separated list
 	// of cluster kinds where this CRD should be installed into.
-	LocationLabel = "kubermatic.k8c.io/location"
+	LocationAnnotation = "kubermatic.k8c.io/location"
 )
 
 func SkipCRDOnCluster(crd ctrlruntimeclient.Object, kind ClusterKind) bool {
-	locationLabel := crd.GetLabels()[LocationLabel]
+	location := crd.GetAnnotations()[LocationAnnotation]
 
 	// only filter out if a label exists
-	if locationLabel == "" {
+	if location == "" {
 		return false
 	}
 
-	return !sets.NewString(strings.Split(locationLabel, ",")...).Has(string(kind))
+	return !sets.NewString(strings.Split(location, ",")...).Has(string(kind))
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Since KKP 2.21 the ApplicationInstallation CRD belongs to the *usercluster* (not the namespace on the seed, but the usercluster itself). This means that KKP will watch the CRD and ensure it exists. If changes to it are made, they are reverted (just like every other object we watch and reconcile).

However this is a problem when you create a usercluster and then try to install KKP into it. Right now, with KKP 2.21 providing the usercluster, one cannot install KKP 2.20 (for testing, for example):

```
INFO[14:36:45] Initializing installer…                     edition="Enterprise Edition" version=v2.20.6
INFO[14:36:45] Validating the provided configuration…
WARN[14:36:45]    kubermaticOperator.imagePullSecret is empty, setting to spec.imagePullSecret from KubermaticConfiguration
INFO[14:36:45] Provided configuration is valid.
INFO[14:36:46] Validating existing installation…
INFO[14:36:46] Existing installation is valid.
INFO[14:36:46] Deploying KKP master stack…
INFO[14:36:46]    Deploying kubermatic-fast StorageClass…
INFO[14:36:47]    StorageClass exists, nothing to do.
INFO[14:36:47]    Deploying nginx-ingress-controller…
INFO[14:36:47]       Deploying Helm chart…
INFO[14:36:47]       Re-installing because --force is set…
INFO[14:37:10]    Success.
INFO[14:37:10]    Deploying cert-manager…
INFO[14:37:11]       Deploying Custom Resource Definitions…
INFO[14:37:14]       Deploying Helm chart…
INFO[14:37:14]       Re-installing because --force is set…
INFO[14:37:24]    Success.
INFO[14:37:24]    Deploying Dex…
INFO[14:37:25]       Re-installing because --force is set…
INFO[14:37:28]    Success.
INFO[14:37:28]    Deploying Kubermatic Operator…
INFO[14:37:28]       Deploying Custom Resource Definitions…
ERRO[14:37:28] Operation failed: failed to deploy Kubermatic Operator: failed to deploy CRDs: failed to deploy CRD applicationinstallations.apps.kubermatic.k8c.io: CustomResourceDefinition.apiextensions.k8s.io "applicationinstallations.apps.kubermatic.k8c.io" is invalid: spec.scope: Invalid value: "Cluster": field is immutable.
```

In this scenario the installer is fighting with the usercluster-ctrl-mgr, and it's losing.

To prevent (rare) conflicts like this from happening, this PR adds a new annotation onto all our CRDs. This new `kubermatic.k8c.io/location` annotation will tell the installer/operator where each CRD is supposed to live. This way they can easily skip the ApplicationInstallation CRD.

This issue would otherwise re-surface everytime we introduce a new CRD in KKP that is managed inside userclusters.

CRDs without this new annotation will be treated like before (i.e. always installed).

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix rare CRD conflict when installing old KKP versions into userclusters created by a different KKP version.
```