### PR TITLE
use vcenter internal address

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -100,7 +100,8 @@ spec:
           cluster: vcenter.dc.k8c.io
           datacenter: Hamburg
           datastore: alpha1
-          endpoint: https://vcenter.dc.k8c.io
+          endpoint: https://10.10.0.100
+          allowInsecure: true
           ipv6Enabled: true
           rootPath: /Hamburg/vm/Kubermatic-ci
           templates:


### PR DESCRIPTION
**What this PR does / why we need it**:

Change seed vcenter endpoint to use internal address

Part of https://github.com/kubermatic/infra/issues/1845

```release-note
NONE
```

**Documentation**:

```documentation
NONE
```
