### PR TITLE
Gatkeeper to 3.7.2

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -639,7 +639,9 @@ func (r *reconciler) reconcileCRDs(ctx context.Context) error {
 			gatekeeper.ConstraintTemplatePodStatusCRDCreator(),
 			gatekeeper.MutatorPodStatusCRDCreator(),
 			gatekeeper.AssignCRDCreator(),
-			gatekeeper.AssignMetadataCRDCreator())
+			gatekeeper.AssignMetadataCRDCreator(),
+			gatekeeper.ModifySetCRDCreator(),
+			gatekeeper.ProviderCRDCreator())
 	}
 
 	if err := reconciling.ReconcileCustomResourceDefinitions(ctx, creators, "", r.Client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
@@ -47,6 +47,12 @@ var (
 
 	//go:embed static/assignmetadata-customresourcedefinition.yaml
 	assignMetadataYAML string
+
+	//go:embed static/modifyset-customresourcedefinition.yaml
+	modifySetYAML string
+
+	//go:embed static/provider-customresourcedefinition.yaml
+	providerYAML string
 )
 
 // ConfigCRDCreator returns the gatekeeper config CRD definition.
@@ -184,6 +190,48 @@ func AssignMetadataCRDCreator() reconciling.NamedCustomResourceDefinitionCreator
 		return resources.GatekeeperAssignMetadataCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
 			var fileCRD *apiextensionsv1.CustomResourceDefinition
 			err := yaml.UnmarshalStrict([]byte(assignMetadataYAML), &fileCRD)
+			if err != nil {
+				return nil, err
+			}
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
+
+			return crd, nil
+		}
+	}
+}
+
+func ModifySetCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
+	return func() (string, reconciling.CustomResourceDefinitionCreator) {
+		return resources.GatekeeperModifySetCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.UnmarshalStrict([]byte(modifySetYAML), &fileCRD)
+			if err != nil {
+				return nil, err
+			}
+
+			crd.Labels = fileCRD.Labels
+			crd.Annotations = fileCRD.Annotations
+			crd.Spec = fileCRD.Spec
+
+			// reconcile fails if conversion is not set as it's set by default to None
+			crd.Spec.Conversion = &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter}
+
+			return crd, nil
+		}
+	}
+}
+
+func ProviderCRDCreator() reconciling.NamedCustomResourceDefinitionCreatorGetter {
+	return func() (string, reconciling.CustomResourceDefinitionCreator) {
+		return resources.GatekeeperProviderCRDName, func(crd *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
+			var fileCRD *apiextensionsv1.CustomResourceDefinition
+			err := yaml.UnmarshalStrict([]byte(providerYAML), &fileCRD)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/deployment.go
@@ -35,7 +35,7 @@ const (
 	controllerName = resources.GatekeeperControllerDeploymentName
 	auditName      = resources.GatekeeperAuditDeploymentName
 	imageName      = "openpolicyagent/gatekeeper"
-	tag            = "v3.6.0"
+	tag            = "v3.7.2"
 	// Namespace used by Dashboard to find required resources.
 	webhookServerPort  = 8443
 	metricsPort        = 8888

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/removal.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/removal.go
@@ -128,6 +128,14 @@ func GetResourcesToRemoveOnDelete() []ctrlruntimeclient.Object {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: resources.GatekeeperAssignMetadataCRDName,
 		}})
+	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperModifySetCRDName,
+		}})
+	toRemove = append(toRemove, &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: resources.GatekeeperProviderCRDName,
+		}})
 	// Namespace
 	toRemove = append(toRemove, &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/assign-customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# Source: https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
+# Source: https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/assign-customresourcedefinition.yaml
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -30,12 +30,16 @@ spec:
               description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
               type: string
             metadata:
+              properties:
+                name:
+                  maxLength: 63
+                  type: string
               type: object
             spec:
               description: AssignSpec defines the desired state of Assign.
               properties:
                 applyTo:
-                  description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "make" to regenerate code after modifying this file'
+                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
                   items:
                     description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
                     properties:
@@ -54,12 +58,15 @@ spec:
                     type: object
                   type: array
                 location:
+                  description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
                   type: string
                 match:
-                  description: Match selects objects to apply mutations to.
+                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
                   properties:
                     excludedNamespaces:
                       items:
+                        description: 'A string that supports globbing at its end.  Ex: "kube-*" will match "kube-system" or "kube-public".  The asterisk is required for wildcard matching.'
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
                         type: string
                       type: array
                     kinds:
@@ -107,6 +114,10 @@ spec:
                           description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                           type: object
                       type: object
+                    name:
+                      description: 'Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix-based glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`.'
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      type: string
                     namespaceSelector:
                       description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
                       properties:
@@ -139,6 +150,8 @@ spec:
                       type: object
                     namespaces:
                       items:
+                        description: 'A string that supports globbing at its end.  Ex: "kube-*" will match "kube-system" or "kube-public".  The asterisk is required for wildcard matching.'
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
                         type: string
                       type: array
                     scope:
@@ -146,13 +159,21 @@ spec:
                       type: string
                   type: object
                 parameters:
+                  description: Parameters define the behavior of the mutator.
                   properties:
                     assign:
                       description: Assign.value holds the value to be assigned
-                      type: object
-                      x-kubernetes-preserve-unknown-fields: true
-                    assignIf:
-                      description: once https://github.com/kubernetes-sigs/controller-tools/pull/528 is merged, we can use an actual object
+                      properties:
+                        fromMetadata:
+                          description: FromMetadata assigns a value from the specified metadata field.
+                          properties:
+                            field:
+                              description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                              type: string
+                          type: object
+                        value:
+                          description: Value is a constant value that will be assigned to `location`
+                          x-kubernetes-preserve-unknown-fields: true
                       type: object
                     pathTests:
                       items:
@@ -184,6 +205,220 @@ spec:
                           description: MutatorError represents a single error caught while adding a mutator to a system.
                           properties:
                             message:
+                              type: string
+                            type:
+                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
+                              type: string
+                          required:
+                            - message
+                          type: object
+                        type: array
+                      id:
+                        type: string
+                      mutatorUID:
+                        description: Storing the mutator UID allows us to detect drift, such as when a mutator has been recreated after its CRD was deleted out from under it, interrupting the watch
+                        type: string
+                      observedGeneration:
+                        format: int64
+                        type: integer
+                      operations:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+              type: object
+          type: object
+      served: true
+      storage: false
+      subresources:
+        status: {}
+    - name: v1beta1
+      schema:
+        openAPIV3Schema:
+          description: Assign is the Schema for the assign API.
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: AssignSpec defines the desired state of Assign.
+              properties:
+                applyTo:
+                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  items:
+                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    properties:
+                      groups:
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                      versions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
+                location:
+                  description: 'Location describes the path to be mutated, for example: `spec.containers[name: main]`.'
+                  type: string
+                match:
+                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
+                  properties:
+                    excludedNamespaces:
+                      items:
+                        description: 'A string that supports globbing at its end.  Ex: "kube-*" will match "kube-system" or "kube-public".  The asterisk is required for wildcard matching.'
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        type: string
+                      type: array
+                    kinds:
+                      items:
+                        description: Kinds accepts a list of objects with apiGroups and kinds fields that list the groups/kinds of objects to which the mutation will apply. If multiple groups/kinds objects are specified, only one match is needed for the resource to be in scope.
+                        properties:
+                          apiGroups:
+                            description: APIGroups is the API groups the resources belong to. '*' is all groups. If '*' is present, the length of the slice must be one. Required.
+                            items:
+                              type: string
+                            type: array
+                          kinds:
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      type: array
+                    labelSelector:
+                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    name:
+                      description: 'Name is the name of an object.  If defined, it will match against objects with the specified name.  Name also supports a prefix-based glob.  For example, `name: pod-*` would match both `pod-a` and `pod-b`.'
+                      pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                      type: string
+                    namespaceSelector:
+                      description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                items:
+                                  type: string
+                                type: array
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                    namespaces:
+                      items:
+                        description: 'A string that supports globbing at its end.  Ex: "kube-*" will match "kube-system" or "kube-public".  The asterisk is required for wildcard matching.'
+                        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\*|-\*)?$
+                        type: string
+                      type: array
+                    scope:
+                      description: ResourceScope is an enum defining the different scopes available to a custom resource
+                      type: string
+                  type: object
+                parameters:
+                  description: Parameters define the behavior of the mutator.
+                  properties:
+                    assign:
+                      description: Assign.value holds the value to be assigned
+                      properties:
+                        fromMetadata:
+                          description: FromMetadata assigns a value from the specified metadata field.
+                          properties:
+                            field:
+                              description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
+                              type: string
+                          type: object
+                        value:
+                          description: Value is a constant value that will be assigned to `location`
+                          x-kubernetes-preserve-unknown-fields: true
+                      type: object
+                    pathTests:
+                      items:
+                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        properties:
+                          condition:
+                            description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                            enum:
+                              - MustExist
+                              - MustNotExist
+                            type: string
+                          subPath:
+                            type: string
+                        type: object
+                      type: array
+                  type: object
+              type: object
+            status:
+              description: AssignStatus defines the observed state of Assign.
+              properties:
+                byPod:
+                  items:
+                    description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
+                    properties:
+                      enforced:
+                        type: boolean
+                      errors:
+                        items:
+                          description: MutatorError represents a single error caught while adding a mutator to a system.
+                          properties:
+                            message:
+                              type: string
+                            type:
+                              description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
                               type: string
                           required:
                             - message

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/config-customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/assignmetadata-customresourcedefinition.yaml
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constraintpodstatus-customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/constraintpodstatus-customresourcedefinition.yaml
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplate-customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/constrainttemplate-customresourcedefinition.yaml
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -32,7 +32,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
               properties:
                 crd:
                   properties:
@@ -48,6 +48,8 @@ spec:
                               type: array
                           type: object
                         validation:
+                          default:
+                            legacySchema: false
                           properties:
                             legacySchema:
                               default: false
@@ -73,7 +75,7 @@ spec:
                   type: array
               type: object
             status:
-              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate.
               properties:
                 byPod:
                   items:
@@ -125,7 +127,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
               properties:
                 crd:
                   properties:
@@ -141,6 +143,8 @@ spec:
                               type: array
                           type: object
                         validation:
+                          default:
+                            legacySchema: true
                           properties:
                             legacySchema:
                               default: true
@@ -166,7 +170,7 @@ spec:
                   type: array
               type: object
             status:
-              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate.
               properties:
                 byPod:
                   items:
@@ -218,7 +222,7 @@ spec:
             metadata:
               type: object
             spec:
-              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate
+              description: ConstraintTemplateSpec defines the desired state of ConstraintTemplate.
               properties:
                 crd:
                   properties:
@@ -234,6 +238,8 @@ spec:
                               type: array
                           type: object
                         validation:
+                          default:
+                            legacySchema: true
                           properties:
                             legacySchema:
                               default: true
@@ -259,7 +265,7 @@ spec:
                   type: array
               type: object
             status:
-              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate
+              description: ConstraintTemplateStatus defines the observed state of ConstraintTemplate.
               properties:
                 byPod:
                   items:

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/constrainttemplatepodstatus-customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -66,4 +66,3 @@ spec:
           type: object
       served: true
       storage: true
-

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/modifyset-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/modifyset-customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/config-customresourcedefinition.yaml
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/constrainttemplatepodstatus-customresourcedefinition.yaml
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -7,21 +7,21 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.5.0
   labels:
     gatekeeper.sh/system: "yes"
-  name: assignmetadata.mutations.gatekeeper.sh
+  name: modifyset.mutations.gatekeeper.sh
 spec:
   group: mutations.gatekeeper.sh
   names:
-    kind: AssignMetadata
-    listKind: AssignMetadataList
-    plural: assignmetadata
-    singular: assignmetadata
+    kind: ModifySet
+    listKind: ModifySetList
+    plural: modifyset
+    singular: modifyset
   preserveUnknownFields: false
   scope: Cluster
   versions:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: AssignMetadata is the Schema for the assignmetadata API.
+          description: ModifySet allows the user to modify non-keyed lists, such as the list of arguments to a container.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -36,12 +36,32 @@ spec:
                   type: string
               type: object
             spec:
-              description: AssignMetadataSpec defines the desired state of AssignMetadata.
+              description: ModifySetSpec defines the desired state of ModifySet.
               properties:
+                applyTo:
+                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  items:
+                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    properties:
+                      groups:
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                      versions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
                 location:
+                  description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
                   type: string
                 match:
-                  description: Match selects objects to apply mutations to.
+                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
                   properties:
                     excludedNamespaces:
                       items:
@@ -139,28 +159,40 @@ spec:
                       type: string
                   type: object
                 parameters:
+                  description: Parameters define the behavior of the mutator.
                   properties:
-                    assign:
-                      description: Assign.value holds the value to be assigned
-                      properties:
-                        fromMetadata:
-                          description: FromMetadata assigns a value from the specified metadata field.
-                          properties:
-                            field:
-                              description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
-                              type: string
-                          type: object
-                        value:
-                          description: Value is a constant value that will be assigned to `location`
-                          x-kubernetes-preserve-unknown-fields: true
+                    operation:
+                      default: merge
+                      description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                      enum:
+                        - merge
+                        - prune
+                      type: string
+                    pathTests:
+                      description: PathTests are a series of existence tests that can be checked before a mutation is applied
+                      items:
+                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        properties:
+                          condition:
+                            description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                            enum:
+                              - MustExist
+                              - MustNotExist
+                            type: string
+                          subPath:
+                            type: string
+                        type: object
+                      type: array
+                    values:
+                      description: Values describes the values provided to the operation as `values.fromList`.
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
               type: object
             status:
-              description: AssignMetadataStatus defines the observed state of AssignMetadata.
+              description: ModifySetStatus defines the observed state of ModifySet.
               properties:
                 byPod:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
                   items:
                     description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
                     properties:
@@ -202,7 +234,7 @@ spec:
     - name: v1beta1
       schema:
         openAPIV3Schema:
-          description: AssignMetadata is the Schema for the assignmetadata API.
+          description: ModifySet allows the user to modify non-keyed lists, such as the list of arguments to a container.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -213,12 +245,32 @@ spec:
             metadata:
               type: object
             spec:
-              description: AssignMetadataSpec defines the desired state of AssignMetadata.
+              description: ModifySetSpec defines the desired state of ModifySet.
               properties:
+                applyTo:
+                  description: ApplyTo lists the specific groups, versions and kinds a mutation will be applied to. This is necessary because every mutation implies part of an object schema and object schemas are associated with specific GVKs.
+                  items:
+                    description: ApplyTo determines what GVKs items the mutation should apply to. Globs are not allowed.
+                    properties:
+                      groups:
+                        items:
+                          type: string
+                        type: array
+                      kinds:
+                        items:
+                          type: string
+                        type: array
+                      versions:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  type: array
                 location:
+                  description: 'Location describes the path to be mutated, for example: `spec.containers[name: main].args`.'
                   type: string
                 match:
-                  description: Match selects objects to apply mutations to.
+                  description: Match allows the user to limit which resources get mutated. Individual match criteria are AND-ed together. An undefined match criteria matches everything.
                   properties:
                     excludedNamespaces:
                       items:
@@ -316,28 +368,40 @@ spec:
                       type: string
                   type: object
                 parameters:
+                  description: Parameters define the behavior of the mutator.
                   properties:
-                    assign:
-                      description: Assign.value holds the value to be assigned
-                      properties:
-                        fromMetadata:
-                          description: FromMetadata assigns a value from the specified metadata field.
-                          properties:
-                            field:
-                              description: Field specifies which metadata field provides the assigned value. Valid fields are `namespace` and `name`.
-                              type: string
-                          type: object
-                        value:
-                          description: Value is a constant value that will be assigned to `location`
-                          x-kubernetes-preserve-unknown-fields: true
+                    operation:
+                      default: merge
+                      description: Operation describes whether values should be merged in ("merge"), or pruned ("prune"). Default value is "merge"
+                      enum:
+                        - merge
+                        - prune
+                      type: string
+                    pathTests:
+                      description: PathTests are a series of existence tests that can be checked before a mutation is applied
+                      items:
+                        description: "PathTest allows the user to customize how the mutation works if parent paths are missing. It traverses the list in order. All sub paths are tested against the provided condition, if the test fails, the mutation is not applied. All `subPath` entries must be a prefix of `location`. Any glob characters will take on the same value as was used to expand the matching glob in `location`. \n Available Tests: * MustExist    - the path must exist or do not mutate * MustNotExist - the path must not exist or do not mutate."
+                        properties:
+                          condition:
+                            description: Condition describes whether the path either MustExist or MustNotExist in the original object
+                            enum:
+                              - MustExist
+                              - MustNotExist
+                            type: string
+                          subPath:
+                            type: string
+                        type: object
+                      type: array
+                    values:
+                      description: Values describes the values provided to the operation as `values.fromList`.
                       type: object
+                      x-kubernetes-preserve-unknown-fields: true
                   type: object
               type: object
             status:
-              description: AssignMetadataStatus defines the observed state of AssignMetadata.
+              description: ModifySetStatus defines the observed state of ModifySet.
               properties:
                 byPod:
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state of cluster Important: Run "make" to regenerate code after modifying this file'
                   items:
                     description: MutatorPodStatusStatus defines the observed state of MutatorPodStatus.
                     properties:
@@ -376,3 +440,9 @@ spec:
       storage: true
       subresources:
         status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/mutatorpodstatus-customresourcedefinition.yaml
@@ -1,4 +1,4 @@
-# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.5.2/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
 
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -41,6 +41,9 @@ spec:
                     description: MutatorError represents a single error caught while adding a mutator to a system.
                     properties:
                       message:
+                        type: string
+                      type:
+                        description: Type indicates a specific class of error for use by controller code. If not present, the error should be treated as not matching any known type.
                         type: string
                     required:
                       - message

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/provider-customresourcedefinition.yaml
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static/provider-customresourcedefinition.yaml
@@ -1,0 +1,46 @@
+# Source:  https://github.com/open-policy-agent/gatekeeper/blob/v3.7.2/charts/gatekeeper/crds/mutatorpodstatus-customresourcedefinition.yaml
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.5.0
+  labels:
+    gatekeeper.sh/system: "yes"
+  name: providers.externaldata.gatekeeper.sh
+spec:
+  group: externaldata.gatekeeper.sh
+  names:
+    kind: Provider
+    listKind: ProviderList
+    plural: providers
+    singular: provider
+  preserveUnknownFields: false
+  scope: Cluster
+  versions:
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: Provider is the Schema for the Provider API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Spec defines the Provider specifications.
+              properties:
+                timeout:
+                  description: Timeout is the timeout when querying the provider.
+                  type: integer
+                url:
+                  description: URL is the url for the provider. URL is prefixed with http:// or https://.
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -444,6 +444,10 @@ const (
 	GatekeeperConstraintPodStatusCRDName = "constraintpodstatuses.status.gatekeeper.sh"
 	// GatekeeperConstraintTemplatePodStatusCRDName defines the CRD name for gatekeeper ConstraintTemplatePodStatus objects.
 	GatekeeperConstraintTemplatePodStatusCRDName = "constrainttemplatepodstatuses.status.gatekeeper.sh"
+	// GatekeeperModifySetCRDName defines the CRD name for gatekeeper modify set objects.
+	GatekeeperModifySetCRDName = "modifyset.mutations.gatekeeper.sh"
+	// GatekeeperProviderCRDName defines the CRD name for gatekeeper provider objects.
+	GatekeeperProviderCRDName = "providers.externaldata.gatekeeper.sh"
 
 	// MachineControllerMutatingWebhookConfigurationName is the name of the machine-controllers mutating webhook
 	// configuration.


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrades OPA integration gatekeeper from 3.6.0 to 3.7.2

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11180 

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgraded OPA integration Gatekeeper from 3.6.0 to 3.7.2
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1375
```
