### PR TITLE
Check KKP and seed versions in installer to prevent minor version skips

### DIFF
--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -32,6 +32,8 @@ import (
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/util"
+	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	k8csemver "k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
@@ -60,7 +62,22 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 	kkpMinorVersion := semverlib.MustParse(opt.Versions.Kubermatic).Minor()
 	minMinorRequired := kkpMinorVersion - 1
 
-	if currentVersion := opt.KubermaticConfiguration.Status.KubermaticVersion; currentVersion != "" {
+	// The configured KubermaticConfiguration might be a static YAML file,
+	// which would not have a status set at all. To ensure that we always
+	// get the currently live config, we fetch it from the cluster. This
+	// dynamically fetched config is only relevant to the version check, all
+	// other validations are supposed to be based on the given config.
+	config, err := kubernetes.GetRawKubermaticConfiguration(ctx, opt.KubeClient, KubermaticOperatorNamespace)
+	if err != nil && !errors.Is(err, provider.ErrNoKubermaticConfigurationFound) {
+		return append(errs, fmt.Errorf("failed to create fetch KubermaticConfiguration: %w", err))
+	}
+
+	var currentVersion string
+	if config != nil {
+		currentVersion = config.Status.KubermaticVersion
+	}
+
+	if currentVersion != "" {
 		currentSemver, err := semverlib.NewVersion(currentVersion)
 		if err != nil {
 			return append(errs, fmt.Errorf("failed to parse existing KKP version %q: %w", currentVersion, err))

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -35,6 +35,8 @@ import (
 	k8csemver "k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/serviceaccount"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
@@ -52,6 +54,21 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 
 	if !crdsExists {
 		return nil // nothing to do
+	}
+
+	// Ensure that no KKP upgrade was skipped.
+	kkpMinorVersion := semverlib.MustParse(opt.Versions.Kubermatic).Minor()
+	minMinorRequired := kkpMinorVersion - 1
+
+	if currentVersion := opt.KubermaticConfiguration.Status.KubermaticVersion; currentVersion != "" {
+		currentSemver, err := semverlib.NewVersion(currentVersion)
+		if err != nil {
+			return append(errs, fmt.Errorf("failed to parse existing KKP version %q: %w", currentVersion, err))
+		}
+
+		if currentSemver.Minor() < minMinorRequired {
+			return append(errs, fmt.Errorf("existing installation is on version %s and must be updated to KKP 2.%d first (sequentially to all minor releases in-between)", currentVersion, kkpMinorVersion))
+		}
 	}
 
 	// we need the actual, effective versioning configuration, which most users will
@@ -73,6 +90,30 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 
 	for seedName, seed := range allSeeds {
 		opt.Logger.WithField("seed", seedName).Info("Checking seed cluster…")
+
+		// ensure seeds are also up-to-date before we continue
+		seedVersion := seed.Status.Versions.Kubermatic
+		if seedVersion != "" {
+			seedSemver, err := semverlib.NewVersion(seedVersion)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("Seed cluster %q version %q is invalid: %w", seedName, seedVersion, err))
+				continue
+			}
+
+			if seedSemver.Minor() < minMinorRequired {
+				errs = append(errs, fmt.Errorf("Seed cluster %q is on version %s and must be updated first", seedName, seedVersion))
+				continue
+			}
+		}
+
+		// if the operator has the chance to reconcile the seed...
+		if conditions := seed.Status.Conditions; conditions[kubermaticv1.SeedConditionKubeconfigValid].Status == corev1.ConditionTrue {
+			// ... it should be healthy
+			if conditions[kubermaticv1.SeedConditionResourcesReconciled].Status != corev1.ConditionTrue {
+				errs = append(errs, fmt.Errorf("Seed cluster %q is not healthy, please verify the operator logs or events on the Seed object", seedName))
+				continue
+			}
+		}
 
 		// create client into seed
 		seedClient, err := opt.SeedClientGetter(seed)


### PR DESCRIPTION
**What this PR does / why we need it**:
To ensure a safer upgrade experience, this PR adds additional validations to the installer. They are based on the work in 2.21, thanks to which we now have version information available for both KKP and each Seed :-)

When installing, the installer checks

1. That the KKP version (`KubermaticConfiguration.Status.KubermaticVersion`) is exactly the previous minor version (judging from the installer's own compiled-in version).
2. Each seed cluster satisfies the same condition.
3. Each seed, when a valid kubeconfig is available, must be properly reconciled. This check does not rely on the `status.phase` as that field is explicitly for informational purpose only.

When no version is available, no check happens. This is to allow for someone to create CRDs manually (for whatever reason) and preload the KubermaticConfiguration/Seed objects before running the installer.

The version check will fail if we ever release KKP 3.x, but there is little I can do about that now: when 3.0 hits, we must know the latest 2.x minor and right now, we don't.

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The KKP installer will ensure that neither the master nor any seed violate the KKP version skew policy, i.e. skipping a minor release during an upgrade is not permitted. Additionally, all seeds must be healthy for an upgrade to be possible. These changes are to ensure that smaller issues now do not lead to bigger problems during upgrades and migrations.
```
