### PR TITLE
Fix Seed-Proxy ServiceAccount token not being generated

### DIFF
--- a/pkg/controller/master-controller-manager/seed-proxy/controller.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/controller.go
@@ -63,6 +63,10 @@ const (
 	// inside the seed cluster.
 	SeedServiceAccountName = "seed-proxy"
 
+	// SeedSecretName is the name used for service accounts
+	// inside the seed cluster.
+	SeedSecretName = "seed-proxy-token"
+
 	// SeedMonitoringNamespace is the namespace inside the seed
 	// cluster where Prometheus, Grafana etc. are installed.
 	SeedMonitoringNamespace = "monitoring"

--- a/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
@@ -159,6 +159,17 @@ func (r *Reconciler) reconcileSeedProxy(ctx context.Context, seed *kubermaticv1.
 		return fmt.Errorf("failed to ensure ServiceAccount: %w", err)
 	}
 
+	// Since Kubernetes 1.24, the LegacyServiceAccountTokenNoAutoGeneration was enabled
+	// by default. To ensure the old behaviour, KKP has to create the token secrets
+	// itself and wait for Kubernetes to fill in the token details.
+	// On clusters using older Kubernetes versions, this code will create a second Secret
+	// (next to the auto-generated one) and will use the token from it, ignoring the
+	// auto-generated Secret entirely.
+	log.Debug("reconciling Secrets...")
+	if err := r.reconcileSeedSecrets(ctx, seed, client, log); err != nil {
+		return fmt.Errorf("failed to ensure Secret: %w", err)
+	}
+
 	log.Debug("reconciling RBAC...")
 	if err := r.reconcileSeedRBAC(ctx, seed, client, log); err != nil {
 		return fmt.Errorf("failed to ensure RBAC: %w", err)
@@ -167,11 +178,11 @@ func (r *Reconciler) reconcileSeedProxy(ctx context.Context, seed *kubermaticv1.
 	log.Debug("fetching ServiceAccount details from seed cluster...")
 	serviceAccountSecret, err := r.fetchServiceAccountSecret(ctx, seed, client, log)
 	if err != nil {
-		return fmt.Errorf("failed to fetch ServiceAccount: %w", err)
+		return fmt.Errorf("failed to fetch ServiceAccount Secret: %w", err)
 	}
 
 	if err := r.reconcileMaster(ctx, seed, cfg, serviceAccountSecret, log); err != nil {
-		return fmt.Errorf("failed to reconcile master: %w", err)
+		return fmt.Errorf("failed to reconcile master cluster: %w", err)
 	}
 
 	return nil
@@ -188,6 +199,18 @@ func (r *Reconciler) reconcileSeedServiceAccounts(ctx context.Context, seed *kub
 
 	if err := r.deleteResource(ctx, client, SeedServiceAccountName, metav1.NamespaceSystem, &corev1.ServiceAccount{}); err != nil {
 		return fmt.Errorf("failed to cleanup ServiceAccount: %w", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) reconcileSeedSecrets(ctx context.Context, seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+	creators := []reconciling.NamedSecretCreatorGetter{
+		seedSecretCreator(seed),
+	}
+
+	if err := reconciling.ReconcileSecrets(ctx, creators, seed.Namespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile Secrets in the namespace %s: %w", seed.Namespace, err)
 	}
 
 	return nil
@@ -250,28 +273,14 @@ func (r *Reconciler) reconcileSeedRBAC(ctx context.Context, seed *kubermaticv1.S
 }
 
 func (r *Reconciler) fetchServiceAccountSecret(ctx context.Context, seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) (*corev1.Secret, error) {
-	sa := &corev1.ServiceAccount{}
+	secret := &corev1.Secret{}
 	name := types.NamespacedName{
 		Namespace: seed.Namespace,
-		Name:      SeedServiceAccountName,
-	}
-
-	if err := client.Get(ctx, name, sa); err != nil {
-		return nil, fmt.Errorf("could not find ServiceAccount '%s'", name)
-	}
-
-	if len(sa.Secrets) == 0 {
-		return nil, fmt.Errorf("no Secret associated with ServiceAccount '%s'", name)
-	}
-
-	secret := &corev1.Secret{}
-	name = types.NamespacedName{
-		Namespace: seed.Namespace,
-		Name:      sa.Secrets[0].Name,
+		Name:      SeedSecretName,
 	}
 
 	if err := client.Get(ctx, name, secret); err != nil {
-		return nil, fmt.Errorf("could not find Secret '%s'", name)
+		return nil, fmt.Errorf("failed to retrieve token secret: %w", err)
 	}
 
 	return secret, nil

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -95,9 +95,12 @@ func seedSecretCreator(seed *kubermaticv1.Seed) reconciling.NamedSecretCreatorGe
 
 			// ensure Kubernetes has enough info to fill in the SA token
 			sa.Type = corev1.SecretTypeServiceAccountToken
-			sa.Annotations = map[string]string{
-				corev1.ServiceAccountNameKey: SeedServiceAccountName,
+
+			if sa.Annotations == nil {
+				sa.Annotations = map[string]string{}
 			}
+
+			sa.Annotations[corev1.ServiceAccountNameKey] = SeedServiceAccountName
 
 			return sa, nil
 		}

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -88,6 +88,22 @@ func seedServiceAccountCreator(seed *kubermaticv1.Seed) reconciling.NamedService
 	}
 }
 
+func seedSecretCreator(seed *kubermaticv1.Seed) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return SeedSecretName, func(sa *corev1.Secret) (*corev1.Secret, error) {
+			sa.Labels = defaultLabels(SeedSecretName, "")
+
+			// ensure Kubernetes has enough info to fill in the SA token
+			sa.Type = corev1.SecretTypeServiceAccountToken
+			sa.Annotations = map[string]string{
+				corev1.ServiceAccountNameKey: SeedServiceAccountName,
+			}
+
+			return sa, nil
+		}
+	}
+}
+
 func seedMonitoringRoleCreator(seed *kubermaticv1.Seed) reconciling.NamedRoleCreatorGetter {
 	name := seedMonitoringRoleName(seed)
 

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -91,7 +91,7 @@ func seedServiceAccountCreator(seed *kubermaticv1.Seed) reconciling.NamedService
 func seedSecretCreator(seed *kubermaticv1.Seed) reconciling.NamedSecretCreatorGetter {
 	return func() (string, reconciling.SecretCreator) {
 		return SeedSecretName, func(sa *corev1.Secret) (*corev1.Secret, error) {
-			sa.Labels = defaultLabels(SeedSecretName, "")
+			sa.Labels = defaultLabels(SeedSecretName, seed.Name)
 
 			// ensure Kubernetes has enough info to fill in the SA token
 			sa.Type = corev1.SecretTypeServiceAccountToken


### PR DESCRIPTION
**What this PR does / why we need it**:
Since v1.24, Kubernetes does not auto-generate token Secrets for ServiceAccounts, but instead only generates tokens "on the fly" when a pod is actually mounting the ServiceAccount.

Since for the seed-proxy, we do not actually mount the SA anywhere, we do not get any tokens for it anymore, leading the master-ctrl-mgr to log

> {"level":"error","time":"2022-10-10T09:19:00.192Z","caller":"controller/controller.go:273","msg":"Reconciler error","controller":"kkp-seed-proxy-controller","object":{"name":"kubermatic","namespace":"kubermatic"},"namespace":"kubermatic","name":"kubermatic","reconcileID":"0bdd4a78-75ac-4bde-9a24-0a98d5418fda","error":"failed to reconcile: failed to fetch ServiceAccount: no Secret associated with ServiceAccount 'kubermatic/seed-proxy'"}

This PR fixes that bug by creating the necessary Secret ourselves so that Kubernetes will then fill-in the token. This PR also removes some migration code for when we moved resources around. That migration has happened like in 2.15 or so, a long time ago.

/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note bugfixes
Fix Seed-Proxy ServiceAccount token not being generated
```

**Documentation**:
```documentation
NONE
```
