### PR TITLE
Add limitation for concurrent active Web Terminal websocket connections

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -235,6 +235,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 			log.Logger.Debug(err)
 			w.WriteHeader(http.StatusTooManyRequests)
 			_, _ = w.Write([]byte(err.Error()))
+			return
 		}
 		connectionsPerUser.increaseActiveConnections(userProjectClusterUniqueKey)
 		defer connectionsPerUser.decreaseActiveConnections(userProjectClusterUniqueKey)

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -234,8 +234,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 			err = errors.New("reached the maximum number of terminal active connections for the user")
 			log.Logger.Debug(err)
 			w.WriteHeader(http.StatusTooManyRequests)
-			w.Write([]byte(err.Error()))
-			return
+			_, _ = w.Write([]byte(err.Error()))
 		}
 		connectionsPerUser.increaseActiveConnections(userProjectClusterUniqueKey)
 		defer connectionsPerUser.decreaseActiveConnections(userProjectClusterUniqueKey)

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -18,9 +18,13 @@ package handler
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/url"
+	"sync"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
@@ -79,12 +83,17 @@ type WebsocketSettingsWriter func(ctx context.Context, providers watcher.Provide
 type WebsocketUserWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, userEmail string)
 type WebsocketTerminalWriter func(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string)
 
+const (
+	maxNumberOfTerminalActiveConnectionsPerUser = 5
+	terminalActiveConnectionsMemoryDuration     = 24 * time.Hour
+)
+
 func (r Routing) RegisterV1Websocket(mux *mux.Router) {
 	providers := getProviders(r)
 
 	mux.HandleFunc("/ws/admin/settings", getSettingsWatchHandler(wsh.WriteSettings, providers, r))
 	mux.HandleFunc("/ws/me", getUserWatchHandler(wsh.WriteUser, providers, r))
-	mux.HandleFunc("/ws/projects/{project_id}/clusters/{cluster_id}/terminal", getTerminalWatchHandler(wsh.Terminal, providers, r))
+	mux.HandleFunc("/ws/projects/{project_id}/clusters/{cluster_id}/terminal", getTerminalWatchHandler(wsh.Terminal, providers, r, maxNumberOfTerminalActiveConnectionsPerUser, terminalActiveConnectionsMemoryDuration))
 }
 
 func getProviders(r Routing) watcher.Providers {
@@ -140,7 +149,66 @@ func getUserWatchHandler(writer WebsocketUserWriter, providers watcher.Providers
 	}
 }
 
-func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.Providers, routing Routing) func(w http.ResponseWriter, req *http.Request) {
+type connections struct {
+	active map[string]int
+	mutex  sync.Mutex
+}
+
+func newConnections() *connections {
+	return &connections{
+		active: make(map[string]int),
+	}
+}
+
+func (l *connections) getActiveConnections(key string) int {
+	l.mutex.Lock()
+	activeConnections := l.active[key]
+	l.mutex.Unlock()
+
+	return activeConnections
+}
+
+func (l *connections) increaseActiveConnections(key string) {
+	l.mutex.Lock()
+	_, alreadyCreated := l.active[key]
+	if !alreadyCreated {
+		l.active[key] = 0
+	}
+	l.active[key]++
+	l.mutex.Unlock()
+}
+
+func (l *connections) decreaseActiveConnections(key string) {
+	l.mutex.Lock()
+	_, alreadyCreated := l.active[key]
+	if !alreadyCreated {
+		l.active[key] = 0
+	}
+	if l.active[key] > 0 {
+		l.active[key]--
+	}
+	l.mutex.Unlock()
+}
+
+func (l *connections) releaseMemory() {
+	l.mutex.Lock()
+	for key := range l.active {
+		delete(l.active, key)
+	}
+	l.mutex.Unlock()
+}
+
+func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.Providers, routing Routing, maxNumberOfConnections int, memoryDuration time.Duration) func(w http.ResponseWriter, req *http.Request) {
+	connectionsPerUser := newConnections()
+
+	// Cleaning the map from time to time to release the memory
+	go func() {
+		for {
+			time.Sleep(memoryDuration)
+			connectionsPerUser.releaseMemory()
+		}
+	}()
+
 	return func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		authenticatedUser, err := verifyAuthorizationToken(req, routing.tokenVerifiers, routing.tokenExtractors)
@@ -159,6 +227,18 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 			return
 		}
 		projectID := projectReq.(common.ProjectReq).ProjectID
+
+		// Checking user active connections for project cluster
+		userProjectClusterUniqueKey := fmt.Sprintf("%s-%s-%s", projectID, clusterID, authenticatedUser.Email)
+		if connectionsPerUser.getActiveConnections(userProjectClusterUniqueKey) >= maxNumberOfConnections {
+			err = errors.New("reached the maximum number of terminal active connections for the user")
+			log.Logger.Debug(err)
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(err.Error()))
+			return
+		}
+		connectionsPerUser.increaseActiveConnections(userProjectClusterUniqueKey)
+		defer connectionsPerUser.decreaseActiveConnections(userProjectClusterUniqueKey)
 
 		request := terminalReq{
 			ClusterID: clusterID,


### PR DESCRIPTION
**What this PR does / why we need it**:
We should limit the number of concurrent web terminal connections per user (maximum of 5) to avoid performance issues in the backend.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10999

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
