### PR TITLE
Use unordered comparison of vsphere networks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	go.etcd.io/etcd/etcdutl/v3 v3.5.4
 	go.uber.org/zap v1.23.0
 	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
+	golang.org/x/exp v0.0.0-20220921164117-439092de6870
 	golang.org/x/oauth2 v0.0.0-20220822191816-0ebed06d0094
 	golang.org/x/tools v0.1.12
 	gomodules.xyz/jsonpatch/v2 v2.2.0

--- a/go.sum
+++ b/go.sum
@@ -1292,6 +1292,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220921164117-439092de6870 h1:j8b6j9gzSigH28O5SjSpQSSh9lFd6f5D/q0aHjNTulc=
+golang.org/x/exp v0.0.0-20220921164117-439092de6870/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/provider/cloud/vsphere/network_test.go
+++ b/pkg/provider/cloud/vsphere/network_test.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/exp/slices"
+
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 )
 
@@ -68,9 +70,14 @@ func TestGetPossibleVMNetworks(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
-			if !diff.SemanticallyEqual(test.expectedNetworkInfos, networkInfos) {
-				t.Fatalf("Got network infos differ from expected ones:\n%v", diff.ObjectDiff(test.expectedNetworkInfos, networkInfos))
+			for _, expectedNetworkInfo := range test.expectedNetworkInfos {
+				index := slices.Index(networkInfos, expectedNetworkInfo)
+				if index < 0 {
+					t.Fatalf("Expected Network not found:\n%v", expectedNetworkInfo)
+				}
+				if !diff.SemanticallyEqual(expectedNetworkInfo, networkInfos[index]) {
+					t.Fatalf("Got network infos differ from expected ones:\n%v", diff.ObjectDiff(expectedNetworkInfo, networkInfos[index]))
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Use unordered comparison of vsphere networks. 
This prevents tests to fail just because the order of the slice changed

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
