### PR TITLE
Update tests to kind 0.16

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -32,7 +32,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - "./hack/ci/run-api-e2e.sh"
           env:

--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -68,7 +68,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -107,7 +107,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
@@ -97,7 +97,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
@@ -133,7 +133,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
@@ -175,7 +175,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
@@ -294,7 +294,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
@@ -692,7 +692,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -724,7 +724,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -751,7 +751,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -783,7 +783,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -813,7 +813,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -849,7 +849,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-      - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+      - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
         env:
         - name: KUBERMATIC_EDITION
           value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -118,7 +118,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -163,7 +163,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: "ce"
@@ -209,7 +209,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: "ee"

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -75,7 +75,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -124,7 +124,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-2
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-2
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-2
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-2
           command:
             - ./hack/ci/test-github-release.sh
           resources:

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.16-2
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/charts/mla/minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
+++ b/charts/mla/minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: minio-lifecycle-mgr

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -161,7 +161,7 @@ fi
 # there are no cloud providers in that preloaded image.
 # As a solution, we remove the preloaded image after starting the kind
 # cluster, which will force KKP to pull the correct image.
-docker exec "kubermatic-control-plane" bash -c "crictl images | grep kube-controller-manager | awk '{print \$2}' | xargs -I{} crictl rmi k8s.gcr.io/kube-controller-manager:{}" || true
+docker exec "kubermatic-control-plane" bash -c "crictl images | grep kube-controller-manager | awk '{print \$2}' | xargs -I{} crictl rmi registry.k8s.io/kube-controller-manager:{}" || true
 
 if [ -z "${DISABLE_CLUSTER_EXPOSER:-}" ]; then
   # Start cluster exposer, which will expose services from within kind as

--- a/hack/ci/setup-kubermatic-mla-in-kind.sh
+++ b/hack/ci/setup-kubermatic-mla-in-kind.sh
@@ -189,6 +189,8 @@ cortex:
     replicas: 1
   alertmanager:
     replicas: 1
+  nginx:
+    replicas: 1
 
 loki-distributed:
   ingester:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-1 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-2 containerize ./hack/update-codegen.sh
 
 echodate "Running go generate"
 go generate ./pkg/...

--- a/hack/update-swagger.sh
+++ b/hack/update-swagger.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-1 containerize ./hack/update-swagger.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-2 containerize ./hack/update-swagger.sh
 
 echodate "Generating swagger spec"
 cd cmd/kubermatic-api/

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-1 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-2 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-1 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-2 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Time to update our kind version and test KKP on Kubernetes 1.25. Amazingly, nothing special has to be done on our side to upgrade :-)

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
