### PR TITLE
fix installer version check

### DIFF
--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -59,7 +59,7 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 	}
 
 	// Ensure that no KKP upgrade was skipped.
-	kkpMinorVersion := semverlib.MustParse(opt.Versions.Kubermatic).Minor()
+	kkpMinorVersion := semverlib.MustParse(opt.Versions.KubermaticCommit).Minor()
 	minMinorRequired := kkpMinorVersion - 1
 
 	// The configured KubermaticConfiguration might be a static YAML file,

--- a/pkg/version/kubermatic/versions.go
+++ b/pkg/version/kubermatic/versions.go
@@ -31,7 +31,7 @@ var (
 	// but is not monotone (gaps can occur, this can go from v2.20.0-1234-d6aef3
 	// to v2.34.0-912-dd79178e to v3.0.1).
 	// Also this value does not necessarily reflect the current release branch,
-	// as releases are taggedo on the release branch and on those tags are not
+	// as releases are tagged on the release branch and on those tags are not
 	// visible from the master branch.
 	gitVersion string
 


### PR DESCRIPTION
**What this PR does / why we need it**:
#10907 used the wrong variable. In dev builds, the "kubermaticDockerTag" is only a Git hash and not a proper semver.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
