### PR TITLE
bump Dex to 2.35.1

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: oauth
 version: v9.9.9-dev
-appVersion: v2.32.0
+appVersion: v2.35.1
 description: Dex
 keywords:
   - kubermatic

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -15,7 +15,7 @@
 dex:
   image:
     repository: "ghcr.io/dexidp/dex"
-    tag: "v2.32.0"
+    tag: "v2.35.1"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec


### PR DESCRIPTION
**What this PR does / why we need it**:
An update for all Dex <= 2.34 versions is recommended: https://github.com/dexidp/dex/security/advisories/GHSA-vh7g-p26c-j2cw

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Dex to 2.35.1 (contains [security fix](https://github.com/dexidp/dex/security/advisories/GHSA-vh7g-p26c-j2cw))
```

**Documentation**:
```documentation
NONE
```
