### PR TITLE
add EtcdLauncherNotEnabled phase to etcd restore

### DIFF
--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -38,7 +38,7 @@ const (
 	EtcdRestorePhaseCompleted EtcdRestorePhase = "Completed"
 
 	// EtcdRestorePhaseEtcdLauncherNotEnabled value indicating that etcd-launcher is not enabled.
-	EtcdRestorePhaseEtcdLauncherNotEnabled EtcdRestorePhase = "EtcdRestorePhaseEtcdLauncherNotEnabled"
+	EtcdRestorePhaseEtcdLauncherNotEnabled EtcdRestorePhase = "EtcdLauncherNotEnabled"
 )
 
 // +kubebuilder:validation:Enum=Started;StsRebuilding;Completed;EtcdRestorePhaseEtcdLauncherNotEnabled

--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -41,7 +41,7 @@ const (
 	EtcdRestorePhaseEtcdLauncherNotEnabled EtcdRestorePhase = "EtcdLauncherNotEnabled"
 )
 
-// +kubebuilder:validation:Enum=Started;StsRebuilding;Completed;EtcdRestorePhaseEtcdLauncherNotEnabled
+// +kubebuilder:validation:Enum=Started;StsRebuilding;Completed;EtcdLauncherNotEnabled
 
 // EtcdRestorePhase represents the lifecycle phase of an EtcdRestore.
 type EtcdRestorePhase string

--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -41,7 +41,7 @@ const (
 	EtcdRestorePhaseEtcdLauncherNotEnabled EtcdRestorePhase = "EtcdRestorePhaseEtcdLauncherNotEnabled"
 )
 
-// +kubebuilder:validation:Enum=Started;StsRebuilding;Completed
+// +kubebuilder:validation:Enum=Started;StsRebuilding;Completed;EtcdRestorePhaseEtcdLauncherNotEnabled
 
 // EtcdRestorePhase represents the lifecycle phase of an EtcdRestore.
 type EtcdRestorePhase string

--- a/pkg/apis/kubermatic/v1/etcd_restore.go
+++ b/pkg/apis/kubermatic/v1/etcd_restore.go
@@ -36,6 +36,9 @@ const (
 
 	// EtcdRestorePhaseCompleted value indicating that the old Etcd statefulset has completed successfully.
 	EtcdRestorePhaseCompleted EtcdRestorePhase = "Completed"
+
+	// EtcdRestorePhaseEtcdLauncherNotEnabled value indicating that etcd-launcher is not enabled.
+	EtcdRestorePhaseEtcdLauncherNotEnabled EtcdRestorePhase = "EtcdRestorePhaseEtcdLauncherNotEnabled"
 )
 
 // +kubebuilder:validation:Enum=Started;StsRebuilding;Completed

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -172,6 +172,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, restore *kubermaticv1.EtcdRestore, cluster *kubermaticv1.Cluster,
 	seed *kubermaticv1.Seed) (*reconcile.Result, error) {
 	if !cluster.Spec.Features[kubermaticv1.ClusterFeatureEtcdLauncher] {
+		restore.Status.Phase = kubermaticv1.EtcdRestorePhaseEtcdLauncherNotEnabled
 		return nil, fmt.Errorf("etcdLauncher not enabled on cluster: %q", cluster.Name)
 	}
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -90,6 +90,7 @@ spec:
                     - Started
                     - StsRebuilding
                     - Completed
+                    - EtcdRestorePhaseEtcdLauncherNotEnabled
                   type: string
                 restoreTime:
                   format: date-time

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_etcdrestores.yaml
@@ -90,7 +90,7 @@ spec:
                     - Started
                     - StsRebuilding
                     - Completed
-                    - EtcdRestorePhaseEtcdLauncherNotEnabled
+                    - EtcdLauncherNotEnabled
                   type: string
                 restoreTime:
                   format: date-time


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `EtcdLauncherNotEnabled` phase to `EtcdRestore`. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #9665 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
EtcdRestores are moved to a 'EtcdLauncherNotEnabled' phase if required etcd-launcher is not enabled
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
