### PR TITLE
Re-enable k8s dashboard and add konnectivity images to `mirror-images`

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -231,7 +231,6 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 							return fmt.Errorf("failed to get images: %w", err)
 						}
 						imageSet.Insert(imagesWithKonnectivity...)
-
 					}
 				}
 			}

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/zap"
 
 	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/install/images"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
@@ -197,11 +198,12 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 					)
 
 					versionLogger.Debug("Collecting images…")
-					images, err := images.GetImagesForVersion(
+					imagesWithoutKonnectivity, err := images.GetImagesForVersion(
 						versionLogger,
 						clusterVersion,
 						cloudSpec,
 						cniPlugin,
+						false,
 						kubermaticConfig,
 						options.AddonsPath,
 						versions,
@@ -210,7 +212,27 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 					if err != nil {
 						return fmt.Errorf("failed to get images: %w", err)
 					}
-					imageSet.Insert(images...)
+					imageSet.Insert(imagesWithoutKonnectivity...)
+
+					if kubermaticConfig.Spec.FeatureGates[features.KonnectivityService] {
+						imagesWithKonnectivity, err := images.GetImagesForVersion(
+							versionLogger,
+							clusterVersion,
+							cloudSpec,
+							cniPlugin,
+							true,
+							kubermaticConfig,
+							options.AddonsPath,
+							versions,
+							caBundle,
+						)
+
+						if err != nil {
+							return fmt.Errorf("failed to get images: %w", err)
+						}
+						imageSet.Insert(imagesWithKonnectivity...)
+
+					}
 				}
 			}
 		}

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -34,6 +34,7 @@ import (
 	kubernetescontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/monitoring"
+	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity"
 	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
@@ -43,6 +44,7 @@ import (
 	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	ksemver "k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/version"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
@@ -56,6 +58,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -105,8 +108,8 @@ func ProcessImages(ctx context.Context, log logrus.FieldLogger, dockerBinary str
 	return nil
 }
 
-func GetImagesForVersion(log logrus.FieldLogger, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, config *kubermaticv1.KubermaticConfiguration, addonsPath string, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (images []string, err error) {
-	templateData, err := getTemplateData(config, clusterVersion, cloudSpec, cniPlugin, kubermaticVersions, caBundle)
+func GetImagesForVersion(log logrus.FieldLogger, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, konnectivityEnabled bool, config *kubermaticv1.KubermaticConfiguration, addonsPath string, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (images []string, err error) {
+	templateData, err := getTemplateData(config, clusterVersion, cloudSpec, cniPlugin, konnectivityEnabled, kubermaticVersions, caBundle)
 	if err != nil {
 		return nil, err
 	}
@@ -149,8 +152,12 @@ func getImagesFromCreators(log logrus.FieldLogger, templateData *resources.Templ
 	deploymentCreators = append(deploymentCreators, mla.GatewayDeploymentCreator(templateData, nil))
 	deploymentCreators = append(deploymentCreators, operatingsystemmanager.DeploymentCreator(templateData))
 
-	if val, ok := templateData.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider]; ok && val {
+	if templateData.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 		deploymentCreators = append(deploymentCreators, cloudcontroller.DeploymentCreator(templateData))
+	}
+
+	if templateData.IsKonnectivityEnabled() {
+		deploymentCreators = append(deploymentCreators, konnectivity.DeploymentCreator("dummy", 0, registry.GetOverwriteFunc(templateData.OverwriteRegistry)))
 	}
 
 	cronjobCreators := kubernetescontroller.GetCronJobCreators(templateData)
@@ -213,7 +220,7 @@ func getImagesFromPodSpec(spec corev1.PodSpec) (images []string) {
 	return images
 }
 
-func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (*resources.TemplateData, error) {
+func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersion *version.Version, cloudSpec kubermaticv1.CloudSpec, cniPlugin *kubermaticv1.CNIPluginSettings, konnectivityEnabled bool, kubermaticVersions kubermatic.Versions, caBundle resources.CABundle) (*resources.TemplateData, error) {
 	// We need listers and a set of objects to not have our deployment/statefulset creators fail
 	caBundleConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -245,9 +252,15 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 			Namespace: mockNamespaceName,
 		},
 	}
-	admissionControlConfigMapName := corev1.ConfigMap{
+	admissionControlConfigMap := corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resources.AdmissionControlConfigMapName,
+			Namespace: mockNamespaceName,
+		},
+	}
+	konnectivityKubeApiserverEgressConfigMap := corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.KonnectivityKubeApiserverEgress,
 			Namespace: mockNamespaceName,
 		},
 	}
@@ -258,7 +271,8 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 			dnsResolverConfigMap,
 			openvpnClientConfigsConfigMap,
 			auditConfigMap,
-			admissionControlConfigMapName,
+			admissionControlConfigMap,
+			konnectivityKubeApiserverEgressConfigMap,
 		},
 	}
 	apiServerService := corev1.Service{
@@ -291,11 +305,23 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 			ClusterIP: "192.0.2.11",
 		},
 	}
+	konnectivityService := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.KonnectivityProxyServiceName,
+			Namespace: mockNamespaceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:     []corev1.ServicePort{{Name: "secure", Port: 443, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(8132)}},
+			ClusterIP: "192.0.2.20",
+		},
+	}
+
 	serviceList := &corev1.ServiceList{
 		Items: []corev1.Service{
 			apiServerService,
 			openvpnserverService,
 			dnsService,
+			konnectivityService,
 		},
 	}
 	secretList := createNamedSecrets([]string{
@@ -328,6 +354,8 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		resources.AdminKubeconfigSecretName,
 		resources.GatekeeperWebhookServerCertSecretName,
 		resources.OperatingSystemManagerKubeconfigSecretName,
+		resources.KonnectivityKubeconfigSecretName,
+		resources.KonnectivityProxyTLSSecretName,
 	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{
@@ -353,6 +381,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 	fakeCluster.Spec.ClusterNetwork.Pods.CIDRBlocks = []string{"172.25.0.0/16"}
 	fakeCluster.Spec.ClusterNetwork.Services.CIDRBlocks = []string{"10.10.10.0/24"}
 	fakeCluster.Spec.ClusterNetwork.DNSDomain = "cluster.local"
+	fakeCluster.Spec.ClusterNetwork.KonnectivityEnabled = pointer.Bool(konnectivityEnabled)
 	fakeCluster.Spec.CNIPlugin = cniPlugin
 
 	if fakeCluster.Spec.Cloud.Openstack != nil || fakeCluster.Spec.Cloud.Hetzner != nil || fakeCluster.Spec.Cloud.Azure != nil || fakeCluster.Spec.Cloud.VSphere != nil || fakeCluster.Spec.Cloud.Anexia != nil {
@@ -365,7 +394,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 	fakeCluster.Spec.EnableUserSSHKeyAgent = pointer.Bool(true)
 	fakeCluster.Spec.EnableOperatingSystemManager = pointer.Bool(true)
 	fakeCluster.Spec.KubernetesDashboard = &kubermaticv1.KubernetesDashboard{
-		Enabled: false,
+		Enabled: true,
 	}
 
 	fakeCluster.Status.NamespaceName = mockNamespaceName
@@ -392,6 +421,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		WithFailureDomainZoneAntiaffinity(false).
 		WithVersions(kubermaticVersions).
 		WithCABundle(caBundle).
+		WithKonnectivityEnabled(konnectivityEnabled).
 		Build(), nil
 }
 

--- a/pkg/install/images/images_test.go
+++ b/pkg/install/images/images_test.go
@@ -52,7 +52,7 @@ func TestRetagImageForAllVersions(t *testing.T) {
 	for _, clusterVersion := range clusterVersions {
 		for _, cloudSpec := range GetCloudSpecs() {
 			for _, cniPlugin := range GetCNIPlugins() {
-				images, err := GetImagesForVersion(log, clusterVersion, cloudSpec, cniPlugin, config, addonPath, kubermaticVersions, caBundle)
+				images, err := GetImagesForVersion(log, clusterVersion, cloudSpec, cniPlugin, false, config, addonPath, kubermaticVersions, caBundle)
 				if err != nil {
 					t.Errorf("Error calling getImagesForVersion: %v", err)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds konnectivity images to the images mirrored by `kubermatic-installer mirror-images`, if konnectivity as a feature is enabled on the passed `KubermaticConfiguration`.

In addition, it fixes a regression introduced by #10169 (https://github.com/kubermatic/kubermatic/commit/98562df6296a35e40362bd4979f17ce105ce6f6a) that flipped the Kubernetes dashboard from enabled to disabled.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfixes
`kubermatic-installer mirror-images` correctly picks up konnectivity and Kubernetes dashboard images
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
