### PR TITLE
Make externalcluster crd fields optional

### DIFF
--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -111,7 +111,7 @@ type ExternalClusterSpec struct {
 	// CloudSpec contains provider specific fields
 	CloudSpec ExternalClusterCloudSpec `json:"cloudSpec"`
 
-	ClusterNetwork ExternalClusterNetworkingConfig `json:"clusterNetwork"`
+	ClusterNetwork ExternalClusterNetworkingConfig `json:"clusterNetwork,omitempty"`
 
 	// If this is set to true, the cluster will not be reconciled by KKP.
 	// This indicates that the user needs to do some action to resolve the pause.
@@ -128,17 +128,17 @@ type ExternalClusterNetworkingConfig struct {
 	// The network ranges from which service VIPs are allocated.
 	// It can contain one IPv4 and/or one IPv6 CIDR.
 	// If both address families are specified, the first one defines the primary address family.
-	Services NetworkRanges `json:"services"`
+	Services ExternalClusterNetworkRanges `json:"services,omitempty"`
 
 	// The network ranges from which POD networks are allocated.
 	// It can contain one IPv4 and/or one IPv6 CIDR.
 	// If both address families are specified, the first one defines the primary address family.
-	Pods NetworkRanges `json:"pods"`
+	Pods ExternalClusterNetworkRanges `json:"pods,omitempty"`
 }
 
 // ExternalClusterNetworkRanges represents ranges of network addresses.
 type ExternalClusterNetworkRanges struct {
-	CIDRBlocks []string `json:"cidrBlocks"`
+	CIDRBlocks []string `json:"cidrBlocks,omitempty"`
 }
 
 // ExternalClusterCloudSpec mutually stores access data to a cloud provider.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -330,8 +330,6 @@ spec:
                           items:
                             type: string
                           type: array
-                      required:
-                        - cidrBlocks
                       type: object
                     services:
                       description: The network ranges from which service VIPs are allocated. It can contain one IPv4 and/or one IPv6 CIDR. If both address families are specified, the first one defines the primary address family.
@@ -340,12 +338,7 @@ spec:
                           items:
                             type: string
                           type: array
-                      required:
-                        - cidrBlocks
                       type: object
-                  required:
-                    - pods
-                    - services
                   type: object
                 humanReadableName:
                   description: HumanReadableName is the cluster name provided by the user
@@ -386,7 +379,6 @@ spec:
                   type: string
               required:
                 - cloudSpec
-                - clusterNetwork
                 - humanReadableName
                 - pause
               type: object


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: Make externalcluster crd fields optional

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
