### PR TITLE
adjust to the dashboard's new primary branch name

### DIFF
--- a/hack/ci/canary-github-release.sh
+++ b/hack/ci/canary-github-release.sh
@@ -32,7 +32,15 @@ export GIT_TAG="$(git rev-parse HEAD)"
 # or the name of the base branch in case of a PR. Since this is running
 # for untagged revisions, we cannot refer to the same revision in the
 # dashboard and must instead get the dashboard's latest revision.
-export DASHBOARD_GIT_TAG="$(get_latest_dashboard_hash "$PULL_BASE_REF")"
+UIBRANCH="${PULL_BASE_REF:-master}"
+
+# dashboard's primary branch was renamed before KKP's, so until KKP follows suite,
+# we have to temporarily adjust the branch name here
+if [ "$UIBRANCH" == "master" ]; then
+  UIBRANCH=main
+fi
+
+export DASHBOARD_GIT_TAG="$(get_latest_dashboard_hash "$UIBRANCH")"
 
 git config --global user.email "dev@kubermatic.com"
 git config --global user.name "Prow CI Robot"

--- a/hack/ci/deploy-offline.sh
+++ b/hack/ci/deploy-offline.sh
@@ -67,9 +67,16 @@ function finish {
 }
 trap finish EXIT
 
+# dashboard's primary branch was renamed before KKP's, so until KKP follows suite,
+# we have to temporarily adjust the branch name here
+UIBRANCH="${PULL_BASE_REF:-master}"
+if [ "$UIBRANCH" == "master" ]; then
+  UIBRANCH=main
+fi
+
 # PULL_BASE_REF is the name of the current branch in case of a post-submit
 # or the name of the base branch in case of a PR.
-export UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF}")"
+export UIDOCKERTAG="$(get_latest_dashboard_hash "${UIBRANCH}")"
 export KUBERMATICCOMMIT="${GIT_HEAD_HASH}"
 
 make kubermatic-installer

--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -54,6 +54,12 @@ if [ -z "$GIT_HEAD_TAG" ]; then
   # only defined in presubmits); in postsubmits we check against the current branch
   UIBRANCH="${PULL_BASE_REF:-$GIT_BRANCH}"
 
+  # dashboard's primary branch was renamed before KKP's, so until KKP follows suite,
+  # we have to temporarily adjust the branch name here
+  if [ "$UIBRANCH" == "master" ]; then
+    UIBRANCH=main
+  fi
+
   # the dasboard only publishes Docker images for tagged releases and all
   # master branch revisions; this means for Kubermatic tests in release branches
   # we need to use the latest tagged dashboard of the same branch

--- a/hack/run-operator.sh
+++ b/hack/run-operator.sh
@@ -49,7 +49,7 @@ fi
 
 if [ -z "$UIDOCKERTAG" ]; then
   echo "Finding latest dashboard master revision..."
-  UIDOCKERTAG=$(git ls-remote https://github.com/kubermatic/dashboard refs/heads/master | awk '{print $1}')
+  UIDOCKERTAG=$(git ls-remote https://github.com/kubermatic/dashboard refs/heads/main | awk '{print $1}')
   echo
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the sister PR to https://github.com/kubermatic/dashboard/pull/5090

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
