### PR TITLE
Prefer InternalIP for Hetzner dual-stack clusters

### DIFF
--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -394,20 +394,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--api-audiences", strings.Join(audiences, ","),
 	)
 
-	if cluster.Spec.Cloud.GCP != nil {
-		flags = append(flags, "--kubelet-preferred-address-types", "InternalIP")
-	} else {
-		// KAS tries to connect to kubelet via konnectivity-agent in the user-cluster.
-		// This request fails because of security policies disallow external traffic to the node.
-		// So we prefer InternalIP for contacting kubelet when konnectivity is enabled.
-		// Refer: https://github.com/kubermatic/kubermatic/pull/7504#discussion_r700992387
-		// and https://kubermatic.slack.com/archives/C01EWQZEW69/p1628769575001400
-		if data.IsKonnectivityEnabled() {
-			flags = append(flags, "--kubelet-preferred-address-types", "InternalIP,ExternalIP")
-		} else {
-			flags = append(flags, "--kubelet-preferred-address-types", "ExternalIP,InternalIP")
-		}
-	}
+	flags = append(flags, "--kubelet-preferred-address-types", resources.GetKubeletPreferredAddressTypes(cluster, data.IsKonnectivityEnabled()))
 
 	cloudProviderName := resources.GetKubernetesCloudProviderName(data.Cluster(), resources.ExternalCloudProviderEnabled(data.Cluster()))
 	if cloudProviderName != "" && cloudProviderName != "external" {

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -123,7 +123,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 						"--secure-port", "4443",
 						"--metric-resolution", "15s",
 						// We use the same as the API server as we use the same dnat-controller
-						"--kubelet-preferred-address-types", "ExternalIP,InternalIP",
+						"--kubelet-preferred-address-types", resources.GetKubeletPreferredAddressTypes(data.Cluster(), data.IsKonnectivityEnabled()),
 						"--v", "1",
 						"--tls-cert-file", servingCertMountFolder + "/" + resources.ServingCertSecretKey,
 						"--tls-private-key-file", servingCertMountFolder + "/" + resources.ServingCertKeySecretKey,


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Due to https://github.com/hetznercloud/hcloud-cloud-controller-manager/issues/305 it is better to prefer `InternalIP` over `ExternalIP` in dual-stack Hetzner clusters. That should resolve potential `kubectl logs` etc. issues when using Hetzner dual-stack without Konnectivity.

The PR also ensures that the metrics-server deployed in seed in non-Konnectivity case uses the same preference as the apiserver.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prefer InternalIP when connecting to Kubelet for Hetzner dual-stack clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
