### PR TITLE
Add Kubernetes 1.22.14, 1.23.11 and 1.24.5

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -13930,6 +13930,13 @@
         "parameters": [
           {
             "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
+          },
+          {
+            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13941,13 +13948,6 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
-          },
-          {
-            "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
           }
         ],
         "responses": {

--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -13930,13 +13930,6 @@
         "parameters": [
           {
             "type": "string",
-            "x-go-name": "Architecture",
-            "description": "architecture query parameter. Supports: arm64 and x64 types.",
-            "name": "architecture",
-            "in": "query"
-          },
-          {
-            "type": "string",
             "x-go-name": "ProjectID",
             "name": "project_id",
             "in": "path",
@@ -13948,6 +13941,13 @@
             "name": "cluster_id",
             "in": "path",
             "required": true
+          },
+          {
+            "type": "string",
+            "x-go-name": "Architecture",
+            "description": "architecture query parameter. Supports: arm64 and x64 types.",
+            "name": "architecture",
+            "in": "query"
           }
         ],
         "responses": {

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.23.9
+    default: v1.23.11
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -543,9 +543,12 @@ spec:
       - v1.22.5
       - v1.22.9
       - v1.22.12
+      - v1.22.14
       - v1.23.6
       - v1.23.9
+      - v1.23.11
       - v1.24.3
+      - v1.24.5
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -528,16 +528,22 @@ spec:
       - from: 1.22.*
         to: 1.22.*
       - automatic: true
-        from: '>= 1.22.0, < 1.22.5'
-        to: 1.22.5
+        from: '>= 1.22.0, < 1.22.14'
+        to: 1.22.14
       - from: 1.22.*
         to: 1.23.*
       - from: 1.23.*
         to: 1.23.*
+      - automatic: true
+        from: '>= 1.23.0, < 1.23.11'
+        to: 1.23.11
       - from: 1.23.*
         to: 1.24.*
       - from: 1.24.*
         to: 1.24.*
+      - automatic: true
+        from: '>= 1.24.0, < 1.24.5'
+        to: 1.24.5
     # Versions lists the available versions.
     versions:
       - v1.22.5

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,17 +216,20 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.23.9"),
+		Default: semver.NewSemverOrDie("v1.23.11"),
 		Versions: []semver.Semver{
 			// Kubernetes 1.22
 			newSemver("v1.22.5"),
 			newSemver("v1.22.9"),
 			newSemver("v1.22.12"),
+			newSemver("v1.22.14"),
 			// Kubernetes 1.23
 			newSemver("v1.23.6"),
 			newSemver("v1.23.9"),
+			newSemver("v1.23.11"),
 			// Kubernetes 1.24
 			newSemver("v1.24.3"),
+			newSemver("v1.24.5"),
 		},
 		Updates: []kubermaticv1.Update{
 			{

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -252,8 +252,10 @@ var (
 				// - CVE-2021-33910 (fixed >= 1.22.4)
 				// - CVE-2021-44716 (fixed >= 1.22.5)
 				// - CVE-2021-44717 (fixed >= 1.22.5)
-				From:      ">= 1.22.0, < 1.22.5",
-				To:        "1.22.5",
+				// - CVE-2022-3172 (fixed >= 1.22.14)
+				// - CVE-2021-25749 (fixed >= 1.22.14)
+				From:      ">= 1.22.0, < 1.22.14",
+				To:        "1.22.14",
 				Automatic: pointer.BoolPtr(true),
 			},
 			{
@@ -269,6 +271,14 @@ var (
 				To:   "1.23.*",
 			},
 			{
+				// Auto-upgrade because of CVEs:
+				// - CVE-2022-3172 (fixed >= 1.23.11)
+				// - CVE-2021-25749 (fixed >= 1.23.11)
+				From:      ">= 1.23.0, < 1.23.11",
+				To:        "1.23.11",
+				Automatic: pointer.BoolPtr(true),
+			},
+			{
 				// Allow to next minor release
 				From: "1.23.*",
 				To:   "1.24.*",
@@ -278,6 +288,14 @@ var (
 				// Allow to change to any patch version
 				From: "1.24.*",
 				To:   "1.24.*",
+			},
+			{
+				// Auto-upgrade because of CVEs:
+				// - CVE-2022-3172 (fixed >= 1.24.5)
+				// - CVE-2021-25749 (fixed >= 1.24.5)
+				From:      ">= 1.24.0, < 1.24.5",
+				To:        "1.24.5",
+				Automatic: pointer.BoolPtr(true),
 			},
 		},
 		ProviderIncompatibilities: []kubermaticv1.Incompatibility{

--- a/pkg/handler/v1/cluster/cluster_test.go
+++ b/pkg/handler/v1/cluster/cluster_test.go
@@ -820,7 +820,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		},
 		Spec: kubermaticv1.KubermaticConfigurationSpec{
 			Versions: kubermaticv1.KubermaticVersioningConfiguration{
-				Versions: test.GenDefaultVersions(),
+				Versions: defaulting.DefaultKubernetesVersioning.Versions,
 			},
 		},
 	}

--- a/pkg/handler/v2/cluster/cluster_test.go
+++ b/pkg/handler/v2/cluster/cluster_test.go
@@ -298,7 +298,7 @@ func TestCreateClusterEndpoint(t *testing.T) {
 		},
 		Spec: kubermaticv1.KubermaticConfigurationSpec{
 			Versions: kubermaticv1.KubermaticVersioningConfiguration{
-				Versions: test.GenDefaultVersions(),
+				Versions: defaulting.DefaultKubernetesVersioning.Versions,
 			},
 		},
 	}

--- a/pkg/handler/v2/cluster_template/cluster_template_test.go
+++ b/pkg/handler/v2/cluster_template/cluster_template_test.go
@@ -155,7 +155,7 @@ func TestCreateClusterTemplateEndpoint(t *testing.T) {
 		},
 		Spec: kubermaticv1.KubermaticConfigurationSpec{
 			Versions: kubermaticv1.KubermaticVersioningConfiguration{
-				Versions: test.GenDefaultVersions(),
+				Versions: defaulting.DefaultKubernetesVersioning.Versions,
 			},
 		},
 	}
@@ -796,7 +796,7 @@ func TestImportClusterTemplateEndpoint(t *testing.T) {
 		},
 		Spec: kubermaticv1.KubermaticConfigurationSpec{
 			Versions: kubermaticv1.KubermaticVersioningConfiguration{
-				Versions: test.GenDefaultVersions(),
+				Versions: defaulting.DefaultKubernetesVersioning.Versions,
 			},
 		},
 	}

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -1418,7 +1418,7 @@ func TestHandle(t *testing.T) {
 						NodePortRange: "30000-32000",
 					},
 				},
-				Version: semver.NewSemverOrDie("1.23.9"),
+				Version: test.LatestKubernetesVersionForRelease("1.23", &config),
 			}.Build(),
 			oldCluster: rawClusterGen{
 				Name:      "foo",


### PR DESCRIPTION
**What this PR does / why we need it**:
These new Kubernetes releases fix CVEs and so I also configured auto-update rules for all existing Kubernetes releases in KKP.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add support for Kubernetes 1.22.14, 1.23.11 and 1.24.5; existing clusters using these Kubernetes releases will be automatically updated as any previous version is affected by CVEs.
```
