### PR TITLE
Fix for AKS external cluster: "delete" permission shouldn't be checked for import

### DIFF
--- a/pkg/handler/v2/external_cluster/aks.go
+++ b/pkg/handler/v2/external_cluster/aks.go
@@ -464,17 +464,19 @@ func createOrImportAKSCluster(ctx context.Context, name string, userInfoGetter p
 		}
 	}
 
+	// If Spec is not nil, it is interpreted as create cluster on the provider.
+	isCreation := (spec != nil && spec.AKSClusterSpec != nil)
+
 	if err := aks.ValidateCredentialsPermissions(ctx, resources.AKSCredentials{
 		TenantID:       cloud.AKS.TenantID,
 		ClientID:       cloud.AKS.ClientID,
 		SubscriptionID: cloud.AKS.SubscriptionID,
 		ClientSecret:   cloud.AKS.ClientSecret,
-	}, cloud.AKS.ResourceGroup); err != nil {
+	}, cloud.AKS.ResourceGroup, isCreation); err != nil {
 		return nil, err
 	}
 
-	// If Spec is not nil, it is interpreted as create cluster on the provider.
-	if spec != nil && spec.AKSClusterSpec != nil {
+	if isCreation {
 		if err := checkCreateClusterReqValidity(cloud.AKS, spec.AKSClusterSpec); err != nil {
 			return nil, err
 		}

--- a/pkg/provider/cloud/aks/provider.go
+++ b/pkg/provider/cloud/aks/provider.go
@@ -360,7 +360,7 @@ func ValidateCredentials(ctx context.Context, cred resources.AKSCredentials) err
 	return DecodeError(err)
 }
 
-func ValidateCredentialsPermissions(ctx context.Context, cred resources.AKSCredentials, resourceGroup string) error {
+func ValidateCredentialsPermissions(ctx context.Context, cred resources.AKSCredentials, resourceGroup string, isCreation bool) error {
 	azcred, err := azidentity.NewClientSecretCredential(cred.TenantID, cred.ClientID, cred.ClientSecret, nil)
 	if err != nil {
 		return DecodeError(err)
@@ -374,8 +374,10 @@ func ValidateCredentialsPermissions(ctx context.Context, cred resources.AKSCrede
 	var requiredPermissions = map[string]bool{
 		"Microsoft.ContainerService/managedClusters/read":                              false,
 		"Microsoft.ContainerService/managedClusters/write":                             false,
-		"Microsoft.ContainerService/managedClusters/delete":                            false,
 		"Microsoft.ContainerService/managedClusters/listClusterAdminCredential/action": false,
+	}
+	if isCreation {
+		requiredPermissions["Microsoft.ContainerService/managedClusters/delete"] = false
 	}
 
 	pager := permissionsClient.NewListForResourceGroupPager(resourceGroup, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the unnecessary requirement of "delete" permission when importing an external cluster from AKS.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
