### PR TITLE
prevent dangling resource fixtures, ensure name/namespace are set

### DIFF
--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-adm-control-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-adm-control-externalCloudProvider.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-adm-control.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-adm-control.yaml
@@ -6,3 +6,5 @@ data:
     apiVersion: apiserver.config.k8s.io/v1
 metadata:
   creationTimestamp: null
+  name: adm-control
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-audit-config-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-audit-config-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-audit-config.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-audit-config.yaml
@@ -9,3 +9,5 @@ data:
       - level: Metadata
 metadata:
   creationTimestamp: null
+  name: audit-config
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-ca-bundle-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-ca-bundle-externalCloudProvider.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-ca-bundle.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-ca-bundle.yaml
@@ -22,3 +22,5 @@ data:
     -----END CERTIFICATE-----
 metadata:
   creationTimestamp: null
+  name: ca-bundle
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-dns-resolver.yaml
@@ -19,3 +19,5 @@ data:
     }
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-openvpn-client-configs-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-openvpn-client-configs-externalCloudProvider.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-openvpn-client-configs.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-openvpn-client-configs.yaml
@@ -9,3 +9,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: openvpn-server
+  name: openvpn-client-configs
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus.yaml
@@ -627,3 +627,5 @@ metadata:
   creationTimestamp: null
   labels:
     app: prometheus
+  name: prometheus
+  namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/cronjob-aws-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.22.1-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-aws-1.23.5-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.23.5-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-aws-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.24.0-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.22.1-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.23.5-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.23.5-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.23.5-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.23.5-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.22.1-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.23.5-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.23.5-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.24.0-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.22.1-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.23.5-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.23.5-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.24.0-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.22.1-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.23.5-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.23.5-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.23.5-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.23.5-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.22.1-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.23.5-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.23.5-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.23.5-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.23.5-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd-defragger
+  namespace: cluster-de-test-01
 spec:
   concurrencyPolicy: Forbid
   jobTemplate:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: azure-cloud-controller-manager
   name: azure-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: azure-cloud-controller-manager
   name: azure-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: azure-cloud-controller-manager
   name: azure-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openstack-cloud-controller-manager
   name: openstack-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openstack-cloud-controller-manager
   name: openstack-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openstack-cloud-controller-manager
   name: openstack-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: vsphere-cloud-controller-manager
   name: vsphere-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   selector:
     matchLabels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: vsphere-cloud-controller-manager
   name: vsphere-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   selector:
     matchLabels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: controller-manager
   name: controller-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: dns-resolver
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kube-state-metrics
   name: kube-state-metrics
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: kubernetes-dashboard
   name: kubernetes-dashboard
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller
   name: machine-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-envoy
   name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   replicas: 2
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-lb-updater-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-lb-updater.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-lb-updater.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: nodeport-proxy-lb-updater
   name: nodeport-proxy-lb-updater
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-openvpn-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-openvpn-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: operating-system-manager
   name: operating-system-manager
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: scheduler
   name: scheduler
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-controller.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-controller
   name: usercluster-controller
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-usercluster-webhook.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: vsphere-cloud-controller-manager
   name: vsphere-cloud-controller-manager
+  namespace: cluster-de-test-01
 spec:
   selector:
     matchLabels:

--- a/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.22.1-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.22.1-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.23.5-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.23.5-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.24.0-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-aws-1.24.0-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.22.1-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.22.1-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.22.1-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.22.1-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.23.5-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.23.5-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.23.5-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.23.5-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.24.0-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.24.0-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.24.0-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-azure-1.24.0-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.22.1-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.22.1-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.23.5-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.23.5-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.24.0-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-bringyourown-1.24.0-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.22.1-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.22.1-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.23.5-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.23.5-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.24.0-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-digitalocean-1.24.0-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.22.1-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.23.5-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.23.5-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.23.5-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.23.5-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.24.0-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.24.0-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.24.0-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-openstack-1.24.0-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.22.1-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.23.5-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.23.5-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.23.5-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.23.5-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.24.0-default-backups-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.24.0-default-backups-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.24.0-default-backups.yaml
+++ b/pkg/resources/test/fixtures/etcdbackupconfig-vsphere-1.24.0-default-backups.yaml
@@ -4,6 +4,8 @@ metadata:
   creationTimestamp: null
   labels:
     project-id: my-project
+  name: default-backups
+  namespace: cluster-de-test-01
 spec:
   cluster:
     apiVersion: kubermatic.k8c.io/v1

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.22.1-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.23.5-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-aws-1.24.0-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.22.1-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.23.5-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-azure-1.24.0-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.22.1-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.23.5-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.22.1-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.23.5-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.22.1-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.23.5-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-openstack-1.24.0-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.22.1-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.23.5-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-apiserver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: apiserver
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-dns-resolver.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-etcd-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-etcd.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: etcd
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 2
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-metrics-server.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   minAvailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/poddisruptionbudget-vsphere-1.24.0-nodeport-proxy-envoy.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: nodeport-proxy-envoy
+  namespace: cluster-de-test-01
 spec:
   maxUnavailable: 1
   selector:

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-front-loadbalancer.yaml
@@ -6,6 +6,8 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.22.1-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-front-loadbalancer.yaml
@@ -6,6 +6,8 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-front-loadbalancer.yaml
@@ -6,6 +6,8 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled: "true"
     service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.22.1-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.22.1-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.22.1-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.22.1-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.22.1-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-apiserver-external-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-apiserver-external-externalCloudProvider.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-apiserver-external.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-apiserver-external.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     nodeport-proxy.k8s.io/expose-namespaced: "true"
   creationTimestamp: null
+  name: apiserver-external
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-dns-resolver.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: dns-resolver
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: dns

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   clusterIP: None
   ports:

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-front-loadbalancer-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-front-loadbalancer.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  name: front-loadbalancer
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-machine-controller-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: machine-controller-webhook
   name: machine-controller-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-metrics-server.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: metrics-server
   name: metrics-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - port: 443

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-openvpn-server-externalCloudProvider.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-openvpn-server.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: openvpn-server
   name: openvpn-server
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: secure

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook-externalCloudProvider.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-usercluster-webhook.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     app: usercluster-webhook
   name: usercluster-webhook
+  namespace: cluster-de-test-01
 spec:
   ports:
   - name: seed

--- a/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.22.1-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.22.1-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.22.1-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.22.1-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.22.1-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.22.1-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
@@ -3,6 +3,7 @@
 metadata:
   creationTimestamp: null
   name: etcd
+  namespace: cluster-de-test-01
 spec:
   podManagementPolicy: Parallel
   replicas: 3

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
     app: prometheus
     cluster: de-test-01
   name: prometheus
+  namespace: cluster-de-test-01
 spec:
   replicas: 1
   selector:

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -63,6 +63,135 @@ import (
 var (
 	update     = flag.Bool("update", false, "Update test fixtures")
 	fixtureDir = "fixtures"
+
+	kubernetesVersions = []*version.Version{
+		{
+			Version: semverlib.MustParse("1.22.1"),
+		},
+		{
+			Version: semverlib.MustParse("1.23.5"),
+		},
+		{
+			Version: semverlib.MustParse("1.24.0"),
+		},
+	}
+
+	featureSets = []map[string]bool{
+		{},
+		{kubermaticv1.ClusterFeatureExternalCloudProvider: true},
+	}
+
+	cloudProviders = map[string]kubermaticv1.CloudSpec{
+		"azure": {
+			Azure: &kubermaticv1.AzureCloudSpec{
+				TenantID:        "az-tenant-id",
+				SubscriptionID:  "az-subscription-id",
+				ClientID:        "az-client-id",
+				ClientSecret:    "az-client-secret",
+				ResourceGroup:   "az-res-group",
+				VNetName:        "az-vnet-name",
+				SubnetName:      "az-subnet-name",
+				RouteTableName:  "az-route-table-name",
+				SecurityGroup:   "az-sec-group",
+				AvailabilitySet: "az-availability-set",
+				LoadBalancerSKU: kubermaticv1.AzureBasicLBSKU,
+			},
+		},
+		"vsphere": {
+			VSphere: &kubermaticv1.VSphereCloudSpec{
+				Username: "vs-username",
+				Password: "vs-password",
+			},
+		},
+		"digitalocean": {
+			Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
+				Token: "do-token",
+			},
+		},
+		"aws": {
+			AWS: &kubermaticv1.AWSCloudSpec{
+				AccessKeyID:          "aws-access-key-id",
+				SecretAccessKey:      "aws-secret-access-key",
+				AssumeRoleARN:        "aws-assume-role-arn",
+				AssumeRoleExternalID: "aws-assume-role-external-id",
+				InstanceProfileName:  "aws-instance-profile-name",
+				RouteTableID:         "aws-route-table-id",
+				SecurityGroupID:      "aws-security-group",
+				VPCID:                "aws-vpn-id",
+				ControlPlaneRoleARN:  "aws-role-arn",
+			},
+		},
+		"openstack": {
+			Openstack: &kubermaticv1.OpenstackCloudSpec{
+				SubnetID:       "openstack-subnet-id",
+				Username:       "openstack-username",
+				Project:        "openstack-project",
+				Domain:         "openstack-domain",
+				FloatingIPPool: "openstack-floating-ip-pool",
+				Network:        "openstack-network",
+				Password:       "openstack-password",
+				RouterID:       "openstack-router-id",
+				SecurityGroups: "openstack-security-group1,openstack-security-group2",
+			},
+		},
+		"bringyourown": {
+			BringYourOwn: &kubermaticv1.BringYourOwnCloudSpec{},
+		},
+	}
+
+	config = &kubermaticv1.KubermaticConfiguration{
+		Spec: kubermaticv1.KubermaticConfigurationSpec{
+			UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{
+				Monitoring: kubermaticv1.KubermaticUserClusterMonitoringConfiguration{
+					ScrapeAnnotationPrefix: defaulting.DefaultUserClusterScrapeAnnotationPrefix,
+					CustomScrapingConfigs: `
+- job_name: custom-test-config
+  scheme: https
+  metrics_path: '/metrics'
+  static_configs:
+  - targets:
+    - 'foo.bar:12345'
+`,
+				},
+			},
+		},
+	}
+
+	datacenter = &kubermaticv1.Datacenter{
+		Spec: kubermaticv1.DatacenterSpec{
+			Azure: &kubermaticv1.DatacenterSpecAzure{
+				Location: "az-location",
+			},
+			VSphere: &kubermaticv1.DatacenterSpecVSphere{
+				Endpoint:         "https://vs-endpoint.io",
+				AllowInsecure:    false,
+				DefaultDatastore: "vs-datastore",
+				Datacenter:       "vs-datacenter",
+				Cluster:          "vs-cluster",
+				RootPath:         "vs-cluster",
+			},
+			AWS: &kubermaticv1.DatacenterSpecAWS{
+				Images: kubermaticv1.ImageList{
+					providerconfig.OperatingSystemUbuntu:  "ubuntu-ami",
+					providerconfig.OperatingSystemCentOS:  "centos-ami",
+					providerconfig.OperatingSystemSLES:    "sles-ami",
+					providerconfig.OperatingSystemRHEL:    "rhel-ami",
+					providerconfig.OperatingSystemFlatcar: "flatcar-ami",
+				},
+				Region: "us-central1",
+			},
+			Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{
+				Region: "fra1",
+			},
+			Openstack: &kubermaticv1.DatacenterSpecOpenstack{
+				AuthURL:          "https://example.com:8000/v3",
+				AvailabilityZone: "zone1",
+				DNSServers:       []string{"8.8.8.8", "8.8.4.4"},
+				IgnoreVolumeAZ:   true,
+				Region:           "cbk",
+			},
+		},
+	}
 )
 
 func checkTestResult(t *testing.T, resFile string, testObj interface{}) {
@@ -133,138 +262,78 @@ func (tc testCase) fixturePath(resType, resName string) string {
 	return path
 }
 
-func TestLoadFiles(t *testing.T) {
-	versions := []*version.Version{
-		{
-			Version: semverlib.MustParse("1.22.1"),
-		},
-		{
-			Version: semverlib.MustParse("1.23.5"),
-		},
-		{
-			Version: semverlib.MustParse("1.24.0"),
-		},
-	}
+func createClusterObject(version semverlib.Version, cloudSpec kubermaticv1.CloudSpec, features map[string]bool) *kubermaticv1.Cluster {
+	sversion := *ksemver.NewSemverOrDie(version.String())
 
-	clouds := map[string]kubermaticv1.CloudSpec{
-		"azure": {
-			Azure: &kubermaticv1.AzureCloudSpec{
-				TenantID:        "az-tenant-id",
-				SubscriptionID:  "az-subscription-id",
-				ClientID:        "az-client-id",
-				ClientSecret:    "az-client-secret",
-				ResourceGroup:   "az-res-group",
-				VNetName:        "az-vnet-name",
-				SubnetName:      "az-subnet-name",
-				RouteTableName:  "az-route-table-name",
-				SecurityGroup:   "az-sec-group",
-				AvailabilitySet: "az-availability-set",
-				LoadBalancerSKU: kubermaticv1.AzureBasicLBSKU,
+	return &kubermaticv1.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "de-test-01",
+			UID:  types.UID("1234567890"),
+			Labels: map[string]string{
+				"my-label":                     "my-value",
+				kubermaticv1.ProjectIDLabelKey: "my-project",
 			},
 		},
-		"vsphere": {
-			VSphere: &kubermaticv1.VSphereCloudSpec{
-				Username: "vs-username",
-				Password: "vs-password",
-			},
-		},
-		"digitalocean": {
-			Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
-				Token: "do-token",
-			},
-		},
-		"aws": {
-			AWS: &kubermaticv1.AWSCloudSpec{
-				AccessKeyID:          "aws-access-key-id",
-				SecretAccessKey:      "aws-secret-access-key",
-				AssumeRoleARN:        "aws-assume-role-arn",
-				AssumeRoleExternalID: "aws-assume-role-external-id",
-				InstanceProfileName:  "aws-instance-profile-name",
-				RouteTableID:         "aws-route-table-id",
-				SecurityGroupID:      "aws-security-group",
-				VPCID:                "aws-vpn-id",
-				ControlPlaneRoleARN:  "aws-role-arn",
-			},
-		},
-		"openstack": {
-			Openstack: &kubermaticv1.OpenstackCloudSpec{
-				SubnetID:       "openstack-subnet-id",
-				Username:       "openstack-username",
-				Project:        "openstack-project",
-				Domain:         "openstack-domain",
-				FloatingIPPool: "openstack-floating-ip-pool",
-				Network:        "openstack-network",
-				Password:       "openstack-password",
-				RouterID:       "openstack-router-id",
-				SecurityGroups: "openstack-security-group1,openstack-security-group2",
-			},
-		},
-		"bringyourown": {
-			BringYourOwn: &kubermaticv1.BringYourOwnCloudSpec{},
-		},
-	}
-
-	featureSets := []map[string]bool{
-		{},
-		{kubermaticv1.ClusterFeatureExternalCloudProvider: true},
-	}
-
-	dc := &kubermaticv1.Datacenter{
-		Spec: kubermaticv1.DatacenterSpec{
-			Azure: &kubermaticv1.DatacenterSpecAzure{
-				Location: "az-location",
-			},
-			VSphere: &kubermaticv1.DatacenterSpecVSphere{
-				Endpoint:         "https://vs-endpoint.io",
-				AllowInsecure:    false,
-				DefaultDatastore: "vs-datastore",
-				Datacenter:       "vs-datacenter",
-				Cluster:          "vs-cluster",
-				RootPath:         "vs-cluster",
-			},
-			AWS: &kubermaticv1.DatacenterSpecAWS{
-				Images: kubermaticv1.ImageList{
-					providerconfig.OperatingSystemUbuntu:  "ubuntu-ami",
-					providerconfig.OperatingSystemCentOS:  "centos-ami",
-					providerconfig.OperatingSystemSLES:    "sles-ami",
-					providerconfig.OperatingSystemRHEL:    "rhel-ami",
-					providerconfig.OperatingSystemFlatcar: "flatcar-ami",
+		Spec: kubermaticv1.ClusterSpec{
+			Features:       features,
+			ExposeStrategy: kubermaticv1.ExposeStrategyLoadBalancer,
+			Cloud:          cloudSpec,
+			Version:        sversion,
+			ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
+				Services: kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{"10.240.16.0/20"},
 				},
-				Region: "us-central1",
+				Pods: kubermaticv1.NetworkRanges{
+					CIDRBlocks: []string{"172.25.0.0/16"},
+				},
+				DNSDomain:                "cluster.local",
+				ProxyMode:                resources.IPVSProxyMode,
+				NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
 			},
-			Digitalocean: &kubermaticv1.DatacenterSpecDigitalocean{
-				Region: "fra1",
+			CNIPlugin: &kubermaticv1.CNIPluginSettings{
+				Type:    kubermaticv1.CNIPluginTypeCanal,
+				Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
 			},
-			Openstack: &kubermaticv1.DatacenterSpecOpenstack{
-				AuthURL:          "https://example.com:8000/v3",
-				AvailabilityZone: "zone1",
-				DNSServers:       []string{"8.8.8.8", "8.8.4.4"},
-				IgnoreVolumeAZ:   true,
-				Region:           "cbk",
+			MachineNetworks: []kubermaticv1.MachineNetworkingConfig{
+				{
+					CIDR: "192.168.1.1/24",
+					DNSServers: []string{
+						"8.8.8.8",
+					},
+					Gateway: "192.168.1.1",
+				},
+			},
+			ServiceAccount: &kubermaticv1.ServiceAccountSettings{
+				TokenVolumeProjectionEnabled: true,
+			},
+			MLA: &kubermaticv1.MLASettings{
+				MonitoringEnabled: true,
+				LoggingEnabled:    false,
+			},
+		},
+		Status: kubermaticv1.ClusterStatus{
+			NamespaceName: "cluster-de-test-01",
+			Versions: kubermaticv1.ClusterVersionsStatus{
+				ControlPlane:      sversion,
+				Apiserver:         sversion,
+				ControllerManager: sversion,
+				Scheduler:         sversion,
+			},
+			Address: kubermaticv1.ClusterAddress{
+				ExternalName: "jh8j81chn.europe-west3-c.dev.kubermatic.io",
+				IP:           "35.198.93.90",
+				AdminToken:   "6hzr76.u8txpkk4vhgmtgdp",
+				InternalName: "apiserver-external.cluster-de-test-01.svc.cluster.local.",
+				URL:          "https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000",
+				Port:         30000,
 			},
 		},
 	}
+}
 
+func TestLoadFiles(t *testing.T) {
 	kubermaticVersions := kubermatic.NewFakeVersions()
 	caBundle := certificates.NewFakeCABundle()
-
-	config := &kubermaticv1.KubermaticConfiguration{
-		Spec: kubermaticv1.KubermaticConfigurationSpec{
-			UserCluster: kubermaticv1.KubermaticUserClusterConfiguration{
-				Monitoring: kubermaticv1.KubermaticUserClusterMonitoringConfiguration{
-					ScrapeAnnotationPrefix: defaulting.DefaultUserClusterScrapeAnnotationPrefix,
-					CustomScrapingConfigs: `
-- job_name: custom-test-config
-  scheme: https
-  metrics_path: '/metrics'
-  static_configs:
-  - targets:
-    - 'foo.bar:12345'
-`,
-				},
-			},
-		},
-	}
 
 	if *update {
 		if err := os.RemoveAll(fixtureDir); err != nil {
@@ -290,8 +359,8 @@ func TestLoadFiles(t *testing.T) {
 		allFiles.Delete(filename)
 	}
 
-	for _, ver := range versions {
-		for prov, cloudspec := range clouds {
+	for _, ver := range kubernetesVersions {
+		for prov, cloudspec := range cloudProviders {
 			for _, features := range featureSets {
 				tc := testCase{
 					provider: prov,
@@ -299,70 +368,7 @@ func TestLoadFiles(t *testing.T) {
 					features: features,
 				}
 				t.Run(tc.name(), func(t *testing.T) {
-					cluster := &kubermaticv1.Cluster{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "de-test-01",
-							UID:  types.UID("1234567890"),
-							Labels: map[string]string{
-								"my-label":                     "my-value",
-								kubermaticv1.ProjectIDLabelKey: "my-project",
-							},
-						},
-						Spec: kubermaticv1.ClusterSpec{
-							Features:       features,
-							ExposeStrategy: kubermaticv1.ExposeStrategyLoadBalancer,
-							Cloud:          cloudspec,
-							Version:        *ksemver.NewSemverOrDie(ver.Version.String()),
-							ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
-								Services: kubermaticv1.NetworkRanges{
-									CIDRBlocks: []string{"10.240.16.0/20"},
-								},
-								Pods: kubermaticv1.NetworkRanges{
-									CIDRBlocks: []string{"172.25.0.0/16"},
-								},
-								DNSDomain:                "cluster.local",
-								ProxyMode:                resources.IPVSProxyMode,
-								NodeLocalDNSCacheEnabled: pointer.BoolPtr(true),
-							},
-							CNIPlugin: &kubermaticv1.CNIPluginSettings{
-								Type:    kubermaticv1.CNIPluginTypeCanal,
-								Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
-							},
-							MachineNetworks: []kubermaticv1.MachineNetworkingConfig{
-								{
-									CIDR: "192.168.1.1/24",
-									DNSServers: []string{
-										"8.8.8.8",
-									},
-									Gateway: "192.168.1.1",
-								},
-							},
-							ServiceAccount: &kubermaticv1.ServiceAccountSettings{
-								TokenVolumeProjectionEnabled: true,
-							},
-							MLA: &kubermaticv1.MLASettings{
-								MonitoringEnabled: true,
-								LoggingEnabled:    false,
-							},
-						},
-						Status: kubermaticv1.ClusterStatus{
-							NamespaceName: "cluster-de-test-01",
-							Versions: kubermaticv1.ClusterVersionsStatus{
-								ControlPlane:      *ksemver.NewSemverOrDie(ver.Version.String()),
-								Apiserver:         *ksemver.NewSemverOrDie(ver.Version.String()),
-								ControllerManager: *ksemver.NewSemverOrDie(ver.Version.String()),
-								Scheduler:         *ksemver.NewSemverOrDie(ver.Version.String()),
-							},
-							Address: kubermaticv1.ClusterAddress{
-								ExternalName: "jh8j81chn.europe-west3-c.dev.kubermatic.io",
-								IP:           "35.198.93.90",
-								AdminToken:   "6hzr76.u8txpkk4vhgmtgdp",
-								InternalName: "apiserver-external.cluster-de-test-01.svc.cluster.local.",
-								URL:          "https://jh8j81chn.europe-west3-c.dev.kubermatic.io:30000",
-								Port:         30000,
-							},
-						},
-					}
+					cluster := createClusterObject(*ver.Version, cloudspec, features)
 
 					caBundleConfigMap := &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{
@@ -372,7 +378,7 @@ func TestLoadFiles(t *testing.T) {
 						},
 					}
 
-					if features[kubermaticv1.ClusterFeatureExternalCloudProvider] && !resources.ExternalCloudControllerFeatureSupported(dc, &cluster.Spec.Cloud, cluster.Spec.Version) {
+					if features[kubermaticv1.ClusterFeatureExternalCloudProvider] && !resources.ExternalCloudControllerFeatureSupported(datacenter, &cluster.Spec.Cloud, cluster.Spec.Version) {
 						t.Log("Unsupported configuration")
 						return
 					}
@@ -684,7 +690,7 @@ func TestLoadFiles(t *testing.T) {
 						WithContext(ctx).
 						WithClient(dynamicClient).
 						WithCluster(cluster).
-						WithDatacenter(dc).
+						WithDatacenter(datacenter).
 						WithSeed(&kubermaticv1.Seed{
 							ObjectMeta: metav1.ObjectMeta{Name: "testdc"},
 							Spec: kubermaticv1.SeedSpec{
@@ -710,144 +716,7 @@ func TestLoadFiles(t *testing.T) {
 						WithVersions(kubermaticVersions).
 						Build()
 
-					var deploymentCreators []reconciling.NamedDeploymentCreatorGetter
-					deploymentCreators = append(deploymentCreators, kubernetescontroller.GetDeploymentCreators(data, true)...)
-					deploymentCreators = append(deploymentCreators, monitoringcontroller.GetDeploymentCreators(data)...)
-					for _, create := range deploymentCreators {
-						name, creator := create()
-						res, err := creator(&appsv1.Deployment{})
-						if err != nil {
-							t.Fatalf("failed to create Deployment: %v", err)
-						}
-						res.Name = name
-						res.Namespace = cluster.Status.NamespaceName
-
-						fixturePath := tc.fixturePath("deployment", res.Name)
-
-						verifyContainerResources(fmt.Sprintf("Deployment/%s", res.Name), res.Spec.Template, t)
-						markFixtureUsed(fixturePath)
-						checkTestResult(t, fixturePath, res)
-					}
-
-					var namedConfigMapCreatorGetters []reconciling.NamedConfigMapCreatorGetter
-					namedConfigMapCreatorGetters = append(namedConfigMapCreatorGetters, kubernetescontroller.GetConfigMapCreators(data)...)
-					namedConfigMapCreatorGetters = append(namedConfigMapCreatorGetters, monitoringcontroller.GetConfigMapCreators(data)...)
-					for _, namedGetter := range namedConfigMapCreatorGetters {
-						name, create := namedGetter()
-						res, err := create(&corev1.ConfigMap{})
-						if err != nil {
-							t.Fatalf("failed to create ConfigMap: %v", err)
-						}
-						res.Name = name
-						res.Namespace = cluster.Status.NamespaceName
-
-						fixturePath := tc.fixturePath("configmap", res.Name)
-						markFixtureUsed(fixturePath)
-						checkTestResult(t, fixturePath, res)
-					}
-
-					serviceCreators := kubernetescontroller.GetServiceCreators(data)
-					for _, creatorGetter := range serviceCreators {
-						name, create := creatorGetter()
-						res, err := create(&corev1.Service{})
-						if err != nil {
-							t.Fatalf("failed to create Service: %v", err)
-						}
-						res.Name = name
-						res.Namespace = cluster.Status.NamespaceName
-
-						fixturePath := tc.fixturePath("service", res.Name)
-						markFixtureUsed(fixturePath)
-						checkTestResult(t, fixturePath, res)
-					}
-
-					var statefulSetCreators []reconciling.NamedStatefulSetCreatorGetter
-					statefulSetCreators = append(statefulSetCreators, kubernetescontroller.GetStatefulSetCreators(data, false, false)...)
-					statefulSetCreators = append(statefulSetCreators, monitoringcontroller.GetStatefulSetCreators(data)...)
-					for _, creatorGetter := range statefulSetCreators {
-						name, create := creatorGetter()
-						res, err := create(&appsv1.StatefulSet{})
-						if err != nil {
-							t.Fatalf("failed to create StatefulSet: %v", err)
-						}
-						res.Name = name
-						res.Namespace = cluster.Status.NamespaceName
-
-						fixturePath := tc.fixturePath("statefulset", res.Name)
-						if err != nil {
-							t.Fatalf("failed to create StatefulSet for %s: %v", fixturePath, err)
-						}
-
-						markFixtureUsed(fixturePath)
-
-						// Verify that every StatefulSet has the ImagePullSecret set
-						if len(res.Spec.Template.Spec.ImagePullSecrets) == 0 {
-							t.Errorf("StatefulSet %s is missing the ImagePullSecret on the PodTemplate", res.Name)
-						}
-
-						verifyContainerResources(fmt.Sprintf("StatefulSet/%s", res.Name), res.Spec.Template, t)
-
-						checkTestResult(t, fixturePath, res)
-					}
-
-					for _, creatorGetter := range kubernetescontroller.GetPodDisruptionBudgetCreators(data) {
-						name, create := creatorGetter()
-						res, err := create(&policyv1.PodDisruptionBudget{})
-						if err != nil {
-							t.Fatalf("failed to create PodDisruptionBudget: %v", err)
-						}
-						res.Name = name
-						res.Namespace = cluster.Status.NamespaceName
-
-						fixturePath := tc.fixturePath("poddisruptionbudget", name)
-						if err != nil {
-							t.Fatalf("failed to create PodDisruptionBudget for %s: %v", fixturePath, err)
-						}
-
-						markFixtureUsed(fixturePath)
-						checkTestResult(t, fixturePath, res)
-					}
-
-					for _, creatorGetter := range kubernetescontroller.GetCronJobCreators(data) {
-						name, create := creatorGetter()
-						res, err := create(&batchv1.CronJob{})
-						if err != nil {
-							t.Fatalf("failed to create CronJob: %v", err)
-						}
-						res.Name = name
-						res.Namespace = cluster.Status.NamespaceName
-
-						fixturePath := tc.fixturePath("cronjob", res.Name)
-						if err != nil {
-							t.Fatalf("failed to create CronJob for %s: %v", fixturePath, err)
-						}
-
-						// Verify that every CronJob has the ImagePullSecret set
-						if len(res.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets) == 0 {
-							t.Errorf("CronJob %s is missing the ImagePullSecret on the PodTemplate", res.Name)
-						}
-
-						markFixtureUsed(fixturePath)
-						checkTestResult(t, fixturePath, res)
-					}
-
-					for _, creatorGetter := range kubernetescontroller.GetEtcdBackupConfigCreators(data, test.GenTestSeed()) {
-						name, create := creatorGetter()
-						res, err := create(&kubermaticv1.EtcdBackupConfig{})
-						if err != nil {
-							t.Fatalf("failed to create EtcdBackupConfig: %v", err)
-						}
-						res.Name = name
-						res.Namespace = cluster.Status.NamespaceName
-
-						fixturePath := tc.fixturePath("etcdbackupconfig", res.Name)
-						if err != nil {
-							t.Fatalf("failed to create EtcdBackupConfig for %s: %v", fixturePath, err)
-						}
-
-						markFixtureUsed(fixturePath)
-						checkTestResult(t, fixturePath, res)
-					}
+					generateAndVerifyResources(t, data, tc, markFixtureUsed)
 				})
 			}
 		}
@@ -855,6 +724,149 @@ func TestLoadFiles(t *testing.T) {
 
 	if leftover := allFiles.List(); len(leftover) > 0 {
 		t.Fatalf("Leftover fixtures found that do not belong to any of the configured testcases: %v", leftover)
+	}
+}
+
+func generateAndVerifyResources(t *testing.T, data *resources.TemplateData, tc testCase, fixtureDone func(string)) {
+	cluster := data.Cluster()
+
+	var deploymentCreators []reconciling.NamedDeploymentCreatorGetter
+	deploymentCreators = append(deploymentCreators, kubernetescontroller.GetDeploymentCreators(data, true)...)
+	deploymentCreators = append(deploymentCreators, monitoringcontroller.GetDeploymentCreators(data)...)
+	for _, create := range deploymentCreators {
+		name, creator := create()
+		res, err := creator(&appsv1.Deployment{})
+		if err != nil {
+			t.Fatalf("failed to create Deployment: %v", err)
+		}
+		res.Name = name
+		res.Namespace = cluster.Status.NamespaceName
+
+		fixturePath := tc.fixturePath("deployment", res.Name)
+
+		verifyContainerResources(fmt.Sprintf("Deployment/%s", res.Name), res.Spec.Template, t)
+		fixtureDone(fixturePath)
+		checkTestResult(t, fixturePath, res)
+	}
+
+	var namedConfigMapCreatorGetters []reconciling.NamedConfigMapCreatorGetter
+	namedConfigMapCreatorGetters = append(namedConfigMapCreatorGetters, kubernetescontroller.GetConfigMapCreators(data)...)
+	namedConfigMapCreatorGetters = append(namedConfigMapCreatorGetters, monitoringcontroller.GetConfigMapCreators(data)...)
+	for _, namedGetter := range namedConfigMapCreatorGetters {
+		name, create := namedGetter()
+		res, err := create(&corev1.ConfigMap{})
+		if err != nil {
+			t.Fatalf("failed to create ConfigMap: %v", err)
+		}
+		res.Name = name
+		res.Namespace = cluster.Status.NamespaceName
+
+		fixturePath := tc.fixturePath("configmap", res.Name)
+		fixtureDone(fixturePath)
+		checkTestResult(t, fixturePath, res)
+	}
+
+	serviceCreators := kubernetescontroller.GetServiceCreators(data)
+	for _, creatorGetter := range serviceCreators {
+		name, create := creatorGetter()
+		res, err := create(&corev1.Service{})
+		if err != nil {
+			t.Fatalf("failed to create Service: %v", err)
+		}
+		res.Name = name
+		res.Namespace = cluster.Status.NamespaceName
+
+		fixturePath := tc.fixturePath("service", res.Name)
+		fixtureDone(fixturePath)
+		checkTestResult(t, fixturePath, res)
+	}
+
+	var statefulSetCreators []reconciling.NamedStatefulSetCreatorGetter
+	statefulSetCreators = append(statefulSetCreators, kubernetescontroller.GetStatefulSetCreators(data, false, false)...)
+	statefulSetCreators = append(statefulSetCreators, monitoringcontroller.GetStatefulSetCreators(data)...)
+	for _, creatorGetter := range statefulSetCreators {
+		name, create := creatorGetter()
+		res, err := create(&appsv1.StatefulSet{})
+		if err != nil {
+			t.Fatalf("failed to create StatefulSet: %v", err)
+		}
+		res.Name = name
+		res.Namespace = cluster.Status.NamespaceName
+
+		fixturePath := tc.fixturePath("statefulset", res.Name)
+		if err != nil {
+			t.Fatalf("failed to create StatefulSet for %s: %v", fixturePath, err)
+		}
+
+		fixtureDone(fixturePath)
+
+		// Verify that every StatefulSet has the ImagePullSecret set
+		if len(res.Spec.Template.Spec.ImagePullSecrets) == 0 {
+			t.Errorf("StatefulSet %s is missing the ImagePullSecret on the PodTemplate", res.Name)
+		}
+
+		verifyContainerResources(fmt.Sprintf("StatefulSet/%s", res.Name), res.Spec.Template, t)
+
+		checkTestResult(t, fixturePath, res)
+	}
+
+	for _, creatorGetter := range kubernetescontroller.GetPodDisruptionBudgetCreators(data) {
+		name, create := creatorGetter()
+		res, err := create(&policyv1.PodDisruptionBudget{})
+		if err != nil {
+			t.Fatalf("failed to create PodDisruptionBudget: %v", err)
+		}
+		res.Name = name
+		res.Namespace = cluster.Status.NamespaceName
+
+		fixturePath := tc.fixturePath("poddisruptionbudget", name)
+		if err != nil {
+			t.Fatalf("failed to create PodDisruptionBudget for %s: %v", fixturePath, err)
+		}
+
+		fixtureDone(fixturePath)
+		checkTestResult(t, fixturePath, res)
+	}
+
+	for _, creatorGetter := range kubernetescontroller.GetCronJobCreators(data) {
+		name, create := creatorGetter()
+		res, err := create(&batchv1.CronJob{})
+		if err != nil {
+			t.Fatalf("failed to create CronJob: %v", err)
+		}
+		res.Name = name
+		res.Namespace = cluster.Status.NamespaceName
+
+		fixturePath := tc.fixturePath("cronjob", res.Name)
+		if err != nil {
+			t.Fatalf("failed to create CronJob for %s: %v", fixturePath, err)
+		}
+
+		// Verify that every CronJob has the ImagePullSecret set
+		if len(res.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets) == 0 {
+			t.Errorf("CronJob %s is missing the ImagePullSecret on the PodTemplate", res.Name)
+		}
+
+		fixtureDone(fixturePath)
+		checkTestResult(t, fixturePath, res)
+	}
+
+	for _, creatorGetter := range kubernetescontroller.GetEtcdBackupConfigCreators(data, test.GenTestSeed()) {
+		name, create := creatorGetter()
+		res, err := create(&kubermaticv1.EtcdBackupConfig{})
+		if err != nil {
+			t.Fatalf("failed to create EtcdBackupConfig: %v", err)
+		}
+		res.Name = name
+		res.Namespace = cluster.Status.NamespaceName
+
+		fixturePath := tc.fixturePath("etcdbackupconfig", res.Name)
+		if err != nil {
+			t.Fatalf("failed to create EtcdBackupConfig for %s: %v", fixturePath, err)
+		}
+
+		fixtureDone(fixturePath)
+		checkTestResult(t, fixturePath, res)
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves the resource fixture tests by

1. ensuring that a realistic name/namespace are set
2. no dangling files remaing when `-update` is used
3. if dangling files are present, the test will fail

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

```documentation
NONE
```