### PR TITLE
Bump Openstack CCM to 1.23.4 for k8s 1.23

### DIFF
--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -177,7 +177,7 @@ func getOSVersion(version semver.Semver) (string, error) {
 	case v122:
 		return "1.22.0", nil
 	case v123:
-		return "1.23.1", nil
+		return "1.23.4", nil
 	case v124:
 		fallthrough
 	default:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.1
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.23.4
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes issue of service ports mapping, more info: kubernetes/cloud-provider-openstack#1795

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump OpenStack version for k8s 1.23 to fix services ports mapping issue.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
