### PR TITLE
Revert "bump Dex to 2.35.1 (#11131)"

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: oauth
 version: v9.9.9-dev
-appVersion: v2.35.1
+appVersion: v2.32.0
 description: Dex
 keywords:
   - kubermatic

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -15,7 +15,7 @@
 dex:
   image:
     repository: "ghcr.io/dexidp/dex"
-    tag: "v2.35.1"
+    tag: "v2.32.0"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec


### PR DESCRIPTION
**What this PR does / why we need it**:
New Dex seems to require additional configuration to work on GKE nodes, which seems to be a regression: https://github.com/dexidp/dex/issues/2676#issuecomment-1268229850

Before we can proceed we need to ensure upstream is certain about this direction. A number of related tickets were created for Dex already.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
