### PR TITLE
Fix for panic when creating dc on nil map

### DIFF
--- a/pkg/handler/v1/dc/datacenter.go
+++ b/pkg/handler/v1/dc/datacenter.go
@@ -288,6 +288,9 @@ func CreateEndpoint(seedsGetter provider.SeedsGetter, userInfoGetter provider.Us
 		}
 
 		// Add DC, update seed
+		if seed.Spec.Datacenters == nil {
+			seed.Spec.Datacenters = map[string]kubermaticv1.Datacenter{}
+		}
 		seed.Spec.Datacenters[req.Body.Name] = convertExternalDCToInternal(&req.Body.Spec)
 
 		if err = masterClient.Update(ctx, seed); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for panic when creating datacenter on a Seed which datacenter map is nil

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10942

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed issue in KKP API where deleting all datacenters from a Seed and then trying to add a new one would cause a panic.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
