### PR TITLE
[release/v2.20] Fix webhook on seed-only clusters (#10951)

### DIFF
--- a/pkg/controller/master-controller-manager/seed-sync/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler.go
@@ -134,6 +134,19 @@ func (r *Reconciler) reconcile(ctx context.Context, config *kubermaticv1.Kuberma
 		}
 	}
 
+	seedKubeconfig, err := provider.GetSeedKubeconfigSecret(ctx, r, seed)
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig for seed: %w", err)
+	}
+
+	seedKubeconfigCreators := []reconciling.NamedSecretCreatorGetter{
+		secretCreator(seedKubeconfig),
+	}
+
+	if err := reconciling.ReconcileSecrets(ctx, seedKubeconfigCreators, seedKubeconfig.Namespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile seed kubeconfig: %w", err)
+	}
+
 	seedCreators := []reconciling.NamedSeedCreatorGetter{
 		seedCreator(seed),
 	}

--- a/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
+++ b/pkg/controller/master-controller-manager/seed-sync/reconciler_test.go
@@ -26,7 +26,9 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/provider"
 
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,6 +45,16 @@ func init() {
 }
 
 func TestReconcilingSeed(t *testing.T) {
+	kubeconfigSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-seed-kubeconfig",
+			Namespace: "kubermatic",
+		},
+		Data: map[string][]byte{
+			provider.DefaultKubeconfigFieldPath: []byte("this-is-not-a-kubeconfig-but-that-doesnt-matter-here"),
+		},
+	}
+
 	existingSeeds := []ctrlruntimeclient.Object{
 		&kubermaticv1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
@@ -78,6 +90,9 @@ func TestReconcilingSeed(t *testing.T) {
 				Spec: kubermaticv1.SeedSpec{
 					Country:        "Germany",
 					ExposeStrategy: kubermaticv1.ExposeStrategyNodePort,
+					Kubeconfig: corev1.ObjectReference{
+						Name: kubeconfigSecret.Name,
+					},
 				},
 			},
 			config: &kubermaticv1.KubermaticConfiguration{
@@ -120,6 +135,9 @@ func TestReconcilingSeed(t *testing.T) {
 				},
 				Spec: kubermaticv1.SeedSpec{
 					Country: "Germany",
+					Kubeconfig: corev1.ObjectReference{
+						Name: kubeconfigSecret.Name,
+					},
 				},
 			},
 			config: &kubermaticv1.KubermaticConfiguration{
@@ -186,6 +204,9 @@ func TestReconcilingSeed(t *testing.T) {
 				Spec: kubermaticv1.SeedSpec{
 					Country:        "Germany",
 					ExposeStrategy: kubermaticv1.ExposeStrategyNodePort,
+					Kubeconfig: corev1.ObjectReference{
+						Name: kubeconfigSecret.Name,
+					},
 				},
 			},
 			config: &kubermaticv1.KubermaticConfiguration{
@@ -225,7 +246,7 @@ func TestReconcilingSeed(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			masterClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(test.seed).Build()
+			masterClient := fakectrlruntimeclient.NewClientBuilder().WithObjects(test.seed, kubeconfigSecret).Build()
 			seedClient := fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #10951.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
Fix kubermatic-webhook failing to start on external seed clusters.
```
