### PR TITLE
Fix updating CRDs on seeds for development versions

### DIFF
--- a/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	ControllerName = "kp-seed-lifecycle-controller"
+	ControllerName = "kkp-seed-lifecycle-controller"
 
 	// We must only enqueue this one key.
 	queueKey = ControllerName


### PR DESCRIPTION
**What this PR does / why we need it**:
As it turns out, `v1.2.3-0000` is not a valid semver, as the prerelease must not having leading zeros.

This lead me down a rabbit hole of ineffective unit tests (the original test did in fact have one special case at the end, but it tested _with_ "alpha.something" in it (the seemingly "harder" test case) and so it didn't trigger the issue) and so this PR fixes the original issue and makes sure the unit tests actually test what is important: does their output compare in a way we expect? What exact string magic is going on behind the scenes should be irrelevant.

...and that's good, because oh boy did this friendly little function suddenly get scary. `zeta` was really my only option and without unit tests and ensuring that this function stays local to this one specific usecase I would not even approve this.

Thankfully only development versions are affected from the original issue, so this does not need to be backported.

Oh, and I also recently tried to improve the seed-lifecycle-controller and failed, but at least wanted to sneak the fix for the controll name typo in somewhere.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```
