### PR TITLE
Improve registry overwrite mechanism

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -31,7 +31,7 @@ hubble:
 	  >> $(OUTPUT_FILE)
 	cat hubble/_extras.txt >> $(OUTPUT_FILE)
 	cat hubble/_footer.txt >> $(OUTPUT_FILE)
-	sed -i 's/quay.io/{{ Registry "quay.io" }}/g' $(OUTPUT_FILE)
+	./templatify-images.sh $(OUTPUT_FILE)
 
 .PHONY: aws-node-termination-handler
 aws-node-termination-handler: OUTPUT_FILE=aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -45,7 +45,7 @@ aws-node-termination-handler:
 	  --values values-aws-node-termination-handler.yaml \
 	  >> $(OUTPUT_FILE)
 	cat aws-node-termination-handler/_footer.txt >> $(OUTPUT_FILE)
-	sed -i 's/public.ecr.aws/{{ Registry "public.ecr.aws" }}/g' $(OUTPUT_FILE)
+	./templatify-images.sh $(OUTPUT_FILE)
 
 .PHONY: aws-ebs-csi-driver
 aws-ebs-csi-driver: OUTPUT_FILE=csi/aws-ebs/driver.yaml
@@ -68,4 +68,4 @@ metallb: OUTPUT_FILE=metallb/00_metallb.yaml
 metallb:
 	cat metallb/_header.txt > $(OUTPUT_FILE)
 	wget -q -O- https://raw.githubusercontent.com/metallb/metallb/v0.13.3/config/manifests/metallb-native.yaml >> $(OUTPUT_FILE)
-	sed -i 's/quay.io/{{ Registry "quay.io" }}/g' $(OUTPUT_FILE)
+	./templatify-images.sh $(OUTPUT_FILE)

--- a/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
+++ b/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -226,7 +226,7 @@ spec:
             runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
-          image: {{ Registry "public.ecr.aws" }}/aws-ec2/aws-node-termination-handler:v1.16.2
+          image: {{ Image "public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.16.2" }}
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME

--- a/addons/azure-cloud-node-manager/cloud-node-manager.yaml
+++ b/addons/azure-cloud-node-manager/cloud-node-manager.yaml
@@ -107,7 +107,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: cloud-node-manager
-        image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes/azure-cloud-node-manager:{{ $version }}
+        image: {{ Image (print "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager:" $version) }}
         imagePullPolicy: IfNotPresent
         command:
         - cloud-node-manager

--- a/addons/canal/canal.yaml
+++ b/addons/canal/canal.yaml
@@ -411,7 +411,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "docker.io" }}/calico/cni:v3.8.0'
+          image: '{{ Image "calico/cni:v3.8.0" }}'
           command: ["/install-cni.sh"]
           env:
             # Name of the CNI config file to create.
@@ -442,7 +442,7 @@ spec:
         # host.
         - name: calico-node
           # FIXME: Remove FELIX_IGNORELOOSERPF from env when this is v3.12.0+
-          image: '{{ Registry "docker.io" }}/calico/node:v3.8.0'
+          image: '{{ Image "calico/node:v3.8.0" }}'
           env:
             # Use Kubernetes API as the backing datastore.
             - name: DATASTORE_TYPE
@@ -529,7 +529,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.11.0'
+          image: '{{ Image "quay.io/coreos/flannel:v0.11.0" }}'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true

--- a/addons/canal/canal_v3.19.yaml
+++ b/addons/canal/canal_v3.19.yaml
@@ -3591,7 +3591,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "docker.io" }}/calico/cni:v3.19.1'
+          image: '{{ Image "calico/cni:v3.19.1" }}'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3634,7 +3634,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "docker.io" }}/calico/node:v3.19.1'
+          image: '{{ Image "calico/node:v3.19.1" }}'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -3735,7 +3735,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.15.1'
+          image: '{{ Image "quay.io/coreos/flannel:v0.15.1" }}'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -3851,7 +3851,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "docker.io" }}/calico/kube-controllers:v3.19.1'
+          image: '{{ Image "calico/kube-controllers:v3.19.1" }}'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/canal/canal_v3.20.yaml
+++ b/addons/canal/canal_v3.20.yaml
@@ -3791,7 +3791,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "quay.io" }}/calico/cni:v3.20.5'
+          image: '{{ Image "quay.io/calico/cni:v3.20.5" }}'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3834,7 +3834,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "quay.io" }}/calico/node:v3.20.5'
+          image: '{{ Image "quay.io/calico/node:v3.20.5" }}'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -3949,7 +3949,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.15.1'
+          image: '{{ Image "quay.io/coreos/flannel:v0.15.1" }}'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -4065,7 +4065,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "quay.io" }}/calico/kube-controllers:v3.20.5'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.20.5" }}'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/canal/canal_v3.21.yaml
+++ b/addons/canal/canal_v3.21.yaml
@@ -4136,7 +4136,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "quay.io" }}/calico/cni:v3.21.6'
+          image: '{{ Image "quay.io/calico/cni:v3.21.6" }}'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4179,7 +4179,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "quay.io" }}/calico/node:v3.21.6'
+          image: '{{ Image "quay.io/calico/node:v3.21.6" }}'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4294,7 +4294,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.15.1'
+          image: '{{ Image "quay.io/coreos/flannel:v0.15.1" }}'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -4410,7 +4410,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "quay.io" }}/calico/kube-controllers:v3.21.6'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.21.6" }}'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/canal/canal_v3.22.yaml
+++ b/addons/canal/canal_v3.22.yaml
@@ -4148,7 +4148,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "quay.io" }}/calico/cni:v3.22.4'
+          image: '{{ Image "quay.io/calico/cni:v3.22.4" }}'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4191,7 +4191,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "quay.io" }}/calico/node:v3.22.4'
+          image: '{{ Image "quay.io/calico/node:v3.22.4" }}'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4316,7 +4316,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.15.1'
+          image: '{{ Image "quay.io/coreos/flannel:v0.15.1" }}'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -4432,7 +4432,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "quay.io" }}/calico/kube-controllers:v3.22.4'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.22.4" }}'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/canal/canal_v3.23.yaml
+++ b/addons/canal/canal_v3.23.yaml
@@ -4381,7 +4381,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: '{{ Registry "quay.io" }}/calico/cni:v3.23.3'
+          image: '{{ Image "quay.io/calico/cni:v3.23.3" }}'
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -4429,7 +4429,7 @@ spec:
         # i.e. bpf at /sys/fs/bpf and cgroup2 at /run/calico/cgroup. Calico-node initialisation is executed
         # in best effort fashion, i.e. no failure for errors, to not disrupt pod creation in iptable mode.
         - name: "mount-bpffs"
-          image: '{{ Registry "quay.io" }}/calico/node:v3.23.3'
+          image: '{{ Image "quay.io/calico/node:v3.23.3" }}'
           command: ["calico-node", "-init", "-best-effort"]
           volumeMounts:
             - mountPath: /sys/fs
@@ -4454,7 +4454,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: '{{ Registry "quay.io" }}/calico/node:v3.23.3'
+          image: '{{ Image "quay.io/calico/node:v3.23.3" }}'
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.
@@ -4587,7 +4587,7 @@ spec:
         # This container runs flannel using the kube-subnet-mgr backend
         # for allocating subnets.
         - name: kube-flannel
-          image: '{{ Registry "quay.io" }}/coreos/flannel:v0.15.1'
+          image: '{{ Image "quay.io/coreos/flannel:v0.15.1" }}'
           command: [ "/opt/bin/flanneld", "--ip-masq", "--kube-subnet-mgr" ]
           securityContext:
             privileged: true
@@ -4711,7 +4711,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: calico-kube-controllers
-          image: '{{ Registry "quay.io" }}/calico/kube-controllers:v3.23.3'
+          image: '{{ Image "quay.io/calico/kube-controllers:v3.23.3" }}'
           env:
             # Choose which controllers to run.
             - name: ENABLED_CONTROLLERS

--- a/addons/cilium/cilium_v1.11.yaml
+++ b/addons/cilium/cilium_v1.11.yaml
@@ -479,7 +479,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: cilium-agent
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Image "quay.io/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878" }}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -598,7 +598,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Image "quay.io/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -625,7 +625,7 @@ spec:
         securityContext:
           privileged: true
       - name: apply-sysctl-overwrites
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Image "quay.io/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -651,7 +651,7 @@ spec:
         securityContext:
           privileged: true
       - name: clean-cilium-state
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Image "quay.io/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878" }}"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -807,7 +807,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: cilium-operator
-        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.11.6@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17"
+        image: "{{ Image "quay.io/cilium/operator-generic:v1.11.6@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17" }}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/addons/cilium/cilium_v1.12.yaml
+++ b/addons/cilium/cilium_v1.12.yaml
@@ -573,7 +573,7 @@ spec:
     spec:
       containers:
       - name: cilium-agent
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Image "quay.io/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36" }}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -740,7 +740,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Image "quay.io/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -782,7 +782,7 @@ spec:
               - SYS_CHROOT
               - SYS_PTRACE
       - name: apply-sysctl-overwrites
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Image "quay.io/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -825,7 +825,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Image "quay.io/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36" }}"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -841,7 +841,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Image "quay.io/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36" }}"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1031,7 +1031,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.12.2@sha256:00508f78dae5412161fa40ee30069c2802aef20f7bdd20e91423103ba8c0df6e"
+        image: "{{ Image "quay.io/cilium/operator-generic:v1.12.2@sha256:00508f78dae5412161fa40ee30069c2802aef20f7bdd20e91423103ba8c0df6e" }}"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -176,7 +176,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: '{{ Registry "registry.k8s.io" }}/autoscaling/cluster-autoscaler:{{ $version }}'
+      - image: '{{ Image (print "registry.k8s.io/autoscaling/cluster-autoscaler:" $version) }}'
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler

--- a/addons/csi/azure-disk/csi-azuredisk-controller.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-controller.yaml
@@ -50,7 +50,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-provisioner
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-provisioner:v3.1.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v3.1.0" }}
           args:
             - "--feature-gates=Topology=true"
             - "--csi-address=$(ADDRESS)"
@@ -74,7 +74,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-attacher
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-attacher:v3.4.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v3.4.0" }}
           args:
             - "-v=2"
             - "-csi-address=$(ADDRESS)"
@@ -95,7 +95,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-snapshotter
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-snapshotter:v5.0.1
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v5.0.1" }}
           args:
             - "-csi-address=$(ADDRESS)"
             - "-leader-election"
@@ -114,7 +114,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-resizer
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-resizer:v1.4.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v1.4.0" }}
           args:
             - "-csi-address=$(ADDRESS)"
             - "-v=2"
@@ -136,7 +136,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/livenessprobe:v2.6.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0" }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -152,7 +152,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azuredisk
-          image: {{ Registry "mcr.microsoft.com" }}/k8s/csi/azuredisk-csi:v{{ $version }}
+          image: {{ Image (print "mcr.microsoft.com/k8s/csi/azuredisk-csi:v" $version) }}
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/addons/csi/azure-disk/csi-azuredisk-node.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-node.yaml
@@ -58,7 +58,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/livenessprobe:v2.6.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0" }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -71,7 +71,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: node-driver-registrar
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0" }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -101,7 +101,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azuredisk
-          image: {{ Registry "mcr.microsoft.com" }}/k8s/csi/azuredisk-csi:v{{ $version }}
+          image: {{ Image (print "mcr.microsoft.com/k8s/csi/azuredisk-csi:v" $version) }}
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/addons/csi/azure-file/csi-azurefile-controller.yaml
+++ b/addons/csi/azure-file/csi-azurefile-controller.yaml
@@ -49,7 +49,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-provisioner
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-provisioner:v3.1.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v3.1.0" }}
           args:
             - "-v=2"
             - "--csi-address=$(ADDRESS)"
@@ -70,7 +70,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-attacher
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-attacher:v3.4.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v3.4.0" }}
           args:
             - "-v=2"
             - "-csi-address=$(ADDRESS)"
@@ -90,7 +90,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-snapshotter
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-snapshotter:v5.0.1
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v5.0.1" }}
           args:
             - "-v=2"
             - "-csi-address=$(ADDRESS)"
@@ -109,7 +109,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-resizer
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-resizer:v1.4.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v1.4.0" }}
           args:
             - "-csi-address=$(ADDRESS)"
             - "-v=2"
@@ -131,7 +131,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/livenessprobe:v2.6.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0" }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -147,7 +147,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azurefile
-          image: {{ Registry "mcr.microsoft.com" }}/k8s/csi/azurefile-csi:v{{ $version }}
+          image: {{ Image (print "mcr.microsoft.com/k8s/csi/azurefile-csi:v" $version) }}
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/addons/csi/azure-file/csi-azurefile-node.yaml
+++ b/addons/csi/azure-file/csi-azurefile-node.yaml
@@ -57,7 +57,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/livenessprobe:v2.6.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.6.0" }}
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -70,7 +70,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: node-driver-registrar
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.0" }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -100,7 +100,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azurefile
-          image: {{ Registry "mcr.microsoft.com" }}/k8s/csi/azurefile-csi:v{{ $version }}
+          image: {{ Image (print "mcr.microsoft.com/k8s/csi/azurefile-csi:v" $version) }}
           imagePullPolicy: IfNotPresent
           args:
             - "--v=5"

--- a/addons/csi/azure-snapshot-controller/csi-snapshot-controller.yaml
+++ b/addons/csi/azure-snapshot-controller/csi-snapshot-controller.yaml
@@ -46,7 +46,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-snapshot-controller
-          image: {{ Registry "mcr.microsoft.com" }}/oss/kubernetes-csi/snapshot-controller:v5.0.1
+          image: {{ Image "mcr.microsoft.com/oss/kubernetes-csi/snapshot-controller:v5.0.1" }}
           args:
             - "--v=2"
             - "--leader-election=true"

--- a/addons/csi/digitalocean/csi-driver.yaml
+++ b/addons/csi/digitalocean/csi-driver.yaml
@@ -64,7 +64,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-provisioner
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.2.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-provisioner:v3.2.1" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--default-fstype=ext4"
@@ -77,7 +77,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-attacher
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.5.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v3.5.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -91,7 +91,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v6.0.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v6.0.1" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
@@ -103,7 +103,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.5.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.5.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=30s"
@@ -118,7 +118,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-do-plugin
-          image: '{{ Registry "docker.io" }}/digitalocean/do-csi-plugin:v4.2.0'
+          image: '{{ Image "digitalocean/do-csi-plugin:v4.2.0" }}'
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--token=$(DIGITALOCEAN_ACCESS_TOKEN)"
@@ -321,7 +321,7 @@ spec:
         # devices briefly and may conflict with CSI-managed droplets (leading to
         # "resource busy" errors). We can safely delete it in DOKS.
         - name: automount-udev-deleter
-          image: '{{ Registry "docker.io" }}/alpine:3'
+          image: '{{ Image "alpine:3" }}'
           args:
             - "rm"
             - "-f"
@@ -331,7 +331,7 @@ spec:
               mountPath: /etc/udev/rules.d/
       containers:
         - name: csi-node-driver-registrar
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.5.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1" }}'
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -355,7 +355,7 @@ spec:
             - name: registration-dir
               mountPath: /registration/
         - name: csi-do-plugin
-          image: '{{ Registry "docker.io" }}/digitalocean/do-csi-plugin:v4.2.0'
+          image: '{{ Image "digitalocean/do-csi-plugin:v4.2.0" }}'
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--url=$(DIGITALOCEAN_API_URL)"

--- a/addons/csi/digitalocean/snapshot-controller.yaml
+++ b/addons/csi/digitalocean/snapshot-controller.yaml
@@ -43,7 +43,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-controller
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v6.0.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/snapshot-controller:v6.0.1" }}'
           args:
             - "--v=5"
           imagePullPolicy: IfNotPresent

--- a/addons/csi/digitalocean/snapshot-webhook.yaml
+++ b/addons/csi/digitalocean/snapshot-webhook.yaml
@@ -51,7 +51,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v6.0.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1" }}'
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/cert.pem', '--tls-private-key-file=/run/secrets/tls/key.pem']
           ports:

--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -138,7 +138,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.2.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v3.2.1" }}'
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi
@@ -148,7 +148,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-resizer
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.2.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.2.0" }}'
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi
@@ -158,7 +158,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-provisioner
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.2.2'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2" }}'
           args:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
@@ -171,7 +171,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: hcloud-csi-driver
-          image: '{{ Registry "docker.io" }}/hetznercloud/hcloud-csi-driver:1.6.0'
+          image: '{{ Image "hetznercloud/hcloud-csi-driver:1.6.0" }}'
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
@@ -214,7 +214,7 @@ spec:
             allowPrivilegeEscalation: true
         - name: liveness-probe
           imagePullPolicy: Always
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.3.0" }}'
           volumeMounts:
             - mountPath: /run/csi
               name: socket-dir
@@ -260,7 +260,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-node-driver-registrar
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0" }}'
           args:
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
           env:
@@ -277,7 +277,7 @@ spec:
           securityContext:
             privileged: true
         - name: hcloud-csi-driver
-          image: '{{ Registry "docker.io" }}/hetznercloud/hcloud-csi-driver:1.6.0'
+          image: '{{ Image "hetznercloud/hcloud-csi-driver:1.6.0" }}'
           imagePullPolicy: Always
           env:
             - name: CSI_ENDPOINT
@@ -322,7 +322,7 @@ spec:
             periodSeconds: 2
         - name: liveness-probe
           imagePullPolicy: Always
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.3.0" }}'
           volumeMounts:
             - mountPath: /run/csi
               name: plugin-dir

--- a/addons/csi/nutanix/csi-driver.yaml
+++ b/addons/csi/nutanix/csi-driver.yaml
@@ -158,7 +158,7 @@ spec:
       hostNetwork: true
       containers:
         - name: driver-registrar
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: {{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0" }}
           imagePullPolicy: IfNotPresent
           args:
             - --v=5
@@ -189,7 +189,7 @@ spec:
           securityContext:
             privileged: true
             allowPrivilegeEscalation: true
-          image: {{ Registry "quay.io" }}/karbon/ntnx-csi:v2.5.0
+          image: {{ Image "quay.io/karbon/ntnx-csi:v2.5.0" }}
           imagePullPolicy: IfNotPresent
           args :
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -250,7 +250,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: plugin-dir
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0
+          image: {{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.3.0" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -310,7 +310,7 @@ spec:
       hostNetwork: true
       containers:
         - name: csi-provisioner
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.2.2
+          image: {{ Image "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -336,7 +336,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-resizer
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.2.0
+          image: {{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.2.0" }}
           imagePullPolicy: IfNotPresent
           args:
             - --v=5
@@ -353,7 +353,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v4.2.1
+          image: {{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v4.2.1" }}
           imagePullPolicy: IfNotPresent
           args:
           - --csi-address=$(ADDRESS)
@@ -367,7 +367,7 @@ spec:
           - name: socket-dir
             mountPath: /csi
         - name: ntnx-csi-plugin
-          image: {{ Registry "quay.io" }}/karbon/ntnx-csi:v2.5.0
+          image: {{ Image "quay.io/karbon/ntnx-csi:v2.5.0" }}
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: true
@@ -417,7 +417,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0
+          image: {{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.3.0" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/addons/csi/nutanix/snapshot-controller.yaml
+++ b/addons/csi/nutanix/snapshot-controller.yaml
@@ -646,7 +646,7 @@ spec:
       serviceAccount: snapshot-controller
       containers:
       - name: snapshot-controller
-        image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v4.2.1
+        image: {{ Image "registry.k8s.io/sig-storage/snapshot-controller:v4.2.1" }}
         imagePullPolicy: IfNotPresent
         args:
         - --v=5
@@ -689,7 +689,7 @@ spec:
     spec:
       containers:
       - name: snapshot-validation
-        image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v4.2.1
+        image: {{ Image "registry.k8s.io/sig-storage/snapshot-validation-webhook:v4.2.1" }}
         imagePullPolicy: IfNotPresent
         args:
           - --tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -56,7 +56,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.4.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-attacher:v3.4.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -69,7 +69,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.1.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -83,7 +83,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v5.0.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -96,7 +96,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.4.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.4.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -110,7 +110,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.6.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
           env:
@@ -120,7 +120,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
-          image: '{{ Registry "docker.io" }}/k8scloudprovider/cinder-csi-plugin:{{ $version }}'
+          image: '{{ Image (print "k8scloudprovider/cinder-csi-plugin:" $version) }}'
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -54,7 +54,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.5.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -78,7 +78,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.6.0" }}'
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:
@@ -90,7 +90,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: '{{ Registry "docker.io" }}/k8scloudprovider/cinder-csi-plugin:{{ $version }}'
+          image: '{{ Image (print "k8scloudprovider/cinder-csi-plugin:" $version) }}'
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/addons/csi/openstack/snapshot-controller.yaml
+++ b/addons/csi/openstack/snapshot-controller.yaml
@@ -135,7 +135,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-controller
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v5.0.1'
+          image: '{{ Image "registry.k8s.io/sig-storage/snapshot-controller:v5.0.1" }}'
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/addons/csi/openstack/snapshot-webhook.yaml
+++ b/addons/csi/openstack/snapshot-webhook.yaml
@@ -20,7 +20,6 @@
 #   - change webhook-certs secret name
 #   - add seccomp profile
 
-
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 
@@ -46,7 +45,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: '{{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v5.0.1' # change the image if you wish to use your own custom validation server image
+          image: '{{ Image "registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.1" }}' # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
           ports:

--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -134,7 +134,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.2.1
+          image: {{ Image "registry.k8s.io/sig-storage/csi-attacher:v3.2.1" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -147,7 +147,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.2.2
+          image: {{ Image "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -165,7 +165,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image:  {{ Registry "projects.registry.vmware.com" }}/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest
+          image:  {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest" }}
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/addons/csi/vmware-cloud-director/csi-node.yaml
+++ b/addons/csi/vmware-cloud-director/csi-node.yaml
@@ -73,7 +73,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: node-driver-registrar
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: {{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.2.0" }}
           imagePullPolicy: "IfNotPresent"
           args:
             - "--v=5"
@@ -108,7 +108,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ Registry "projects.registry.vmware.com" }}/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest
+          image: {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.2.0.latest" }}
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/addons/csi/vsphere/csi-migration-webhook.yaml
+++ b/addons/csi/vsphere/csi-migration-webhook.yaml
@@ -80,7 +80,7 @@ spec:
       serviceAccountName: csi-migration-webhook
       containers:
         - name: vsphere-webhook
-          image: '{{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/syncer:v2.3.0'
+          image: '{{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.3.0" }}'
           args:
             - "--operation-mode=WEBHOOK_SERVER"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"

--- a/addons/csi/vsphere/snapshot-controller.yaml
+++ b/addons/csi/vsphere/snapshot-controller.yaml
@@ -151,7 +151,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-controller
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-controller:v5.0.1
+          image: {{ Image "registry.k8s.io/sig-storage/snapshot-controller:v5.0.1" }}
           args:
             - "--v=5"
             - "--leader-election=true"

--- a/addons/csi/vsphere/snapshot-webhook.yaml
+++ b/addons/csi/vsphere/snapshot-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/snapshot-validation-webhook:v5.0.1 # change the image if you wish to use your own custom validation server image
+          image: {{ Image "registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.1" }} # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/run/secrets/tls/cert.pem', '--tls-private-key-file=/run/secrets/tls/key.pem']
           ports:

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -269,7 +269,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.4.0
+          image: {{ Image "registry.k8s.io/sig-storage/csi-attacher:v3.4.0" }}
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -284,7 +284,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.4.0
+          image: {{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.4.0" }}
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -300,7 +300,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: vsphere-csi-controller
-          image: {{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/driver:v2.5.1
+          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.1" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -354,7 +354,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0
+          image: {{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.6.0" }}
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -362,7 +362,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: vsphere-syncer
-          image: {{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/syncer:v2.5.1
+          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.5.1" }}
           args:
             - "--leader-election"
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
@@ -397,7 +397,7 @@ spec:
               name: ca-bundle
               readOnly: true
         - name: csi-provisioner
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.1.0
+          image: {{ Image "registry.k8s.io/sig-storage/csi-provisioner:v3.1.0" }}
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -416,7 +416,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-snapshotter
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v5.0.1
+          image: {{ Image "registry.k8s.io/sig-storage/csi-snapshotter:v5.0.1" }}
           args:
             - "--v=4"
             - "--kube-api-qps=100"
@@ -469,7 +469,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: node-driver-registrar
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.5.0
+          image: {{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0" }}
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -492,7 +492,7 @@ spec:
                 - --mode=kubelet-registration-probe
             initialDelaySeconds: 3
         - name: vsphere-csi-node
-          image: {{ Registry "gcr.io" }}/cloud-provider-vsphere/csi/release/driver:v2.5.1
+          image: {{ Image "gcr.io/cloud-provider-vsphere/csi/release/driver:v2.5.1" }}
           args:
             - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
             - "--fss-namespace=$(CSI_NAMESPACE)"
@@ -558,7 +558,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0
+          image: {{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.6.0" }}
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"

--- a/addons/heapster/heapster-controller.yaml
+++ b/addons/heapster/heapster-controller.yaml
@@ -42,7 +42,7 @@ spec:
     spec:
       serviceAccount: heapster
       containers:
-      - image: '{{ Registry "gcr.io" }}/google_containers/heapster-amd64:v1.5.2'
+      - image: '{{ Image "gcr.io/google_containers/heapster-amd64:v1.5.2" }}'
         name: heapster
         livenessProbe:
           httpGet:

--- a/addons/hubble/hubble_v1.11.yaml
+++ b/addons/hubble/hubble_v1.11.yaml
@@ -241,7 +241,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: hubble-relay
-          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.11.9@sha256:0b2f19895de281e4a416700b17a4dc9b8d3b80eb7b5b65dac173880f5113084e"
+          image: "{{ Image "quay.io/cilium/hubble-relay:v1.11.9@sha256:0b2f19895de281e4a416700b17a4dc9b8d3b80eb7b5b65dac173880f5113084e" }}"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -320,7 +320,7 @@ spec:
       serviceAccountName: "hubble-ui"
       containers:
       - name: frontend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"
+        image: "{{ Image "quay.io/cilium/hubble-ui:v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e" }}"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -330,7 +330,7 @@ spec:
             mountPath: /etc/nginx/conf.d/default.conf
             subPath: nginx.conf
       - name: backend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"
+        image: "{{ Image "quay.io/cilium/hubble-ui-backend:v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: EVENTS_SERVER_PORT
@@ -364,7 +364,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.5@sha256:0c2b71bb3469990e7990e7e26243617aa344b5a69a4ce465740b8577f9d48ab9"
+          image: "{{ Image "quay.io/cilium/certgen:v0.1.5@sha256:0c2b71bb3469990e7990e7e26243617aa344b5a69a4ce465740b8577f9d48ab9" }}"
           imagePullPolicy: IfNotPresent
           command:
             - "/usr/bin/cilium-certgen"
@@ -406,7 +406,7 @@ spec:
         spec:
           containers:
             - name: certgen
-              image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.5@sha256:0c2b71bb3469990e7990e7e26243617aa344b5a69a4ce465740b8577f9d48ab9"
+              image: "{{ Image "quay.io/cilium/certgen:v0.1.5@sha256:0c2b71bb3469990e7990e7e26243617aa344b5a69a4ce465740b8577f9d48ab9" }}"
               imagePullPolicy: IfNotPresent
               command:
                 - "/usr/bin/cilium-certgen"

--- a/addons/hubble/hubble_v1.12.yaml
+++ b/addons/hubble/hubble_v1.12.yaml
@@ -232,7 +232,7 @@ spec:
     spec:
       containers:
         - name: hubble-relay
-          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.12.2@sha256:6f3496c28f23542f2645d614c0a9e79e3b0ae2732080da794db41c33e4379e5c"
+          image: "{{ Image "quay.io/cilium/hubble-relay:v1.12.2@sha256:6f3496c28f23542f2645d614c0a9e79e3b0ae2732080da794db41c33e4379e5c" }}"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -320,7 +320,7 @@ spec:
       serviceAccountName: "hubble-ui"
       containers:
       - name: frontend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"
+        image: "{{ Image "quay.io/cilium/hubble-ui:v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e" }}"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -333,7 +333,7 @@ spec:
             mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"
+        image: "{{ Image "quay.io/cilium/hubble-ui-backend:v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7" }}"
         imagePullPolicy: IfNotPresent
         env:
         - name: EVENTS_SERVER_PORT
@@ -371,7 +371,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"
+          image: "{{ Image "quay.io/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd" }}"
           imagePullPolicy: IfNotPresent
           command:
             - "/usr/bin/cilium-certgen"
@@ -413,7 +413,7 @@ spec:
         spec:
           containers:
             - name: certgen
-              image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"
+              image: "{{ Image "quay.io/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd" }}"
               imagePullPolicy: IfNotPresent
               command:
                 - "/usr/bin/cilium-certgen"

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: kube-proxy
-        image: '{{ Registry "registry.k8s.io" }}/kube-proxy:v{{ .Cluster.Version }}'
+        image: '{{ Image (print "registry.k8s.io/kube-proxy:v" .Cluster.Version) }}'
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy

--- a/addons/kube-state-metrics/deployment.yaml
+++ b/addons/kube-state-metrics/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: '{{ Registry "registry.k8s.io" }}/kube-state-metrics/kube-state-metrics:v2.1.1'
+          image: '{{ Image "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.1.1" }}'
           name: kube-state-metrics
           resources:
             limits:
@@ -58,7 +58,7 @@ spec:
             - --secure-listen-address=:8443
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
             - --upstream=http://127.0.0.1:8081/
-          image: '{{ Registry "quay.io" }}/brancz/kube-rbac-proxy:v0.11.0'
+          image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.11.0" }}'
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/addons/metallb/00_metallb.yaml
+++ b/addons/metallb/00_metallb.yaml
@@ -1593,7 +1593,7 @@ spec:
           value: memberlist
         - name: METALLB_DEPLOYMENT
           value: controller
-        image: {{ Registry "quay.io" }}/metallb/controller:v0.13.3
+        image: {{ Image "quay.io/metallb/controller:v0.13.3" }}
         livenessProbe:
           failureThreshold: 3
           httpGet:
@@ -1689,7 +1689,7 @@ spec:
             secretKeyRef:
               key: secretkey
               name: memberlist
-        image: {{ Registry "quay.io" }}/metallb/speaker:v0.13.3
+        image: {{ Image "quay.io/metallb/speaker:v0.13.3" }}
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/addons/multus/daemonset.yaml
+++ b/addons/multus/daemonset.yaml
@@ -43,7 +43,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: '{{ Registry "ghcr.io" }}/k8snetworkplumbingwg/multus-cni:v3.8.1'
+        image: '{{ Image "ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8.1" }}'
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"
@@ -64,7 +64,7 @@ spec:
           mountPath: /host/opt/cni/bin
       initContainers:
         - name: install-multus-binary
-          image: '{{ Registry "ghcr.io" }}/k8snetworkplumbingwg/multus-cni:v3.8.1'
+          image: '{{ Image "ghcr.io/k8snetworkplumbingwg/multus-cni:v3.8.1" }}'
           command:
             - "cp"
             - "/usr/src/multus-cni/bin/multus"

--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: node-exporter
       containers:
       - name: node-exporter
-        image: '{{ Registry "quay.io" }}/prometheus/node-exporter:v1.2.2'
+        image: '{{ Image "quay.io/prometheus/node-exporter:v1.2.2" }}'
         args:
         - '--path.procfs=/host/proc'
         - '--path.sysfs=/host/sys'
@@ -64,7 +64,7 @@ spec:
           mountPropagation: HostToContainer
 
       - name: kube-rbac-proxy
-        image: '{{ Registry "quay.io" }}/brancz/kube-rbac-proxy:v0.11.0'
+        image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.11.0" }}'
         args:
         - '--logtostderr'
         - '--secure-listen-address=$(IP):9100'

--- a/addons/openvpn/openvpn-client-dep.yaml
+++ b/addons/openvpn/openvpn-client-dep.yaml
@@ -32,7 +32,7 @@ spec:
       serviceAccountName: vpn-client
       containers:
       - name: openvpn-client
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.5.2-r0'
+        image: '{{ Image "quay.io/kubermatic/openvpn:v2.5.2-r0" }}'
         command: ["/usr/sbin/openvpn"]
         args: ["--config", "/etc/openvpn/config/config"]
         resources:
@@ -71,7 +71,7 @@ spec:
           name: openvpn-client-certificates
           readOnly: true
       - name: dnat-controller
-        image: '{{ Registry "quay.io" }}/kubermatic/openvpn:v2.5.2-r0'
+        image: '{{ Image "quay.io/kubermatic/openvpn:v2.5.2-r0" }}'
         command:
         - bash
         - -ec

--- a/addons/templatify-images.sh
+++ b/addons/templatify-images.sh
@@ -1,5 +1,19 @@
 #!/usr/bin/env bash
 
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -euo pipefail
 
 dqreplacement='"{{ Image \1 }}"'

--- a/addons/templatify-images.sh
+++ b/addons/templatify-images.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dqreplacement='"{{ Image \1 }}"'
+sqreplacement=$'\'{{ Image "\1" }}\''
+replacement='{{ Image "\1" }}'
+
+for registry in docker.io quay.io public.ecr.aws; do
+  sed -i "s/\(\"$registry.*\"\)/$dqreplacement/g" $@
+  sed -i "s/\('$registry.*'\)/$sqreplacement/g" $@
+
+  # the space makes it so that this does not match the
+  # output of the previous two sed invocations
+  sed -i "s/ \($registry.*\)/ $replacement/g" $@
+done

--- a/addons/values-aws-node-termination-handler.yaml
+++ b/addons/values-aws-node-termination-handler.yaml
@@ -15,7 +15,7 @@
 # This does not work, as the chart's templating explodes if
 # we inject a templating directive here. `sed` it is, then.
 #image:
-#  repository: '{{ Registry "public.ecr.aws" }}/aws-ec2/aws-node-termination-handler'
+#  repository: '{{ Image "public.ecr.aws/aws-ec2/aws-node-termination-handler" }}'
 
 fullnameOverride: "aws-node-termination-handler"
 

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -45,6 +45,7 @@ const (
 
 func txtFuncMap(overwriteRegistry string) template.FuncMap {
 	funcs := sprig.TxtFuncMap()
+	// Registry is deprecated and should not be used anymore.
 	funcs["Registry"] = registry.GetOverwriteFunc(overwriteRegistry)
 	funcs["Image"] = registry.GetImageRewriterFunc(overwriteRegistry)
 	funcs["join"] = strings.Join

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -46,6 +46,7 @@ const (
 func txtFuncMap(overwriteRegistry string) template.FuncMap {
 	funcs := sprig.TxtFuncMap()
 	funcs["Registry"] = registry.GetOverwriteFunc(overwriteRegistry)
+	funcs["Image"] = registry.GetImageRewriterFunc(overwriteRegistry)
 	funcs["join"] = strings.Join
 	return funcs
 }

--- a/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
@@ -326,7 +326,7 @@ func (r *Reconciler) reconcileMasterDeployments(ctx context.Context, seed *kuber
 	}
 
 	creators := []reconciling.NamedDeploymentCreatorGetter{
-		masterDeploymentCreator(seed, secret, registry.GetOverwriteFunc(config.Spec.UserCluster.OverwriteRegistry)),
+		masterDeploymentCreator(seed, secret, registry.GetImageRewriterFunc(config.Spec.UserCluster.OverwriteRegistry)),
 	}
 
 	if err := reconciling.ReconcileDeployments(ctx, creators, seed.Namespace, r.Client); err != nil {

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -189,7 +189,7 @@ func convertServiceAccountToKubeconfig(host string, credentials *corev1.Secret) 
 	return clientcmd.Write(*kubeconfig)
 }
 
-func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret, getRegistry registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
+func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret, imageRewriter registry.ImageRewriter) reconciling.NamedDeploymentCreatorGetter {
 	name := deploymentName(seed)
 
 	return func() (string, reconciling.DeploymentCreator) {
@@ -230,7 +230,7 @@ func masterDeploymentCreator(seed *kubermaticv1.Seed, secret *corev1.Secret, get
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   getRegistry(resources.RegistryQuay) + "/kubermatic/util:2.2.0",
+					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kubermatic/util:2.2.0")),
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -257,6 +258,7 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 		},
 		caBundle:                caBundle,
 		userClusterConnProvider: new(testUserClusterConnectionProvider),
+		versions:                kubermatic.NewFakeVersions(),
 	}
 
 	if _, err := r.ensureResourcesAreDeployed(ctx, testCluster, namespace); err != nil {

--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -34,6 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/resources/nodeportproxy"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -313,7 +314,7 @@ func GatewayDeploymentCreator(data *resources.TemplateData, settings *kubermatic
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "nginx",
-					Image:           data.ImageRegistry(resources.RegistryDocker) + "/" + image + ":" + version,
+					Image:           registry.Must(data.RewriteImage(resources.RegistryDocker + "/" + image + ":" + version)),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Ports: []corev1.ContainerPort{
 						{

--- a/pkg/controller/user-cluster-controller-manager/flatcar/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/controller.go
@@ -141,14 +141,14 @@ func (r *Reconciler) reconcileUpdateOperatorResources(ctx context.Context) error
 	}
 
 	depCreators := []reconciling.NamedDeploymentCreatorGetter{
-		resources.OperatorDeploymentCreator(registry.GetOverwriteFunc(r.overwriteRegistry), r.updateWindow),
+		resources.OperatorDeploymentCreator(registry.GetImageRewriterFunc(r.overwriteRegistry), r.updateWindow),
 	}
 	if err := reconciling.ReconcileDeployments(ctx, depCreators, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile the Deployments: %w", err)
 	}
 
 	dsCreators := []reconciling.NamedDaemonSetCreatorGetter{
-		resources.AgentDaemonSetCreator(registry.GetOverwriteFunc(r.overwriteRegistry)),
+		resources.AgentDaemonSetCreator(registry.GetImageRewriterFunc(r.overwriteRegistry)),
 	}
 	if err := reconciling.ReconcileDaemonSets(ctx, dsCreators, metav1.NamespaceSystem, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile the DaemonSets: %w", err)

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_agent.go
@@ -37,7 +37,7 @@ var (
 	hostPathType            = corev1.HostPathUnset
 )
 
-func AgentDaemonSetCreator(getRegistry registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
+func AgentDaemonSetCreator(imageRewriter registry.ImageRewriter) reconciling.NamedDaemonSetCreatorGetter {
 	var userCore int64 = 500 // UID of the flatcar admin user 'core'
 
 	return func() (string, reconciling.DaemonSetCreator) {
@@ -64,7 +64,7 @@ func AgentDaemonSetCreator(getRegistry registry.WithOverwriteFunc) reconciling.N
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "update-agent",
-					Image:   getRegistry(resources.RegistryQuay) + "/kinvolk/flatcar-linux-update-operator:v0.7.3",
+					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kinvolk/flatcar-linux-update-operator:v0.7.3")),
 					Command: []string{"/bin/update-agent"},
 					SecurityContext: &corev1.SecurityContext{
 						RunAsUser: &userCore,

--- a/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
+++ b/pkg/controller/user-cluster-controller-manager/flatcar/resources/update_operator.go
@@ -38,7 +38,7 @@ var (
 	deploymentMaxUnavailable       = intstr.FromString("25%")
 )
 
-func OperatorDeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc, updateWindow kubermaticv1.UpdateWindow) reconciling.NamedDeploymentCreatorGetter {
+func OperatorDeploymentCreator(imageRewriter registry.ImageRewriter, updateWindow kubermaticv1.UpdateWindow) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return OperatorDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Spec.Replicas = &deploymentReplicas
@@ -86,7 +86,7 @@ func OperatorDeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc,
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "update-operator",
-					Image:   registryWithOverwrite(resources.RegistryQuay) + "/kinvolk/flatcar-linux-update-operator:v0.7.3",
+					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kinvolk/flatcar-linux-update-operator:v0.7.3")),
 					Command: []string{"/bin/update-operator"},
 					Env:     env,
 				},

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -109,7 +109,7 @@ func Add(
 		namespace:              namespace,
 		clusterURL:             clusterURL,
 		clusterIsPaused:        clusterIsPaused,
-		overwriteRegistryFunc:  registry.GetOverwriteFunc(overwriteRegistry),
+		imageRewriter:          registry.GetImageRewriterFunc(overwriteRegistry),
 		openvpnServerPort:      openvpnServerPort,
 		kasSecurePort:          kasSecurePort,
 		tunnelingAgentIP:       tunnelingAgentIP,
@@ -280,7 +280,7 @@ type reconciler struct {
 	namespace              string
 	clusterURL             *url.URL
 	clusterIsPaused        userclustercontrollermanager.IsPausedChecker
-	overwriteRegistryFunc  registry.WithOverwriteFunc
+	imageRewriter          registry.ImageRewriter
 	openvpnServerPort      uint32
 	kasSecurePort          uint32
 	tunnelingAgentIP       net.IP

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -51,7 +51,7 @@ var (
 )
 
 // DeploymentCreator returns the function to create and update the CoreDNS deployment.
-func DeploymentCreator(kubernetesVersion *semverlib.Version, replicas *int32, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(kubernetesVersion *semverlib.Version, replicas *int32, imageRewriter registry.ImageRewriter) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.CoreDNSDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.CoreDNSDeploymentName
@@ -100,7 +100,7 @@ func DeploymentCreator(kubernetesVersion *semverlib.Version, replicas *int32, re
 			volumes := getVolumes()
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			dep.Spec.Template.Spec.Containers = getContainers(kubernetesVersion, registryWithOverwrite)
+			dep.Spec.Template.Spec.Containers = getContainers(kubernetesVersion, imageRewriter)
 			err := resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
@@ -143,14 +143,11 @@ func PodDisruptionBudgetCreator() reconciling.NamedPodDisruptionBudgetCreatorGet
 	}
 }
 
-func getContainers(
-	clusterVersion *semverlib.Version,
-	registryWithOverwrite registry.WithOverwriteFunc,
-) []corev1.Container {
+func getContainers(clusterVersion *semverlib.Version, imageRewriter registry.ImageRewriter) []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:            resources.CoreDNSDeploymentName,
-			Image:           fmt.Sprintf("%s/%s", registryWithOverwrite(resources.RegistryK8S), dns.GetCoreDNSImage(clusterVersion)),
+			Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s", resources.RegistryK8S, dns.GetCoreDNSImage(clusterVersion)))),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			Args: []string{"-conf", "/etc/coredns/Corefile"},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -52,7 +52,7 @@ const (
 )
 
 // DaemonSetCreator returns the function to create and update the Envoy DaemonSet.
-func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, configHash string, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, configHash string, imageRewriter registry.ImageRewriter) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.EnvoyAgentDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Name = resources.EnvoyAgentDaemonSetName
@@ -74,9 +74,19 @@ func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, configHash s
 				Annotations: map[string]string{"checksum/config": configHash},
 			}
 
+			initContainers, err := getInitContainers(agentIP, versions, imageRewriter)
+			if err != nil {
+				return nil, err
+			}
+
+			containers, err := getContainers(versions, imageRewriter)
+			if err != nil {
+				return nil, err
+			}
+
 			ds.Spec.Template.Spec = corev1.PodSpec{
-				InitContainers: getInitContainers(agentIP, versions, registryWithOverwrite),
-				Containers:     getContainers(versions, registryWithOverwrite),
+				InitContainers: initContainers,
+				Containers:     containers,
 				// TODO(youssefazrak) needed?
 				PriorityClassName:             "system-cluster-critical",
 				DNSPolicy:                     corev1.DNSClusterFirst,
@@ -110,7 +120,12 @@ func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, configHash s
 	}
 }
 
-func getInitContainers(ip net.IP, versions kubermatic.Versions, registryWithOverwrite registry.WithOverwriteFunc) []corev1.Container {
+func getInitContainers(ip net.IP, versions kubermatic.Versions, imageRewriter registry.ImageRewriter) ([]corev1.Container, error) {
+	image, err := imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic))
+	if err != nil {
+		return nil, err
+	}
+
 	// TODO: we are creating and configuring the a dummy interface
 	// using init containers. This approach is good enough for the tech preview
 	// but it is definitely not production ready. This should be replaced with
@@ -119,7 +134,7 @@ func getInitContainers(ip net.IP, versions kubermatic.Versions, registryWithOver
 	return []corev1.Container{
 		{
 			Name:    resources.EnvoyAgentCreateInterfaceInitContainerName,
-			Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryQuay), resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic),
+			Image:   image,
 			Command: []string{"sh", "-c", "ip link add envoyagent type dummy || true"},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
@@ -134,7 +149,7 @@ func getInitContainers(ip net.IP, versions kubermatic.Versions, registryWithOver
 		},
 		{
 			Name:    resources.EnvoyAgentAssignAddressInitContainerName,
-			Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryQuay), resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic),
+			Image:   image,
 			Command: []string{"sh", "-c", fmt.Sprintf("ip addr add %s/32 dev envoyagent scope host || true", ip.String())},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
@@ -147,14 +162,19 @@ func getInitContainers(ip net.IP, versions kubermatic.Versions, registryWithOver
 				},
 			},
 		},
-	}
+	}, nil
 }
 
-func getContainers(versions kubermatic.Versions, registryWithOverwrite registry.WithOverwriteFunc) []corev1.Container {
+func getContainers(versions kubermatic.Versions, imageRewriter registry.ImageRewriter) ([]corev1.Container, error) {
+	image, err := imageRewriter(fmt.Sprintf("%s:%s", envoyImageName, versions.Kubermatic))
+	if err != nil {
+		return nil, err
+	}
+
 	return []corev1.Container{
 		{
 			Name:            resources.EnvoyAgentDaemonSetName,
-			Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryDocker), envoyImageName, versions.Envoy),
+			Image:           image,
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			// This amount of logs will be kept for the Tech Preview of
@@ -181,7 +201,7 @@ func getContainers(versions kubermatic.Versions, registryWithOverwrite registry.
 				},
 			},
 		},
-	}
+	}, nil
 }
 
 func getVolumes() []corev1.Volume {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -121,10 +121,7 @@ func DaemonSetCreator(agentIP net.IP, versions kubermatic.Versions, configHash s
 }
 
 func getInitContainers(ip net.IP, versions kubermatic.Versions, imageRewriter registry.ImageRewriter) ([]corev1.Container, error) {
-	image, err := imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic))
-	if err != nil {
-		return nil, err
-	}
+	image := registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, resources.EnvoyAgentDeviceSetupImage, versions.Kubermatic)))
 
 	// TODO: we are creating and configuring the a dummy interface
 	// using init containers. This approach is good enough for the tech preview
@@ -166,15 +163,10 @@ func getInitContainers(ip net.IP, versions kubermatic.Versions, imageRewriter re
 }
 
 func getContainers(versions kubermatic.Versions, imageRewriter registry.ImageRewriter) ([]corev1.Container, error) {
-	image, err := imageRewriter(fmt.Sprintf("%s:%s", envoyImageName, versions.Kubermatic))
-	if err != nil {
-		return nil, err
-	}
-
 	return []corev1.Container{
 		{
 			Name:            resources.EnvoyAgentDaemonSetName,
-			Image:           image,
+			Image:           registry.Must(imageRewriter(fmt.Sprintf("%s:%s", envoyImageName, versions.Kubermatic))),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			// This amount of logs will be kept for the Tech Preview of

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -166,7 +166,7 @@ func getContainers(versions kubermatic.Versions, imageRewriter registry.ImageRew
 	return []corev1.Container{
 		{
 			Name:            resources.EnvoyAgentDaemonSetName,
-			Image:           registry.Must(imageRewriter(fmt.Sprintf("%s:%s", envoyImageName, versions.Kubermatic))),
+			Image:           registry.Must(imageRewriter(fmt.Sprintf("%s:%s", envoyImageName, versions.Envoy))),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			// This amount of logs will be kept for the Tech Preview of

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -48,7 +48,7 @@ var (
 )
 
 // DeploymentCreator returns function to create/update deployment for konnectivity agents in user cluster.
-func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(kServerHost string, kServerPort int, imageRewriter registry.ImageRewriter) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		const (
 			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
@@ -78,7 +78,7 @@ func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrit
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            resources.KonnectivityAgentContainer,
-					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryEUGCR), name, version),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryEUGCR, name, version))),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/proxy-agent"},
 					Args: []string{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard/deployment.go
@@ -53,7 +53,7 @@ const (
 )
 
 // DeploymentCreator returns the function to create and update the dashboard-metrics-scraper deployment.
-func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(imageRewriter registry.ImageRewriter) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return scraperName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = scraperName
@@ -70,7 +70,7 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 			volumes := getVolumes()
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			dep.Spec.Template.Spec.Containers = getContainers(registryWithOverwrite)
+			dep.Spec.Template.Spec.Containers = getContainers(imageRewriter)
 			err := resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, defaultResourceRequirements, nil, dep.Annotations)
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
@@ -89,11 +89,11 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 	}
 }
 
-func getContainers(registryWithOverwrite registry.WithOverwriteFunc) []corev1.Container {
+func getContainers(imageRewriter registry.ImageRewriter) []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:            scraperName,
-			Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryDocker), scraperImageName, scraperTag),
+			Image:           registry.Must(imageRewriter(fmt.Sprintf("%s:%s", scraperImageName, scraperTag))),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"/metrics-sidecar"},
 			VolumeMounts: []corev1.VolumeMount{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -62,7 +62,7 @@ func TLSServingCertSecretCreator(caGetter servingcerthelper.CAGetter) reconcilin
 }
 
 // DeploymentCreator returns the function to create and update the metrics server deployment.
-func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
+func DeploymentCreator(imageRewriter registry.ImageRewriter) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		return resources.MetricsServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			dep.Name = resources.MetricsServerDeploymentName
@@ -91,7 +91,7 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.MetricsServerDeploymentName,
-					Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryK8S), imageName, imageTag),
+					Image:   registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryK8S, imageName, imageTag))),
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubelet-insecure-tls",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(imageRewriter registry.ImageRewriter) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return resources.NodeLocalDNSDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			maxUnavailable := intstr.FromString("10%")
@@ -87,7 +87,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
-					Image:           fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.21.1", registryWithOverwrite(resources.RegistryK8S)),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.21.1", resources.RegistryK8S))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys/daemonset.go
@@ -40,7 +40,7 @@ var (
 	hostPathType            = corev1.HostPathDirectoryOrCreate
 )
 
-func DaemonSetCreator(versions kubermatic.Versions, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDaemonSetCreatorGetter {
+func DaemonSetCreator(versions kubermatic.Versions, imageRewriter registry.ImageRewriter) reconciling.NamedDaemonSetCreatorGetter {
 	return func() (string, reconciling.DaemonSetCreator) {
 		return daemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Spec.UpdateStrategy.Type = appsv1.RollingUpdateDaemonSetStrategyType
@@ -62,7 +62,7 @@ func DaemonSetCreator(versions kubermatic.Versions, registryWithOverwrite regist
 				{
 					Name:            daemonSetName,
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryQuay), dockerImage, versions.Kubermatic),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, dockerImage, versions.Kubermatic))),
 					Command:         []string{fmt.Sprintf("/usr/local/bin/%v", daemonSetName)},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -40,7 +40,7 @@ import (
 )
 
 // cronJobCreator returns the func to create/update the metering report cronjob.
-func cronJobCreator(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, getRegistry registry.WithOverwriteFunc, namespace string) reconciling.NamedCronJobCreatorGetter {
+func cronJobCreator(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, getRegistry registry.ImageRewriter, namespace string) reconciling.NamedCronJobCreatorGetter {
 	return func() (string, reconciling.CronJobCreator) {
 		return reportName, func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
 			var args []string

--- a/pkg/ee/metering/prometheus/reconcile.go
+++ b/pkg/ee/metering/prometheus/reconcile.go
@@ -42,7 +42,7 @@ const (
 )
 
 // ReconcilePrometheus reconciles the prometheus instance used as a datasource for metering.
-func ReconcilePrometheus(ctx context.Context, client ctrlruntimeclient.Client, scheme *runtime.Scheme, getRegistry registry.WithOverwriteFunc, seed *kubermaticv1.Seed) error {
+func ReconcilePrometheus(ctx context.Context, client ctrlruntimeclient.Client, scheme *runtime.Scheme, getRegistry registry.ImageRewriter, seed *kubermaticv1.Seed) error {
 	seedOwner := common.OwnershipModifierFactory(seed, scheme)
 
 	if err := reconciling.ReconcileServiceAccounts(ctx, []reconciling.NamedServiceAccountCreatorGetter{

--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -41,12 +41,12 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func getPrometheusImage(overwriter registry.WithOverwriteFunc) string {
-	return overwriter(resources.RegistryQuay) + "/prometheus/prometheus:v2.37.0"
+func getPrometheusImage(overwriter registry.ImageRewriter) string {
+	return registry.Must(overwriter(resources.RegistryQuay + "/prometheus/prometheus:v2.37.0"))
 }
 
 // prometheusStatefulSet creates a StatefulSet for prometheus.
-func prometheusStatefulSet(getRegistry registry.WithOverwriteFunc, seed *kubermaticv1.Seed) reconciling.NamedStatefulSetCreatorGetter {
+func prometheusStatefulSet(getRegistry registry.ImageRewriter, seed *kubermaticv1.Seed) reconciling.NamedStatefulSetCreatorGetter {
 	return func() (string, reconciling.StatefulSetCreator) {
 		return Name, func(sts *appsv1.StatefulSet) (*appsv1.StatefulSet, error) {
 			if sts.Labels == nil {

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -54,13 +54,13 @@ const (
 	meteringName = "metering"
 )
 
-func getMeteringImage(overwriter registry.WithOverwriteFunc) string {
-	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v1.0.0"
+func getMeteringImage(overwriter registry.ImageRewriter) string {
+	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.0"))
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.
 func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, scheme *runtime.Scheme, cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) error {
-	overwriter := registry.GetOverwriteFunc(cfg.Spec.UserCluster.OverwriteRegistry)
+	overwriter := registry.GetImageRewriterFunc(cfg.Spec.UserCluster.OverwriteRegistry)
 
 	if seed.Spec.Metering == nil || !seed.Spec.Metering.Enabled {
 		return undeploy(ctx, client, seed.Namespace)
@@ -83,7 +83,7 @@ func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Cl
 	return nil
 }
 
-func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed, overwriter registry.WithOverwriteFunc, modifiers ...reconciling.ObjectModifier) error {
+func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed, overwriter registry.ImageRewriter, modifiers ...reconciling.ObjectModifier) error {
 	if err := cleanupOrphanedReportingCronJobs(ctx, client, seed.Spec.Metering.ReportConfigurations, seed.Namespace); err != nil {
 		return fmt.Errorf("failed to cleanup orphaned reporting cronjobs: %w", err)
 	}

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -157,7 +157,7 @@ func getImagesFromCreators(log logrus.FieldLogger, templateData *resources.Templ
 	}
 
 	if templateData.IsKonnectivityEnabled() {
-		deploymentCreators = append(deploymentCreators, konnectivity.DeploymentCreator("dummy", 0, registry.GetOverwriteFunc(templateData.OverwriteRegistry)))
+		deploymentCreators = append(deploymentCreators, konnectivity.DeploymentCreator("dummy", 0, registry.GetImageRewriterFunc(templateData.OverwriteRegistry)))
 	}
 
 	cronjobCreators := kubernetescontroller.GetCronJobCreators(templateData)

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -165,9 +165,9 @@ func getImagesFromCreators(log logrus.FieldLogger, templateData *resources.Templ
 	var daemonsetCreators []reconciling.NamedDaemonSetCreatorGetter
 	daemonsetCreators = append(daemonsetCreators, usersshkeys.DaemonSetCreator(
 		kubermaticVersions,
-		templateData.ImageRegistry,
+		templateData.RewriteImage,
 	))
-	daemonsetCreators = append(daemonsetCreators, nodelocaldns.DaemonSetCreator(templateData.ImageRegistry))
+	daemonsetCreators = append(daemonsetCreators, nodelocaldns.DaemonSetCreator(templateData.RewriteImage))
 
 	for _, creatorGetter := range statefulsetCreators {
 		_, creator := creatorGetter()

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/etcd/etcdrunning"
 	"k8c.io/kubermatic/v2/pkg/resources/konnectivity"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -150,7 +151,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 
 			apiserverContainer := &corev1.Container{
 				Name:    resources.ApiserverDeploymentName,
-				Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-apiserver:v" + version.String(),
+				Image:   registry.Must(data.RewriteImage(resources.RegistryK8S + "/kube-apiserver:v" + version.String())),
 				Command: []string{"/usr/local/bin/kube-apiserver"},
 				Env:     envVars,
 				Args:    flags,
@@ -235,7 +236,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 				dep.Spec.Template.Spec.Containers = append(dep.Spec.Template.Spec.Containers,
 					corev1.Container{
 						Name:    auditLogsSidecarName,
-						Image:   data.ImageRegistry(resources.RegistryDocker) + "/fluent/fluent-bit:1.9.5",
+						Image:   registry.Must(data.RewriteImage(resources.RegistryDocker + "/fluent/fluent-bit:1.9.5")),
 						Command: []string{"/fluent-bit/bin/fluent-bit"},
 						Args:    []string{"-c", "/etc/fluent-bit/fluent-bit.conf"},
 						VolumeMounts: []corev1.VolumeMount{

--- a/pkg/resources/apiserver/is-running.go
+++ b/pkg/resources/apiserver/is-running.go
@@ -24,6 +24,7 @@ import (
 	httpproberapi "k8c.io/kubermatic/v2/cmd/http-prober/api"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -37,7 +38,7 @@ const (
 
 // IsRunningInitContainer returns a init container which will wait until the apiserver is reachable via its ClusterIP.
 type isRunningInitContainerData interface {
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 	Cluster() *kubermaticv1.Cluster
 }
 
@@ -82,7 +83,7 @@ func IsRunningWrapper(data isRunningInitContainerData, spec corev1.PodSpec, cont
 	}
 	copyContainer := corev1.Container{
 		Name:    initContainerName,
-		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/http-prober:" + tag,
+		Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/http-prober:" + tag)),
 		Command: []string{"/bin/cp", "/usr/local/bin/http-prober", "/http-prober-bin/http-prober"},
 		VolumeMounts: []corev1.VolumeMount{{
 			Name:      emptyDirVolumeName,

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +56,7 @@ func anexiaDeploymentCreator(data *resources.TemplateData) reconciling.NamedDepl
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:1.4.4",
+					Image: registry.Must(data.RewriteImage(resources.RegistryAnexia + "/anexia/anx-cloud-controller-manager:1.4.4")),
 					Command: []string{
 						"/app/ccm",
 						"--cloud-provider=anexia",

--- a/pkg/resources/cloudcontroller/aws.go
+++ b/pkg/resources/cloudcontroller/aws.go
@@ -22,6 +22,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -93,7 +94,7 @@ func awsDeploymentCreator(data *resources.TemplateData) reconciling.NamedDeploym
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    ccmContainerName,
-					Image:   data.ImageRegistry(resources.RegistryK8S) + "/provider-aws/cloud-controller-manager:" + ccmVersion,
+					Image:   registry.Must(data.RewriteImage(resources.RegistryK8S + "/provider-aws/cloud-controller-manager:" + ccmVersion)),
 					Command: flags,
 					Env: append(
 						getEnvVars(),

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -22,6 +22,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -85,7 +86,7 @@ func azureDeploymentCreator(data *resources.TemplateData) reconciling.NamedDeplo
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        data.ImageRegistry(resources.RegistryMCR) + "/oss/kubernetes/azure-cloud-controller-manager:v" + version,
+					Image:        registry.Must(data.RewriteImage(resources.RegistryMCR + "/oss/kubernetes/azure-cloud-controller-manager:v" + version)),
 					Command:      []string{"cloud-controller-manager"},
 					Args:         getAzureFlags(data),
 					Env:          getEnvVars(),

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -79,7 +80,7 @@ func hetznerDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: data.ImageRegistry(resources.RegistryDocker) + "/hetznercloud/hcloud-cloud-controller-manager:" + hetznerCCMVersion,
+					Image: registry.Must(data.RewriteImage(resources.RegistryDocker + "/hetznercloud/hcloud-cloud-controller-manager:" + hetznerCCMVersion)),
 					Command: []string{
 						"/bin/hcloud-cloud-controller-manager",
 						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -22,6 +22,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +103,7 @@ func kubevirtDeploymentCreator(data *resources.TemplateData) reconciling.NamedDe
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/kubevirt-cloud-controller-manager:" + KubeVirtCCMTag,
+					Image:        registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/kubevirt-cloud-controller-manager:" + KubeVirtCCMTag)),
 					Command:      []string{"/bin/kubevirt-cloud-controller-manager"},
 					Args:         getKVFlags(data),
 					Env:          getEnvVars(),

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -22,6 +22,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -85,7 +86,7 @@ func openStackDeploymentCreator(data *resources.TemplateData) reconciling.NamedD
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        data.ImageRegistry(resources.RegistryDocker) + "/k8scloudprovider/openstack-cloud-controller-manager:v" + version,
+					Image:        registry.Must(data.RewriteImage(resources.RegistryDocker + "/k8scloudprovider/openstack-cloud-controller-manager:v" + version)),
 					Command:      []string{"/bin/openstack-cloud-controller-manager"},
 					Args:         getOSFlags(data),
 					Env:          getEnvVars(),

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -17,11 +17,10 @@ limitations under the License.
 package cloudcontroller
 
 import (
-	"fmt"
-
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -90,7 +89,7 @@ func vsphereDeploymentCreator(data *resources.TemplateData) reconciling.NamedDep
 }
 
 func getVSphereCCMContainer(version string, data *resources.TemplateData) corev1.Container {
-	controllerManagerImage := fmt.Sprintf("%s/cloud-provider-vsphere/cpi/release/manager:v%s", data.ImageRegistry(resources.RegistryGCR), version)
+	controllerManagerImage := registry.Must(data.RewriteImage(resources.RegistryGCR + "/cloud-provider-vsphere/cpi/release/manager:v" + version))
 	c := corev1.Container{
 		Name:  ccmContainerName,
 		Image: controllerManagerImage,

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudconfig"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -151,7 +152,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ControllerManagerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-controller-manager:v" + version.String(),
+					Image:   registry.Must(data.RewriteImage(resources.RegistryK8S + "/kube-controller-manager:v" + version.String())),
 					Command: []string{"/usr/local/bin/kube-controller-manager"},
 					Args:    flags,
 					Env:     envVars,

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -374,7 +374,7 @@ func (d *TemplateData) GetLegacyOverwriteRegistry() string {
 	return d.OverwriteRegistry
 }
 
-// ImageRewriter returns a Docker image rewriter
+// ImageRewriter returns a Docker image rewriter.
 func (d *TemplateData) ImageRewriter() registry.ImageRewriter {
 	return registry.GetImageRewriterFunc(d.OverwriteRegistry)
 }

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	semverlib "github.com/Masterminds/semver/v3"
-	"github.com/distribution/distribution/v3/reference"
 	"go.uber.org/zap"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -38,6 +37,7 @@ import (
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -258,7 +258,7 @@ func (d *TemplateData) EtcdDiskSize() resource.Quantity {
 }
 
 func (d *TemplateData) EtcdLauncherImage() string {
-	return d.parseImage(d.etcdLauncherImage)
+	return registry.Must(d.RewriteImage(d.etcdLauncherImage))
 }
 
 func (d *TemplateData) EtcdLauncherTag() string {
@@ -368,12 +368,20 @@ func (d *TemplateData) ProviderName() string {
 	return p
 }
 
-// ImageRegistry returns the image registry to use or the passed in default if no override is specified.
-func (d *TemplateData) ImageRegistry(defaultRegistry string) string {
-	if d.OverwriteRegistry != "" {
-		return d.OverwriteRegistry
-	}
-	return defaultRegistry
+// GetLegacyOverwriteRegistry should not be used by new code, rather the
+// ImageRewriter() should be used instead.
+func (d *TemplateData) GetLegacyOverwriteRegistry() string {
+	return d.OverwriteRegistry
+}
+
+// ImageRewriter returns a Docker image rewriter
+func (d *TemplateData) ImageRewriter() registry.ImageRewriter {
+	return registry.GetImageRewriterFunc(d.OverwriteRegistry)
+}
+
+// RewriteImage rewrites a Docker image to apply a custom registry if specified.
+func (d *TemplateData) RewriteImage(image string) (string, error) {
+	return d.ImageRewriter()(image)
 }
 
 // GetRootCA returns the root CA of the cluster.
@@ -453,22 +461,7 @@ func (d *TemplateData) NodeLocalDNSCacheEnabled() bool {
 }
 
 func (d *TemplateData) KubermaticAPIImage() string {
-	return d.parseImage(d.kubermaticImage)
-}
-
-func (d *TemplateData) parseImage(image string) string {
-	named, _ := reference.ParseNormalizedNamed(image)
-	domain := reference.Domain(named)
-	remainder := reference.Path(named)
-
-	if d.OverwriteRegistry != "" {
-		domain = d.OverwriteRegistry
-	}
-	if domain == "" {
-		domain = RegistryDocker
-	}
-
-	return domain + "/" + remainder
+	return registry.Must(d.RewriteImage(d.kubermaticImage))
 }
 
 func (d *TemplateData) KubermaticDockerTag() string {
@@ -476,7 +469,7 @@ func (d *TemplateData) KubermaticDockerTag() string {
 }
 
 func (d *TemplateData) DNATControllerImage() string {
-	return d.parseImage(d.dnatControllerImage)
+	return registry.Must(d.RewriteImage(d.dnatControllerImage))
 }
 
 func (d *TemplateData) BackupSchedule() time.Duration {

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -24,6 +24,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -82,7 +83,7 @@ func ServiceCreator() reconciling.NamedServiceCreatorGetter {
 type deploymentCreatorData interface {
 	Cluster() *kubermaticv1.Cluster
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 	IsKonnectivityEnabled() bool
 }
 
@@ -119,7 +120,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 				{
 					Name: resources.DNSResolverDeploymentName,
 					// like etcd, this component follows the apiserver version and not the controller-manager version
-					Image: data.ImageRegistry(resources.RegistryK8S) + "/" + GetCoreDNSImage(data.Cluster().Status.Versions.Apiserver.Semver()),
+					Image: registry.Must(data.RewriteImage(resources.RegistryK8S + "/" + GetCoreDNSImage(data.Cluster().Status.Versions.Apiserver.Semver()))),
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/resources/encryption/job.go
+++ b/pkg/resources/encryption/job.go
@@ -22,6 +22,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +48,7 @@ done
 )
 
 type encryptionData interface {
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 }
 
 func EncryptionJobCreator(data encryptionData, cluster *kubermaticv1.Cluster, secret *corev1.Secret, res []string, key string) batchv1.Job {
@@ -74,7 +75,7 @@ func EncryptionJobCreator(data encryptionData, cluster *kubermaticv1.Cluster, se
 					Containers: []corev1.Container{
 						{
 							Name:    "encryption-runner",
-							Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/util:2.2.0",
+							Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.2.0")),
 							Command: []string{"/bin/bash", "-c"},
 							Args: []string{
 								fmt.Sprintf(encryptionJobScript, resourceList),

--- a/pkg/resources/etcd/etcdrunning/etcdrunning.go
+++ b/pkg/resources/etcd/etcdrunning/etcdrunning.go
@@ -23,19 +23,20 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/etcd"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	corev1 "k8s.io/api/core/v1"
 )
 
 type etcdRunningData interface {
-	ImageRegistry(defaultRegistry string) string
+	RewriteImage(string) (string, error)
 	Cluster() *kubermaticv1.Cluster
 }
 
 func Container(etcdEndpoints []string, data etcdRunningData) corev1.Container {
 	return corev1.Container{
 		Name:  "etcd-running",
-		Image: data.ImageRegistry(resources.RegistryGCR) + "/etcd-development/etcd:" + etcd.ImageTag(data.Cluster()),
+		Image: registry.Must(data.RewriteImage(resources.RegistryGCR + "/etcd-development/etcd:" + etcd.ImageTag(data.Cluster()))),
 		Command: []string{
 			"/bin/sh",
 			"-ec",

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -48,7 +49,7 @@ func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Cont
 
 	return &corev1.Container{
 		Name:            resources.KonnectivityServerContainer,
-		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryEUGCR), name, version),
+		Image:           registry.Must(data.RewriteImage(fmt.Sprintf("%s/%s:%s", resources.RegistryEUGCR, name, version))),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/proxy-server",

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -23,6 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -61,7 +62,7 @@ const (
 type kubernetesDashboardData interface {
 	Cluster() *kubermaticv1.Cluster
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 }
 
 // DeploymentCreator returns the function to create and update the Kubernetes Dashboard deployment.
@@ -132,7 +133,7 @@ func getContainers(data kubernetesDashboardData, existingContainers []corev1.Con
 
 	return []corev1.Container{{
 		Name:            name,
-		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryDocker), imageName, tag),
+		Image:           registry.Must(data.RewriteImage(fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, imageName, tag))),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/dashboard"},
 		Args: []string{

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -22,6 +22,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -85,7 +86,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-state-metrics/kube-state-metrics:" + version,
+					Image:   registry.Must(data.RewriteImage(resources.RegistryK8S + "/kube-state-metrics/kube-state-metrics:" + version)),
 					Command: []string{"/kube-state-metrics"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -25,6 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,7 +58,7 @@ const (
 type machinecontrollerData interface {
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
 	GetGlobalSecretKeySelectorValue(configVar *providerconfig.GlobalSecretKeySelector, key string) (string, error)
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 	Cluster() *kubermaticv1.Cluster
 	ClusterIPByServiceName(string) (string, error)
 	DC() *kubermaticv1.Datacenter
@@ -135,7 +136,7 @@ func DeploymentCreatorWithoutInitWrapper(data machinecontrollerData) reconciling
 
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 
-			repository := data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/machine-controller"
+			repository := registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/machine-controller"))
 			if r := data.MachineControllerImageRepository(); r != "" {
 				repository = r
 			}

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -25,6 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -102,7 +103,7 @@ func WebhookDeploymentCreator(data machinecontrollerData) reconciling.NamedDeplo
 
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 
-			repository := data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/machine-controller"
+			repository := registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/machine-controller"))
 			if r := data.MachineControllerImageRepository(); r != "" {
 				repository = r
 			}

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -25,6 +25,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/servingcerthelper"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -63,7 +64,7 @@ type metricsServerData interface {
 	Cluster() *kubermaticv1.Cluster
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
 	GetRootCA() (*triple.KeyPair, error)
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 	DNATControllerImage() string
 	DNATControllerTag() string
 	NodeAccessNetwork() string
@@ -112,7 +113,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryK8S) + "/metrics-server/metrics-server:" + tag,
+					Image:   registry.Must(data.RewriteImage(resources.RegistryK8S + "/metrics-server/metrics-server:" + tag)),
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -26,6 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -60,7 +61,7 @@ type operatingSystemManagerData interface {
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
 	GetGlobalSecretKeySelectorValue(configVar *providerconfig.GlobalSecretKeySelector, key string) (string, error)
 	Cluster() *kubermaticv1.Cluster
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 	NodeLocalDNSCacheEnabled() bool
 	GetCSIMigrationFeatureGates() []string
 	DC() *kubermaticv1.Datacenter
@@ -154,7 +155,7 @@ func DeploymentCreatorWithoutInitWrapper(data operatingSystemManagerData) reconc
 				nodePortRange:    data.ComputedNodePortRange(),
 			}
 
-			repository := data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/operating-system-manager"
+			repository := registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/operating-system-manager"))
 			if r := data.OperatingSystemManagerImageRepository(); r != "" {
 				repository = r
 			}

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -98,7 +99,7 @@ func StatefulSetCreator(data *resources.TemplateData) reconciling.NamedStatefulS
 			set.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  resources.PrometheusStatefulSetName,
-					Image: data.ImageRegistry(resources.RegistryQuay) + "/prometheus/prometheus:" + tag,
+					Image: registry.Must(data.RewriteImage(resources.RegistryQuay + "/prometheus/prometheus:" + tag)),
 					Args: []string{
 						"--config.file=/etc/prometheus/config/prometheus.yaml",
 						"--storage.tsdb.path=/var/prometheus/data",

--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -17,17 +17,82 @@ limitations under the License.
 // Package registry groups all container registry related types and helpers in one place.
 package registry
 
+import (
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+	"k8c.io/kubermatic/v2/pkg/resources"
+)
+
 // WithOverwriteFunc is a function that takes a string and either returns that string or a defined override value.
 type WithOverwriteFunc func(string) string
 
 // GetOverwriteFunc returns a WithOverwriteFunc based on the given override value.
 func GetOverwriteFunc(overwriteRegistry string) WithOverwriteFunc {
-	if overwriteRegistry != "" {
-		return func(string) string {
-			return overwriteRegistry
+	if overwriteRegistry == "" {
+		return func(s string) string {
+			return s
 		}
 	}
-	return func(s string) string {
-		return s
+
+	return func(_ string) string {
+		return overwriteRegistry
 	}
+}
+
+// ImageRewriter is a function that takes a Docker image reference
+// (for example "docker.io/repo/image:tag@sha256:abc123") and
+// potentially changes the registry to point to a local registry.
+// It's a distinct type from WithOverwriteFunc as it does not just
+// work on a registry, but a full image reference.
+type ImageRewriter func(string) (string, error)
+
+// GetImageRewriterFunc returns a ImageRewriter that will apply the given
+// overwriteRegistry to a given docker image reference.
+func GetImageRewriterFunc(overwriteRegistry string) ImageRewriter {
+	return func(image string) (string, error) {
+		return RewriteImage(image, overwriteRegistry)
+	}
+}
+
+// RewriteImage will apply the given overwriteRegistry to a given docker
+// image reference.
+func RewriteImage(image, overwriteRegistry string) (string, error) {
+	named, err := reference.ParseNormalizedNamed(image)
+	if err != nil {
+		return "", fmt.Errorf("invalid reference %q: %w", image, err)
+	}
+
+	domain := reference.Domain(named)
+	origDomain := domain
+	if origDomain == "" {
+		origDomain = resources.RegistryDocker
+	}
+
+	if overwriteRegistry != "" {
+		domain = overwriteRegistry
+	}
+	if domain == "" {
+		domain = resources.RegistryDocker
+	}
+
+	// construct name image name
+	image = domain + "/" + reference.Path(named)
+
+	if tagged, ok := named.(reference.Tagged); ok {
+		image += ":" + tagged.Tag()
+	}
+
+	// If the registry (domain) has been changed, remove the
+	// digest as it's unlikely that a) the repo digest has
+	// been kept when mirroring the image and b) the chance
+	// of a local registry being poisoned with bad images is
+	// much lower anyhow.
+	if origDomain == domain {
+		if digested, ok := named.(reference.Digested); ok {
+			image += "@" + string(digested.Digest())
+		}
+	}
+
+	return image, nil
 }

--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -21,13 +21,27 @@ import (
 	"fmt"
 
 	"github.com/docker/distribution/reference"
-	"k8c.io/kubermatic/v2/pkg/resources"
 )
+
+const (
+	// RegistryDocker exists to prevent an import loop between the resources and this package.
+	RegistryDocker = "docker.io"
+)
+
+func Must(s string, err error) string {
+	if err != nil {
+		panic(err)
+	}
+
+	return s
+}
 
 // WithOverwriteFunc is a function that takes a string and either returns that string or a defined override value.
 type WithOverwriteFunc func(string) string
 
 // GetOverwriteFunc returns a WithOverwriteFunc based on the given override value.
+// This function is deprecated and should not be used anymore. Use the much more
+// flexible GetImageRewriterFunc instead.
 func GetOverwriteFunc(overwriteRegistry string) WithOverwriteFunc {
 	if overwriteRegistry == "" {
 		return func(s string) string {
@@ -66,14 +80,14 @@ func RewriteImage(image, overwriteRegistry string) (string, error) {
 	domain := reference.Domain(named)
 	origDomain := domain
 	if origDomain == "" {
-		origDomain = resources.RegistryDocker
+		origDomain = RegistryDocker
 	}
 
 	if overwriteRegistry != "" {
 		domain = overwriteRegistry
 	}
 	if domain == "" {
-		domain = resources.RegistryDocker
+		domain = RegistryDocker
 	}
 
 	// construct name image name

--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -40,7 +40,7 @@ func Must(s string, err error) string {
 type WithOverwriteFunc func(string) string
 
 // GetOverwriteFunc returns a WithOverwriteFunc based on the given override value.
-// This function is deprecated and should not be used anymore. Use the much more
+// Deprecated: This function should not be used anymore. Use the much more
 // flexible GetImageRewriterFunc instead.
 func GetOverwriteFunc(overwriteRegistry string) WithOverwriteFunc {
 	if overwriteRegistry == "" {

--- a/pkg/resources/registry/registry.go
+++ b/pkg/resources/registry/registry.go
@@ -20,7 +20,7 @@ package registry
 import (
 	"fmt"
 
-	"github.com/docker/distribution/reference"
+	"github.com/distribution/distribution/v3/reference"
 )
 
 const (

--- a/pkg/resources/registry/registry_test.go
+++ b/pkg/resources/registry/registry_test.go
@@ -56,7 +56,7 @@ func TestImageRewriter(t *testing.T) {
 			expected:  addDigest("docker.io/foo/bar:v1.2.3"),
 		},
 		{
-			name:      "untagged digests are kept if the registry is unchanged (with default registy)",
+			name:      "untagged digests are kept if the registry is unchanged (with default registry)",
 			overwrite: "",
 			input:     addDigest("foo/bar"),
 			expected:  addDigest("docker.io/foo/bar"),

--- a/pkg/resources/registry/registry_test.go
+++ b/pkg/resources/registry/registry_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package registry groups all container registry related types and helpers in one place.
+package registry
+
+import (
+	"testing"
+)
+
+func TestImageRewriter(t *testing.T) {
+	addDigest := func(s string) string {
+		return s + "@sha256:0b2f19895de281e4a416700b17a4dc9b8d3b80eb7b5b65dac173880f5113084e"
+	}
+
+	testcases := []struct {
+		name      string
+		overwrite string
+		input     string
+		expected  string
+	}{
+		{
+			name:      "default registry is applied",
+			overwrite: "",
+			input:     "foo/bar",
+			expected:  "docker.io/foo/bar",
+		},
+		{
+			name:      "tags are kept",
+			overwrite: "",
+			input:     "foo/bar:v1.2.3",
+			expected:  "docker.io/foo/bar:v1.2.3",
+		},
+		{
+			name:      "digests are kept if the registry is unchanged (with default registry)",
+			overwrite: "",
+			input:     addDigest("foo/bar:v1.2.3"),
+			expected:  addDigest("docker.io/foo/bar:v1.2.3"),
+		},
+		{
+			name:      "digests are kept if the registry is unchanged",
+			overwrite: "",
+			input:     addDigest("docker.io/foo/bar:v1.2.3"),
+			expected:  addDigest("docker.io/foo/bar:v1.2.3"),
+		},
+		{
+			name:      "untagged digests are kept if the registry is unchanged (with default registy)",
+			overwrite: "",
+			input:     addDigest("foo/bar"),
+			expected:  addDigest("docker.io/foo/bar"),
+		},
+		{
+			name:      "untagged digests are kept if the registry is unchanged",
+			overwrite: "",
+			input:     addDigest("docker.io/foo/bar"),
+			expected:  addDigest("docker.io/foo/bar"),
+		},
+		{
+			name:      "images can survive unchanged",
+			overwrite: "",
+			input:     "docker.io/foo/bar",
+			expected:  "docker.io/foo/bar",
+		},
+		{
+			name:      "a registry overwrite is applied",
+			overwrite: "registry.local",
+			input:     "docker.io/foo/bar",
+			expected:  "registry.local/foo/bar",
+		},
+		{
+			name:      "a registry overwrite will remove the digest",
+			overwrite: "registry.local",
+			input:     addDigest("docker.io/foo/bar:v1.2.3"),
+			expected:  "registry.local/foo/bar:v1.2.3",
+		},
+		{
+			name:      "a NOP rewrite should keep the digest",
+			overwrite: "registry.local",
+			input:     addDigest("registry.local/foo/bar:v1.2.3"),
+			expected:  addDigest("registry.local/foo/bar:v1.2.3"),
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			rewriter := GetImageRewriterFunc(testcase.overwrite)
+
+			output, err := rewriter(testcase.input)
+			if err != nil {
+				t.Fatalf("Expected no error, but got: %v", err)
+			}
+
+			if output != testcase.expected {
+				t.Fatalf("Expected %q to write to %q (with overwrite %q), but got %q.", testcase.input, testcase.expected, testcase.overwrite, output)
+			}
+		})
+	}
+}

--- a/pkg/resources/registry/registry_test.go
+++ b/pkg/resources/registry/registry_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package registry groups all container registry related types and helpers in one place.
 package registry
 
 import (

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -24,6 +24,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -136,7 +137,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.SchedulerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-scheduler:v" + version.String(),
+					Image:   registry.Must(data.RewriteImage(resources.RegistryK8S + "/kube-scheduler:v" + version.String())),
 					Command: []string{"/usr/local/bin/kube-scheduler"},
 					Args:    flags,
 					Env: []corev1.EnvVar{

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -53,7 +53,7 @@ var (
 )
 
 type webhookData interface {
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 	Cluster() *kubermaticv1.Cluster
 	DC() *kubermaticv1.Datacenter
 	KubermaticAPIImage() string

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -61,7 +61,8 @@ const name = "usercluster-controller"
 // easier as only have to implement the parts that are actually in use.
 type userclusterControllerData interface {
 	GetPodTemplateLabels(string, []corev1.Volume, map[string]string) (map[string]string, error)
-	ImageRegistry(string) string
+	GetLegacyOverwriteRegistry() string
+	RewriteImage(string) (string, error)
 	Cluster() *kubermaticv1.Cluster
 	NodeLocalDNSCacheEnabled() bool
 	GetOpenVPNServerPort() (int32, error)
@@ -142,7 +143,7 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				"-cluster-url", address.URL,
 				"-cluster-name", data.Cluster().Name,
 				"-dns-cluster-ip", dnsClusterIP,
-				"-overwrite-registry", data.ImageRegistry(""),
+				"-overwrite-registry", data.GetLegacyOverwriteRegistry(),
 				"-version", data.Cluster().Status.Versions.ControlPlane.String(),
 				"-application-cache", resources.ApplicationCacheMountPath,
 				fmt.Sprintf("-enable-ssh-key-agent=%t", *enableUserSSHKeyAgent),

--- a/pkg/resources/vpnsidecar/dnatController.go
+++ b/pkg/resources/vpnsidecar/dnatController.go
@@ -37,7 +37,6 @@ var (
 )
 
 type dnatControllerData interface {
-	ImageRegistry(string) string
 	NodeAccessNetwork() string
 	DNATControllerImage() string
 	DNATControllerTag() string

--- a/pkg/resources/vpnsidecar/openvpnClient.go
+++ b/pkg/resources/vpnsidecar/openvpnClient.go
@@ -19,6 +19,7 @@ package vpnsidecar
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -38,7 +39,7 @@ var (
 )
 
 type openvpnData interface {
-	ImageRegistry(string) string
+	RewriteImage(string) (string, error)
 	Cluster() *kubermaticv1.Cluster
 }
 
@@ -50,7 +51,7 @@ type openvpnData interface {
 func OpenVPNSidecarContainer(data openvpnData, name string) (*corev1.Container, error) {
 	return &corev1.Container{
 		Name:    name,
-		Image:   data.ImageRegistry(resources.RegistryQuay) + "/kubermatic/openvpn:v2.5.2-r0",
+		Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/openvpn:v2.5.2-r0")),
 		Command: []string{"/usr/sbin/openvpn"},
 		Args: []string{
 			"--client",

--- a/pkg/test/e2e/expose-strategy/agent.go
+++ b/pkg/test/e2e/expose-strategy/agent.go
@@ -125,7 +125,7 @@ func (a *AgentConfig) newAgentConfigMap(ns string) *corev1.ConfigMap {
 
 // newAgnhostPod returns a pod returns the manifest of the agent pod.
 func (a *AgentConfig) newAgentPod(ns string) *corev1.Pod {
-	agentName, createDaemonSet := envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), a.Versions, "", registry.GetOverwriteFunc(""))()
+	agentName, createDaemonSet := envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), a.Versions, "", registry.GetImageRewriterFunc(""))()
 	// TODO: errors should never be thrown here
 	ds, _ := createDaemonSet(&appsv1.DaemonSet{})
 	// We don't need the init containers in this context.

--- a/pkg/test/e2e/expose-strategy/agent.go
+++ b/pkg/test/e2e/expose-strategy/agent.go
@@ -126,8 +126,12 @@ func (a *AgentConfig) newAgentConfigMap(ns string) *corev1.ConfigMap {
 // newAgnhostPod returns a pod returns the manifest of the agent pod.
 func (a *AgentConfig) newAgentPod(ns string) *corev1.Pod {
 	agentName, createDaemonSet := envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), a.Versions, "", registry.GetImageRewriterFunc(""))()
-	// TODO: errors should never be thrown here
-	ds, _ := createDaemonSet(&appsv1.DaemonSet{})
+
+	ds, err := createDaemonSet(&appsv1.DaemonSet{})
+	if err != nil {
+		panic(err)
+	}
+
 	// We don't need the init containers in this context.
 	ds.Spec.Template.Spec.InitContainers = []corev1.Container{}
 	// We don't use host network

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -73,7 +73,7 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 		Log:       logger,
 		Client:    seedClient,
 		Namespace: cluster.Status.NamespaceName,
-		Versions:  kubermatic.NewDefaultVersions(),
+		Versions:  kubermatic.NewFakeVersions(),
 	}
 	if err := agentConfig.DeployAgentPod(ctx); err != nil {
 		t.Fatalf("Failed to deploy agent: %v", err)

--- a/pkg/version/kubermatic/versions.go
+++ b/pkg/version/kubermatic/versions.go
@@ -72,7 +72,7 @@ func NewFakeVersions() Versions {
 		Kubermatic:        "v0.0.0-test",
 		UI:                "v1.1.1-test",
 		VPA:               "0.5.0",
-		Envoy:             "v1.16.0",
+		Envoy:             "v1.17.1",
 		KubermaticEdition: edition.KubermaticEdition,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
When mirroring images into a local registry, it's very easy to alter the RepoDigest of an image. This will lead to problems with custom registries in KKP, as an image like

```
quay.io/cilium/cilium:v1.11.10@sha256:abc123
```

gets rewritten to

```
myregistry.initech.local/cilium/cilium:v1.11.10@sha256:abc123
```

but the image on the local registry might have another repo digest.

There are supposedly ways around this ([crane](https://github.com/google/go-containerregistry/tree/main/cmd/crane)?), but until those are implemented in KKP (in the `mirror-images` command) and to not force admins to follow a special procedure when mirroring images, this PR extends our registry overwrite mechanism.

Previously we would only take the registry itself into account, but with the new code, we look at and rewrite the entire Docker image (so `quay.io/kubermatic/foo:v1.2.3` instead of just `quay.io`). This allows the rewriting mechanism to behave smarter and -- for now -- always drop the digest if a local registry is used.

In the future we might make this configurable (e.g. adding an `keepImageDigests` option somewhere), but for now we drop the digest always when changing registries. The chances of a local registry getting poisoned with bad images is much smaller than with a public registry anyway.

The signature is `func(string) (string, error)`, which made all the creators a bit more tedious to write, but my thought was that the function can be used on user-supplied input where catching the error might be important. But in all cases in KKP, the images and tags are basically hardcoded, so for now I added a `Must()` helper to panic in cases that the hardcoded values are malformed.

**What type of PR is this?**
/kind bug
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Repo Digests are now dropped when a docker image is changed by using the overwrite-registry mechanism. Previously kept digests could lead to issues with mirrored Docker images.
```

**Documentation**:
```documentation
NONE
```
