### PR TITLE
[release/v2.21] fix spellcheck findings

### DIFF
--- a/addons/cilium/cilium_v1.11.yaml
+++ b/addons/cilium/cilium_v1.11.yaml
@@ -145,7 +145,7 @@ data:
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # Unique ID of the cluster. Must be unique across all connected clusters and
   # in the range of 1 and 255. Only relevant when building a mesh of clusters.
   cluster-id: ""
 

--- a/addons/cilium/cilium_v1.12.yaml
+++ b/addons/cilium/cilium_v1.12.yaml
@@ -145,7 +145,7 @@ data:
 
   # Name of the cluster. Only relevant when building a mesh of clusters.
   cluster-name: default
-  # Unique ID of the cluster. Must be unique across all conneted clusters and
+  # Unique ID of the cluster. Must be unique across all connected clusters and
   # in the range of 1 and 255. Only relevant when building a mesh of clusters.
   cluster-id: "0"
 

--- a/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
@@ -98,7 +98,7 @@ groups:
           service: kubelet
       - alert: KubeletRuntimeErrors
         annotations:
-          message: The kubelet on {{ $labels.instance }} is having an elevated error rate for container runtime oprations.
+          message: The kubelet on {{ $labels.instance }} is having an elevated error rate for container runtime operations.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat-sheets/alerting-runbook/#alert-kubeletruntimeerrors
         expr: |
           sum(rate(kubelet_runtime_operations_errors_total{job="kubelet"}[5m])) by (instance) > 0.1

--- a/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
@@ -108,7 +108,7 @@ groups:
 
       - alert: KubeletRuntimeErrors
         annotations:
-          message: The kubelet on {{ $labels.instance }} is having an elevated error rate for container runtime oprations.
+          message: The kubelet on {{ $labels.instance }} is having an elevated error rate for container runtime operations.
           runbook_url: https://docs.kubermatic.com/kubermatic/master/cheat-sheets/alerting-runbook/#alert-kubeletruntimeerrors
         expr: |
           sum(rate(kubelet_runtime_operations_errors_total{job="kubelet"}[5m])) by (instance) > 0.1

--- a/cmd/conformance-tester/pkg/clients/client_api.go
+++ b/cmd/conformance-tester/pkg/clients/client_api.go
@@ -239,7 +239,7 @@ func (c *apiClient) CreateCluster(ctx context.Context, log *zap.SugaredLogger, s
 
 	cluster := scenario.APICluster(c.opts.Secrets)
 	// The cluster name must be unique per project;
-	// we build up a readable name with the various cli parameters annd
+	// we build up a readable name with the various cli parameters and
 	// add a random string in the end to ensure we really have a unique name.
 	if c.opts.NamePrefix != "" {
 		cluster.Cluster.Name = c.opts.NamePrefix + "-"

--- a/cmd/conformance-tester/pkg/clients/client_kube.go
+++ b/cmd/conformance-tester/pkg/clients/client_kube.go
@@ -169,7 +169,7 @@ func (c *kubeClient) CreateCluster(ctx context.Context, log *zap.SugaredLogger, 
 	name := fmt.Sprintf("%s-%s", c.opts.NamePrefix, rand.String(5))
 
 	// The cluster humanReadableName must be unique per project;
-	// we build up a readable humanReadableName with the various cli parameters annd
+	// we build up a readable humanReadableName with the various cli parameters and
 	// add a random string in the end to ensure we really have a unique humanReadableName.
 	humanReadableName := ""
 	if c.opts.NamePrefix != "" {

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,4 +2,4 @@
 
 This directory contains documentation relevant for _developing_
 Kubermatic. Please refer to the [official documentation](https://docs.kubermatic.com/kubermatic/)
-for general intallation, usage and other information.
+for general installation, usage and other information.

--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -6,7 +6,7 @@ environment, then configuring that cluster to be managed by a locally running co
 The basic steps to get started on this are these:
 
 * Clone the dashboard repo onto your `GOPATH`: `git clone git@github.com:kubermatic/dashboard.git $(go env GOPATH)/src/k8c.io/dashboard`
-* Start all the components via the respective scripts. All of them are blocking so it is suggested to start a termial instance for each:
+* Start all the components via the respective scripts. All of them are blocking so it is suggested to start a terminal instance for each:
     * API: `$(go env GOPATH)/src/k8c.io/kubermatic/hack/run-api.sh`
     * Dashboard: `$(go env GOPATH)/src/k8c.io/dashboard/hack/run-local-dashboard.sh`
     * Controller-Manager: `$(go env GOPATH)/src/k8c.io/kubermatic/hack/run-controller.sh`

--- a/docs/proposals/integrate-upstream-machineset-and-machinedeployment-controllers.md
+++ b/docs/proposals/integrate-upstream-machineset-and-machinedeployment-controllers.md
@@ -12,7 +12,7 @@ via `machineDeployments`. This in turn means, that we need controllers for both 
 
 These controllers already exist within the [sig cluster-api repo](https://github.com/kubernetes-sigs/cluster-api/tree/c8f5046fb0b9a3a16b7f8b92f6dda7b0f65b4f55):
 
-* [machineSet controlller]: https://github.com/kubernetes-sigs/cluster-api/tree/c8f5046fb0b9a3a16b7f8b92f6dda7b0f65b4f55/pkg/controller/machineset
+* [machineSet controller]: https://github.com/kubernetes-sigs/cluster-api/tree/c8f5046fb0b9a3a16b7f8b92f6dda7b0f65b4f55/pkg/controller/machineset
 * [machineDeployment controller]: https://github.com/kubernetes-sigs/cluster-api/tree/c8f5046fb0b9a3a16b7f8b92f6dda7b0f65b4f55/pkg/controller/machinedeployment
 
 To reduce development efforts we would like to use the upstream controllers. However simply importing them is

--- a/docs/proposals/kubermatic-installer.md
+++ b/docs/proposals/kubermatic-installer.md
@@ -35,7 +35,7 @@ The "chain of command" is then as follows:
 
 As our documentation already separates Kubermatic from the monitoring and logging stack,
 the installer will do the same. The first version will only include support for
-intalling the Kubermatic stack (cert-manager, nginx, Dex, Kubermatic Operator), later
+installing the Kubermatic stack (cert-manager, nginx, Dex, Kubermatic Operator), later
 versions will then gain support for the other stacks.
 
 ### User Story

--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -48,7 +48,7 @@ type Addon struct {
 	// Spec describes the desired addon state.
 	Spec AddonSpec `json:"spec,omitempty"`
 
-	// Status contrains information about the reconciliation status.
+	// Status contains information about the reconciliation status.
 	Status AddonStatus `json:"status,omitempty"`
 }
 
@@ -92,7 +92,7 @@ type AddonList struct {
 	Items []Addon `json:"items"`
 }
 
-// AddonStatus contrains information about the reconciliation status.
+// AddonStatus contains information about the reconciliation status.
 type AddonStatus struct {
 	Conditions map[AddonConditionType]AddonCondition `json:"conditions,omitempty"`
 }

--- a/pkg/apis/kubermatic/v1/user.go
+++ b/pkg/apis/kubermatic/v1/user.go
@@ -59,7 +59,7 @@ type UserStatus struct {
 
 // UserSpec specifies a user.
 type UserSpec struct {
-	// ID is an unnused legacy field.
+	// ID is an unused legacy field.
 	// Deprecated: do not set this field anymore.
 	ID string `json:"id,omitempty"`
 	// Name is the full name of this user.

--- a/pkg/applications/installer_test.go
+++ b/pkg/applications/installer_test.go
@@ -45,7 +45,7 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 		namespaceSpec appskubermaticv1.NamespaceSpec
 	}{
 		{
-			name: "scenario 1: when Namespace.create=true and no labels or annotations are defined then namespace should be cretated without labels or annotations",
+			name: "scenario 1: when Namespace.create=true and no labels or annotations are defined then namespace should be created without labels or annotations",
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),
@@ -57,7 +57,7 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario 2: when Namespace.create=true, labels field is defined and annotations field nil then namespace should be cretated with labels",
+			name: "scenario 2: when Namespace.create=true, labels field is defined and annotations field nil then namespace should be created with labels",
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),
@@ -69,7 +69,7 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario 3: when Namespace.create=true, labels field is nil and annotations field is defined then namespace should be cretated with annotations",
+			name: "scenario 3: when Namespace.create=true, labels field is nil and annotations field is defined then namespace should be created with annotations",
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),
@@ -81,7 +81,7 @@ func TestApplicationManager_applyNamespaceWithCreateNs(t *testing.T) {
 			},
 		},
 		{
-			name: "scenario 4: when Namespace.create=true, labels and annotations are defined then namespace should be cretated with labels and annotations",
+			name: "scenario 4: when Namespace.create=true, labels and annotations are defined then namespace should be created with labels and annotations",
 			userClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				Build(),

--- a/pkg/applications/providers/util/util.go
+++ b/pkg/applications/providers/util/util.go
@@ -49,7 +49,7 @@ func CleanUpHelmTempDir(cacheDir string, logger *zap.SugaredLogger) {
 }
 
 // StatusUpdater is a function that postpone the update of the applicationInstallation.
-// It used to set status's filed of a specific template Porvider (eg status.HelmRelease).
+// It used to set status's filed of a specific template Provider (eg status.HelmRelease).
 type StatusUpdater func(status *appskubermaticv1.ApplicationInstallationStatus)
 
 // NoStatusUpdate is a StatusUpdater that does not update the status.

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/suite_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/suite_test.go
@@ -48,7 +48,7 @@ var applicationInstallerRecorder fake.ApplicationInstallerRecorder
 func TestApplicationInstallerController(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "Application Intallation controller test suite")
+	RunSpecs(t, "Application Installation controller test suite")
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -119,7 +119,7 @@ spec:
             - name
             type: object
           status:
-            description: Status contrains information about the reconciliation status.
+            description: Status contains information about the reconciliation status.
             properties:
               conditions:
                 additionalProperties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_users.yaml
@@ -67,7 +67,7 @@ spec:
                   type: string
                 type: array
               id:
-                description: 'ID is an unnused legacy field. Deprecated: do not set
+                description: 'ID is an unused legacy field. Deprecated: do not set
                   this field anymore.'
                 type: string
               invalidTokensReference:

--- a/pkg/provider/seed_test.go
+++ b/pkg/provider/seed_test.go
@@ -97,7 +97,7 @@ func TestSeedsGetterFactorySetsDefaults(t *testing.T) {
 		t.Fatalf("failed calling seedsGetter: %v", err)
 	}
 	if _, exists := seeds[DefaultSeedName]; !exists || len(seeds) != 1 {
-		t.Fatalf("expceted to get a map with exactly one key `my-seed`, got %v", seeds)
+		t.Fatalf("expected to get a map with exactly one key `my-seed`, got %v", seeds)
 	}
 
 	seed := seeds[DefaultSeedName]

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -65,7 +65,7 @@ type CloudProvider interface {
 }
 
 // ReconcilingCloudProvider is a cloud provider that can not just created resources
-// once, but is capable of continuously reconciling annd fixing any problems with them.
+// once, but is capable of continuously reconciling and fixing any problems with them.
 type ReconcilingCloudProvider interface {
 	CloudProvider
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The new spellcheck version in the Go 1.19 Docker image found a bunch of typos, some of which are worth being fixed in 2.21. So this PR backports the spellcheck fixes from #10665 into the 2.21 release branch.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
