### PR TITLE
Allow removal of specific datacenter IPAM Pool

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -226,7 +226,7 @@ func main() {
 	// /////////////////////////////////////////
 	// setup IPAMPool webhook
 
-	ipamPoolValidator := ipampoolvalidation.NewValidator(seedGetter, seedClientGetter)
+	ipamPoolValidator := ipampoolvalidation.NewValidator()
 	if err := builder.WebhookManagedBy(mgr).For(&kubermaticv1.IPAMPool{}).WithValidator(ipamPoolValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup IPAMPool validation webhook", zap.Error(err))
 	}

--- a/pkg/controller/seed-controller-manager/ipam/controller_test.go
+++ b/pkg/controller/seed-controller-manager/ipam/controller_test.go
@@ -141,7 +141,7 @@ func TestReconcileCluster(t *testing.T) {
 					},
 					Spec: kubermaticv1.IPAMPoolSpec{
 						Datacenters: map[string]kubermaticv1.IPAMPoolDatacenterSettings{
-							"test-dc-2": {
+							"test-dc-1": {
 								Type:             "prefix",
 								PoolCIDR:         "192.168.1.0/27",
 								AllocationPrefix: 28,
@@ -241,6 +241,40 @@ func TestReconcileCluster(t *testing.T) {
 						},
 					},
 				},
+			},
+		},
+		{
+			name:    "delete allocation with datacenter not present in the IPAM pool spec",
+			cluster: generateTestCluster("test-cluster-1", "test-dc-1"),
+			objects: []ctrlruntimeclient.Object{
+				&kubermaticv1.IPAMPool{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-pool-1",
+					},
+					Spec: kubermaticv1.IPAMPoolSpec{
+						Datacenters: map[string]kubermaticv1.IPAMPoolDatacenterSettings{},
+					},
+				},
+				&kubermaticv1.IPAMAllocation{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "test-pool-1",
+						Namespace:       fmt.Sprintf("cluster-%s", "test-cluster-1"),
+						ResourceVersion: "1",
+						OwnerReferences: []metav1.OwnerReference{{APIVersion: "kubermatic.k8c.io/v1", Kind: "IPAMPool", Name: "test-pool-1"}},
+					},
+					Spec: kubermaticv1.IPAMAllocationSpec{
+						Type:      kubermaticv1.IPAMPoolAllocationTypeRange,
+						DC:        "test-dc-1",
+						Addresses: []string{"192.168.1.0-192.168.1.7"},
+					},
+				},
+			},
+			expectedClusterAllocations: &kubermaticv1.IPAMAllocationList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "IPAMAllocationList",
+					APIVersion: "kubermatic.k8c.io/v1",
+				},
+				Items: []kubermaticv1.IPAMAllocation{},
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR it would be possible to remove a datacenter from the `IPAMPool` spec, even if some user clusters are still running in it and have existing allocations from the pool. Deleting the whole `IPAMPool` is not desirable, as that would affect other datacenters as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10814

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
