### PR TITLE
Fix STS tokens generated for EKS clusters

### DIFF
--- a/pkg/provider/cloud/eks/authenticator/token.go
+++ b/pkg/provider/cloud/eks/authenticator/token.go
@@ -315,6 +315,7 @@ func (g generator) GetWithSTS(ctx context.Context, clusterID string, stsAPI *sts
 	presignedURLRequest, err := presignClient.PresignGetCallerIdentity(ctx, &sts.GetCallerIdentityInput{}, func(presignOpts *sts.PresignOptions) {
 		presignOpts.ClientOptions = append(presignOpts.ClientOptions, func(stsOpts *sts.Options) {
 			stsOpts.APIOptions = append(stsOpts.APIOptions, smithyhttp.SetHeaderValue(clusterIDHeader, clusterID))
+			stsOpts.APIOptions = append(stsOpts.APIOptions, smithyhttp.SetHeaderValue("X-Amz-Expires", "60"))
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the tokens generated for accessing EKS (no, really, this is all that is needed).

Reference: https://github.com/weaveworks/eksctl/pull/5016/files#diff-73c5fd3d701e0ae7a76ddde1b6319a989fd7ebae87a9f1f2241d9c73d9dd1d17R71

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11038

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

Signed-off-by: Marvin Beckers <marvin@kubermatic.com>