### PR TITLE
Bump Kubernetes versions

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.23.11
+    default: v1.23.12
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -528,33 +528,33 @@ spec:
       - from: 1.22.*
         to: 1.22.*
       - automatic: true
-        from: '>= 1.22.0, < 1.22.14'
-        to: 1.22.14
+        from: '>= 1.22.0, < 1.22.15'
+        to: 1.22.15
       - from: 1.22.*
         to: 1.23.*
       - from: 1.23.*
         to: 1.23.*
       - automatic: true
-        from: '>= 1.23.0, < 1.23.11'
-        to: 1.23.11
+        from: '>= 1.23.0, < 1.23.12'
+        to: 1.23.12
       - from: 1.23.*
         to: 1.24.*
       - from: 1.24.*
         to: 1.24.*
       - automatic: true
-        from: '>= 1.24.0, < 1.24.5'
-        to: 1.24.5
+        from: '>= 1.24.0, < 1.24.6'
+        to: 1.24.6
     # Versions lists the available versions.
     versions:
       - v1.22.5
       - v1.22.9
       - v1.22.12
-      - v1.22.14
+      - v1.22.15
       - v1.23.6
       - v1.23.9
-      - v1.23.11
+      - v1.23.12
       - v1.24.3
-      - v1.24.5
+      - v1.24.6
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,20 +216,20 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.23.11"),
+		Default: semver.NewSemverOrDie("v1.23.12"),
 		Versions: []semver.Semver{
 			// Kubernetes 1.22
 			newSemver("v1.22.5"),
 			newSemver("v1.22.9"),
 			newSemver("v1.22.12"),
-			newSemver("v1.22.14"),
+			newSemver("v1.22.15"),
 			// Kubernetes 1.23
 			newSemver("v1.23.6"),
 			newSemver("v1.23.9"),
-			newSemver("v1.23.11"),
+			newSemver("v1.23.12"),
 			// Kubernetes 1.24
 			newSemver("v1.24.3"),
-			newSemver("v1.24.5"),
+			newSemver("v1.24.6"),
 		},
 		Updates: []kubermaticv1.Update{
 			{
@@ -254,8 +254,8 @@ var (
 				// - CVE-2021-44717 (fixed >= 1.22.5)
 				// - CVE-2022-3172 (fixed >= 1.22.14)
 				// - CVE-2021-25749 (fixed >= 1.22.14)
-				From:      ">= 1.22.0, < 1.22.14",
-				To:        "1.22.14",
+				From:      ">= 1.22.0, < 1.22.15",
+				To:        "1.22.15",
 				Automatic: pointer.BoolPtr(true),
 			},
 			{
@@ -274,8 +274,8 @@ var (
 				// Auto-upgrade because of CVEs:
 				// - CVE-2022-3172 (fixed >= 1.23.11)
 				// - CVE-2021-25749 (fixed >= 1.23.11)
-				From:      ">= 1.23.0, < 1.23.11",
-				To:        "1.23.11",
+				From:      ">= 1.23.0, < 1.23.12",
+				To:        "1.23.12",
 				Automatic: pointer.BoolPtr(true),
 			},
 			{
@@ -293,8 +293,8 @@ var (
 				// Auto-upgrade because of CVEs:
 				// - CVE-2022-3172 (fixed >= 1.24.5)
 				// - CVE-2021-25749 (fixed >= 1.24.5)
-				From:      ">= 1.24.0, < 1.24.5",
-				To:        "1.24.5",
+				From:      ">= 1.24.0, < 1.24.6",
+				To:        "1.24.6",
 				Automatic: pointer.BoolPtr(true),
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
A regression in the recently released patch releases required new upstream releases and this PR integrates them.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add support for Kubernetes 1.22.15, 1.23.12 and 1.24.6; existing clusters using these Kubernetes releases will be automatically updated as any previous version is affected by CVEs.
```
