### PR TITLE
Enable EtcdLauncher feature gate on CI KubermaticConfigurations

### DIFF
--- a/hack/ci/testdata/kubermatic.yaml
+++ b/hack/ci/testdata/kubermatic.yaml
@@ -28,6 +28,7 @@ spec:
     replicas: 1
     debugLog: true
   featureGates:
+    EtcdLauncher: true
     # VPA won't do anything useful due to missing Prometheus, but we can
     # at least ensure we deploy a working set of Deployments.
     VerticalPodAutoscaler: true

--- a/hack/ci/testdata/kubermatic_dualstack.yaml
+++ b/hack/ci/testdata/kubermatic_dualstack.yaml
@@ -30,6 +30,7 @@ spec:
     accessibleAddons:
       - hubble
   featureGates:
+    EtcdLauncher: true
     # VPA won't do anything useful due to missing Prometheus, but we can
     # at least ensure we deploy a working set of Deployments.
     VerticalPodAutoscaler: false

--- a/hack/ci/testdata/kubermatic_headless.yaml
+++ b/hack/ci/testdata/kubermatic_headless.yaml
@@ -28,4 +28,5 @@ spec:
   userCluster:
     apiserverReplicas: 1
   featureGates:
+    EtcdLauncher: true
     HeadlessInstallation: true

--- a/hack/ci/testdata/kubermatic_konnectivity.yaml
+++ b/hack/ci/testdata/kubermatic_konnectivity.yaml
@@ -29,4 +29,5 @@ spec:
     apiserverReplicas: 1
   featureGates:
     KonnectivityService: true
+    EtcdLauncher: true
     HeadlessInstallation: true

--- a/hack/ci/testdata/kubermatic_mla.yaml
+++ b/hack/ci/testdata/kubermatic_mla.yaml
@@ -29,4 +29,5 @@ spec:
     apiserverReplicas: 1
   featureGates:
     HeadlessInstallation: true
+    EtcdLauncher: true
     UserClusterMLA: true


### PR DESCRIPTION

**What this PR does / why we need it**:

This PR adds the `EtcdLauncher` flag to `KubermaticConfiguration` resources used to set up various environments in CI. It skips `kubermatic_backup.yaml` on purpose because we want that to keep testing the TLS migration with that.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>
