### PR TITLE
fix convert-kubeconfig command not generating a SA token

### DIFF
--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -189,7 +189,7 @@ func convertServiceAccountToKubeconfig(host string, credentials *corev1.Secret) 
 	authName := "token-based"
 
 	cluster := api.NewCluster()
-	cluster.CertificateAuthorityData = credentials.Data["ca.crt"]
+	cluster.CertificateAuthorityData = credentials.Data[corev1.ServiceAccountRootCAKey]
 	cluster.Server = host
 
 	context := api.NewContext()
@@ -197,7 +197,7 @@ func convertServiceAccountToKubeconfig(host string, credentials *corev1.Secret) 
 	context.AuthInfo = authName
 
 	user := api.NewAuthInfo()
-	user.Token = string(credentials.Data["token"])
+	user.Token = string(credentials.Data[corev1.ServiceAccountTokenKey])
 
 	kubeconfig := api.NewConfig()
 	kubeconfig.Clusters[clusterName] = cluster


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a follow-up to #11190, applying the same simple fix to the `convert-kubeconfig` subcommand in the KKP installer.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note bugfixes
Fix `convert-kubeconfig` installer command not generating a SA token
```

**Documentation**:
```documentation
NONE
```
