### PR TITLE
Fix CCM migration tests

### DIFF
--- a/pkg/test/e2e/ccm-migration/ccm_migration_test.go
+++ b/pkg/test/e2e/ccm-migration/ccm_migration_test.go
@@ -228,6 +228,7 @@ func testBody(t *testing.T, ctx context.Context, clusterJig providers.ClusterJig
 	newCluster := cluster.DeepCopy()
 	newCluster.Spec.Features = map[string]bool{
 		kubermaticv1.ClusterFeatureExternalCloudProvider: true,
+		kubermaticv1.ClusterFeatureEtcdLauncher:          true,
 	}
 	if err := seedClient.Patch(ctx, newCluster, ctrlruntimeclient.MergeFrom(cluster)); err != nil {
 		return fmt.Errorf("failed to patch cluster: %w", err)


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:

Error from tests:
```
ccm_migration_test.go:117: failed to patch cluster: admission webhook "clusters.kubermatic.io" denied the request: spec.features[etcdLauncher]: Invalid value: false: feature gate "etcdLauncher" cannot be disabled once it's enabled
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
