### PR TITLE
fix: make cri a list item

### DIFF
--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -102,7 +102,7 @@ promtail:
           kubernetes_sd_configs:
           - role: pod
           pipeline_stages:
-            cri: {}
+          - cri: {}
           relabel_configs:
           - source_labels:
             - __meta_kubernetes_pod_label_name
@@ -145,7 +145,7 @@ promtail:
           kubernetes_sd_configs:
           - role: pod
           pipeline_stages:
-            cri: {}
+          - cri: {}
           relabel_configs:
           - action: drop
             regex: .+
@@ -192,7 +192,7 @@ promtail:
           kubernetes_sd_configs:
           - role: pod
           pipeline_stages:
-            cri: {}
+          - cri: {}
           relabel_configs:
           - action: drop
             regex: .+
@@ -245,7 +245,7 @@ promtail:
           kubernetes_sd_configs:
           - role: pod
           pipeline_stages:
-            cri: {}
+          - cri: {}
           relabel_configs:
           - action: drop
             regex: .+
@@ -300,7 +300,7 @@ promtail:
           kubernetes_sd_configs:
           - role: pod
           pipeline_stages:
-            cri: {}
+          - cri: {}
           relabel_configs:
           - action: drop
             regex: ''


### PR DESCRIPTION
**What this PR does / why we need it**:
`cri` should be a list item otherwise promtail fails to parse the config. 

I missed this fix in https://github.com/kubermatic/kubermatic/pull/10996 
It is there in dev so that isn't broken. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
