### PR TITLE
user MLA: Enable alert-management with Grafana

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -408,15 +408,15 @@ func (r *datasourceGrafanaController) handleDeletion(ctx context.Context, cluste
 		// that's mostly means that Grafana organization doesn't exists anymore
 		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(alertmanagerType, cluster)); err != nil {
 			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
-				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+				err, pointer.StringDeref(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
 		}
 		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(lokiType, cluster)); err != nil {
 			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
-				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+				err, pointer.StringDeref(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
 		}
 		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(PrometheusType, cluster)); err != nil {
 			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
-				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+				err, pointer.StringDeref(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
 		}
 	}
 	if cluster.DeletionTimestamp.IsZero() && cluster.Status.NamespaceName != "" {

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -49,8 +49,9 @@ import (
 )
 
 const (
-	PrometheusType = "prometheus"
-	lokiType       = "loki"
+	PrometheusType   = "prometheus"
+	lokiType         = "loki"
+	alertmanagerType = "alertmanager"
 )
 
 // datasourceGrafanaReconciler stores necessary components that are required to manage MLA(Monitoring, Logging, and Alerting) setup.
@@ -255,6 +256,22 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 		return nil, fmt.Errorf("failed to reconcile Services in namespace %s: %w", "mla", err)
 	}
 
+	alertmanagerDS := grafanasdk.Datasource{
+		OrgID:  org.ID,
+		UID:    getDatasourceUIDForCluster(alertmanagerType, cluster),
+		Name:   getAlertmanagerDatasourceNameForCluster(cluster),
+		Type:   alertmanagerType,
+		Access: "proxy",
+		URL:    fmt.Sprintf("http://mla-gateway.%s.svc.cluster.local/api/prom", cluster.Status.NamespaceName),
+		JSONData: map[string]interface{}{
+			"handleGrafanaManagedAlerts": true,
+			"implementation":             "cortex",
+		},
+	}
+	if err := r.reconcileDatasource(ctx, cluster.Spec.MLA.MonitoringEnabled || cluster.Spec.MLA.LoggingEnabled, alertmanagerDS, grafanaClient); err != nil {
+		return nil, fmt.Errorf("failed to ensure Grafana Alertmanager Datasources: %w", err)
+	}
+
 	lokiDS := grafanasdk.Datasource{
 		OrgID:  org.ID,
 		UID:    getDatasourceUIDForCluster(lokiType, cluster),
@@ -262,6 +279,9 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 		Type:   lokiType,
 		Access: "proxy",
 		URL:    fmt.Sprintf("http://mla-gateway.%s.svc.cluster.local", cluster.Status.NamespaceName),
+		JSONData: map[string]interface{}{
+			"alertmanagerUid": getDatasourceUIDForCluster(alertmanagerType, cluster),
+		},
 	}
 	if err := r.reconcileDatasource(ctx, cluster.Spec.MLA.LoggingEnabled, lokiDS, grafanaClient); err != nil {
 		return nil, fmt.Errorf("failed to ensure Grafana Loki Datasources: %w", err)
@@ -274,6 +294,10 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 		Type:   PrometheusType,
 		Access: "proxy",
 		URL:    fmt.Sprintf("http://mla-gateway.%s.svc.cluster.local/api/prom", cluster.Status.NamespaceName),
+		JSONData: map[string]interface{}{
+			"alertmanagerUid": getDatasourceUIDForCluster(alertmanagerType, cluster),
+			"httpMethod":      "POST",
+		},
 	}
 	if err := r.reconcileDatasource(ctx, cluster.Spec.MLA.MonitoringEnabled, prometheusDS, grafanaClient); err != nil {
 		return nil, fmt.Errorf("failed to ensure Grafana Prometheus Datasources: %w", err)
@@ -382,6 +406,10 @@ func (r *datasourceGrafanaController) cleanUpMlaGatewayHealthStatus(ctx context.
 func (r *datasourceGrafanaController) handleDeletion(ctx context.Context, cluster *kubermaticv1.Cluster, grafanaClient *grafanasdk.Client) error {
 	if grafanaClient != nil {
 		// that's mostly means that Grafana organization doesn't exists anymore
+		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(alertmanagerType, cluster)); err != nil {
+			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
+				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+		}
 		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(lokiType, cluster)); err != nil {
 			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
 				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -408,15 +408,15 @@ func (r *datasourceGrafanaController) handleDeletion(ctx context.Context, cluste
 		// that's mostly means that Grafana organization doesn't exists anymore
 		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(alertmanagerType, cluster)); err != nil {
 			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
-				err, pointer.StringDeref(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+				err, pointer.StringDeref(status.Status, "no status"), pointer.StringDeref(status.Message, "no message"))
 		}
 		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(lokiType, cluster)); err != nil {
 			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
-				err, pointer.StringDeref(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
 		}
 		if status, err := grafanaClient.DeleteDatasourceByUID(ctx, getDatasourceUIDForCluster(PrometheusType, cluster)); err != nil {
 			return fmt.Errorf("unable to delete datasource: %w (status: %s, message: %s)",
-				err, pointer.StringDeref(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
+				err, pointer.StringPtrDerefOr(status.Status, "no status"), pointer.StringPtrDerefOr(status.Message, "no message"))
 		}
 	}
 	if cluster.DeletionTimestamp.IsZero() && cluster.Status.NamespaceName != "" {

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller_test.go
@@ -129,6 +129,25 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					name: "get datasource by uid",
 					request: &http.Request{
 						Method: http.MethodGet,
+						URL:    &url.URL{Path: "/api/datasources/uid/alertmanager-clusterUID"},
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{StatusCode: http.StatusNotFound},
+				},
+				{
+					name: "create alertmanager datasource",
+					request: &http.Request{
+						Method: http.MethodPost,
+						URL:    &url.URL{Path: "/api/datasources"},
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Alertmanager Super Cluster", "orgId":1,  "type":"alertmanager", "uid":"alertmanager-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name: "get datasource by uid",
+					request: &http.Request{
+						Method: http.MethodGet,
 						URL:    &url.URL{Path: "/api/datasources/uid/loki-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
@@ -142,7 +161,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						Body:   io.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 2}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get datasource by uid",
@@ -161,7 +180,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						Body:   io.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 2}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 3}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -205,6 +224,15 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name: "delete alertmanager datasource",
+					request: &http.Request{
+						Method: http.MethodDelete,
+						URL:    &url.URL{Path: "/api/datasources/uid/alertmanager-clusterUID"},
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete loki datasource",
@@ -269,23 +297,42 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
+					name: "get alertmanager datasource by uid",
+					request: &http.Request{
+						Method: http.MethodGet,
+						URL:    &url.URL{Path: "/api/datasources/uid/alertmanager-clusterUID"},
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"name":"Alertmanager Super Cluster", "orgId":1,  "type":"alertmanager", "uid":"alertmanager-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name: "update alertmanager datasource",
+					request: &http.Request{
+						Method: http.MethodPut,
+						URL:    &url.URL{Path: "/api/datasources/1"},
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Alertmanager New Super Cluster", "orgId":1,  "type":"alertmanager", "uid":"alertmanager-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 1}`)), StatusCode: http.StatusOK},
+				},
+				{
 					name: "get loki datasource by uid",
 					request: &http.Request{
 						Method: http.MethodGet,
 						URL:    &url.URL{Path: "/api/datasources/uid/loki-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "update loki datasource",
 					request: &http.Request{
 						Method: http.MethodPut,
-						URL:    &url.URL{Path: "/api/datasources/1"},
-						Body:   io.NopCloser(strings.NewReader(`{"name":"Loki New Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":1, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						URL:    &url.URL{Path: "/api/datasources/2"},
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Loki New Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 2}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "get prometheus datasource by uid",
@@ -294,17 +341,17 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						URL:    &url.URL{Path: "/api/datasources/uid/prometheus-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"name":"Prometheus Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":3, "isDefault":false, "jsonData":null, "secureJsonData":null}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "update prometheus datasource",
 					request: &http.Request{
 						Method: http.MethodPut,
-						URL:    &url.URL{Path: "/api/datasources/2"},
-						Body:   io.NopCloser(strings.NewReader(`{"name":"Prometheus New Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":2, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						URL:    &url.URL{Path: "/api/datasources/3"},
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Prometheus New Super Cluster", "orgId":1,  "type":"prometheus", "uid":"prometheus-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":3, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 2}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource updated", "id": 3}`)), StatusCode: http.StatusOK},
 				},
 			},
 		},
@@ -368,6 +415,15 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name: "delete alertmanager datasource",
+					request: &http.Request{
+						Method: http.MethodDelete,
+						URL:    &url.URL{Path: "/api/datasources/uid/alertmanager-clusterUID"},
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource deleted"}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete loki datasource",
@@ -434,6 +490,25 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-projectUID","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name: "get datasource by uid",
+					request: &http.Request{
+						Method: http.MethodGet,
+						URL:    &url.URL{Path: "/api/datasources/uid/alertmanager-clusterUID"},
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{StatusCode: http.StatusNotFound},
+				},
+				{
+					name: "create alertmanager datasource",
+					request: &http.Request{
+						Method: http.MethodPost,
+						URL:    &url.URL{Path: "/api/datasources"},
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Alertmanager Super Cluster", "orgId":1,  "type":"alertmanager", "uid":"alertmanager-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/api/prom", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete loki datasource",
@@ -514,6 +589,25 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 					name: "get datasource by uid",
 					request: &http.Request{
 						Method: http.MethodGet,
+						URL:    &url.URL{Path: "/api/datasources/uid/alertmanager-clusterUID"},
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{StatusCode: http.StatusNotFound},
+				},
+				{
+					name: "create alertmanager datasource",
+					request: &http.Request{
+						Method: http.MethodPost,
+						URL:    &url.URL{Path: "/api/datasources"},
+						Body:   io.NopCloser(strings.NewReader(`{"name":"Alertmanager Super Cluster", "orgId":1,  "type":"alertmanager", "uid":"alertmanager-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local/prom/api", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
+						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
+					},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
+				},
+				{
+					name: "get datasource by uid",
+					request: &http.Request{
+						Method: http.MethodGet,
 						URL:    &url.URL{Path: "/api/datasources/uid/loki-clusterUID"},
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
@@ -527,7 +621,7 @@ func TestDatasourceGrafanaReconcile(t *testing.T) {
 						Body:   io.NopCloser(strings.NewReader(`{"name":"Loki Super Cluster", "orgId":1,  "type":"loki", "uid":"loki-clusterUID", "url":"http://mla-gateway.cluster-clusterUID.svc.cluster.local", "access":"proxy", "id":0, "isDefault":false, "jsonData":null, "secureJsonData":null}`)),
 						Header: map[string][]string{"X-Grafana-Org-Id": {"1"}},
 					},
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 1}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "datasource created", "id": 2}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name: "delete prometheus datasource",

--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -190,6 +190,10 @@ func getDatasourceUIDForCluster(datasourceType string, cluster *kubermaticv1.Clu
 	return fmt.Sprintf("%s-%s", datasourceType, cluster.Name)
 }
 
+func getAlertmanagerDatasourceNameForCluster(cluster *kubermaticv1.Cluster) string {
+	return fmt.Sprintf("Alertmanager %s", cluster.Spec.HumanReadableName)
+}
+
 func getLokiDatasourceNameForCluster(cluster *kubermaticv1.Cluster) string {
 	return fmt.Sprintf("Loki %s", cluster.Spec.HumanReadableName)
 }

--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -110,6 +110,16 @@ http {
 	  auth_basic off;
 	}
 
+	# Alertmanager Alerts
+	location ~ /api/prom/alertmanager/.* {
+	  proxy_pass      http://cortex-alertmanager.{{ .Namespace }}.svc.cluster.local:8080$request_uri;
+	}
+	
+	# Alertmanager Config
+	location = /api/prom/api/v1/alerts {
+	  proxy_pass      http://cortex-alertmanager.{{ .Namespace }}.svc.cluster.local:8080/api/v1/alerts;
+	}
+
 	# Loki
 	location ~ /loki/api/.* {
 {{ if .LokiReadLimit }}
@@ -118,12 +128,22 @@ http {
 	  proxy_pass       http://loki-distributed-query-frontend.{{ .Namespace }}.svc.cluster.local:3100$request_uri;
 	}
 
+	# Loki Ruler
+	location ~ /prometheus/.* {
+	  proxy_pass       http://loki-distributed-ruler.{{ .Namespace }}.svc.cluster.local:3100$request_uri;
+	}
+
 	# Cortex
 	location ~ /api/prom/.* {
 {{ if .CortexReadLimit }}
       limit_req zone=cortex_read_limit{{ if .CortexReadLimitBurst }} burst={{ .CortexReadLimitBurst }} nodelay{{ end }};
 {{ end }}
 	  proxy_pass       http://cortex-query-frontend.{{ .Namespace }}.svc.cluster.local:8080$request_uri;
+	}
+
+	# Cortex Ruler, alternative for /api/v1/rules which is also used by loki)
+	location = /api/prom/api/v1/rules {
+	  proxy_pass       http://cortex-ruler.{{ .Namespace }}.svc.cluster.local:8080/prometheus/api/v1/rules;
 	}
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Newer versions of Grafana now include much better alert management. This is a huge improvement over the Cortex Alertmanager. However, for this to work we need to adapt the grafana datasources created by the seed-controller-manager.

This PR adds the following:
- Alertmanager datasource in Grafana
- Specify in Loki & Prometheus datasources the corresponding Alertmanager datasource
- add the Rest-API URLs to the MLA-Gateway which are used for alertmangement.

It allows for:
- Displaying alerts in Grafana (instead of only Cortex-Alertmanager)
- Editing silences in Grafana

It does not enable editing alert rules in Grafana since the rules would later again be overwitten by the rules defined via Kubermatic-API.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:
This PR also needs https://github.com/kubermatic/mla/pull/142
The alertmanger datasource is added when either user-mla monitoring or user mla logging is enabled.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
enable alert-management using Grafana
```

