### PR TITLE
[release/v2.20] Fix Seed-Proxy ServiceAccount token not being generated (#11190)

### DIFF
--- a/pkg/controller/master-controller-manager/seed-proxy/controller.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/controller.go
@@ -61,6 +61,10 @@ const (
 	// inside the seed cluster.
 	SeedServiceAccountName = "seed-proxy"
 
+	// SeedSecretName is the name used for service accounts
+	// inside the seed cluster.
+	SeedSecretName = "seed-proxy-token"
+
 	// SeedMonitoringNamespace is the namespace inside the seed
 	// cluster where Prometheus, Grafana etc. are installed.
 	SeedMonitoringNamespace = "monitoring"

--- a/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/reconciler.go
@@ -28,9 +28,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -153,6 +151,17 @@ func (r *Reconciler) reconcileSeedProxy(ctx context.Context, seed *kubermaticv1.
 		return fmt.Errorf("failed to ensure ServiceAccount: %w", err)
 	}
 
+	// Since Kubernetes 1.24, the LegacyServiceAccountTokenNoAutoGeneration was enabled
+	// by default. To ensure the old behaviour, KKP has to create the token secrets
+	// itself and wait for Kubernetes to fill in the token details.
+	// On clusters using older Kubernetes versions, this code will create a second Secret
+	// (next to the auto-generated one) and will use the token from it, ignoring the
+	// auto-generated Secret entirely.
+	log.Debug("reconciling Secrets...")
+	if err := r.reconcileSeedSecrets(ctx, seed, client, log); err != nil {
+		return fmt.Errorf("failed to ensure Secret: %w", err)
+	}
+
 	log.Debug("reconciling RBAC...")
 	if err := r.reconcileSeedRBAC(ctx, seed, client, log); err != nil {
 		return fmt.Errorf("failed to ensure RBAC: %w", err)
@@ -161,11 +170,11 @@ func (r *Reconciler) reconcileSeedProxy(ctx context.Context, seed *kubermaticv1.
 	log.Debug("fetching ServiceAccount details from seed cluster...")
 	serviceAccountSecret, err := r.fetchServiceAccountSecret(ctx, seed, client, log)
 	if err != nil {
-		return fmt.Errorf("failed to fetch ServiceAccount: %w", err)
+		return fmt.Errorf("failed to fetch ServiceAccount Secret: %w", err)
 	}
 
 	if err := r.reconcileMaster(ctx, seed, cfg, serviceAccountSecret, log); err != nil {
-		return fmt.Errorf("failed to reconcile master: %w", err)
+		return fmt.Errorf("failed to reconcile master cluster: %w", err)
 	}
 
 	return nil
@@ -180,8 +189,16 @@ func (r *Reconciler) reconcileSeedServiceAccounts(ctx context.Context, seed *kub
 		return fmt.Errorf("failed to reconcile ServiceAccounts in the namespace %s: %w", seed.Namespace, err)
 	}
 
-	if err := r.deleteResource(ctx, client, SeedServiceAccountName, metav1.NamespaceSystem, &corev1.ServiceAccount{}); err != nil {
-		return fmt.Errorf("failed to cleanup ServiceAccount: %w", err)
+	return nil
+}
+
+func (r *Reconciler) reconcileSeedSecrets(ctx context.Context, seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) error {
+	creators := []reconciling.NamedSecretCreatorGetter{
+		seedSecretCreator(seed),
+	}
+
+	if err := reconciling.ReconcileSecrets(ctx, creators, seed.Namespace, client); err != nil {
+		return fmt.Errorf("failed to reconcile Secrets in the namespace %s: %w", seed.Namespace, err)
 	}
 
 	return nil
@@ -196,10 +213,6 @@ func (r *Reconciler) reconcileSeedRoles(ctx context.Context, seed *kubermaticv1.
 		return fmt.Errorf("failed to reconcile Roles in the namespace %s: %w", SeedMonitoringNamespace, err)
 	}
 
-	if err := r.deleteResource(ctx, client, "seed-proxy", SeedMonitoringNamespace, &rbacv1.Role{}); err != nil {
-		return fmt.Errorf("failed to cleanup Role: %w", err)
-	}
-
 	return nil
 }
 
@@ -210,10 +223,6 @@ func (r *Reconciler) reconcileSeedRoleBindings(ctx context.Context, seed *kuberm
 
 	if err := reconciling.ReconcileRoleBindings(ctx, creators, SeedMonitoringNamespace, client); err != nil {
 		return fmt.Errorf("failed to reconcile RoleBindings in the namespace %s: %w", SeedMonitoringNamespace, err)
-	}
-
-	if err := r.deleteResource(ctx, client, "seed-proxy", SeedMonitoringNamespace, &rbacv1.RoleBinding{}); err != nil {
-		return fmt.Errorf("failed to cleanup RoleBinding: %w", err)
 	}
 
 	return nil
@@ -244,28 +253,14 @@ func (r *Reconciler) reconcileSeedRBAC(ctx context.Context, seed *kubermaticv1.S
 }
 
 func (r *Reconciler) fetchServiceAccountSecret(ctx context.Context, seed *kubermaticv1.Seed, client ctrlruntimeclient.Client, log *zap.SugaredLogger) (*corev1.Secret, error) {
-	sa := &corev1.ServiceAccount{}
+	secret := &corev1.Secret{}
 	name := types.NamespacedName{
 		Namespace: seed.Namespace,
-		Name:      SeedServiceAccountName,
-	}
-
-	if err := client.Get(ctx, name, sa); err != nil {
-		return nil, fmt.Errorf("could not find ServiceAccount '%s'", name)
-	}
-
-	if len(sa.Secrets) == 0 {
-		return nil, fmt.Errorf("no Secret associated with ServiceAccount '%s'", name)
-	}
-
-	secret := &corev1.Secret{}
-	name = types.NamespacedName{
-		Namespace: seed.Namespace,
-		Name:      sa.Secrets[0].Name,
+		Name:      SeedSecretName,
 	}
 
 	if err := client.Get(ctx, name, secret); err != nil {
-		return nil, fmt.Errorf("could not find Secret '%s'", name)
+		return nil, fmt.Errorf("failed to retrieve token secret: %w", err)
 	}
 
 	return secret, nil
@@ -359,24 +354,6 @@ func (r *Reconciler) reconcileMasterGrafanaProvisioning(ctx context.Context, see
 
 	if err := reconciling.ReconcileConfigMaps(ctx, creators, MasterGrafanaNamespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile ConfigMaps in the namespace %s: %w", MasterGrafanaNamespace, err)
-	}
-
-	return nil
-}
-
-func (r *Reconciler) deleteResource(ctx context.Context, client ctrlruntimeclient.Client, name string, namespace string, obj ctrlruntimeclient.Object) error {
-	key := types.NamespacedName{Name: name, Namespace: namespace}
-
-	if err := client.Get(ctx, key, obj); err != nil {
-		if !kerrors.IsNotFound(err) {
-			return fmt.Errorf("failed to probe for %s: %w", key, err)
-		}
-
-		return nil
-	}
-
-	if err := client.Delete(ctx, obj); err != nil {
-		return fmt.Errorf("failed to delete %s: %w", key, err)
 	}
 
 	return nil

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -88,6 +88,25 @@ func seedServiceAccountCreator(seed *kubermaticv1.Seed) reconciling.NamedService
 	}
 }
 
+func seedSecretCreator(seed *kubermaticv1.Seed) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return SeedSecretName, func(sa *corev1.Secret) (*corev1.Secret, error) {
+			sa.Labels = defaultLabels(SeedSecretName, seed.Name)
+
+			// ensure Kubernetes has enough info to fill in the SA token
+			sa.Type = corev1.SecretTypeServiceAccountToken
+
+			if sa.Annotations == nil {
+				sa.Annotations = map[string]string{}
+			}
+
+			sa.Annotations[corev1.ServiceAccountNameKey] = SeedServiceAccountName
+
+			return sa, nil
+		}
+	}
+}
+
 func seedMonitoringRoleCreator(seed *kubermaticv1.Seed) reconciling.NamedRoleCreatorGetter {
 	name := seedMonitoringRoleName(seed)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #11190.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix Seed-Proxy ServiceAccount token not being generated
```

**Documentation**:
```documentation
NONE
```
