### PR TITLE
Handle web terminal connection errors inside websocket tunnel

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -52,7 +52,6 @@ var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
-		return true
 		origin := r.Header["Origin"]
 		if len(origin) == 0 {
 			return true
@@ -271,10 +270,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 			log.Logger.Debug(err)
 			return
 		}
-		defer func(ws *websocket.Conn) {
-			_ = ws.WriteJSON(wsh.TerminalMessage{Op: "msg", Data: "connection closed"})
-			_ = ws.Close()
-		}(ws)
+		defer ws.Close()
 
 		// Checking user active connections for project cluster
 		userProjectClusterUniqueKey := fmt.Sprintf("%s-%s-%s", projectID, clusterID, authenticatedUser.Email)

--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -86,6 +86,7 @@ type WebsocketTerminalWriter func(ctx context.Context, ws *websocket.Conn, clien
 const (
 	maxNumberOfTerminalActiveConnectionsPerUser = 5
 	terminalActiveConnectionsMemoryDuration     = 24 * time.Hour
+	waitForKubeconfigSecretTimeout              = 5 * time.Minute
 )
 
 func (r Routing) RegisterV1Websocket(mux *mux.Router) {
@@ -286,7 +287,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 		connectionsPerUser.increaseActiveConnections(userProjectClusterUniqueKey)
 		defer connectionsPerUser.decreaseActiveConnections(userProjectClusterUniqueKey)
 
-		if !wsh.WaitFor(5*time.Second, 2*time.Minute, func() bool {
+		if !wsh.WaitFor(5*time.Second, waitForKubeconfigSecretTimeout, func() bool {
 			kubeconfigSecret := &corev1.Secret{}
 			if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{
 				Namespace: metav1.NamespaceSystem,

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -214,10 +214,7 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 		default:
 			status = fmt.Sprintf("pod in %s phase", pod.Status.Phase)
 		}
-		_ = websocketConn.WriteJSON(TerminalMessage{
-			Op:   "msg",
-			Data: status,
-		})
+		SendMessage(websocketConn, status)
 		return false
 	}) {
 		return fmt.Errorf("the WEB terminal Pod is not ready")
@@ -382,4 +379,13 @@ func WaitFor(interval time.Duration, timeout time.Duration, callback func() bool
 		return callback(), nil
 	})
 	return err == nil
+}
+
+// SendMessage sends TerminalMessage to the client. It usually contains a context related
+// to the status of background tasks responsible for setting up the terminal.
+func SendMessage(wsConn *websocket.Conn, message string) {
+	_ = wsConn.WriteJSON(TerminalMessage{
+		Op:   "msg",
+		Data: message,
+	})
 }

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -329,8 +329,6 @@ func getVolumeMounts() []corev1.VolumeMount {
 
 // Terminal is called for any new websocket connection.
 func Terminal(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *restclient.Config, userEmailID string) {
-	defer ws.Close()
-
 	if err := startProcess(
 		ctx,
 		client,


### PR DESCRIPTION
**What this PR does / why we need it**:
To handle different stages of establishing connection with remote web terminal pod on the client side, error handling has been moved inside the websocket tunnel.

**Which issue(s) this PR fixes**:
Fixes #11106 

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
