### PR TITLE
enhance cluster rbac: allow to bind service account to clusterRole and Role

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -24678,6 +24678,14 @@
           "type": "string",
           "x-go-name": "Group"
         },
+        "serviceAccount": {
+          "type": "string",
+          "x-go-name": "ServiceAccount"
+        },
+        "serviceAccountNamespace": {
+          "type": "string",
+          "x-go-name": "ServiceAccountNamespace"
+        },
         "userEmail": {
           "type": "string",
           "x-go-name": "UserEmail"
@@ -32156,6 +32164,14 @@
         "group": {
           "type": "string",
           "x-go-name": "Group"
+        },
+        "serviceAccount": {
+          "type": "string",
+          "x-go-name": "ServiceAccount"
+        },
+        "serviceAccountNamespace": {
+          "type": "string",
+          "x-go-name": "ServiceAccountNamespace"
         },
         "userEmail": {
           "type": "string",

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2545,15 +2545,19 @@ type ClusterRoleName struct {
 // RoleUser defines associated user with role
 // swagger:model RoleUser
 type RoleUser struct {
-	UserEmail string `json:"userEmail"`
-	Group     string `json:"group"`
+	UserEmail               string `json:"userEmail"`
+	Group                   string `json:"group"`
+	ServiceAccount          string `json:"serviceAccount"`
+	ServiceAccountNamespace string `json:"serviceAccountNamespace"`
 }
 
 // ClusterRoleUser defines associated user with cluster role
 // swagger:model ClusterRoleUser
 type ClusterRoleUser struct {
-	UserEmail string `json:"userEmail"`
-	Group     string `json:"group"`
+	UserEmail               string `json:"userEmail"`
+	Group                   string `json:"group"`
+	ServiceAccount          string `json:"serviceAccount"`
+	ServiceAccountNamespace string `json:"serviceAccountNamespace"`
 }
 
 // Role defines RBAC role for the user cluster

--- a/pkg/handler/common/binding.go
+++ b/pkg/handler/common/binding.go
@@ -82,6 +82,9 @@ func BindUserToRoleEndpoint(ctx context.Context, userInfoGetter provider.UserInf
 		if roleUser.Group != "" && subject.Name == roleUser.Group {
 			return nil, utilerrors.NewBadRequest("group %s already connected to role %s", roleUser.Group, roleID)
 		}
+		if roleUser.ServiceAccount != "" && subject.Name == roleUser.ServiceAccount && subject.Namespace == roleUser.ServiceAccountNamespace {
+			return nil, utilerrors.NewBadRequest("service account %s/%s already connected to the role %s", roleUser.ServiceAccountNamespace, roleUser.ServiceAccount, roleID)
+		}
 	}
 
 	if roleUser.UserEmail != "" {
@@ -98,6 +101,15 @@ func BindUserToRoleEndpoint(ctx context.Context, userInfoGetter provider.UserInf
 				Kind:     rbacv1.GroupKind,
 				APIGroup: rbacv1.GroupName,
 				Name:     roleUser.Group,
+			})
+	}
+	if roleUser.ServiceAccount != "" {
+		existingRoleBinding.Subjects = append(existingRoleBinding.Subjects,
+			rbacv1.Subject{
+				Kind:      rbacv1.ServiceAccountKind,
+				APIGroup:  "",
+				Name:      roleUser.ServiceAccount,
+				Namespace: roleUser.ServiceAccountNamespace,
 			})
 	}
 
@@ -150,6 +162,9 @@ func BindUserToClusterRoleEndpoint(ctx context.Context, userInfoGetter provider.
 		if clusterRoleUser.Group != "" && subject.Name == clusterRoleUser.Group {
 			return nil, utilerrors.NewBadRequest("group %s already connected to the cluster role %s", clusterRoleUser.Group, roleID)
 		}
+		if clusterRoleUser.ServiceAccount != "" && subject.Name == clusterRoleUser.ServiceAccount && subject.Namespace == clusterRoleUser.ServiceAccountNamespace {
+			return nil, utilerrors.NewBadRequest("service account %s/%s already connected to the cluster role %s", clusterRoleUser.ServiceAccountNamespace, clusterRoleUser.ServiceAccount, roleID)
+		}
 	}
 
 	if clusterRoleUser.UserEmail != "" {
@@ -166,6 +181,16 @@ func BindUserToClusterRoleEndpoint(ctx context.Context, userInfoGetter provider.
 				Kind:     rbacv1.GroupKind,
 				APIGroup: rbacv1.GroupName,
 				Name:     clusterRoleUser.Group,
+			})
+	}
+
+	if clusterRoleUser.ServiceAccount != "" {
+		existingClusterRoleBinding.Subjects = append(existingClusterRoleBinding.Subjects,
+			rbacv1.Subject{
+				Kind:      rbacv1.ServiceAccountKind,
+				APIGroup:  "",
+				Name:      clusterRoleUser.ServiceAccount,
+				Namespace: clusterRoleUser.ServiceAccountNamespace,
 			})
 	}
 
@@ -217,6 +242,9 @@ func UnbindUserFromRoleBindingEndpoint(ctx context.Context, userInfoGetter provi
 			continue
 		}
 		if roleUser.Group != "" && subject.Name == roleUser.Group {
+			continue
+		}
+		if roleUser.ServiceAccount != "" && subject.Name == roleUser.ServiceAccount && subject.Namespace == roleUser.ServiceAccountNamespace {
 			continue
 		}
 		newSubjects = append(newSubjects, subject)
@@ -271,6 +299,9 @@ func UnbindUserFromClusterRoleBindingEndpoint(ctx context.Context, userInfoGette
 			continue
 		}
 		if clusterRoleUser.Group != "" && subject.Name == clusterRoleUser.Group {
+			continue
+		}
+		if clusterRoleUser.ServiceAccount != "" && subject.Name == clusterRoleUser.ServiceAccount && subject.Namespace == clusterRoleUser.ServiceAccountNamespace {
 			continue
 		}
 		newSubjects = append(newSubjects, subject)

--- a/pkg/handler/test/helper.go
+++ b/pkg/handler/test/helper.go
@@ -1719,6 +1719,20 @@ func GenDefaultGroupRoleBinding(name, namespace, roleID, group string) *rbacv1.R
 	}
 }
 
+func GenDefaultServiceAccoutnRoleBinding(name string, namespace string, roleID string, subjects []rbacv1.Subject) *rbacv1.RoleBinding {
+	return &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Labels:    map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterBindingComponentValue},
+			Namespace: namespace,
+		},
+		Subjects: subjects,
+		RoleRef: rbacv1.RoleRef{
+			Name: roleID,
+		},
+	}
+}
+
 func GenDefaultClusterRoleBinding(name, roleID, userEmail string) *rbacv1.ClusterRoleBinding {
 	return &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1749,6 +1763,19 @@ func GenDefaultGroupClusterRoleBinding(name, roleID, group string) *rbacv1.Clust
 				Name: group,
 			},
 		},
+		RoleRef: rbacv1.RoleRef{
+			Name: roleID,
+		},
+	}
+}
+
+func GenDefaultServiceAccountClusterRoleBinding(name string, roleID string, subjects []rbacv1.Subject) *rbacv1.ClusterRoleBinding {
+	return &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{handlercommon.UserClusterComponentKey: handlercommon.UserClusterBindingComponentValue},
+		},
+		Subjects: subjects,
 		RoleRef: rbacv1.RoleRef{
 			Name: roleID,
 		},

--- a/pkg/handler/v2/cluster/binding_test.go
+++ b/pkg/handler/v2/cluster/binding_test.go
@@ -26,7 +26,10 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/test"
 	"k8c.io/kubermatic/v2/pkg/handler/test/hack"
+	"k8c.io/kubermatic/v2/pkg/handler/v1/common"
+	"k8c.io/kubermatic/v2/pkg/handler/v2/cluster"
 
+	rbacv1 "k8s.io/api/rbac/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -211,6 +214,98 @@ func TestBindUserToRole(t *testing.T) {
 			},
 			existingAPIUser: test.GenDefaultAPIUser(),
 		},
+		// service account tests
+		{
+			name:             "scenario 10: bind service account to role test-1",
+			roleName:         "role-1",
+			namespace:        "default",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace":"default"}`,
+			expectedResponse: `{"namespace":"default","subjects":[{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultRole("role-1", "default"),
+				test.GenDefaultRole("role-1", "test"),
+				test.GenDefaultClusterRole("role-1"),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 11: create role binding when cluster role doesn't exist",
+			roleName:         "role-1",
+			namespace:        "default",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace":"default"}`,
+			expectedResponse: `{"error":{"code":404,"message":"roles.rbac.authorization.k8s.io \"role-1\" not found"}}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusNotFound,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultRole("role-1", "test"),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 12: update existing binding for the new service account",
+			roleName:         "role-1",
+			namespace:        "default",
+			body:             `{"serviceAccount":"test-2", "serviceAccountNamespace":"kube-system"}`,
+			expectedResponse: `{"namespace":"default","subjects":[{"kind":"ServiceAccount","name":"test","namespace":"default"},{"kind":"ServiceAccount","name":"test-2","namespace":"kube-system"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultRole("role-1", "default"),
+				test.GenDefaultServiceAccoutnRoleBinding("test", "default", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 13: update existing binding for the new service account",
+			roleName:         "role-1",
+			namespace:        "default",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace":"default"}`,
+			expectedResponse: `{"namespace":"default","subjects":[{"kind":"User","name":"bob@acme.com"},{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultRole("role-1", "default"),
+				test.GenDefaultRoleBinding("test", "default", "role-1", "bob@acme.com"),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 14: bind existing service account",
+			roleName:         "role-1",
+			namespace:        "default",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace":"default"}`,
+			expectedResponse: `{"error":{"code":400,"message":"service account default/test already connected to the role role-1"}}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusBadRequest,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultRole("role-1", "default"),
+				test.GenDefaultServiceAccoutnRoleBinding("test", "default", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+
 		{
 			name:             "scenario 10: the admin John can bind user to role test-1 for any cluster",
 			roleName:         "role-1",
@@ -330,7 +425,44 @@ func TestUnbindUserFromRoleBinding(t *testing.T) {
 			existingAPIUser: test.GenDefaultAPIUser(),
 		},
 		{
-			name:             "scenario 3: the admin John can remove user from the binding for the any cluster",
+			name:             "scenario 3: remove service account from the binding",
+			roleName:         "role-1",
+			namespace:        "default",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace":"default"}`,
+			expectedResponse: `{"namespace":"default","roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultRole("role-1", "default"),
+				test.GenDefaultServiceAccoutnRoleBinding("test", "default", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 4: remove service account from another namespace from existing the binding",
+			roleName:         "role-1",
+			namespace:        "default",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace":"another-ns"}`,
+			expectedResponse: `{"namespace":"default","subjects":[{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultRole("role-1", "default"),
+				test.GenDefaultServiceAccoutnRoleBinding("test", "default", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}, {Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "another-ns"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+
+		{
+			name:             "scenario 5: the admin John can remove user from the binding for the any cluster",
 			roleName:         "role-1",
 			namespace:        "default",
 			body:             `{"userEmail":"bob@acme.com"}`,
@@ -349,7 +481,7 @@ func TestUnbindUserFromRoleBinding(t *testing.T) {
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 		},
 		{
-			name:             "scenario 4: the user John can not remove user from the binding for the Bob's cluster",
+			name:             "scenario 6: the user John can not remove user from the binding for the Bob's cluster",
 			roleName:         "role-1",
 			namespace:        "default",
 			body:             `{"userEmail":"bob@acme.com"}`,
@@ -567,8 +699,116 @@ func TestBindUserToClusterRole(t *testing.T) {
 			},
 			existingAPIUser: test.GenDefaultAPIUser(),
 		},
+
+		// service account scenarios
+
 		{
-			name:             "scenario 10: admin can update existing binding for the new user for any cluster",
+			name:             "scenario 10: bind service account to role-1, when cluster role binding doesn't exist",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "default"}`,
+			expectedResponse: `{"error":{"code":500,"message":"the cluster role binding not found"}}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusInternalServerError,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-1"),
+				test.GenDefaultClusterRole("role-2"),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 11: create cluster role binding when cluster role doesn't exist",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "default"}`,
+			expectedResponse: `{"error":{"code":404,"message":"clusterroles.rbac.authorization.k8s.io \"role-1\" not found"}}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusNotFound,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-2"),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 12: update existing binding for the new service account",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "default"}`,
+			expectedResponse: `{"subjects":[{"kind":"User","name":"bob@acme.com"},{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-1"),
+				test.GenDefaultClusterRole("role-2"),
+				test.GenDefaultClusterRoleBinding("test", "role-1", "bob@acme.com"),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 13: update existing binding for the new service account",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "default"}`,
+			expectedResponse: `{"subjects":[{"kind":"Group","name":"admins"},{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-1"),
+				test.GenDefaultClusterRole("role-2"),
+				test.GenDefaultGroupClusterRoleBinding("test", "role-1", "admins"),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 14: update existing binding for the new service account in different namespace",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "another-ns"}`,
+			expectedResponse: `{"subjects":[{"kind":"ServiceAccount","name":"test","namespace":"default"},{"kind":"ServiceAccount","name":"test","namespace":"another-ns"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-1"),
+				test.GenDefaultClusterRole("role-2"),
+				test.GenDefaultServiceAccountClusterRoleBinding("test", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 15: bind existing serviceAccount",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "default"}`,
+			expectedResponse: `{"error":{"code":400,"message":"service account default/test already connected to the cluster role role-1"}}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusBadRequest,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-1"),
+				test.GenDefaultServiceAccountClusterRoleBinding("test", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+
+		{
+			name:             "scenario 16: admin can update existing binding for the new user for any cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"test@example.com"}`,
 			expectedResponse: `{"subjects":[{"kind":"User","name":"bob@acme.com"},{"kind":"User","apiGroup":"rbac.authorization.k8s.io","name":"test@example.com"}],"roleRefName":"role-1"}`,
@@ -587,7 +827,7 @@ func TestBindUserToClusterRole(t *testing.T) {
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 		},
 		{
-			name:             "scenario 11: user John can not update existing binding for the new user for Bob's cluster",
+			name:             "scenario 17: user John can not update existing binding for the new user for Bob's cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"test@example.com"}`,
 			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
@@ -685,7 +925,43 @@ func TestUnbindUserFromClusterRoleBinding(t *testing.T) {
 			existingAPIUser: test.GenDefaultAPIUser(),
 		},
 		{
-			name:             "scenario 3: the admin can remove user from existing cluster role binding for any cluster",
+			name:             "scenario 3: remove service account from existing cluster role binding",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "default"}`,
+			expectedResponse: `{"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-1"),
+				test.GenDefaultClusterRole("role-2"),
+				test.GenDefaultServiceAccountClusterRoleBinding("test", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 4: remove service account from another namespace from existing cluster role binding",
+			roleName:         "role-1",
+			body:             `{"serviceAccount":"test", "serviceAccountNamespace": "another-ns"}`,
+			expectedResponse: `{"subjects":[{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-1"}`,
+			clusterToGet:     test.GenDefaultCluster().Name,
+			httpStatus:       http.StatusOK,
+			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
+				test.GenTestSeed(),
+				test.GenDefaultCluster(),
+			),
+			existingKubernetesObjs: []ctrlruntimeclient.Object{
+				test.GenDefaultClusterRole("role-1"),
+				test.GenDefaultClusterRole("role-2"),
+				test.GenDefaultServiceAccountClusterRoleBinding("test", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}, {Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "another-ns"}}),
+			},
+			existingAPIUser: test.GenDefaultAPIUser(),
+		},
+		{
+			name:             "scenario 5: the admin can remove user from existing cluster role binding for any cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"bob@acme.com"}`,
 			expectedResponse: `{"roleRefName":"role-1"}`,
@@ -704,7 +980,7 @@ func TestUnbindUserFromClusterRoleBinding(t *testing.T) {
 			existingAPIUser: test.GenAPIUser("John", "john@acme.com"),
 		},
 		{
-			name:             "scenario 4: the user can not remove user from existing cluster role binding for Bob's cluster",
+			name:             "scenario 6: the user can not remove user from existing cluster role binding for Bob's cluster",
 			roleName:         "role-1",
 			body:             `{"userEmail":"bob@acme.com"}`,
 			expectedResponse: `{"error":{"code":403,"message":"forbidden: \"john@acme.com\" doesn't belong to project my-first-project-ID"}}`,
@@ -763,7 +1039,7 @@ func TestListRoleBinding(t *testing.T) {
 	}{
 		{
 			name:             "scenario 1: list bindings",
-			expectedResponse: `[{"namespace":"default","subjects":[{"kind":"User","name":"test-1@example.com"}],"roleRefName":"role-1"},{"namespace":"default","subjects":[{"kind":"User","name":"test-2@example.com"}],"roleRefName":"role-2"},{"namespace":"default","subjects":[{"kind":"Group","name":"test"}],"roleRefName":"role-2"},{"namespace":"test","subjects":[{"kind":"User","name":"test-10@example.com"}],"roleRefName":"role-10"},{"namespace":"test","subjects":[{"kind":"Group","name":"test"}],"roleRefName":"role-10"}]`,
+			expectedResponse: `[{"namespace":"default","subjects":[{"kind":"User","name":"test-1@example.com"}],"roleRefName":"role-1"},{"namespace":"default","subjects":[{"kind":"User","name":"test-2@example.com"}],"roleRefName":"role-2"},{"namespace":"default","subjects":[{"kind":"Group","name":"test"}],"roleRefName":"role-2"},{"namespace":"default","subjects":[{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-1"},{"namespace":"default","subjects":[{"kind":"ServiceAccount","name":"test","namespace":"test"}],"roleRefName":"role-1"},{"namespace":"test","subjects":[{"kind":"User","name":"test-10@example.com"}],"roleRefName":"role-10"},{"namespace":"test","subjects":[{"kind":"Group","name":"test"}],"roleRefName":"role-10"}]`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -777,6 +1053,8 @@ func TestListRoleBinding(t *testing.T) {
 				test.GenDefaultRoleBinding("binding-1", "default", "role-1", "test-1@example.com"),
 				test.GenDefaultRoleBinding("binding-2", "default", "role-2", "test-2@example.com"),
 				test.GenDefaultGroupRoleBinding("binding-3", "default", "role-2", "test"),
+				test.GenDefaultServiceAccoutnRoleBinding("binding-4", "default", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
+				test.GenDefaultServiceAccoutnRoleBinding("binding-5", "default", "role-1", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "test"}}),
 				test.GenDefaultRoleBinding("binding-1", "test", "role-10", "test-10@example.com"),
 				test.GenDefaultGroupRoleBinding("binding-2", "test", "role-10", "test"),
 			},
@@ -869,7 +1147,7 @@ func TestListClusterRoleBinding(t *testing.T) {
 		// scenario 1
 		{
 			name:             "scenario 1: list cluster role bindings",
-			expectedResponse: `[{"subjects":[{"kind":"User","name":"test-1"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-2"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-3"}],"roleRefName":"role-2"},{"subjects":[{"kind":"Group","name":"test-4"}],"roleRefName":"role-2"}]`,
+			expectedResponse: ` [{"subjects":[{"kind":"User","name":"test-1"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-2"}],"roleRefName":"role-1"},{"subjects":[{"kind":"User","name":"test-3"}],"roleRefName":"role-2"},{"subjects":[{"kind":"Group","name":"test-4"}],"roleRefName":"role-2"},{"subjects":[{"kind":"ServiceAccount","name":"test","namespace":"default"}],"roleRefName":"role-2"}]`,
 			clusterToGet:     test.GenDefaultCluster().Name,
 			httpStatus:       http.StatusOK,
 			existingKubermaticObjs: test.GenDefaultKubermaticObjects(
@@ -883,6 +1161,7 @@ func TestListClusterRoleBinding(t *testing.T) {
 				test.GenDefaultClusterRoleBinding("binding-1-2", "role-1", "test-2"),
 				test.GenDefaultClusterRoleBinding("binding-2-1", "role-2", "test-3"),
 				test.GenDefaultGroupClusterRoleBinding("binding-2-2", "role-2", "test-4"),
+				test.GenDefaultServiceAccountClusterRoleBinding("binding-2-3", "role-2", []rbacv1.Subject{{Kind: rbacv1.ServiceAccountKind, Name: "test", Namespace: "default"}}),
 			},
 			existingAPIUser: test.GenDefaultAPIUser(),
 		},
@@ -952,6 +1231,274 @@ func TestListClusterRoleBinding(t *testing.T) {
 			}
 
 			test.CompareWithResult(t, res, tc.expectedResponse)
+		})
+	}
+}
+
+func TestClusterRoleUserReqValidate(t *testing.T) {
+	tests := []struct {
+		name             string
+		projectReq       common.ProjectReq
+		body             apiv1.ClusterRoleUser
+		expectedErrorMsg string
+	}{
+		{
+			name:       "valid: userEmail",
+			projectReq: common.ProjectReq{ProjectID: "projectID"},
+			body: apiv1.ClusterRoleUser{
+				UserEmail: "test@example.com",
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name:       "valid: group",
+			projectReq: common.ProjectReq{ProjectID: "projectID"},
+			body: apiv1.ClusterRoleUser{
+				Group: "someGroup",
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name:       "valid: service account",
+			projectReq: common.ProjectReq{ProjectID: "projectID"},
+			body: apiv1.ClusterRoleUser{
+				ServiceAccount:          "sa",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name:       "invalid: projectId can not be empty",
+			projectReq: common.ProjectReq{},
+			body: apiv1.ClusterRoleUser{
+				UserEmail: "test@example.com",
+			},
+			expectedErrorMsg: "the project ID cannot be empty",
+		},
+		{
+			name:             "invalid:  all body can not be empty",
+			projectReq:       common.ProjectReq{ProjectID: "project-id"},
+			body:             apiv1.ClusterRoleUser{},
+			expectedErrorMsg: "either user email or group or service account must be set",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with group",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.ClusterRoleUser{
+				UserEmail: "test@example.com",
+				Group:     "some-group",
+			},
+			expectedErrorMsg: "user email can not be used in conjunction with group or service account",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with service account",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.ClusterRoleUser{
+				UserEmail:      "test@example.com",
+				ServiceAccount: "sa",
+			},
+			expectedErrorMsg: "user email can not be used in conjunction with group or service account",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with service account namespace",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.ClusterRoleUser{
+				UserEmail:               "test@example.com",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "user email can not be used in conjunction with group or service account",
+		},
+		{
+			name:       "invalid: group can not be used in conjunction with service account",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.ClusterRoleUser{
+				Group:          "some-group",
+				ServiceAccount: "sa",
+			},
+			expectedErrorMsg: "group can not be used in conjunction with email or service account",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with service account namespace",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.ClusterRoleUser{
+				Group:                   "some-group",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "group can not be used in conjunction with email or service account",
+		},
+
+		{
+			name:       "invalid: both service account and service account namespace must be defined (sa namspace empty)",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.ClusterRoleUser{
+				ServiceAccount:          "sa",
+				ServiceAccountNamespace: "",
+			},
+			expectedErrorMsg: "both service account and service account namespace must be defined",
+		},
+		{
+			name:       "invalid: both service account and service account namespace must be defined (sa empty)",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.ClusterRoleUser{
+				ServiceAccount:          "",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "both service account and service account namespace must be defined",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := cluster.ClusterRoleUserReq{
+				ProjectReq: tt.projectReq,
+				Body:       tt.body,
+			}
+
+			err := req.Validate()
+
+			if len(tt.expectedErrorMsg) > 0 {
+				if err == nil {
+					t.Fatalf("expect error '%s' but got nil", tt.expectedErrorMsg)
+				}
+				if tt.expectedErrorMsg != err.Error() {
+					t.Errorf("expected error '%s' got '%s'", tt.expectedErrorMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("expect no error but got error=%s", err)
+			}
+		})
+	}
+}
+
+func TestRoleUserReqValidate(t *testing.T) {
+	tests := []struct {
+		name             string
+		projectReq       common.ProjectReq
+		body             apiv1.RoleUser
+		expectedErrorMsg string
+	}{
+		{
+			name:       "valid: userEmail",
+			projectReq: common.ProjectReq{ProjectID: "projectID"},
+			body: apiv1.RoleUser{
+				UserEmail: "test@example.com",
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name:       "valid: group",
+			projectReq: common.ProjectReq{ProjectID: "projectID"},
+			body: apiv1.RoleUser{
+				Group: "someGroup",
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name:       "valid: service account",
+			projectReq: common.ProjectReq{ProjectID: "projectID"},
+			body: apiv1.RoleUser{
+				ServiceAccount:          "sa",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "",
+		},
+		{
+			name:       "invalid: projectId can not be empty",
+			projectReq: common.ProjectReq{},
+			body: apiv1.RoleUser{
+				UserEmail: "test@example.com",
+			},
+			expectedErrorMsg: "the project ID cannot be empty",
+		},
+		{
+			name:             "invalid:  all body can not be empty",
+			projectReq:       common.ProjectReq{ProjectID: "project-id"},
+			body:             apiv1.RoleUser{},
+			expectedErrorMsg: "either user email, group or service account must be set",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with group",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.RoleUser{
+				UserEmail: "test@example.com",
+				Group:     "some-group",
+			},
+			expectedErrorMsg: "user email can not be used in conjunction with group or service account",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with service account",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.RoleUser{
+				UserEmail:      "test@example.com",
+				ServiceAccount: "sa",
+			},
+			expectedErrorMsg: "user email can not be used in conjunction with group or service account",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with service account namespace",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.RoleUser{
+				UserEmail:               "test@example.com",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "user email can not be used in conjunction with group or service account",
+		},
+		{
+			name:       "invalid: group can not be used in conjunction with service account",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.RoleUser{
+				Group:          "some-group",
+				ServiceAccount: "sa",
+			},
+			expectedErrorMsg: "group can not be used in conjunction with email or service account",
+		},
+		{
+			name:       "invalid: user email can not be used in conjunction with service account namespace",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.RoleUser{
+				Group:                   "some-group",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "group can not be used in conjunction with email or service account",
+		},
+
+		{
+			name:       "invalid: both service account and service account namespace must be defined (sa namspace empty)",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.RoleUser{
+				ServiceAccount:          "sa",
+				ServiceAccountNamespace: "",
+			},
+			expectedErrorMsg: "both service account and service account namespace must be defined",
+		},
+		{
+			name:       "invalid: both service account and service account namespace must be defined (sa empty)",
+			projectReq: common.ProjectReq{ProjectID: "project-id"},
+			body: apiv1.RoleUser{
+				ServiceAccount:          "",
+				ServiceAccountNamespace: "default",
+			},
+			expectedErrorMsg: "both service account and service account namespace must be defined",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := cluster.RoleUserReq{
+				ProjectReq: tt.projectReq,
+				Body:       tt.body,
+			}
+
+			err := req.Validate()
+
+			if len(tt.expectedErrorMsg) > 0 {
+				if err == nil {
+					t.Fatalf("expect error '%s' but got nil", tt.expectedErrorMsg)
+				}
+				if tt.expectedErrorMsg != err.Error() {
+					t.Errorf("expected error '%s' got '%s'", tt.expectedErrorMsg, err.Error())
+				}
+			} else if err != nil {
+				t.Fatalf("expect no error but got error=%s", err)
+			}
 		})
 	}
 }

--- a/pkg/test/e2e/utils/apiclient/models/cluster_role_user.go
+++ b/pkg/test/e2e/utils/apiclient/models/cluster_role_user.go
@@ -20,6 +20,12 @@ type ClusterRoleUser struct {
 	// group
 	Group string `json:"group,omitempty"`
 
+	// service account
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+
+	// service account namespace
+	ServiceAccountNamespace string `json:"serviceAccountNamespace,omitempty"`
+
 	// user email
 	UserEmail string `json:"userEmail,omitempty"`
 }

--- a/pkg/test/e2e/utils/apiclient/models/role_user.go
+++ b/pkg/test/e2e/utils/apiclient/models/role_user.go
@@ -20,6 +20,12 @@ type RoleUser struct {
 	// group
 	Group string `json:"group,omitempty"`
 
+	// service account
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+
+	// service account namespace
+	ServiceAccountNamespace string `json:"serviceAccountNamespace,omitempty"`
+
 	// user email
 	UserEmail string `json:"userEmail,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is the first part of #10166 and allow to bind clusterRole and role to a k8s service account. the Second  (manage service account and download kubeconfig) will be done another pr for easier review.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature
/kind api-change

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
enhance cluster rbac to allow to bind service account to clusterRole and Role. Following endpoint has been updated:
- GET /api/v2/projects/{project_id}/clusters/{cluster_id}/bindings 
- POST /api/v2/projects/{project_id}/clusters/{cluster_id}/roles/{namespace}/{role_id}/bindings 
- DELETE /api/v2/projects/{project_id}/clusters/{cluster_id}/roles/{namespace}/{role_id}/bindings
- GET /api/v2/projects/{project_id}/clusters/{cluster_id}/clusterbindings 
- POST /api/v2/projects/{project_id}/clusters/{cluster_id}/clusterroles/role_id/clusterbindings
- DELETE /api/v2/projects/{project_id}/clusters/{cluster_id}/clusterroles/role_id/clusterbindings

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1310
```
