### PR TITLE
Add a temp controller which removes all UPB mla finalizers

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/mla.go
+++ b/pkg/controller/seed-controller-manager/mla/mla.go
@@ -160,6 +160,9 @@ func Add(
 		if err := newRuleGroupSyncReconciler(mgr, log, numWorkers, workerName, versions, ruleGroupSyncController); err != nil {
 			return fmt.Errorf("failed to create rule group controller %w", err)
 		}
+		if err := newUserProjectBindingReconciler(mgr, log, numWorkers); err != nil {
+			return fmt.Errorf("failed to create user project binding controller")
+		}
 	} else {
 		cleanupController := newCleanupController(
 			mgr.GetClient(),

--- a/pkg/controller/seed-controller-manager/mla/upb_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/upb_controller.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package mla
 
 import (

--- a/pkg/controller/seed-controller-manager/mla/upb_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/upb_controller.go
@@ -24,7 +24,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
-	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	"k8s.io/utils/strings/slices"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -42,10 +41,7 @@ import (
 type userProjectBindingReconciler struct {
 	ctrlruntimeclient.Client
 
-	log                          *zap.SugaredLogger
-	workerName                   string
-	versions                     kubermatic.Versions
-	userProjectBindingController *userGrafanaController
+	log *zap.SugaredLogger
 }
 
 func newUserProjectBindingReconciler(

--- a/pkg/controller/seed-controller-manager/mla/upb_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/upb_controller.go
@@ -1,0 +1,81 @@
+package mla
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	"k8s.io/utils/strings/slices"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// TODO remove this in v2.22
+// userProjectBindingReconciler just cleans up the unnecessary mla finalizer from UserProjectBindings, which were made obsolete
+// in 2.21.2, through https://github.com/kubermatic/kubermatic/pull/11076
+type userProjectBindingReconciler struct {
+	ctrlruntimeclient.Client
+
+	log                          *zap.SugaredLogger
+	workerName                   string
+	versions                     kubermatic.Versions
+	userProjectBindingController *userGrafanaController
+}
+
+func newUserProjectBindingReconciler(
+	mgr manager.Manager,
+	log *zap.SugaredLogger,
+	numWorkers int,
+) error {
+	log = log.Named(ControllerName)
+	client := mgr.GetClient()
+
+	reconciler := &userProjectBindingReconciler{
+		Client: client,
+
+		log: log.Named("userprojectbinding-finalizer-cleaner"),
+	}
+
+	ctrlOptions := controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: numWorkers,
+	}
+	c, err := controller.New(ControllerName, mgr, ctrlOptions)
+	if err != nil {
+		return err
+	}
+
+	finalizerPredicate := predicate.NewPredicateFuncs(func(object ctrlruntimeclient.Object) bool {
+		// We don't trigger reconciliation for already cleaned up upb.
+		upb := object.(*kubermaticv1.UserProjectBinding)
+		return slices.Contains(upb.Finalizers, mlaFinalizer)
+	})
+
+	if err := c.Watch(&source.Kind{Type: &kubermaticv1.UserProjectBinding{}}, &handler.EnqueueRequestForObject{}, finalizerPredicate); err != nil {
+		return fmt.Errorf("failed to watch UserProjectBindings: %w", err)
+	}
+
+	return err
+}
+
+func (r *userProjectBindingReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("request", request)
+	log.Debug("Processing")
+
+	upb := &kubermaticv1.UserProjectBinding{}
+	if err := r.Get(ctx, request.NamespacedName, upb); err != nil {
+		return reconcile.Result{}, ctrlruntimeclient.IgnoreNotFound(err)
+	}
+
+	return reconcile.Result{}, kubernetes.TryRemoveFinalizer(ctx, r.Client, upb, mlaFinalizer)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://github.com/kubermatic/kubermatic/pull/11076, the MLA controller for UserProjectBindings was removed. But its finalizers are still there. This PR adds a temporary controller which only job is to remove the finalizer.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11098 

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
