### PR TITLE
remove deprecated golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,6 @@ linters:
     - asciicheck
     - bidichk
     - bodyclose
-    - deadcode
     - depguard
     - durationcheck
     - errcheck
@@ -62,11 +61,9 @@ linters:
     - predeclared
     - promlinter
     - staticcheck
-    - structcheck
     - tenv
     - unconvert
     - unused
-    - varcheck
     - wastedassign
     - whitespace
   disable-all: true


### PR DESCRIPTION
**What this PR does / why we need it**:
The 3 removed linters were deprecated in golangci-lint and are superseded by the `unused` linter.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
