### PR TITLE
Handle APIServerAllowedIPRanges in front-loadbalancer service

### DIFF
--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -421,6 +421,11 @@ func FrontLoadBalancerServiceCreator(data *resources.TemplateData) reconciling.N
 				}
 			}
 
+			// Check if allowed IP ranges are configured and set the LoadBalancer source ranges
+			if data.Cluster().Spec.APIServerAllowedIPRanges != nil {
+				s.Spec.LoadBalancerSourceRanges = append(s.Spec.LoadBalancerSourceRanges, data.Cluster().Spec.APIServerAllowedIPRanges.CIDRBlocks...)
+			}
+
 			if data.Cluster().Spec.Cloud.AWS != nil {
 				// NOTE: While KKP uses in-tree CCM for AWS, we use annotations defined in
 				// https://github.com/kubernetes/kubernetes/blob/v1.22.2/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -115,6 +115,11 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("exposeStrategy"), "cannot create cluster with Tunneling expose strategy because the TunnelingExposeStrategy feature gate is not enabled"))
 	}
 
+	// Validate APIServerAllowedIPRanges for LoadBalancer expose strategy
+	if spec.ExposeStrategy != kubermaticv1.ExposeStrategyLoadBalancer && spec.APIServerAllowedIPRanges != nil {
+		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("APIServerAllowedIPRanges"), "Access control for API server is supported only for LoadBalancer expose strategy"))
+	}
+
 	// External CCM is not supported for all providers and all Kubernetes versions.
 	if spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 		if !resources.ExternalCloudControllerFeatureSupported(dc, &spec.Cloud, spec.Version, versionManager.GetIncompatibilities()...) {


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
Handles APIServerAllowedIPRanges if configured in cluster object and populates LoadBalancerSourceRanges for front-loadbalancer service

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # [11119](https://github.com/kubermatic/kubermatic/issues/11119)

**What type of PR is this?** 
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/networking/apiserver-policies/#api-server-allowed-source-ip-ranges
```
