### PR TITLE
Add annotation to pause any resource updates

### DIFF
--- a/docs/dev-getting-started.md
+++ b/docs/dev-getting-started.md
@@ -79,3 +79,13 @@ scheduler-77c956dbf6-c7cgh                    2/2       Running   0          57m
 * The controller will now run. It does run in foreground, this means that it will block the
   terminal window which is why it is suggested to use a dedicated terminal. You can stop the
   controller by pressing `ctrl + c`.
+
+
+## Pausing resource updates
+
+If you ever have to change something on a KKP-managed resource manually, you can annotate that resource with
+`hacking.k8c.io/pause: "true"`. This will prevent Kubermatic controllers from modifying the resource (but not
+protect it from being deleted).
+
+Great for development and debugging, but really bad to find this in production - so please never use that
+outside development.

--- a/pkg/resources/reconciling/ensure.go
+++ b/pkg/resources/reconciling/ensure.go
@@ -34,6 +34,13 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// ResourceReconciliationPausedAnnotation is the name of the annotation to set to "true" to stop any
+	// automation from modifying it.
+	// This is only meant for development and should never be used in a production(-like) system.
+	ResourceReconciliationPausedAnnotation = "hacking.k8c.io/pause"
+)
+
 //go:generate go run ../../../codegen/reconcile/main.go
 
 // ObjectCreator defines an interface to create/update a ctrlruntimeclient.Object.
@@ -88,6 +95,14 @@ func EnsureNamedObject(ctx context.Context, namespacedName types.NamespacedName,
 			return fmt.Errorf("failed to get Object(%T): %w", existingObject, err)
 		}
 		exists = false
+	}
+
+	if exists {
+		annotations := existingObject.GetAnnotations()
+		if v, ok := annotations[ResourceReconciliationPausedAnnotation]; ok && v == "true" {
+			objectLogger(existingObject).Warn("not touching paused resource")
+			return nil
+		}
 	}
 
 	// Object does not exist in lister -> Create the Object

--- a/pkg/resources/reconciling/ensure_test.go
+++ b/pkg/resources/reconciling/ensure_test.go
@@ -114,6 +114,51 @@ func TestEnsureObjectByAnnotation(t *testing.T) {
 			},
 		},
 		{
+			name: "Object update stopped by annotation",
+			existingObject: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testResourceName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						ResourceReconciliationPausedAnnotation: "true",
+					},
+				},
+				Data: map[string]string{
+					"foo": "hopefully-does-not-get-overwritten",
+				},
+			},
+			creator: func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+				var sa *corev1.ConfigMap
+				if existing == nil {
+					sa = &corev1.ConfigMap{}
+				} else {
+					sa = existing.(*corev1.ConfigMap)
+				}
+				sa.Name = testResourceName
+				sa.Namespace = testNamespace
+				sa.Data = map[string]string{
+					"foo": "bar",
+				}
+				return sa, nil
+			},
+			expectedObject: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testResourceName,
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						ResourceReconciliationPausedAnnotation: "true",
+					},
+				},
+				Data: map[string]string{
+					"foo": "hopefully-does-not-get-overwritten",
+				},
+			},
+		},
+		{
 			name: "Object does not get updated",
 			existingObject: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -191,6 +236,56 @@ func TestEnsureObjectByAnnotation(t *testing.T) {
 				},
 				Data: map[string]string{
 					"foo": "bar-new",
+				},
+			},
+		},
+		{
+			name:     "Object recreation stopped by annotation",
+			recreate: true,
+			existingObject: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            testResourceName,
+					Namespace:       testNamespace,
+					ResourceVersion: "123",
+					UID:             "abcd-1234",
+					Annotations: map[string]string{
+						ResourceReconciliationPausedAnnotation: "true",
+					},
+				},
+				Data: map[string]string{
+					"foo": "hopefully-does-not-get-overwritten",
+				},
+			},
+			creator: func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+				var sa *corev1.ConfigMap
+				if existing == nil {
+					sa = &corev1.ConfigMap{}
+				} else {
+					sa = existing.(*corev1.ConfigMap)
+				}
+				sa.Name = testResourceName
+				sa.Namespace = testNamespace
+				sa.Data = map[string]string{
+					"foo": "bar",
+				}
+				return sa, nil
+			},
+			expectedObject: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            testResourceName,
+					Namespace:       testNamespace,
+					ResourceVersion: "123",
+					UID:             "abcd-1234",
+					Annotations: map[string]string{
+						ResourceReconciliationPausedAnnotation: "true",
+					},
+				},
+				Data: map[string]string{
+					"foo": "hopefully-does-not-get-overwritten",
 				},
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Add annotation on objects to pause any KKP automations on them, preventing them from being updated.

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

There was a short discussion in Slack if this makes sense at all, stating the use case for that: https://kubermatic-community.slack.com/archives/C0PGCH99P/p1665649627499519

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow pausing resource updates by Kubermatic controllers by adding a special annotation
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
