### PR TITLE
Fix webhook on seed-only clusters

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -55,7 +55,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
@@ -288,8 +287,7 @@ func createGetters(ctx context.Context, log *zap.SugaredLogger, mgr manager.Mana
 
 	// if master and seed clusters are shared, the webhook can be configured
 	// with a seed name; if no name is configured, the seed getter will simply
-	// return nil. Note that just because -seed-name is given does not mean the
-	// webhook runs on a seed-only cluster, it can very well be a shared master/seed.
+	// return nil.
 	// The kubermatic-operator takes care of setting the -seed-name flag properly.
 	if options.seedName != "" {
 		seedGetter, err = seedGetterFactory(ctx, client, options)
@@ -312,21 +310,7 @@ func createGetters(ctx context.Context, log *zap.SugaredLogger, mgr manager.Mana
 		log.Fatalw("Failed to create seed kubeconfig getter", zap.Error(err))
 	}
 
-	// To improve performance and to not require the seed kubeconfig Secret to be
-	// present on each seed clusters, we create a custom seed client getter that
-	// will return the local client if the seed's name is equal to -seed-name.
-	// We cannot always return the local client as this would break on shared
-	// master/seed systems (i.e. -seed-name being given means this is _also_ a
-	// seed cluster, not necessarily _only_ a seed cluster).
-	standardClientGetter := kubernetesprovider.SeedClientGetterFactory(seedKubeconfigGetter)
-
-	seedClientGetter = func(seed *kubermaticv1.Seed) (ctrlruntimeclient.Client, error) {
-		if options.seedName != "" && options.seedName == seed.Name {
-			return client, nil
-		}
-
-		return standardClientGetter(seed)
-	}
+	seedClientGetter = kubernetesprovider.SeedClientGetterFactory(seedKubeconfigGetter)
 
 	return
 }

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -143,19 +143,6 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 
 	// see project-synchronizer's syncAllSeeds comment
 	if seedInSeed.UID == "" || seedInSeed.UID != seed.UID {
-		seedKubeconfig, err := kubernetesprovider.GetSeedKubeconfigSecret(ctx, r, seed)
-		if err != nil {
-			return fmt.Errorf("failed to get kubeconfig for seed: %w", err)
-		}
-
-		seedKubeconfigCreators := []reconciling.NamedSecretCreatorGetter{
-			secretCreator(seedKubeconfig),
-		}
-
-		if err := reconciling.ReconcileSecrets(ctx, seedKubeconfigCreators, seedKubeconfig.Namespace, seedClient); err != nil {
-			return fmt.Errorf("failed to reconcile seed kubeconfig: %w", err)
-		}
-
 		seedCreators := []reconciling.NamedSeedCreatorGetter{
 			seedCreator(seed),
 		}

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -143,6 +143,19 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 
 	// see project-synchronizer's syncAllSeeds comment
 	if seedInSeed.UID == "" || seedInSeed.UID != seed.UID {
+		seedKubeconfig, err := kubernetesprovider.GetSeedKubeconfigSecret(ctx, r, seed)
+		if err != nil {
+			return fmt.Errorf("failed to get kubeconfig for seed: %w", err)
+		}
+
+		seedKubeconfigCreators := []reconciling.NamedSecretCreatorGetter{
+			secretCreator(seedKubeconfig),
+		}
+
+		if err := reconciling.ReconcileSecrets(ctx, seedKubeconfigCreators, seedKubeconfig.Namespace, seedClient); err != nil {
+			return fmt.Errorf("failed to reconcile seed kubeconfig: %w", err)
+		}
+
 		seedCreators := []reconciling.NamedSeedCreatorGetter{
 			seedCreator(seed),
 		}

--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -31,6 +31,23 @@ func namespaceCreator(namespace string) reconciling.NamedNamespaceCreatorGetter 
 	}
 }
 
+func secretCreator(original *corev1.Secret) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return original.Name, func(s *corev1.Secret) (*corev1.Secret, error) {
+			s.Labels = original.Labels
+			if s.Labels == nil {
+				s.Labels = make(map[string]string)
+			}
+			s.Labels[ManagedByLabel] = ControllerName
+
+			s.Annotations = original.Annotations
+			s.Data = original.Data
+
+			return s, nil
+		}
+	}
+}
+
 func seedCreator(seed *kubermaticv1.Seed) reconciling.NamedSeedCreatorGetter {
 	return func() (string, reconciling.SeedCreator) {
 		return seed.Name, func(s *kubermaticv1.Seed) (*kubermaticv1.Seed, error) {

--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -31,23 +31,6 @@ func namespaceCreator(namespace string) reconciling.NamedNamespaceCreatorGetter 
 	}
 }
 
-func secretCreator(original *corev1.Secret) reconciling.NamedSecretCreatorGetter {
-	return func() (string, reconciling.SecretCreator) {
-		return original.Name, func(s *corev1.Secret) (*corev1.Secret, error) {
-			s.Labels = original.Labels
-			if s.Labels == nil {
-				s.Labels = make(map[string]string)
-			}
-			s.Labels[ManagedByLabel] = ControllerName
-
-			s.Annotations = original.Annotations
-			s.Data = original.Data
-
-			return s, nil
-		}
-	}
-}
-
 func seedCreator(seed *kubermaticv1.Seed) reconciling.NamedSeedCreatorGetter {
 	return func() (string, reconciling.SeedCreator) {
 		return seed.Name, func(s *kubermaticv1.Seed) (*kubermaticv1.Seed, error) {

--- a/pkg/controller/operator/seed-init/reconciler.go
+++ b/pkg/controller/operator/seed-init/reconciler.go
@@ -100,11 +100,6 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 		return fmt.Errorf("failed to create seed cluster client: %w", err)
 	}
 
-	seedKubeconfig, err := kubernetes.GetSeedKubeconfigSecret(ctx, r.masterClient, seed)
-	if err != nil {
-		return fmt.Errorf("failed to get seed kubeconfig: %w", err)
-	}
-
 	// retrieve the _undefaulted_ config (which is why this cannot use the KubermaticConfigurationGetter)
 	config, err := kubernetes.GetRawKubermaticConfiguration(ctx, r.masterClient, seed.Namespace)
 	if err != nil {
@@ -120,10 +115,6 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 
 	if err := r.createOnSeed(ctx, ns, seedClient, log.With("namespace", ns.Name)); err != nil {
 		return fmt.Errorf("failed to create KKP namespace: %w", err)
-	}
-
-	if err := r.createOnSeed(ctx, seedKubeconfig, seedClient, log.With("seed", seed.Name)); err != nil {
-		return fmt.Errorf("failed to create Seed kubeconfig resource copy: %w", err)
 	}
 
 	if err := r.createOnSeed(ctx, seed, seedClient, log.With("seed", seed.Name)); err != nil {

--- a/pkg/controller/operator/seed-init/reconciler.go
+++ b/pkg/controller/operator/seed-init/reconciler.go
@@ -100,6 +100,11 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 		return fmt.Errorf("failed to create seed cluster client: %w", err)
 	}
 
+	seedKubeconfig, err := kubernetes.GetSeedKubeconfigSecret(ctx, r.masterClient, seed)
+	if err != nil {
+		return fmt.Errorf("failed to get seed kubeconfig: %w", err)
+	}
+
 	// retrieve the _undefaulted_ config (which is why this cannot use the KubermaticConfigurationGetter)
 	config, err := kubernetes.GetRawKubermaticConfiguration(ctx, r.masterClient, seed.Namespace)
 	if err != nil {
@@ -115,6 +120,10 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 
 	if err := r.createOnSeed(ctx, ns, seedClient, log.With("namespace", ns.Name)); err != nil {
 		return fmt.Errorf("failed to create KKP namespace: %w", err)
+	}
+
+	if err := r.createOnSeed(ctx, seedKubeconfig, seedClient, log.With("seed", seed.Name)); err != nil {
+		return fmt.Errorf("failed to create Seed kubeconfig resource copy: %w", err)
 	}
 
 	if err := r.createOnSeed(ctx, seed, seedClient, log.With("seed", seed.Name)); err != nil {

--- a/pkg/provider/kubernetes/seed.go
+++ b/pkg/provider/kubernetes/seed.go
@@ -144,32 +144,51 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, na
 	}, nil
 }
 
+func GetSeedKubeconfigSecret(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	name := types.NamespacedName{
+		Namespace: seed.Spec.Kubeconfig.Namespace,
+		Name:      seed.Spec.Kubeconfig.Name,
+	}
+	if name.Namespace == "" {
+		name.Namespace = seed.Namespace
+	}
+	if err := client.Get(ctx, name, secret); err != nil {
+		return nil, fmt.Errorf("failed to get kubeconfig secret %q: %w", name.String(), err)
+	}
+
+	return secret, nil
+}
+
+func GetSeedKubeconfig(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed) ([]byte, error) {
+	secret, err := GetSeedKubeconfigSecret(ctx, client, seed)
+	if err != nil {
+		return nil, err
+	}
+
+	fieldPath := seed.Spec.Kubeconfig.FieldPath
+	if len(fieldPath) == 0 {
+		fieldPath = provider.DefaultKubeconfigFieldPath
+	}
+	if _, exists := secret.Data[fieldPath]; !exists {
+		return nil, fmt.Errorf("secret %q has no key %q", secret.Name, fieldPath)
+	}
+
+	return secret.Data[fieldPath], nil
+}
+
 func SeedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client) (provider.SeedKubeconfigGetter, error) {
 	return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
-		secret := &corev1.Secret{}
-		name := types.NamespacedName{
-			Namespace: seed.Spec.Kubeconfig.Namespace,
-			Name:      seed.Spec.Kubeconfig.Name,
-		}
-		if name.Namespace == "" {
-			name.Namespace = seed.Namespace
-		}
-		if err := client.Get(ctx, name, secret); err != nil {
-			return nil, fmt.Errorf("failed to get kubeconfig secret %q: %w", name.String(), err)
+		kubeconfig, err := GetSeedKubeconfig(ctx, client, seed)
+		if err != nil {
+			return nil, err
 		}
 
-		fieldPath := seed.Spec.Kubeconfig.FieldPath
-		if len(fieldPath) == 0 {
-			fieldPath = provider.DefaultKubeconfigFieldPath
-		}
-		if _, exists := secret.Data[fieldPath]; !exists {
-			return nil, fmt.Errorf("secret %q has no key %q", name.String(), fieldPath)
-		}
-
-		cfg, err := clientcmd.RESTConfigFromKubeConfig(secret.Data[fieldPath])
+		cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 		}
+
 		return cfg, nil
 	}, nil
 }

--- a/pkg/provider/kubernetes/seed.go
+++ b/pkg/provider/kubernetes/seed.go
@@ -144,51 +144,32 @@ func SeedsGetterFactory(ctx context.Context, client ctrlruntimeclient.Client, na
 	}, nil
 }
 
-func GetSeedKubeconfigSecret(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	name := types.NamespacedName{
-		Namespace: seed.Spec.Kubeconfig.Namespace,
-		Name:      seed.Spec.Kubeconfig.Name,
-	}
-	if name.Namespace == "" {
-		name.Namespace = seed.Namespace
-	}
-	if err := client.Get(ctx, name, secret); err != nil {
-		return nil, fmt.Errorf("failed to get kubeconfig secret %q: %w", name.String(), err)
-	}
-
-	return secret, nil
-}
-
-func GetSeedKubeconfig(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed) ([]byte, error) {
-	secret, err := GetSeedKubeconfigSecret(ctx, client, seed)
-	if err != nil {
-		return nil, err
-	}
-
-	fieldPath := seed.Spec.Kubeconfig.FieldPath
-	if len(fieldPath) == 0 {
-		fieldPath = provider.DefaultKubeconfigFieldPath
-	}
-	if _, exists := secret.Data[fieldPath]; !exists {
-		return nil, fmt.Errorf("secret %q has no key %q", secret.Name, fieldPath)
-	}
-
-	return secret.Data[fieldPath], nil
-}
-
 func SeedKubeconfigGetterFactory(ctx context.Context, client ctrlruntimeclient.Client) (provider.SeedKubeconfigGetter, error) {
 	return func(seed *kubermaticv1.Seed) (*rest.Config, error) {
-		kubeconfig, err := GetSeedKubeconfig(ctx, client, seed)
-		if err != nil {
-			return nil, err
+		secret := &corev1.Secret{}
+		name := types.NamespacedName{
+			Namespace: seed.Spec.Kubeconfig.Namespace,
+			Name:      seed.Spec.Kubeconfig.Name,
+		}
+		if name.Namespace == "" {
+			name.Namespace = seed.Namespace
+		}
+		if err := client.Get(ctx, name, secret); err != nil {
+			return nil, fmt.Errorf("failed to get kubeconfig secret %q: %w", name.String(), err)
 		}
 
-		cfg, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+		fieldPath := seed.Spec.Kubeconfig.FieldPath
+		if len(fieldPath) == 0 {
+			fieldPath = provider.DefaultKubeconfigFieldPath
+		}
+		if _, exists := secret.Data[fieldPath]; !exists {
+			return nil, fmt.Errorf("secret %q has no key %q", name.String(), fieldPath)
+		}
+
+		cfg, err := clientcmd.RESTConfigFromKubeConfig(secret.Data[fieldPath])
 		if err != nil {
 			return nil, fmt.Errorf("failed to load kubeconfig: %w", err)
 		}
-
 		return cfg, nil
 	}, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The webhook on external seed clusters broke because no kubeconfig was available, breaking the seedKubeconfigGetter/seedClientGetter.

This PR wanted to implement @embik's suggestion to use the local client when possible. However the local client, governed by the Kubernetes service account, does not have permissions to do all the things a webhook needs to do, as it was built around the idea that the webhook _always_ goes through the Seed kubeconfig and thereby gains admin permissions. Fine-grained RBAC was not yet planned for the webhook.

This situation lead me to re-consider (see the commit log of this PR) and instead go with the "blunt" approach of copying the seed kubeconfig onto the seed clusters. The potential downside to this is that the webhook needs to connect "from the outside" to the cluster, incurring some network overhead.

An alternate idea would have been to take the kubeconfig and modify its URL to point to the local cluster, but this would require changing the certificate and seems very hacky (especially considering that in the future we want to go with a proper RBAC approach anyway).

For all these reasons this PR goes with the simplest solution (copying the kubeconfig 1:1) that solves the current issue (broken webhook on seed clusters) and defers any RBAC improvements to a future PR. Especially since this PR is going to be backported to 2.20/2.21, I don't want to introduce RBAC changes to those release branches.

**Which issue(s) this PR fixes**:
Fixes #10941

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix kubermatic-webhook failing to start on external seed clusters.
```
