### PR TITLE
Simplify expose-strategy tests

### DIFF
--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -92,14 +92,14 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 	}
 
 	t.Run("Testing SNI when Kubeconfig is used e.g. Kubelet", func(t *testing.T) {
-		if !client.QueryApiserverVersion("", false, jig.ClusterSemver(logger), 5, 4) {
-			t.Fatal("Apiserver should be reachable passing from the SNI entrypoint in nodeport proxy")
+		if err := client.VerifyApiserverVersion(ctx, "", false, jig.ClusterSemver(logger)); err != nil {
+			t.Fatalf("Apiserver should be reachable passing from the SNI entrypoint in nodeport proxy, but: %v", err)
 		}
 	})
 
 	t.Run("Tunneling requests using HTTP/2 CONNECT when no SNI is present e.g. pods relying on kubernetes service in default namespace", func(t *testing.T) {
-		if !client.QueryApiserverVersion(agentConfig.GetKASHostPort(), true, jig.ClusterSemver(logger), 5, 4) {
-			t.Fatal("Apiserver should be reachable passing from the SNI entrypoint in nodeport proxy")
+		if err := client.VerifyApiserverVersion(ctx, agentConfig.GetKASHostPort(), true, jig.ClusterSemver(logger)); err != nil {
+			t.Fatalf("Apiserver should be reachable passing from the SNI entrypoint in nodeport proxy, but: %v", err)
 		}
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR slightly improves the expose strategy tests, which previously used a "must work N out of M times" approach, which I found weird and I could not see a reason for that in the original PR (#6745).

The PR changes the testing logic to just retry until it works, making the test a bit more flexible and robust against slow pod reconciling. I also found a way to get rid of the quite hackish `sed` usage to override the Kubernetes API server address by just using the `--server` flag. Also the error messages have been improved a bit, thanks to our polling functions.

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
