### PR TITLE
add cri pipeline_stage to promtail config

### DIFF
--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -101,6 +101,8 @@ promtail:
         - job_name: kubernetes-pods-name
           kubernetes_sd_configs:
           - role: pod
+          pipeline_stages:
+            cri: {}
           relabel_configs:
           - source_labels:
             - __meta_kubernetes_pod_label_name
@@ -142,6 +144,8 @@ promtail:
         - job_name: kubernetes-pods-app
           kubernetes_sd_configs:
           - role: pod
+          pipeline_stages:
+            cri: {}
           relabel_configs:
           - action: drop
             regex: .+
@@ -187,6 +191,8 @@ promtail:
         - job_name: kubernetes-pods-direct-controllers
           kubernetes_sd_configs:
           - role: pod
+          pipeline_stages:
+            cri: {}
           relabel_configs:
           - action: drop
             regex: .+
@@ -238,6 +244,8 @@ promtail:
         - job_name: kubernetes-pods-indirect-controller
           kubernetes_sd_configs:
           - role: pod
+          pipeline_stages:
+            cri: {}
           relabel_configs:
           - action: drop
             regex: .+
@@ -291,6 +299,8 @@ promtail:
         - job_name: kubernetes-pods-static
           kubernetes_sd_configs:
           - role: pod
+          pipeline_stages:
+            cri: {}
           relabel_configs:
           - action: drop
             regex: ''


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently JSON parsing for logs fails in Loki because our promtail config is missing [cri stage in the pipeline]( https://grafana.com/docs/loki/latest/clients/promtail/configuration/#cri ).

See https://community.grafana.com/t/why-is-the-json-parser-failing/48427 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
