### PR TITLE
Remove proxy url from nutanix e2e flags

### DIFF
--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -15,8 +15,7 @@
 presubmits:
   - name: pre-kubermatic-e2e-nutanix-ubuntu-1.24
     decorate: true
-    optional: true
-    # run_if_changed: "(addons/csi/nutanix|pkg/provider/cloud/nutanix)"
+    run_if_changed: "(addons/csi/nutanix|pkg/provider/cloud/nutanix)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-nutanix: "true"
@@ -62,8 +61,7 @@ presubmits:
 
   - name: pre-kubermatic-e2e-nutanix-centos-1.24
     decorate: true
-    optional: true
-    # run_if_changed: "(addons/csi/nutanix|pkg/provider/cloud/nutanix)"
+    run_if_changed: "(addons/csi/nutanix|pkg/provider/cloud/nutanix)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-nutanix: "true"

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -93,7 +93,6 @@ elif [[ $provider == "nutanix" ]]; then
     -nutanix-csi-username=${NUTANIX_E2E_PE_USERNAME}
     -nutanix-csi-password=${NUTANIX_E2E_PE_PASSWORD}
     -nutanix-csi-endpoint=${NUTANIX_E2E_PE_ENDPOINT}
-    -nutanix-proxy-url=http://${NUTANIX_E2E_PROXY_USERNAME}:${NUTANIX_E2E_PROXY_PASSWORD}@10.240.20.100:${NUTANIX_E2E_PROXY_PORT}/
     -nutanix-cluster-name=${NUTANIX_E2E_CLUSTER_NAME}
     -nutanix-project-name=${NUTANIX_E2E_PROJECT_NAME}
     -nutanix-subnet-name=${NUTANIX_E2E_SUBNET_NAME}


### PR DESCRIPTION
**What this PR does / why we need it**:

We've removed the proxy from our networking setup. This PR updates our e2e job flags to reflect that.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
