### PR TITLE
Fix vSphere integration and e2e tests

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -107,7 +107,7 @@ spec:
             centos: centos-7
             flatcar: flatcar-3033.2.2
             rhel: rhel-8.6
-            ubuntu: ubuntu-20.04
+            ubuntu: kkp-ubuntu-20.04
             rockylinux: rockylinux-8
     azure-westeurope:
       location: "Azure West europe"

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -104,11 +104,11 @@ spec:
           ipv6Enabled: true
           rootPath: /Hamburg/vm/Kubermatic-ci
           templates:
-            centos: centos-7
-            flatcar: flatcar-3033.2.2
-            rhel: rhel-8.6
+            centos: kkp-centos-7
+            flatcar: kkp-flatcar-3033.2.2
+            rhel: kkp-rhel-8.6
             ubuntu: kkp-ubuntu-20.04
-            rockylinux: rockylinux-8
+            rockylinux: kkp-rockylinux-8
     azure-westeurope:
       location: "Azure West europe"
       country: NL

--- a/pkg/provider/cloud/vsphere/network_test.go
+++ b/pkg/provider/cloud/vsphere/network_test.go
@@ -47,16 +47,16 @@ func TestGetPossibleVMNetworks(t *testing.T) {
 					Name:         "Management",
 				},
 				{
-					AbsolutePath: fmt.Sprintf("/%s/network/Default Network", vSphereDatacenter),
-					RelativePath: "Default Network",
-					Type:         "DistributedVirtualPortgroup",
-					Name:         "Default Network",
-				},
-				{
 					AbsolutePath: fmt.Sprintf("/%s/network/DSwitchAlpha-DVUplinks-2001", vSphereDatacenter),
 					RelativePath: "DSwitchAlpha-DVUplinks-2001",
 					Type:         "DistributedVirtualPortgroup",
 					Name:         "DSwitchAlpha-DVUplinks-2001",
+				},
+				{
+					AbsolutePath: fmt.Sprintf("/%s/network/Default Network", vSphereDatacenter),
+					RelativePath: "Default Network",
+					Type:         "DistributedVirtualPortgroup",
+					Name:         "Default Network",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems that the ordering of networks for vSphere integration testing has changed. This PR should fix it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
