### PR TITLE
Add location to getcluster if crd doesnt has location

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -21760,6 +21760,10 @@
           "type": "boolean",
           "x-go-name": "IsImported"
         },
+        "location": {
+          "type": "string",
+          "x-go-name": "Location"
+        },
         "name": {
           "type": "string",
           "x-go-name": "Name"

--- a/pkg/api/v2/types.go
+++ b/pkg/api/v2/types.go
@@ -928,7 +928,7 @@ type EKSSubnet struct {
 	SubnetId string `json:"subnetId"`
 	// The ID of the VPC the subnet is in.
 	VpcId   string `json:"vpcId"`
-	Default bool   `json:"default,omitempty"`
+	Default bool   `json:"default"`
 }
 
 // EKSSecurityGroupList represents an array of EKS securityGroup.
@@ -960,6 +960,7 @@ type EKSVPC struct {
 type AKSCluster struct {
 	Name          string `json:"name"`
 	ResourceGroup string `json:"resourceGroup"`
+	Location      string `json:"location"`
 	IsImported    bool   `json:"imported"`
 }
 

--- a/pkg/handler/common/provider/aks.go
+++ b/pkg/handler/common/provider/aks.go
@@ -96,7 +96,11 @@ func ListAKSClusters(ctx context.Context, projectProvider provider.ProjectProvid
 				imported = true
 			}
 		}
-		clusters = append(clusters, apiv2.AKSCluster{Name: *cluster.Name, ResourceGroup: resourceGroup, IsImported: imported})
+		clusters = append(clusters, apiv2.AKSCluster{
+			Name:          to.String(cluster.Name),
+			Location:      to.String(cluster.Location),
+			ResourceGroup: resourceGroup,
+			IsImported:    imported})
 	}
 	return clusters, nil
 }

--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -460,6 +460,7 @@ func createOrImportAKSCluster(ctx context.Context, name string, userInfoGetter p
 		}
 	}
 
+	// If Spec is not nil, it is interpreted as create cluster on the provider.
 	if spec != nil && spec.AKSClusterSpec != nil {
 		if err := checkCreateClusterReqValidity(cloud.AKS, spec.AKSClusterSpec); err != nil {
 			return nil, err
@@ -1017,6 +1018,7 @@ func getAKSClusterDetails(ctx context.Context, apiCluster *apiv2.ExternalCluster
 		clusterSpec.NetworkProfile.NetworkMode = string(*networkProfile.NetworkMode)
 	}
 	apiCluster.Spec.AKSClusterSpec = clusterSpec
+	apiCluster.Cloud.AKS.Location = to.String(aksCluster.Location)
 
 	return apiCluster, nil
 }

--- a/pkg/test/e2e/utils/apiclient/models/a_k_s_cluster.go
+++ b/pkg/test/e2e/utils/apiclient/models/a_k_s_cluster.go
@@ -20,6 +20,9 @@ type AKSCluster struct {
 	// is imported
 	IsImported bool `json:"imported,omitempty"`
 
+	// location
+	Location string `json:"location,omitempty"`
+
 	// name
 	Name string `json:"name,omitempty"`
 


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: 
- Add location to getclusterdetails to avoid error if crd doesnt has location for aks
- Add location in the externalclusters list response
- Removing omitempty so that default: false if not removed/omitted

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
