### PR TITLE
seed-proxy: increase memory limit from 32Mi to 64Mi

### DIFF
--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -268,7 +268,7 @@ func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret, get
 						},
 						Limits: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("100m"),
-							corev1.ResourceMemory: resource.MustParse("32Mi"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},
 					},
 					ReadinessProbe: &probe,


### PR DESCRIPTION
On a customer setup, the memory limit is almost reached. unfortunately we don't have enough information to know why the limit is almost (it's not the case in our dev environment), so we increase the limit to the next power of 2.



**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
seed-proxy: increase memory limit from 32Mi to 64Mi
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
