### PR TITLE
Fix unauthorized eks kubeconfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -375,3 +375,5 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+require github.com/aws/aws-sdk-go v1.44.37

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d h1:Byv0BzEl3/e6D5CLfI0j/7hiIEtvGVFPCZ7Ei2oq8iQ=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/aws/aws-sdk-go v1.44.37 h1:KvDxCX6dfJeEDC77U5GPGSP0ErecmNnhDHFxw+NIvlI=
+github.com/aws/aws-sdk-go v1.44.37/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go-v2 v1.16.7/go.mod h1:6CpKuLXg2w7If3ABZCl/qZ6rEgwtjZTn4eAf4RcEyuw=
 github.com/aws/aws-sdk-go-v2 v1.16.12/go.mod h1:C+Ym0ag2LIghJbXhfXZ0YEEp49rBWowxKzJLUoob0ts=
 github.com/aws/aws-sdk-go-v2 v1.16.14 h1:db6GvO4Z2UqHt5gvT0lr6J5x5P+oQ7bdRzczVaRekMU=

--- a/pkg/provider/cloud/aws/client.go
+++ b/pkg/provider/cloud/aws/client.go
@@ -29,6 +29,9 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/eks"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	awsv1 "github.com/aws/aws-sdk-go/aws"
+	awscredentialsv1 "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/smithy-go"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -75,6 +78,20 @@ func ValidateCredentials(ctx context.Context, accessKeyID, secretAccessKey strin
 
 func GetClientSet(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region string) (*ClientSet, error) {
 	return getClientSet(ctx, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, "")
+}
+
+func GetEKSConfig(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, endpoint string) (*session.Session, error) {
+	config := awsv1.
+		NewConfig().
+		WithRegion(region).
+		WithCredentials(awscredentialsv1.NewStaticCredentials(accessKeyID, secretAccessKey, "")).
+		WithMaxRetries(maxRetries)
+
+	if endpoint != "" {
+		config = config.WithEndpoint(endpoint)
+	}
+
+	return session.NewSession(config)
 }
 
 func GetAWSConfig(ctx context.Context, accessKeyID, secretAccessKey, assumeRoleARN, assumeRoleExternalID, region, endpoint string) (aws.Config, error) {

--- a/pkg/provider/cloud/eks/authenticator/token.go
+++ b/pkg/provider/cloud/eks/authenticator/token.go
@@ -17,26 +17,29 @@ limitations under the License.
 package authenticator
 
 import (
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/credentials/endpointcreds"
-	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
-	smithymiddleware "github.com/aws/smithy-go/middleware"
-	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/sirupsen/logrus"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/apis/clientauthentication"
 	clientauthv1beta1 "k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
-	"k8s.io/utils/pointer"
 )
 
 // Identity is returned on successful Verify() results. It contains a parsed
@@ -102,7 +105,7 @@ type GetTokenOptions struct {
 	AssumeRoleARN        string
 	AssumeRoleExternalID string
 	SessionName          string
-	Config               *aws.Config
+	Session              *session.Session
 }
 
 // FormatError is returned when there is a problem with token that is
@@ -160,15 +163,15 @@ type getCallerIdentityWrapper struct {
 // Generator provides new tokens for the AWS IAM Authenticator.
 type Generator interface {
 	// Get a token using credentials in the default credentials chain.
-	Get(ctx context.Context, clusterID string) (Token, error)
+	Get(string) (Token, error)
 	// GetWithRole creates a token by assuming the provided role, using the credentials in the default chain.
-	GetWithRole(ctx context.Context, clusterID, roleARN string) (Token, error)
-	// GetWithRoleForSession creates a token by assuming the provided role, using the provided configuration.
-	GetWithRoleForSession(ctx context.Context, clusterID string, roleARN string, cfg *aws.Config) (Token, error)
+	GetWithRole(clusterID, roleARN string) (Token, error)
+	// GetWithRoleForSession creates a token by assuming the provided role, using the provided session.
+	GetWithRoleForSession(clusterID string, roleARN string, sess *session.Session) (Token, error)
 	// Get a token using the provided options
-	GetWithOptions(ctx context.Context, options *GetTokenOptions) (Token, error)
+	GetWithOptions(options *GetTokenOptions) (Token, error)
 	// GetWithSTS returns a token valid for clusterID using the given STS client.
-	GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts.Client) (Token, error)
+	GetWithSTS(clusterID string, stsAPI stsiface.STSAPI) (Token, error)
 	// FormatJSON returns the client auth formatted json for the ExecCredential auth
 	FormatJSON(Token) string
 }
@@ -176,9 +179,6 @@ type Generator interface {
 type generator struct {
 	forwardSessionName bool
 }
-
-// verify interface at compile time
-var _ Generator = &generator{}
 
 // NewGenerator creates a Generator and returns it.
 func NewGenerator(forwardSessionName bool) (Generator, error) {
@@ -189,14 +189,14 @@ func NewGenerator(forwardSessionName bool) (Generator, error) {
 
 // Get uses the directly available AWS credentials to return a token valid for
 // clusterID. It follows the default AWS credential handling behavior.
-func (g generator) Get(ctx context.Context, clusterID string) (Token, error) {
-	return g.GetWithOptions(ctx, &GetTokenOptions{ClusterID: clusterID})
+func (g generator) Get(clusterID string) (Token, error) {
+	return g.GetWithOptions(&GetTokenOptions{ClusterID: clusterID})
 }
 
 // GetWithRole assumes the given AWS IAM role and returns a token valid for
 // clusterID. If roleARN is empty, behaves like Get (does not assume a role).
-func (g generator) GetWithRole(ctx context.Context, clusterID string, roleARN string) (Token, error) {
-	return g.GetWithOptions(ctx, &GetTokenOptions{
+func (g generator) GetWithRole(clusterID string, roleARN string) (Token, error) {
+	return g.GetWithOptions(&GetTokenOptions{
 		ClusterID:     clusterID,
 		AssumeRoleARN: roleARN,
 	})
@@ -204,11 +204,11 @@ func (g generator) GetWithRole(ctx context.Context, clusterID string, roleARN st
 
 // GetWithRoleForSession assumes the given AWS IAM role for the given session and behaves
 // like GetWithRole.
-func (g generator) GetWithRoleForSession(ctx context.Context, clusterID string, roleARN string, cfg *aws.Config) (Token, error) {
-	return g.GetWithOptions(ctx, &GetTokenOptions{
+func (g generator) GetWithRoleForSession(clusterID string, roleARN string, sess *session.Session) (Token, error) {
+	return g.GetWithOptions(&GetTokenOptions{
 		ClusterID:     clusterID,
 		AssumeRoleARN: roleARN,
-		Config:        cfg,
+		Session:       sess,
 	})
 }
 
@@ -223,54 +223,43 @@ func StdinStderrTokenProvider() (string, error) {
 // GetWithOptions takes a GetTokenOptions struct, builds the STS client, and wraps GetWithSTS.
 // If no session has been passed in options, it will build a new session. If an
 // AssumeRoleARN was passed in then assume the role for the session.
-func (g generator) GetWithOptions(ctx context.Context, options *GetTokenOptions) (Token, error) {
+func (g generator) GetWithOptions(options *GetTokenOptions) (Token, error) {
 	if options.ClusterID == "" {
 		return Token{}, fmt.Errorf("ClusterID is required")
 	}
 
-	if options.Config == nil {
-		var loadOptFuncs []func(*awsconfig.LoadOptions) error
-
-		loadOptFuncs = append(loadOptFuncs, awsconfig.WithAPIOptions([]func(*smithymiddleware.Stack) error{
-			smithyhttp.AddHeaderValue("User-Agent", "aws-iam-authenticator/v0.5.8-forked"),
-		}))
-
-		loadOptFuncs = append(loadOptFuncs, awsconfig.WithAssumeRoleCredentialOptions(func(opts *stscreds.AssumeRoleOptions) {
-			opts.TokenProvider = StdinStderrTokenProvider
-		}))
-
-		if options.Region != "" {
-			loadOptFuncs = append(loadOptFuncs, awsconfig.WithRegion(options.Region))
-
-			endpoint, err := sts.NewDefaultEndpointResolver().ResolveEndpoint(options.Region, sts.EndpointResolverOptions{})
-			if err != nil {
-				return Token{}, err
-			}
-
-			loadOptFuncs = append(loadOptFuncs, awsconfig.WithEndpointCredentialOptions(func(opts *endpointcreds.Options) {
-				opts.Endpoint = endpoint.URL
-			}))
-		}
-
-		cfg, err := awsconfig.LoadDefaultConfig(ctx, loadOptFuncs...)
+	if options.Session == nil {
+		// create a session with the "base" credentials available
+		// (from environment variable, profile files, EC2 metadata, etc)
+		sess, err := session.NewSessionWithOptions(session.Options{
+			AssumeRoleTokenProvider: StdinStderrTokenProvider,
+			SharedConfigState:       session.SharedConfigEnable,
+		})
 		if err != nil {
-			return Token{}, fmt.Errorf("failed to get AWS config: %w", err)
+			return Token{}, fmt.Errorf("could not create session: %v", err)
+		}
+		sess.Handlers.Build.PushFrontNamed(request.NamedHandler{
+			Name: "authenticatorUserAgent",
+			Fn:   request.MakeAddToUserAgentHandler("aws-iam-authenticator", "v0.5.8-forked"),
+		})
+		if options.Region != "" {
+			sess = sess.Copy(aws.NewConfig().WithRegion(options.Region).WithSTSRegionalEndpoint(endpoints.RegionalSTSEndpoint))
 		}
 
-		options.Config = &cfg
+		options.Session = sess
 	}
 
 	// use an STS client based on the direct credentials
-	stsAPI := sts.NewFromConfig(*options.Config)
+	stsAPI := sts.New(options.Session)
 
 	// if a roleARN was specified, replace the STS client with one that uses
 	// temporary credentials from that role.
 	if options.AssumeRoleARN != "" {
-		var assumeOptFuncs []func(*stscreds.AssumeRoleOptions)
+		var sessionSetters []func(*stscreds.AssumeRoleProvider)
 
 		if options.AssumeRoleExternalID != "" {
-			assumeOptFuncs = append(assumeOptFuncs, func(opts *stscreds.AssumeRoleOptions) {
-				opts.ExternalID = pointer.String(options.AssumeRoleExternalID)
+			sessionSetters = append(sessionSetters, func(provider *stscreds.AssumeRoleProvider) {
+				provider.ExternalID = &options.AssumeRoleExternalID
 			})
 		}
 
@@ -278,46 +267,46 @@ func (g generator) GetWithOptions(ctx context.Context, options *GetTokenOptions)
 			// If the current session is already a federated identity, carry through
 			// this session name onto the new session to provide better debugging
 			// capabilities
-			resp, err := stsAPI.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+			resp, err := stsAPI.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 			if err != nil {
 				return Token{}, err
 			}
 
-			if resp != nil && resp.UserId != nil {
-				userIDParts := strings.Split(*resp.UserId, ":")
-
-				if len(userIDParts) == 2 {
-					assumeOptFuncs = append(assumeOptFuncs, func(opts *stscreds.AssumeRoleOptions) {
-						opts.RoleSessionName = userIDParts[1]
-					})
-				}
+			userIDParts := strings.Split(*resp.UserId, ":")
+			if len(userIDParts) == 2 {
+				sessionSetters = append(sessionSetters, func(provider *stscreds.AssumeRoleProvider) {
+					provider.RoleSessionName = userIDParts[1]
+				})
 			}
-
 		} else if options.SessionName != "" {
-			assumeOptFuncs = append(assumeOptFuncs, func(opts *stscreds.AssumeRoleOptions) {
-				opts.RoleSessionName = options.SessionName
+			sessionSetters = append(sessionSetters, func(provider *stscreds.AssumeRoleProvider) {
+				provider.RoleSessionName = options.SessionName
 			})
 		}
 
-		cfg := options.Config.Copy()
-		cfg.Credentials = stscreds.NewAssumeRoleProvider(stsAPI, options.AssumeRoleARN, assumeOptFuncs...)
+		// create STS-based credentials that will assume the given role
+		creds := stscreds.NewCredentials(options.Session, options.AssumeRoleARN, sessionSetters...)
 
 		// create an STS API interface that uses the assumed role's temporary credentials
-		stsAPI = sts.NewFromConfig(cfg)
+		stsAPI = sts.New(options.Session, &aws.Config{Credentials: creds})
 	}
 
-	return g.GetWithSTS(ctx, options.ClusterID, stsAPI)
+	return g.GetWithSTS(options.ClusterID, stsAPI)
 }
 
 // GetWithSTS returns a token valid for clusterID using the given STS client.
-func (g generator) GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts.Client) (Token, error) {
-	presignClient := sts.NewPresignClient(stsAPI)
-	presignedURLRequest, err := presignClient.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(presignOpts *sts.PresignOptions) {
-		presignOpts.ClientOptions = append(presignOpts.ClientOptions, func(stsOpts *sts.Options) {
-			stsOpts.APIOptions = append(stsOpts.APIOptions, smithyhttp.SetHeaderValue(clusterIDHeader, clusterID))
-		})
-	})
+func (g generator) GetWithSTS(clusterID string, stsAPI stsiface.STSAPI) (Token, error) {
+	// generate an sts:GetCallerIdentity request and add our custom cluster ID header
+	request, _ := stsAPI.GetCallerIdentityRequest(&sts.GetCallerIdentityInput{})
+	request.HTTPRequest.Header.Add(clusterIDHeader, clusterID)
 
+	// Sign the request.  The expires parameter (sets the x-amz-expires header) is
+	// currently ignored by STS, and the token expires 15 minutes after the x-amz-date
+	// timestamp regardless.  We set it to 60 seconds for backwards compatibility (the
+	// parameter is a required argument to Presign(), and authenticators 0.3.0 and older are expecting a value between
+	// 0 and 60 on the server side).
+	// https://github.com/aws/aws-sdk-go/issues/2167
+	presignedURLString, err := request.Presign(requestPresignParam)
 	if err != nil {
 		return Token{}, err
 	}
@@ -325,7 +314,7 @@ func (g generator) GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts
 	// Set token expiration to 1 minute before the presigned URL expires for some cushion
 	tokenExpiration := time.Now().Local().Add(presignedURLExpiration - 1*time.Minute)
 	// TODO: this may need to be a constant-time base64 encoding
-	return Token{v1Prefix + base64.RawURLEncoding.EncodeToString([]byte(presignedURLRequest.URL)), tokenExpiration}, nil
+	return Token{v1Prefix + base64.RawURLEncoding.EncodeToString([]byte(presignedURLString)), tokenExpiration}, nil
 }
 
 // FormatJSON formats the json to support ExecCredential authentication
@@ -352,4 +341,223 @@ func (g generator) FormatJSON(token Token) string {
 	}
 	enc, _ := json.Marshal(execInput)
 	return string(enc)
+}
+
+// Verifier validates tokens by calling STS and returning the associated identity.
+type Verifier interface {
+	Verify(token string) (*Identity, error)
+}
+
+type tokenVerifier struct {
+	client            *http.Client
+	clusterID         string
+	validSTShostnames map[string]bool
+}
+
+func stsHostsForPartition(partitionID string) map[string]bool {
+	validSTShostnames := map[string]bool{}
+
+	var partition *endpoints.Partition
+	for _, p := range endpoints.DefaultPartitions() {
+		if partitionID == p.ID() {
+			partition = &p
+			break
+		}
+	}
+	if partition == nil {
+		logrus.Errorf("Partition %s not valid", partitionID)
+		return validSTShostnames
+	}
+	stsSvc, ok := partition.Services()["sts"]
+	if !ok {
+		logrus.Errorf("STS service not found in partition %s", partitionID)
+		return validSTShostnames
+	}
+	for epName, ep := range stsSvc.Endpoints() {
+		rep, err := ep.ResolveEndpoint(endpoints.STSRegionalEndpointOption)
+		if err != nil {
+			logrus.WithError(err).Errorf("Error resolving endpoint for %s in partition %s", epName, partitionID)
+			continue
+		}
+		parsedURL, err := url.Parse(rep.URL)
+		if err != nil {
+			logrus.WithError(err).Errorf("Error parsing STS URL %s", rep.URL)
+			continue
+		}
+		validSTShostnames[parsedURL.Hostname()] = true
+	}
+	return validSTShostnames
+}
+
+// NewVerifier creates a Verifier that is bound to the clusterID and uses the default http client.
+func NewVerifier(clusterID string, partitionID string) Verifier {
+	return tokenVerifier{
+		client: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		clusterID:         clusterID,
+		validSTShostnames: stsHostsForPartition(partitionID),
+	}
+}
+
+// verify a sts host, doc: http://docs.amazonaws.cn/en_us/general/latest/gr/rande.html#sts_region
+func (v tokenVerifier) verifyHost(host string) error {
+	if _, ok := v.validSTShostnames[host]; !ok {
+		return FormatError{fmt.Sprintf("unexpected hostname %q in pre-signed URL", host)}
+	}
+	return nil
+}
+
+// Verify a token is valid for the specified clusterID. On success, returns an
+// Identity that contains information about the AWS principal that created the
+// token. On failure, returns nil and a non-nil error.
+func (v tokenVerifier) Verify(token string) (*Identity, error) {
+	if len(token) > maxTokenLenBytes {
+		return nil, FormatError{"token is too large"}
+	}
+
+	if !strings.HasPrefix(token, v1Prefix) {
+		return nil, FormatError{fmt.Sprintf("token is missing expected %q prefix", v1Prefix)}
+	}
+
+	// TODO: this may need to be a constant-time base64 decoding
+	tokenBytes, err := base64.RawURLEncoding.DecodeString(strings.TrimPrefix(token, v1Prefix))
+	if err != nil {
+		return nil, FormatError{err.Error()}
+	}
+
+	parsedURL, err := url.Parse(string(tokenBytes))
+	if err != nil {
+		return nil, FormatError{err.Error()}
+	}
+
+	if parsedURL.Scheme != "https" {
+		return nil, FormatError{fmt.Sprintf("unexpected scheme %q in pre-signed URL", parsedURL.Scheme)}
+	}
+
+	if err = v.verifyHost(parsedURL.Host); err != nil {
+		return nil, err
+	}
+
+	if parsedURL.Path != "/" {
+		return nil, FormatError{"unexpected path in pre-signed URL"}
+	}
+
+	queryParamsLower := make(url.Values)
+	queryParams, err := url.ParseQuery(parsedURL.RawQuery)
+	if err != nil {
+		return nil, FormatError{"malformed query parameter"}
+	}
+
+	for key, values := range queryParams {
+		if !parameterWhitelist[strings.ToLower(key)] {
+			return nil, FormatError{fmt.Sprintf("non-whitelisted query parameter %q", key)}
+		}
+		if len(values) != 1 {
+			return nil, FormatError{"query parameter with multiple values not supported"}
+		}
+		queryParamsLower.Set(strings.ToLower(key), values[0])
+	}
+
+	if queryParamsLower.Get("action") != "GetCallerIdentity" {
+		return nil, FormatError{"unexpected action parameter in pre-signed URL"}
+	}
+
+	if !hasSignedClusterIDHeader(&queryParamsLower) {
+		return nil, FormatError{fmt.Sprintf("client did not sign the %s header in the pre-signed URL", clusterIDHeader)}
+	}
+
+	// We validate x-amz-expires is between 0 and 15 minutes (900 seconds) although currently pre-signed STS URLs, and
+	// therefore tokens, expire exactly 15 minutes after the x-amz-date header, regardless of x-amz-expires.
+	expires, err := strconv.Atoi(queryParamsLower.Get("x-amz-expires"))
+	if err != nil || expires < 0 || expires > 900 {
+		return nil, FormatError{fmt.Sprintf("invalid X-Amz-Expires parameter in pre-signed URL: %d", expires)}
+	}
+
+	date := queryParamsLower.Get("x-amz-date")
+	if date == "" {
+		return nil, FormatError{"X-Amz-Date parameter must be present in pre-signed URL"}
+	}
+
+	// Obtain AWS Access Key ID from supplied credentials
+	accessKeyID := strings.Split(queryParamsLower.Get("x-amz-credential"), "/")[0]
+
+	dateParam, err := time.Parse(dateHeaderFormat, date)
+	if err != nil {
+		return nil, FormatError{fmt.Sprintf("error parsing X-Amz-Date parameter %s into format %s: %s", date, dateHeaderFormat, err.Error())}
+	}
+
+	now := time.Now()
+	expiration := dateParam.Add(presignedURLExpiration)
+	if now.After(expiration) {
+		return nil, FormatError{fmt.Sprintf("X-Amz-Date parameter is expired (%.f minute expiration) %s", presignedURLExpiration.Minutes(), dateParam)}
+	}
+
+	req, err := http.NewRequest("GET", parsedURL.String(), nil)
+	req.Header.Set(clusterIDHeader, v.clusterID)
+	req.Header.Set("accept", "application/json")
+
+	response, err := v.client.Do(req)
+	if err != nil {
+		// special case to avoid printing the full URL if possible
+		if urlErr, ok := err.(*url.Error); ok {
+			return nil, NewSTSError(fmt.Sprintf("error during GET: %v", urlErr.Err))
+		}
+		return nil, NewSTSError(fmt.Sprintf("error during GET: %v", err))
+	}
+	defer response.Body.Close()
+
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, NewSTSError(fmt.Sprintf("error reading HTTP result: %v", err))
+	}
+
+	if response.StatusCode != 200 {
+		return nil, NewSTSError(fmt.Sprintf("error from AWS (expected 200, got %d). Body: %s", response.StatusCode, string(responseBody[:])))
+	}
+
+	var callerIdentity getCallerIdentityWrapper
+	err = json.Unmarshal(responseBody, &callerIdentity)
+	if err != nil {
+		return nil, NewSTSError(err.Error())
+	}
+
+	// parse the response into an Identity
+	id := &Identity{
+		ARN:         callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.Arn,
+		AccountID:   callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.Account,
+		AccessKeyID: accessKeyID,
+	}
+	id.CanonicalARN, err = CanonicalizeARN(id.ARN)
+	if err != nil {
+		return nil, NewSTSError(err.Error())
+	}
+
+	// The user ID is either UserID:SessionName (for assumed roles) or just
+	// UserID (for IAM User principals).
+	userIDParts := strings.Split(callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.UserID, ":")
+	if len(userIDParts) == 2 {
+		id.UserID = userIDParts[0]
+		id.SessionName = userIDParts[1]
+	} else if len(userIDParts) == 1 {
+		id.UserID = userIDParts[0]
+	} else {
+		return nil, STSError{fmt.Sprintf(
+			"malformed UserID %q",
+			callerIdentity.GetCallerIdentityResponse.GetCallerIdentityResult.UserID)}
+	}
+
+	return id, nil
+}
+
+func hasSignedClusterIDHeader(paramsLower *url.Values) bool {
+	signedHeaders := strings.Split(paramsLower.Get("x-amz-signedheaders"), ";")
+	for _, hdr := range signedHeaders {
+		if strings.ToLower(hdr) == strings.ToLower(clusterIDHeader) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**:
Fix unauthorized eks kubeconfig by reverting `migration of aws-sdk-v2`
*This is a temporary change the issue is found with aws-sdk-v2

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
