### PR TITLE
use Nuremburg datacenter for Hetzner-based e2e tests

### DIFF
--- a/hack/ci/run-ipam-e2e-tests.sh
+++ b/hack/ci/run-ipam-e2e-tests.sh
@@ -56,7 +56,7 @@ echodate "Running IPAM tests..."
 
 go_test ipam_e2e -timeout 45m -tags ipam -v ./pkg/test/e2e/ipam \
   -kubeconfig "$KUBECONFIG" \
-  -datacenter hetzner-hel1 \
+  -datacenter hetzner-nbg1 \
   -preset e2e-hetzner
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -69,7 +69,7 @@ echodate "Running MLA tests..."
 
 go_test mla_e2e -timeout 30m -tags mla -v ./pkg/test/e2e/mla \
   -kubeconfig "$KUBECONFIG" \
-  -datacenter hetzner-hel1 \
+  -datacenter hetzner-nbg1 \
   -preset e2e-hetzner
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -54,6 +54,6 @@ retry 2 kubectl apply -f preset-hetzner.yaml
 echodate "Running OPA tests..."
 
 go_test opa_e2e -timeout 30m -tags e2e,ee -v ./pkg/test/e2e/opa \
-  -datacenter hetzner-hel1
+  -datacenter hetzner-nbg1
 
 echodate "Tests completed successfully!"

--- a/pkg/test/e2e/api/hetzner_test.go
+++ b/pkg/test/e2e/api/hetzner_test.go
@@ -33,7 +33,7 @@ func TestCreateUpdateHetznerCluster(t *testing.T) {
 		{
 			name:       "create cluster on Hetzner",
 			dc:         "kubermatic",
-			location:   "hetzner-hel1",
+			location:   "hetzner-nbg1",
 			version:    utils.KubernetesVersion(),
 			credential: "e2e-hetzner",
 			replicas:   1,
@@ -85,7 +85,7 @@ func TestDeleteClusterBeforeIsUp(t *testing.T) {
 		{
 			name:       "delete cluster before is up",
 			dc:         "kubermatic",
-			location:   "hetzner-hel1",
+			location:   "hetzner-nbg1",
 			version:    utils.KubernetesVersion(),
 			credential: "e2e-hetzner",
 			replicas:   0,


### PR DESCRIPTION
**What this PR does / why we need it**:
Helsinki is currently full and this blocks all of our PRs from passing. This PR therefore changes our tests to use Nuremburg as the datacenter.

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
