### PR TITLE
fix --config not being validated in mirror-images command

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -146,6 +146,10 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 			return fmt.Errorf("failed to load KubermaticConfiguration: %w", err)
 		}
 
+		if config == nil {
+			return errors.New("please specify your KubermaticConfiguration via --config")
+		}
+
 		kubermaticConfig, err := defaulting.DefaultConfiguration(config, zap.NewNop().Sugar())
 		if err != nil {
 			return fmt.Errorf("failed to default KubermaticConfiguration: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Since 2.21, the `--config` is optional for doing KKP upgrades, but it being nil can cause issues and I overlooked that the `mirror-images` command actually always needs a config. So this PR adds the missing validation for the CLI flag.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note bugfixes
Fix `--config` flag not being validated in `mirror-images` command in the KKP installer
```

**Documentation**:
```documentation
NONE
```
