### PR TITLE
Fix wrong quota filtering when preset.spec.cpu has no quantity 

### DIFF
--- a/pkg/handler/common/provider/kubevirt.go
+++ b/pkg/handler/common/provider/kubevirt.go
@@ -241,6 +241,10 @@ func filterVMIPresets(vmiPresets apiv2.VirtualMachineInstancePresetList, quota k
 	return filteredVMIPresets
 }
 
+func isCPUSpecified(cpu *kubevirtv1.CPU) bool {
+	return cpu != nil && (cpu.Cores != 0 || cpu.Threads != 0 || cpu.Sockets != 0)
+}
+
 // GetKubeVirtPresetResourceDetails extracts cpu and mem resource requests from the kubevirt preset
 // for CPU, take the value by priority:
 // - check if spec.cpu is set, if socket and threads are set then do the calculation, use that
@@ -254,7 +258,7 @@ func GetKubeVirtPresetResourceDetails(presetSpec kubevirtv1.VirtualMachineInstan
 	// Get CPU
 	cpuReq := resource.Quantity{}
 
-	if presetSpec.Domain.CPU != nil {
+	if isCPUSpecified(presetSpec.Domain.CPU) {
 		if !presetSpec.Domain.Resources.Requests.Cpu().IsZero() || !presetSpec.Domain.Resources.Limits.Cpu().IsZero() {
 			return resource.Quantity{}, resource.Quantity{}, errors.New("should not specify both spec.domain.cpu and spec.domain.resources.[requests/limits].cpu in VMIPreset")
 		}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
We were wrongly discarding some presets, like 
``` yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachineInstancePreset
metadata:
  name: dedicated-cpu
  namespace: default
spec:
  domain:
    ioThreadsPolicy: auto
    cpu:
      dedicatedCpuPlacement: true
      isolateEmulatorThread: true
    devices: {}
    resources:
      requests:
        cpu: 4
        memory: 16Gi
  selector:
    matchLabels:
      kubevirt.io/flavor: dedicated-cpu
``` 

with an error:
`2022-09-23T08:24:16.810+0200 error provider/kubevirt.go:309 skipping VMIPreset:dedicated-cpu, fetching presetResourceDetails failed:should not specify both spec.domain.cpu and spec.domain.resources.[requests/limits].cpu in VMIPreset
`

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11044 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfixes
Fix wrong quota filtering when VirtualMachineInstancePreset.spec.cpu has no quantity but only other fields.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
