### PR TITLE
adds groups in OIDC kubeconfig

### DIFF
--- a/pkg/handler/common/kubeconfig.go
+++ b/pkg/handler/common/kubeconfig.go
@@ -266,7 +266,7 @@ func CreateOIDCKubeconfigEndpoint(ctx context.Context, projectProvider provider.
 	}
 
 	rsp := createOIDCKubeconfigRsp{}
-	scopes := []string{"openid", "email"}
+	scopes := []string{"openid", "email", "groups"}
 	if oidcCfg.OfflineAccessAsScope {
 		scopes = append(scopes, "offline_access")
 	}
@@ -402,7 +402,7 @@ func CreateOIDCKubeconfigSecretEndpoint(ctx context.Context, projectProvider pro
 	}
 
 	rsp := createOIDCKubeconfigRsp{}
-	scopes := []string{"openid", "email"}
+	scopes := []string{"openid", "email", "groups"}
 	if oidcCfg.OfflineAccessAsScope {
 		scopes = append(scopes, "offline_access")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
On the project level, OIDC groups can be bound to KKP roles to give access to users belonging to this groups to the clusters.

However, when a user login into KKP and download the OIDC kubeconfig, the token in the kubeconfig does not contain OIDC groups. So this kubeconfig has only the permission given to the specific user. 

This PR adds groups in OIDC kubeconfig.

_note: even if the OIDC groups are present in the token. The user will still not be able to access the cluster thanks to the group permissions because OIDC groups are not bound to ClusterRole and Role in the k8s cluster. As a workaround, the user can create manually necessary binding using KKP RBAC API at the cluster level.
The automatic binding of OIDC groups to ClusterRole and Role will be implemented in further PR after discussion with sig-cluster-managment_


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
ref #10668

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
adds groups in OIDC kubeconfig
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
