### PR TITLE
Add changelog entries for v2.19.10 and v2.20.8

### DIFF
--- a/docs/changelogs/CHANGELOG-2.19.md
+++ b/docs/changelogs/CHANGELOG-2.19.md
@@ -10,6 +10,13 @@
 - [v2.19.7](#v2197)
 - [v2.19.8](#v2198)
 - [v2.19.9](#v2199)
+- [v2.19.9](#v21910)
+
+## [v2.19.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.19.10)
+
+### Bugfixes
+
+- etcd-launcher is now capable of automatically rejoining the etcd ring when a member is removed during the peer TLS migration ([#9322](https://github.com/kubermatic/kubermatic/pull/9322))
 
 ## [v2.19.9](https://github.com/kubermatic/kubermatic/releases/tag/v2.19.9)
 

--- a/docs/changelogs/CHANGELOG-2.19.md
+++ b/docs/changelogs/CHANGELOG-2.19.md
@@ -10,7 +10,7 @@
 - [v2.19.7](#v2197)
 - [v2.19.8](#v2198)
 - [v2.19.9](#v2199)
-- [v2.19.9](#v21910)
+- [v2.19.10](#v21910)
 
 ## [v2.19.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.19.10)
 

--- a/docs/changelogs/CHANGELOG-2.20.md
+++ b/docs/changelogs/CHANGELOG-2.20.md
@@ -8,6 +8,16 @@
 - [v2.20.5](#v2205)
 - [v2.20.6](#v2206)
 - [v2.20.7](#v2207)
+- [v2.20.8](#v2208)
+
+## [v2.20.8](https://github.com/kubermatic/kubermatic/releases/tag/v2.20.8)
+
+### Bugfixes
+
+- etcd-launcher is now capable of automatically rejoining the etcd ring when a member is removed during the peer TLS migration ([#9322](https://github.com/kubermatic/kubermatic/pull/9322))
+- Fix usercluster-controller crashing when `.status.userEmail` on `Cluster` objects is not set ([#11047](https://github.com/kubermatic/kubermatic/pull/11047))
+- Fix API error in extended disk configuration for provider Anexia ([#11051](https://github.com/kubermatic/kubermatic/pull/11051))
+
 
 ## [v2.20.7](https://github.com/kubermatic/kubermatic/releases/tag/v2.20.7)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds release notes for v2.19.10 and v2.20.8, fresh KKP patch releases for the 2.19 and 2.20 release series.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
