### PR TITLE
validate that admins do not accidentally change the KKP edition during updates

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -63,8 +63,9 @@ type DeployOptions struct {
 	SkipDependencies bool
 	Force            bool
 
-	StorageClass     string
-	DisableTelemetry bool
+	StorageClass       string
+	DisableTelemetry   bool
+	AllowEditionChange bool
 
 	MigrateCertManager         bool
 	MigrateUpstreamCertManager bool
@@ -116,6 +117,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *
 
 	cmd.PersistentFlags().StringVar(&opt.StorageClass, "storageclass", "", fmt.Sprintf("type of StorageClass to create (one of %v)", common.SupportedStorageClassProviders().List()))
 	cmd.PersistentFlags().BoolVar(&opt.DisableTelemetry, "disable-telemetry", false, "disable telemetry agents")
+	cmd.PersistentFlags().BoolVar(&opt.AllowEditionChange, "allow-edition-change", false, "allow up- or downgrading between Community and Enterprise editions")
 
 	cmd.PersistentFlags().BoolVar(&opt.MigrateCertManager, "migrate-cert-manager", false, "enable the migration for cert-manager CRDs from v1alpha2 to v1")
 	cmd.PersistentFlags().BoolVar(&opt.MigrateUpstreamCertManager, "migrate-upstream-cert-manager", false, "enable the migration for cert-manager to chart version 2.1.0+")
@@ -200,6 +202,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt 
 			EnableNginxIngressMigration:        opt.MigrateNginx,
 			DisableTelemetry:                   opt.DisableTelemetry,
 			DisableDependencyUpdate:            opt.SkipDependencies,
+			AllowEditionChange:                 opt.AllowEditionChange,
 			Versions:                           versions,
 		}
 

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -40,6 +40,7 @@ type DeployOptions struct {
 	RawKubermaticConfiguration *unstructured.Unstructured
 	ForceHelmReleaseUpgrade    bool
 	ChartsDirectory            string
+	AllowEditionChange         bool
 
 	SeedsGetter      provider.SeedsGetter
 	SeedClientGetter provider.SeedClientGetter

--- a/pkg/util/edition/types.go
+++ b/pkg/util/edition/types.go
@@ -16,12 +16,28 @@ limitations under the License.
 
 package edition
 
+import (
+	"fmt"
+	"strings"
+)
+
 type Type int
 
 const (
 	CE Type = iota
 	EE
 )
+
+func FromString(edition string) (Type, error) {
+	switch strings.ToLower(edition) {
+	case "ee", "enterprise edition":
+		return EE, nil
+	case "ce", "community edition":
+		return CE, nil
+	default:
+		return 0, fmt.Errorf("unknown edition %q", edition)
+	}
+}
 
 func (e Type) String() string {
 	switch e {


### PR DESCRIPTION
**What this PR does / why we need it**:
This implements the installer part of the ticket mentioned below, but skips the controller part, as I am not sure how we want to implement such a thing even (adding CLI flags to our controller-managers seems super weird).

**Which issue(s) this PR fixes**:
Fixes part of #11063

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The `kubermatic-installer` will now reject installing a different KKP edition over an existing one (for example installing the Community Edition over a previous Enterprise Edition). This safety check can be disabled by adding `--allow-edition-change` to the installer. Installing the EE over the CE (i.e. upgrading) is supported, this change just prevents accidental mixups.
```

**Documentation**:
```documentation
NONE
```
