### PR TITLE
Do not require addons flags in `kubermatic-installer mirror-images`

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -94,7 +94,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 	cmd.PersistentFlags().StringVar(&opt.VersionFilter, "version-filter", "", "Version constraint which can be used to filter for specific versions")
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of found images")
 
-	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Address of the registry to push to, for example localhost:5000")
+	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image")
 	cmd.PersistentFlags().StringVar(&opt.AddonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")
 
 	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
@@ -114,10 +114,6 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 
 		if options.AddonsImage != "" && options.AddonsPath != "" {
 			return errors.New("--addons-image and --addons-path must not be set at the same time")
-		}
-
-		if options.AddonsImage == "" && options.AddonsPath == "" {
-			return errors.New("either --addons-image or --addons-path must be set")
 		}
 
 		// error out early if there is no useful Helm binary


### PR DESCRIPTION
**What this PR does / why we need it**:

The `mirror-images` subcommand requires one of the addons flags (`--addons-path` or `--addons-image`) to be set and fails otherwise. This does not make sense because the code is capable of falling back to the default image configured for addons:

https://github.com/kubermatic/kubermatic/blob/13bcaf1d655e33d517059f8cc8ea26a79124668a/cmd/kubermatic-installer/cmd_mirror_images.go#L165-L182

It is therefore not necessary to provide one of the flags. This PR removes the requirement.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not require addons flags in `kubermatic-installer mirror-images` and fall back to default addons image
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
