### PR TITLE
fix operator using wrong version for seed-init

### DIFF
--- a/pkg/controller/operator/seed-init/reconciler.go
+++ b/pkg/controller/operator/seed-init/reconciler.go
@@ -185,7 +185,7 @@ func (r *Reconciler) createInitialCRDs(ctx context.Context, seed *kubermaticv1.S
 			if crdObject.Annotations == nil {
 				crdObject.Annotations = map[string]string{}
 			}
-			crdObject.Annotations[resources.VersionLabel] = r.versions.Kubermatic
+			crdObject.Annotations[resources.VersionLabel] = r.versions.KubermaticCommit
 
 			err := r.createOnSeed(ctx, &crdObject, client, crdLog)
 			if err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This typo has caused some transient errors on CI:

> {"level":"warn","time":"2022-10-10T08:49:05.401Z","logger":"kkp-seed-operator","caller":"common/resources.go:126","msg":"CRD has invalid version annotation","seed":"kubermatic","crd":"[etcdrestores.kubermatic.k8c.io](http://etcdrestores.kubermatic.k8c.io/)","annotation":"223863b35baf89a093a1ce449768580e19c75406","error":"Invalid Semantic Version"}

This PR fixes that typo.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
