### PR TITLE
Adding APIServerAllowedIPRanges to cluster API

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -24853,6 +24853,9 @@
           },
           "x-go-name": "AdmissionPlugins"
         },
+        "apiServerAllowedIPRanges": {
+          "$ref": "#/definitions/NetworkRanges"
+        },
         "auditLogging": {
           "$ref": "#/definitions/AuditLoggingSettings"
         },

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -991,6 +991,12 @@ type ClusterSpec struct {
 
 	// ExposeStrategy is the strategy used to expose a cluster control plane.
 	ExposeStrategy kubermaticv1.ExposeStrategy `json:"exposeStrategy"`
+
+	// APIServerAllowedIPRanges is a list of IP ranges allowed to access the API server.
+	// Applicable only if the expose strategy of the cluster is LoadBalancer.
+	// If not configured, access to the API server is unrestricted.
+	// +optional
+	APIServerAllowedIPRanges *kubermaticv1.NetworkRanges `json:"apiServerAllowedIPRanges"`
 }
 
 // MarshalJSON marshals ClusterSpec object into JSON. It is overwritten to control data
@@ -1019,6 +1025,7 @@ func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 		ClusterNetwork                       *kubermaticv1.ClusterNetworkingConfig  `json:"clusterNetwork,omitempty"`
 		CNIPlugin                            *kubermaticv1.CNIPluginSettings        `json:"cniPlugin,omitempty"`
 		ExposeStrategy                       kubermaticv1.ExposeStrategy            `json:"exposeStrategy,omitempty"`
+		APIServerAllowedIPRanges             *kubermaticv1.NetworkRanges            `json:"apiserverallowedIPRanges,omitempty"`
 	}{
 		Cloud: PublicCloudSpec{
 			DatacenterName:      cs.Cloud.DatacenterName,
@@ -1059,6 +1066,7 @@ func (cs *ClusterSpec) MarshalJSON() ([]byte, error) {
 		ClusterNetwork:                       cs.ClusterNetwork,
 		CNIPlugin:                            cs.CNIPlugin,
 		ExposeStrategy:                       cs.ExposeStrategy,
+		APIServerAllowedIPRanges:             cs.APIServerAllowedIPRanges,
 	})
 
 	return ret, err

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -158,6 +158,11 @@ type ClusterSpec struct {
 	// ExposeStrategy is the strategy used to expose a cluster control plane.
 	ExposeStrategy ExposeStrategy `json:"exposeStrategy"`
 
+	// Optional: APIServerAllowedIPRanges is a list of IP ranges allowed to access the API server.
+	// Applicable only if the expose strategy of the cluster is LoadBalancer.
+	// If not configured, access to the API server is unrestricted.
+	APIServerAllowedIPRanges *NetworkRanges `json:"apiServerAllowedIPRanges,omitempty"`
+
 	// Optional: Component specific overrides that allow customization of control plane components.
 	ComponentsOverride ComponentSettings `json:"componentsOverride,omitempty"`
 

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -1190,6 +1190,11 @@ func (in *ClusterSpec) DeepCopyInto(out *ClusterSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.APIServerAllowedIPRanges != nil {
+		in, out := &in.APIServerAllowedIPRanges, &out.APIServerAllowedIPRanges
+		*out = new(NetworkRanges)
+		(*in).DeepCopyInto(*out)
+	}
 	in.ComponentsOverride.DeepCopyInto(&out.ComponentsOverride)
 	out.OIDC = in.OIDC
 	if in.Features != nil {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -62,6 +62,16 @@ spec:
                   items:
                     type: string
                   type: array
+                apiServerAllowedIPRanges:
+                  description: 'Optional: APIServerAllowedIPRanges is a list of IP ranges allowed to access the API server. Applicable only if the expose strategy of the cluster is LoadBalancer. If not configured, access to the API server is unrestricted.'
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                    - cidrBlocks
+                  type: object
                 applicationSettings:
                   description: 'Optional: ApplicationSettings contains the settings relative to the application feature.'
                   properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -57,6 +57,16 @@ spec:
                   items:
                     type: string
                   type: array
+                apiServerAllowedIPRanges:
+                  description: 'Optional: APIServerAllowedIPRanges is a list of IP ranges allowed to access the API server. Applicable only if the expose strategy of the cluster is LoadBalancer. If not configured, access to the API server is unrestricted.'
+                  properties:
+                    cidrBlocks:
+                      items:
+                        type: string
+                      type: array
+                  required:
+                    - cidrBlocks
+                  type: object
                 applicationSettings:
                   description: 'Optional: ApplicationSettings contains the settings relative to the application feature.'
                   properties:

--- a/pkg/resources/cluster/cluster.go
+++ b/pkg/resources/cluster/cluster.go
@@ -80,6 +80,7 @@ func Spec(ctx context.Context, apiCluster apiv1.Cluster, template *kubermaticv1.
 		ContainerRuntime:                     apiCluster.Spec.ContainerRuntime,
 		CNIPlugin:                            apiCluster.Spec.CNIPlugin,
 		ExposeStrategy:                       apiCluster.Spec.ExposeStrategy,
+		APIServerAllowedIPRanges:             apiCluster.Spec.APIServerAllowedIPRanges,
 	}
 
 	if apiCluster.Spec.ClusterNetwork != nil {


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
Introducing APIServerAllowedIPRanges in Cluster CRD for enabling IP whitelisting for user cluster API server.
This is part of [#11119](https://github.com/kubermatic/kubermatic/issues/11119).


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This is the initial changes for the feature epic [10407](https://github.com/kubermatic/kubermatic/issues/10407#issuecomment-1257890504) and the related business logic and others will be followed with another PR.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce APIServerAllowedIPRanges in Cluster CRD.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
