### PR TITLE
Use `registry.k8s.io` instead of `k8s.gcr.io` for Kubernetes upstream images

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -176,7 +176,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: '{{ Registry "k8s.gcr.io" }}/autoscaling/cluster-autoscaler:{{ $version }}'
+      - image: '{{ Registry "registry.k8s.io" }}/autoscaling/cluster-autoscaler:{{ $version }}'
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler

--- a/addons/csi/digitalocean/csi-driver.yaml
+++ b/addons/csi/digitalocean/csi-driver.yaml
@@ -64,7 +64,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-provisioner
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v3.2.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.2.1'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--default-fstype=ext4"
@@ -77,7 +77,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.5.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.5.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -91,7 +91,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v6.0.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v6.0.1'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -103,7 +103,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.5.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.5.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"
@@ -331,7 +331,7 @@ spec:
               mountPath: /etc/udev/rules.d/
       containers:
         - name: csi-node-driver-registrar
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.5.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.5.1'
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"

--- a/addons/csi/digitalocean/snapshot-controller.yaml
+++ b/addons/csi/digitalocean/snapshot-controller.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-controller
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-controller:v6.0.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v6.0.1'
           args:
             - "--v=5"
           imagePullPolicy: IfNotPresent

--- a/addons/csi/digitalocean/snapshot-webhook.yaml
+++ b/addons/csi/digitalocean/snapshot-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-validation-webhook:v6.0.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v6.0.1'
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/cert.pem', '--tls-private-key-file=/run/secrets/tls/key.pem']
           ports:

--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -138,7 +138,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.2.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.2.1'
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi
@@ -148,7 +148,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-resizer
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.2.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.2.0'
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi
@@ -158,7 +158,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-provisioner
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.2.2'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.2.2'
           args:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
@@ -214,7 +214,7 @@ spec:
             allowPrivilegeEscalation: true
         - name: liveness-probe
           imagePullPolicy: Always
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0'
           volumeMounts:
             - mountPath: /run/csi
               name: socket-dir
@@ -260,7 +260,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-node-driver-registrar
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0'
           args:
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
           env:
@@ -322,7 +322,7 @@ spec:
             periodSeconds: 2
         - name: liveness-probe
           imagePullPolicy: Always
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0'
           volumeMounts:
             - mountPath: /run/csi
               name: plugin-dir

--- a/addons/csi/nutanix/csi-driver.yaml
+++ b/addons/csi/nutanix/csi-driver.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=5
@@ -250,7 +250,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: plugin-dir
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -310,7 +310,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.2.2
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -336,7 +336,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.2.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.2.0
           imagePullPolicy: IfNotPresent
           args:
             - --v=5
@@ -353,7 +353,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v4.2.1
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v4.2.1
           imagePullPolicy: IfNotPresent
           args:
           - --csi-address=$(ADDRESS)
@@ -417,7 +417,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/addons/csi/nutanix/snapshot-controller.yaml
+++ b/addons/csi/nutanix/snapshot-controller.yaml
@@ -646,7 +646,7 @@ spec:
       serviceAccount: snapshot-controller
       containers:
       - name: snapshot-controller
-        image: {{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-controller:v4.2.1
+        image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v4.2.1
         imagePullPolicy: IfNotPresent
         args:
         - --v=5
@@ -689,7 +689,7 @@ spec:
     spec:
       containers:
       - name: snapshot-validation
-        image: {{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-validation-webhook:v4.2.1
+        image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v4.2.1
         imagePullPolicy: IfNotPresent
         args:
           - --tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -56,7 +56,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.4.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.4.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -69,7 +69,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v3.1.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -83,7 +83,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v5.0.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v5.0.1'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -96,7 +96,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.4.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.4.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -110,7 +110,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.6.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0'
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -54,7 +54,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.5.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.5.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -78,7 +78,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.6.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0'
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/addons/csi/openstack/snapshot-controller.yaml
+++ b/addons/csi/openstack/snapshot-controller.yaml
@@ -135,7 +135,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-controller
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-controller:v5.0.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v5.0.1'
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/addons/csi/openstack/snapshot-webhook.yaml
+++ b/addons/csi/openstack/snapshot-webhook.yaml
@@ -46,7 +46,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-validation-webhook:v5.0.1' # change the image if you wish to use your own custom validation server image
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v5.0.1' # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
           ports:

--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -134,7 +134,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.2.1
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.2.1
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -147,7 +147,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.2.2
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.2.2
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)

--- a/addons/csi/vmware-cloud-director/csi-node.yaml
+++ b/addons/csi/vmware-cloud-director/csi-node.yaml
@@ -73,7 +73,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: node-driver-registrar
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"

--- a/addons/csi/vsphere/snapshot-controller.yaml
+++ b/addons/csi/vsphere/snapshot-controller.yaml
@@ -151,7 +151,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-controller
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-controller:v5.0.1
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v5.0.1
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/addons/csi/vsphere/snapshot-webhook.yaml
+++ b/addons/csi/vsphere/snapshot-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/snapshot-validation-webhook:v5.0.1 # change the image if you wish to use your own custom validation server image
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v5.0.1 # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/cert.pem', '--tls-private-key-file=/run/secrets/tls/key.pem']
           ports:

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -269,7 +269,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.4.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.4.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -284,7 +284,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.4.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.4.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -354,7 +354,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.6.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -397,7 +397,7 @@ spec:
               name: ca-bundle
               readOnly: true
         - name: csi-provisioner
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v3.1.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.1.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -416,7 +416,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v5.0.1
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v5.0.1
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -469,7 +469,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: node-driver-registrar
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.5.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -558,7 +558,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.6.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: kube-proxy
-        image: '{{ Registry "k8s.gcr.io" }}/kube-proxy:v{{ .Cluster.Version }}'
+        image: '{{ Registry "registry.k8s.io" }}/kube-proxy:v{{ .Cluster.Version }}'
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy

--- a/addons/kube-state-metrics/deployment.yaml
+++ b/addons/kube-state-metrics/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: '{{ Registry "k8s.gcr.io" }}/kube-state-metrics/kube-state-metrics:v2.1.1'
+          image: '{{ Registry "registry.k8s.io" }}/kube-state-metrics/kube-state-metrics:v2.1.1'
           name: kube-state-metrics
           resources:
             limits:

--- a/addons/kubeadm-configmap/kubeadm-configmap.yaml
+++ b/addons/kubeadm-configmap/kubeadm-configmap.yaml
@@ -29,7 +29,7 @@ data:
     apiVersion: kubeadm.k8s.io/v1beta3
     {{- end }}
     certificatesDir: /etc/kubernetes/pki
-    imageRepository: k8s.gcr.io
+    imageRepository: registry.k8s.io
     kind: ClusterConfiguration
     kubernetesVersion: {{ .Cluster.Version }}
   ClusterStatus: |

--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: '{{ Registry "k8s.gcr.io" }}/metrics-server-amd64:v0.2.1'
+        image: '{{ Registry "registry.k8s.io" }}/metrics-server-amd64:v0.2.1'
         command:
         - /metrics-server
         - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -14,7 +14,7 @@
 
 kubeStateMetrics:
   image:
-    repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+    repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
     tag: v2.5.0
   resources:
     requests:
@@ -27,7 +27,7 @@ kubeStateMetrics:
 
   resizer:
     image:
-      repository: k8s.gcr.io/autoscaling/addon-resizer
+      repository: registry.k8s.io/autoscaling/addon-resizer
       tag: '1.8.14'
     resources:
       requests:

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -88,7 +88,7 @@ func TestStorage(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Optio
 					Containers: []corev1.Container{
 						{
 							Name:  "busybox",
-							Image: "k8s.gcr.io/busybox",
+							Image: "registry.k8s.io/busybox",
 							Args: []string{
 								"/bin/sh",
 								"-c",

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -559,7 +559,7 @@ spec:
   verticalPodAutoscaler:
     admissionController:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: k8s.gcr.io/autoscaling/vpa-admission-controller
+      dockerRepository: registry.k8s.io/autoscaling/vpa-admission-controller
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Limits describes the maximum amount of compute resources allowed.
@@ -576,7 +576,7 @@ spec:
           memory: 32Mi
     recommender:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: k8s.gcr.io/autoscaling/vpa-recommender
+      dockerRepository: registry.k8s.io/autoscaling/vpa-recommender
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Limits describes the maximum amount of compute resources allowed.
@@ -593,7 +593,7 @@ spec:
           memory: 512Mi
     updater:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: k8s.gcr.io/autoscaling/vpa-updater
+      dockerRepository: registry.k8s.io/autoscaling/vpa-updater
       # Resources describes the requested and maximum allowed CPU/memory usage.
       resources:
         # Limits describes the maximum amount of compute resources allowed.

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -150,7 +150,7 @@ func getContainers(
 	return []corev1.Container{
 		{
 			Name:            resources.CoreDNSDeploymentName,
-			Image:           fmt.Sprintf("%s/%s", registryWithOverwrite(resources.RegistryK8SGCR), dns.GetCoreDNSImage(clusterVersion)),
+			Image:           fmt.Sprintf("%s/%s", registryWithOverwrite(resources.RegistryK8S), dns.GetCoreDNSImage(clusterVersion)),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			Args: []string{"-conf", "/etc/coredns/Corefile"},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -91,7 +91,7 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.MetricsServerDeploymentName,
-					Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryK8SGCR), imageName, imageTag),
+					Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryK8S), imageName, imageTag),
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubelet-insecure-tls",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -87,7 +87,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
-					Image:           fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.21.1", registryWithOverwrite(resources.RegistryK8SGCR)),
+					Image:           fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.21.1", registryWithOverwrite(resources.RegistryK8S)),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -53,9 +53,9 @@ const (
 	DefaultControllerManagerReplicas              = 1
 	DefaultSchedulerReplicas                      = 1
 	DefaultExposeStrategy                         = kubermaticv1.ExposeStrategyNodePort
-	DefaultVPARecommenderDockerRepository         = "k8s.gcr.io/autoscaling/vpa-recommender"
-	DefaultVPAUpdaterDockerRepository             = "k8s.gcr.io/autoscaling/vpa-updater"
-	DefaultVPAAdmissionControllerDockerRepository = "k8s.gcr.io/autoscaling/vpa-admission-controller"
+	DefaultVPARecommenderDockerRepository         = "registry.k8s.io/autoscaling/vpa-recommender"
+	DefaultVPAUpdaterDockerRepository             = "registry.k8s.io/autoscaling/vpa-updater"
+	DefaultVPAAdmissionControllerDockerRepository = "registry.k8s.io/autoscaling/vpa-admission-controller"
 	DefaultEnvoyDockerRepository                  = "docker.io/envoyproxy/envoy-alpine"
 	DefaultUserClusterScrapeAnnotationPrefix      = "monitoring.kubermatic.io"
 	DefaultMaximumParallelReconciles              = 10

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -150,7 +150,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 
 			apiserverContainer := &corev1.Container{
 				Name:    resources.ApiserverDeploymentName,
-				Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-apiserver:v" + version.String(),
+				Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-apiserver:v" + version.String(),
 				Command: []string{"/usr/local/bin/kube-apiserver"},
 				Env:     envVars,
 				Args:    flags,

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -151,7 +151,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ControllerManagerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-controller-manager:v" + version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-controller-manager:v" + version.String(),
 					Command: []string{"/usr/local/bin/kube-controller-manager"},
 					Args:    flags,
 					Env:     envVars,

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -119,7 +119,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				{
 					Name: resources.DNSResolverDeploymentName,
 					// like etcd, this component follows the apiserver version and not the controller-manager version
-					Image: data.ImageRegistry(resources.RegistryK8SGCR) + "/" + GetCoreDNSImage(data.Cluster().Status.Versions.Apiserver.Semver()),
+					Image: data.ImageRegistry(resources.RegistryK8S) + "/" + GetCoreDNSImage(data.Cluster().Status.Versions.Apiserver.Semver()),
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -85,7 +85,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-state-metrics/kube-state-metrics:" + version,
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-state-metrics/kube-state-metrics:" + version,
 					Command: []string{"/kube-state-metrics"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -112,7 +112,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/metrics-server/metrics-server:" + tag,
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/metrics-server/metrics-server:" + tag,
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -400,6 +400,8 @@ const (
 
 	// RegistryK8SGCR defines the kubernetes specific docker registry at google.
 	RegistryK8SGCR = "k8s.gcr.io"
+	// RegistryK8S defines the (new) official registry hosted by the Kubernetes project.
+	RegistryK8S = "registry.k8s.io"
 	// RegistryEUGCR defines the docker registry at google EU.
 	RegistryEUGCR = "eu.gcr.io"
 	// RegistryUSGCR defines the docker registry at google US.

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -136,7 +136,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.SchedulerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-scheduler:v" + version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-scheduler:v" + version.String(),
 					Command: []string{"/usr/local/bin/kube-scheduler"},
 					Args:    flags,
 					Env: []corev1.EnvVar{

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -265,7 +265,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -91,7 +91,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-apiserver.yaml
@@ -267,7 +267,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-controller-manager.yaml
@@ -91,7 +91,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
@@ -267,7 +267,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
@@ -91,7 +91,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -249,7 +249,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver.yaml
@@ -251,7 +251,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
@@ -251,7 +251,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -243,7 +243,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-apiserver.yaml
@@ -243,7 +243,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
@@ -243,7 +243,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-apiserver.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -249,7 +249,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver.yaml
@@ -249,7 +249,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
@@ -249,7 +249,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -249,7 +249,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver.yaml
@@ -251,7 +251,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.23.5
+        image: registry.k8s.io/kube-apiserver:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.23.5
+        image: registry.k8s.io/kube-controller-manager:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.23.5
+        image: registry.k8s.io/kube-scheduler:v1.23.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
@@ -245,7 +245,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
@@ -251,7 +251,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.24.0
+        image: registry.k8s.io/kube-apiserver:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager.yaml
@@ -75,7 +75,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.24.0
+        image: registry.k8s.io/kube-controller-manager:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--secure-port","4443","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.6.1
+        image: registry.k8s.io/metrics-server/metrics-server:v0.6.1
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler.yaml
@@ -61,7 +61,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.24.0
+        image: registry.k8s.io/kube-scheduler:v1.24.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/test/e2e/nodeport-proxy/images.go
+++ b/pkg/test/e2e/nodeport-proxy/images.go
@@ -18,5 +18,5 @@ package nodeportproxy
 
 // TODO make registries configurable.
 const (
-	AgnhostImage = "k8s.gcr.io/e2e-test-images/agnhost:2.21"
+	AgnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.21"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Kubernetes upstream introduced a new registry URL called `registry.k8s.io`, which acts as a kind of proxy (well, technically it only redirects) for upstream images. This can speed up the image pull process if a local mirror is available that you're forwarded to (mainly on AWS, as far as I understand from upstream documentation) and is the suggested source of images now. Let's switch to it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #9987

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ACTION REQUIRED: Use `registry.k8s.io` instead of `k8s.gcr.io` for Kubernetes upstream images. It might be necessary to update firewall rules or mirror registries accordingly
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
