### PR TITLE
[release/v2.20] Fix CCM e2e Tests

### DIFF
--- a/pkg/test/e2e/ccm-migration/ccm_migration_test.go
+++ b/pkg/test/e2e/ccm-migration/ccm_migration_test.go
@@ -99,16 +99,6 @@ var _ = ginkgo.Describe("CCM migration", func() {
 				return err == nil, nil
 			})).NotTo(gomega.HaveOccurred())
 			clusterJig.Log.Debug("MachineDeployment created")
-
-			clusterJig.Log.Debug("Waiting for node(s) to be ready...")
-			gomega.Expect(wait.Poll(userClusterPollInterval, customTestTimeout, func() (done bool, err error) {
-				ready, err := clusterJig.WaitForNodeToBeReady(userClient)
-				if err != nil {
-					clusterJig.Log.Debug("Failed to check node readiness")
-				}
-				return ready, nil
-			})).NotTo(gomega.HaveOccurred())
-			clusterJig.Log.Debug("Node(s) are ready.")
 		})
 
 		ginkgo.AfterEach(func() {


### PR DESCRIPTION
## What this PR does / why we need it
This should hopefully finally fix the CCM tests that I was constantly being asked to override.

Fixes #10949

/kind chore

### Background Infos

So this is a fun one and I'd like to preface this with a quote from the movie Basketball:

> I think this was a team effort and I believe it took everyone to screw this one up.

It all started in #7349, which originally created the CCM tests. This PR was built around a _non-CI_ script (i.e. not in `hack/ci/`) which was meant to be run locally. That is probably the reason why the PR chose `127.0.0.1.nip.io` as the base domain.

After looking long and hard, I cannot find out how any Openstack node should ever be able to reach the control plane using this base domain. And from running quite a few experiments in this PR (changing the OS image, adjusting various settings to the master branch, etc.), I was able to create working VMs just fine, they would just never join the cluster as nodes.

So fast forward to a month ago and #10927 got merged to supposedly only fix vSphere issues, but we snuck some code for _all_ CCM tests into the 2.20 branch: A check that the nodes actually get ready. And this was the point from which on the CCM tests started to fail.

Since I assumed the PR would only touch vSphere code, I mistakenly `/override` the CCM tests in that backport PR.

So when there were never nodes, how did those tests ever work? Well, they only look at Machine objects, not nodes. The tests only assert certain annotations on machines and do not schedule any workload into the cluster.

So this fact, but the `nip.io` base domain and the fact that back in the day the Prowjob would finish in ~11 minutes (too quickly to actually get Openstack nodes), I conclude that the old Openstack CCM tests never had working nodes in the first place.

Since then the tests were heavily refactored, even though remnants of the tunneling/nip.io stuff still remain (as possible dead code) in the master branch. But importantly, the tests now use NodePort as the expose strategy and hence they actually work (in the master branch, we do check node readiness).

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
