### PR TITLE
Improve container check in containerize function

### DIFF
--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -102,6 +102,11 @@ write_junit() {
 EOF
 }
 
+is_containerized() {
+  # we're inside a Kubernetes pod/container or inside a container launched by containerize()
+  [ -n "${KUBERNETES_SERVICE_HOST:-}" ] || [ -n "${CONTAINERIZED:-}" ]
+}
+
 containerize() {
   local cmd="$1"
   local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.2.0}"
@@ -112,7 +117,7 @@ containerize() {
   # short-circuit containerize when in some cases it needs to be avoided
   [ -n "$skip" ] && return
 
-  if ! [ -f /.dockerenv ]; then
+  if ! is_containerized; then
     echodate "Running $cmd in a Docker container using $image..."
     mkdir -p "$gocache"
     mkdir -p "$gomodcache"
@@ -124,6 +129,7 @@ containerize() {
       -w /go/src/k8c.io/kubermatic \
       -e "GOCACHE=$gocache" \
       -e "GOMODCACHE=$gomodcache" \
+      -e "CONTAINERIZED=true" \
       -u "$(id -u):$(id -g)" \
       --entrypoint="$cmd" \
       --rm \


### PR DESCRIPTION
**What this PR does / why we need it**:
When updating our CI cluster from 1.22 to 1.24, Docker wasn't the container runtime anymore. Without Docker, the Prow pods would not have the `.dockerenv` file and so our containerize function would try to do bad things.

This PR improves the check to make it more reliable and explicit (not relying on some magic implementation detail). Just google for "check running inside docker" and marvel at the many, many ugly hacky solutions, of which defining an explicit env variable is probably the least worst.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
