### PR TITLE
change select for lokiloader to app=k8c-events-lokiloader

### DIFF
--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -147,7 +147,7 @@ promtail:
           pipeline_stages:
           - cri: {}
           - match:
-              selector: '{app="events"}'
+              selector: '{app="k8c-events-lokiloader"}'
               stages:
                 - json:
                     expressions:


### PR DESCRIPTION
**What this PR does / why we need it**:

The selector uses `app=events` which could conflict with customer's own pods. It is changed to `app=k8c-events-lokiloader`. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards [kubermatic #9767](https://github.com/kubermatic/kubermatic/issues/9767)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
