### PR TITLE
fix preset CRD not being synced to seed clusters

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -56,7 +56,7 @@ locationMap='{
   "kubermaticconfigurations.kubermatic.k8c.io": "master,seed",
   "kubermaticsettings.kubermatic.k8c.io": "master",
   "mlaadminsettings.kubermatic.k8c.io": "seed",
-  "presets.kubermatic.k8c.io": "master",
+  "presets.kubermatic.k8c.io": "master,seed",
   "projects.kubermatic.k8c.io": "master,seed",
   "resourcequotas.kubermatic.k8c.io": "master",
   "rulegroups.kubermatic.k8c.io": "master",

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.9.2
-    kubermatic.k8c.io/location: master
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: presets.kubermatic.k8c.io
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
We had the `preset-synchronizer` controller since forever, so it was a mistake to mark Presets as a master-only CRD. This PR fixes that, which will make the operator sync the CRD to the seeds, fixing

> {"level":"error","time":"2022-10-08T21:21:13.513Z","caller":"controller/controller.go:273","msg":"Reconciler error","controller":"kkp-preset-synchronizer","object":{"name":"YYYYYY"},"namespace":"","name":"YYYYYY","reconcileID":"c732f9f5-d1f3-48f8-bb80-5a46c6ec8854","error":"reconciled preset: marvin: failed processing Seed XXXXX: failed to ensure Preset /YYYYYY: failed waiting for the cache to contain our latest changes: timed out waiting for the condition"}

This was caused by the seed simply not knowing about the `projects` field.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
