### PR TITLE
Fix Anexia disk config

### DIFF
--- a/pkg/machine/convert.go
+++ b/pkg/machine/convert.go
@@ -44,6 +44,7 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 
 	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/utils/pointer"
 )
 
 // GetAPIV1OperatingSystemSpec returns the api compatible OperatingSystemSpec for the given machine.
@@ -348,11 +349,10 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 				TemplateID: config.TemplateID.Value,
 				CPUs:       config.CPUs,
 				Memory:     int64(config.Memory),
-				DiskSize:   &[]int64{int64(config.DiskSize)}[0],
 			}
 
 			if config.DiskSize > 0 {
-				cloudSpec.Anexia.DiskSize = &[]int64{int64(config.DiskSize)}[0]
+				cloudSpec.Anexia.DiskSize = pointer.Int64(int64(config.DiskSize))
 			}
 
 			if diskCount := len(config.Disks); diskCount > 0 {
@@ -362,7 +362,7 @@ func GetAPIV2NodeCloudSpec(machineSpec clusterv1alpha1.MachineSpec) (*apiv1.Node
 					cloudSpec.Anexia.Disks[diskIndex].Size = int64(diskConfig.Size)
 
 					if diskConfig.PerformanceType.Value != "" {
-						cloudSpec.Anexia.Disks[diskIndex].PerformanceType = &[]string{diskConfig.PerformanceType.Value}[0]
+						cloudSpec.Anexia.Disks[diskIndex].PerformanceType = pointer.String(diskConfig.PerformanceType.Value)
 					}
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a mistake in our new disk config handling code that slipped through in #10816 - this fixes that.

When having a `MachineDeployment` in a user cluster with only the new `disks` attribute set, API still responds with an error stating both the old and the new attribute are set:
`{"error":{"code":500,"message":"json: error calling MarshalJSON for type *v1.AnexiaNodeSpec: missing or invalid required parameter(s): both disks and diskSize configured but only one of those allowed"}}`

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
I have backport branches prepared for v2.20 and v2.21 and will create the PRs once this here is approved.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfixes
Fix API error in extended disk configuration for provider Anexia
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation

```
