### PR TITLE
Don't attempt to manage membership if etcd cluster was not initialised before

### DIFF
--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -125,47 +125,46 @@ func main() {
 		log.Info("peer-tls-mode: strict")
 	}
 
-	// if the cluster already exists, try to connect and update peer URLs that might be out of sync.
-	// etcd might fail to start if peer URLs in the etcd member state and the flags passed to it are different
 	if e.initialState == initialStateExisting {
-		// make sure that peer URLs in the cluster member data is
-		// updated / in sync with the etcd node's configuration
+		// if the cluster already exists, try to connect and update peer URLs that might be out of sync.
+		// etcd might fail to start if peer URLs in the etcd member state and the flags passed to it are different.
+		// make sure that peer URLs in the cluster member data is updated / in sync with the etcd node's configuration.
 		if err := e.UpdatePeerURLs(ctx, log); err != nil {
 			log.Warnw("failed to update peerURL, etcd node might fail to start ...", zap.Error(err))
 		}
-	}
 
-	thisMember, err := e.GetMemberByName(ctx, log, e.podName)
+		thisMember, err := e.GetMemberByName(ctx, log, e.podName)
 
-	switch {
-	case err != nil:
-		log.Warnw("failed to check cluster membership", zap.Error(err))
-	case thisMember != nil:
-		log.Infof("%v is a member", thisMember.GetPeerURLs())
+		switch {
+		case err != nil:
+			log.Warnw("failed to check cluster membership", zap.Error(err))
+		case thisMember != nil:
+			log.Infof("%v is a member", thisMember.GetPeerURLs())
 
-		if _, err := os.Stat(filepath.Join(e.dataDir, "member")); errors.Is(err, fs.ErrNotExist) {
-			client, err := e.GetClusterClient()
-			if err != nil {
-				log.Panicw("can't find cluster client: %v", zap.Error(err))
-			}
+			if _, err := os.Stat(filepath.Join(e.dataDir, "member")); errors.Is(err, fs.ErrNotExist) {
+				client, err := e.GetClusterClient()
+				if err != nil {
+					log.Panicw("can't find cluster client: %v", zap.Error(err))
+				}
 
-			log.Warnw("No data dir, removing stale membership to rejoin cluster as new member")
+				log.Warnw("No data dir, removing stale membership to rejoin cluster as new member")
 
-			_, err = client.MemberRemove(ctx, thisMember.ID)
-			if err != nil {
+				_, err = client.MemberRemove(ctx, thisMember.ID)
+				if err != nil {
+					closeClient(client, log)
+					log.Panicw("failed to remove own member information from cluster before rejoining", zap.Error(err))
+				}
+
 				closeClient(client, log)
-				log.Panicw("remove itself due to data dir loss", zap.Error(err))
+				if err := joinCluster(ctx, e, log); err != nil {
+					log.Panicw("join cluster as fresh member", zap.Error(err))
+				}
 			}
-
-			closeClient(client, log)
+		default:
+			// if no membership information was found but we were able to list from an etcd cluster, we can attempt to join
 			if err := joinCluster(ctx, e, log); err != nil {
-				log.Panicw("join cluster as fresh member", zap.Error(err))
+				log.Panicw("failed to join cluster as fresh member", zap.Error(err))
 			}
-		}
-	default:
-		// if no membership information was found but we were able to list from an etcd cluster, we can attempt to join
-		if err := joinCluster(ctx, e, log); err != nil {
-			log.Panicw("failed to join cluster as fresh member", zap.Error(err))
 		}
 	}
 

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -144,7 +144,7 @@ func main() {
 			if _, err := os.Stat(filepath.Join(e.dataDir, "member")); errors.Is(err, fs.ErrNotExist) {
 				client, err := e.GetClusterClient()
 				if err != nil {
-					log.Panicw("can't find cluster client: %v", zap.Error(err))
+					log.Panicw("can't find cluster client", zap.Error(err))
 				}
 
 				log.Warnw("No data dir, removing stale membership to rejoin cluster as new member")
@@ -157,7 +157,7 @@ func main() {
 
 				closeClient(client, log)
 				if err := joinCluster(ctx, e, log); err != nil {
-					log.Panicw("join cluster as fresh member", zap.Error(err))
+					log.Panicw("failed to join cluster as fresh member", zap.Error(err))
 				}
 			}
 		default:
@@ -171,7 +171,7 @@ func main() {
 	// setup and start etcd command
 	etcdCmd, err := startEtcdCmd(e, log)
 	if err != nil {
-		log.Panicw("start etcd cmd", zap.Error(err))
+		log.Panicw("failed to start etcd cmd", zap.Error(err))
 	}
 
 	if err = wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
@@ -217,7 +217,7 @@ func inClusterClient(log *zap.SugaredLogger) (ctrlruntimeclient.Client, error) {
 
 func startEtcdCmd(e *etcdCluster, log *zap.SugaredLogger) (*exec.Cmd, error) {
 	if _, err := os.Stat(etcdCommandPath); errors.Is(err, fs.ErrNotExist) {
-		return nil, fmt.Errorf("find etcd executable: %w", err)
+		return nil, fmt.Errorf("failed to find etcd executable: %w", err)
 	}
 
 	cmd := exec.Command(etcdCommandPath, etcdCmd(e)...)

--- a/hack/ci/testdata/kubermatic_backup.yaml
+++ b/hack/ci/testdata/kubermatic_backup.yaml
@@ -29,4 +29,3 @@ spec:
     apiserverReplicas: 1
   featureGates:
     HeadlessInstallation: true
-    EtcdLauncher: true

--- a/hack/ci/testdata/kubermatic_backup.yaml
+++ b/hack/ci/testdata/kubermatic_backup.yaml
@@ -29,3 +29,4 @@ spec:
     apiserverReplicas: 1
   featureGates:
     HeadlessInstallation: true
+    EtcdLauncher: true

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -146,18 +146,15 @@ func TestScaling(t *testing.T) {
 	}
 
 	// create test environment
-	testJig := jig.NewBYOCluster(client, logger)
+	testJig := jig.NewBYOClusterWithFeatures(client, logger, map[string]bool{
+		kubermaticv1.ClusterFeatureEtcdLauncher: true,
+	})
 	testJig.ClusterJig.WithTestName("etcd-scaling")
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForNothing)
 	defer testJig.Cleanup(ctx, t, false)
 	if err != nil {
 		t.Fatalf("failed to setup test environment: %v", err)
-	}
-
-	// we run all these tests in the same cluster to speed up the e2e test
-	if err := enableLauncher(ctx, logger, client, cluster); err != nil {
-		t.Fatalf("failed to enable etcd-launcher: %v", err)
 	}
 
 	if err := waitForClusterHealthy(ctx, logger, client, cluster); err != nil {
@@ -195,17 +192,15 @@ func TestRecovery(t *testing.T) {
 	}
 
 	// create test environment
-	testJig := jig.NewBYOCluster(client, logger)
+	testJig := jig.NewBYOClusterWithFeatures(client, logger, map[string]bool{
+		kubermaticv1.ClusterFeatureEtcdLauncher: true,
+	})
 	testJig.ClusterJig.WithTestName("etcd-recovery")
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForNothing)
 	defer testJig.Cleanup(ctx, t, false)
 	if err != nil {
 		t.Fatalf("failed to setup test environment: %v", err)
-	}
-
-	if err := enableLauncher(ctx, logger, client, cluster); err != nil {
-		t.Fatalf("failed to enable etcd-launcher: %v", err)
 	}
 
 	if err := waitForClusterHealthy(ctx, logger, client, cluster); err != nil {

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -195,6 +195,11 @@ func (j *ClusterJig) WithPreset(presetSecret string) *ClusterJig {
 	return j
 }
 
+func (j *ClusterJig) WithFeatures(features map[string]bool) *ClusterJig {
+	j.spec.Features = features
+	return j
+}
+
 func (j *ClusterJig) ClusterName() string {
 	return j.clusterName
 }

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -164,3 +164,22 @@ func NewBYOCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger) *Tes
 		ClusterJig: clusterJig,
 	}
 }
+
+func NewBYOClusterWithFeatures(client ctrlruntimeclient.Client, log *zap.SugaredLogger, features map[string]bool) *TestJig {
+	projectJig := NewProjectJig(client, log)
+
+	clusterJig := NewClusterJig(client, log).
+		WithHumanReadableName("e2e test cluster").
+		WithSSHKeyAgent(false).
+		WithFeatures(features).
+		WithCloudSpec(&kubermaticv1.CloudSpec{
+			DatacenterName: DatacenterName(),
+			ProviderName:   string(kubermaticv1.BringYourOwnCloudProvider),
+			BringYourOwn:   &kubermaticv1.BringYourOwnCloudSpec{},
+		})
+
+	return &TestJig{
+		ProjectJig: projectJig,
+		ClusterJig: clusterJig,
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

#9600 introduced a change in `etcd-launcher` behaviour for cleaning up stale memberships when joining an etcd cluster. Unfortunately, this did not account for the fact that when joining a new cluster that is still initialising, the membership information is in the still forming cluster, but obviously no data dir exists locally yet (as the check happened before starting the `etcd` process). Therefore, the "stale membership" condition triggers and `etcd-launcher` removes itself from the cluster. Because the cluster condition then never reaches `EtcdClusterInitialized`, the bad pod tries to join a new cluster, but cannot as its membership information was removed.

This PR wraps up the cleanup and join logic into a condition to only run if the cluster was once initialised successfully. On first run, `etcd-launcher` should not be too clever and expect that the configuration is all correct to initialise all etcd nodes.

I've also changed some of the clusters created as part of the etcd e2e tests to initialise with `etcd-launcher` enabled, since our test cases did not cover this previously.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10931

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A race condition bug in `etcd-launcher` that can trigger on user cluster initialisation and that prevents the last etcd node from joining the etcd cluster has been fixed
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
