### PR TITLE
Fix Openstack getTenant issue with ErrEndpointNotFound

### DIFF
--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -607,7 +607,7 @@ func isNotFoundErr(err error) bool {
 func isEndpointNotFoundErr(err error) bool {
 	var endpointNotFoundErr *gophercloud.ErrEndpointNotFound
 	// left side of the || to catch any error returned as pointer to struct (current case of gophercloud)
-	// right side of the || to cathc any error returned as struct (in case...)
+	// right side of the || to catch any error returned as struct (in case...)
 	return errors.As(err, &endpointNotFoundErr) || errors.As(err, &gophercloud.ErrEndpointNotFound{})
 }
 

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -605,7 +605,10 @@ func isNotFoundErr(err error) bool {
 }
 
 func isEndpointNotFoundErr(err error) bool {
-	return errors.As(err, &gophercloud.ErrEndpointNotFound{})
+	var endpointNotFoundErr *gophercloud.ErrEndpointNotFound
+	// left side of the || to catch any error returned as pointer to struct (current case of gophercloud)
+	// right side of the || to cathc any error returned as struct (in case...)
+	return errors.As(err, &endpointNotFoundErr) || errors.As(err, &gophercloud.ErrEndpointNotFound{})
 }
 
 func getRouterIDForSubnet(netClient *gophercloud.ServiceClient, subnetID string) (string, error) {

--- a/pkg/provider/cloud/openstack/helper_test.go
+++ b/pkg/provider/cloud/openstack/helper_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+)
+
+func NewPointerEndpointNotFoundErr() error {
+	return &gophercloud.ErrEndpointNotFound{}
+}
+func NewValueEndpointNotFoundErr() error {
+	return gophercloud.ErrEndpointNotFound{}
+}
+func NewPointerNotFoundErr() error {
+	return &gophercloud.ErrDefault404{}
+}
+func NewValueNotFoundErr() error {
+	return &gophercloud.ErrDefault404{}
+}
+
+func Test_isEndpointNotFoundErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "Correct endpoint not found error (as pointer)",
+			err:  NewPointerEndpointNotFoundErr(),
+			want: true,
+		},
+		{
+			name: "Correct endpoint not found error (as value)",
+			err:  NewValueEndpointNotFoundErr(),
+			want: true,
+		},
+		{
+			name: "Incorrect not found error (as pointer)",
+			err:  NewPointerNotFoundErr(),
+			want: false,
+		},
+		{
+			name: "Incorrect not found error (as value)",
+			err:  NewValueNotFoundErr(),
+			want: false,
+		},
+		{
+			name: "Incorrect different error",
+			err:  errors.New("different one"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isEndpointNotFoundErr(tt.err); got != tt.want {
+				t.Errorf("isEndpointNotFoundErr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
The PR fixes the `api/v1/providers/openstack/tenants` API endpoint (support ticket 4373)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfixes
Fixes Openstack `api/v1/providers/openstack/tenants` API endpoint for some cases where "couldn't get projects: couldn't get tenants for region XX: couldn't get identity endpoint: No suitable endpoint could be found in the service catalog." was wrongly returned.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
