### PR TITLE
Fix image references in MLA helm charts and add metrics-scraper image to `mirror-images`

### DIFF
--- a/charts/logging/promtail/test/default.yaml.out
+++ b/charts/logging/promtail/test/default.yaml.out
@@ -39,6 +39,7 @@ stringData:
         batchwait: 1s
         external_labels: {}
         timeout: 10s
+        url: http://loki:3100/loki/api/v1/push
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -47,6 +48,8 @@ stringData:
       - job_name: kubernetes-pods-name
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - source_labels:
           - __meta_kubernetes_pod_label_name
@@ -88,6 +91,20 @@ stringData:
       - job_name: kubernetes-pods-app
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
+        - match:
+            selector: '{app="k8c-events-lokiloader"}'
+            stages:
+              - json:
+                  expressions:
+                    clusterID: clusterID
+                    projectID: projectID
+                    seed: seed
+              - labels:
+                  clusterID:
+                  projectID:
+                  seed:
         relabel_configs:
         - action: drop
           regex: .+
@@ -133,6 +150,8 @@ stringData:
       - job_name: kubernetes-pods-direct-controllers
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: .+
@@ -184,6 +203,8 @@ stringData:
       - job_name: kubernetes-pods-indirect-controller
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: .+
@@ -237,6 +258,8 @@ stringData:
       - job_name: kubernetes-pods-static
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: ''
@@ -378,14 +401,14 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: ec7136d83086e81ed551df43ffb81f8a308bd3d4e463995c53daaf2013d59485
+        checksum/config: cc68b18e6a6109f9b8542a69f8132d80081e6f4b1207440351d8730aa85bf357
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: promtail
       initContainers:
         - name: init
-          image: "docker.io/library/busybox:1.33"
+          image: "docker.io/docker.io/library/busybox:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
@@ -39,6 +39,7 @@ stringData:
         batchwait: 1s
         external_labels: {}
         timeout: 10s
+        url: http://loki:3100/loki/api/v1/push
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -47,6 +48,8 @@ stringData:
       - job_name: kubernetes-pods-name
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - source_labels:
           - __meta_kubernetes_pod_label_name
@@ -88,6 +91,20 @@ stringData:
       - job_name: kubernetes-pods-app
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
+        - match:
+            selector: '{app="k8c-events-lokiloader"}'
+            stages:
+              - json:
+                  expressions:
+                    clusterID: clusterID
+                    projectID: projectID
+                    seed: seed
+              - labels:
+                  clusterID:
+                  projectID:
+                  seed:
         relabel_configs:
         - action: drop
           regex: .+
@@ -133,6 +150,8 @@ stringData:
       - job_name: kubernetes-pods-direct-controllers
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: .+
@@ -184,6 +203,8 @@ stringData:
       - job_name: kubernetes-pods-indirect-controller
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: .+
@@ -237,6 +258,8 @@ stringData:
       - job_name: kubernetes-pods-static
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: ''
@@ -378,14 +401,14 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: ec7136d83086e81ed551df43ffb81f8a308bd3d4e463995c53daaf2013d59485
+        checksum/config: cc68b18e6a6109f9b8542a69f8132d80081e6f4b1207440351d8730aa85bf357
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: promtail
       initContainers:
         - name: init
-          image: "docker.io/library/busybox:1.33"
+          image: "docker.io/docker.io/library/busybox:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
@@ -39,6 +39,7 @@ stringData:
         batchwait: 1s
         external_labels: {}
         timeout: 10s
+        url: http://loki:3100/loki/api/v1/push
     
     positions:
       filename: /run/promtail/positions.yaml
@@ -47,6 +48,8 @@ stringData:
       - job_name: kubernetes-pods-name
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - source_labels:
           - __meta_kubernetes_pod_label_name
@@ -88,6 +91,20 @@ stringData:
       - job_name: kubernetes-pods-app
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
+        - match:
+            selector: '{app="k8c-events-lokiloader"}'
+            stages:
+              - json:
+                  expressions:
+                    clusterID: clusterID
+                    projectID: projectID
+                    seed: seed
+              - labels:
+                  clusterID:
+                  projectID:
+                  seed:
         relabel_configs:
         - action: drop
           regex: .+
@@ -133,6 +150,8 @@ stringData:
       - job_name: kubernetes-pods-direct-controllers
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: .+
@@ -184,6 +203,8 @@ stringData:
       - job_name: kubernetes-pods-indirect-controller
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: .+
@@ -237,6 +258,8 @@ stringData:
       - job_name: kubernetes-pods-static
         kubernetes_sd_configs:
         - role: pod
+        pipeline_stages:
+        - cri: {}
         relabel_configs:
         - action: drop
           regex: ''
@@ -378,14 +401,14 @@ spec:
         app.kubernetes.io/name: promtail
         app.kubernetes.io/instance: release-name
       annotations:
-        checksum/config: ec7136d83086e81ed551df43ffb81f8a308bd3d4e463995c53daaf2013d59485
+        checksum/config: cc68b18e6a6109f9b8542a69f8132d80081e6f4b1207440351d8730aa85bf357
         prometheus.io/port: "3101"
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: promtail
       initContainers:
         - name: init
-          image: "docker.io/library/busybox:1.33"
+          image: "docker.io/docker.io/library/busybox:1.33"
           imagePullPolicy: IfNotPresent
           command:
             - sh

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -21,7 +21,7 @@ promtail:
     enabled: true
     fsInotifyMaxUserInstances: 256
     image:
-      repository: library/busybox
+      repository: docker.io/library/busybox
 
   podAnnotations:
     prometheus.io/scrape: "true"

--- a/charts/mla/alertmanager-proxy/test/default.yaml.out
+++ b/charts/mla/alertmanager-proxy/test/default.yaml.out
@@ -419,7 +419,7 @@ spec:
     spec:
       containers:
         - name: envoy
-          image: 'envoyproxy/envoy:v1.18.3'
+          image: 'docker.io/envoyproxy/envoy:v1.18.3'
           ports:
             - containerPort: 8080
               name: proxy

--- a/charts/mla/alertmanager-proxy/values.yaml
+++ b/charts/mla/alertmanager-proxy/values.yaml
@@ -17,7 +17,7 @@ alertmanagerProxy:
     backendAddress: cortex-alertmanager
     backendPort: 8080
     image:
-      repository: "envoyproxy/envoy"
+      repository: "docker.io/envoyproxy/envoy"
       tag: "v1.18.3"
     replicas: 1
     resources:

--- a/charts/mla/consul/test/config.yaml.out
+++ b/charts/mla/consul/test/config.yaml.out
@@ -270,7 +270,7 @@ spec:
             name: release-name-consul-server-config
       containers:
         - name: consul
-          image: "hashicorp/consul:1.10.3"
+          image: "docker.io/hashicorp/consul:1.10.3"
           env:
             - name: ADVERTISE_IP
               valueFrom:
@@ -398,7 +398,7 @@ metadata:
 spec:
   containers:
     - name: consul-test
-      image: "hashicorp/consul:1.10.3"
+      image: "docker.io/hashicorp/consul:1.10.3"
       env:
         - name: HOST_IP
           valueFrom:

--- a/charts/mla/consul/test/default.yaml.out
+++ b/charts/mla/consul/test/default.yaml.out
@@ -270,7 +270,7 @@ spec:
             name: release-name-consul-server-config
       containers:
         - name: consul
-          image: "hashicorp/consul:1.10.3"
+          image: "docker.io/hashicorp/consul:1.10.3"
           env:
             - name: ADVERTISE_IP
               valueFrom:
@@ -398,7 +398,7 @@ metadata:
 spec:
   containers:
     - name: consul-test
-      image: "hashicorp/consul:1.10.3"
+      image: "docker.io/hashicorp/consul:1.10.3"
       env:
         - name: HOST_IP
           valueFrom:

--- a/charts/mla/consul/values.yaml
+++ b/charts/mla/consul/values.yaml
@@ -90,7 +90,7 @@ consul:
     # image: "hashicorp/consul-enterprise:1.10.0-ent"
     # ```
     # @default: hashicorp/consul:<latest version>
-    #image: "hashicorp/consul:1.10.3"
+    image: "docker.io/hashicorp/consul:1.10.3"
 
     # Array of objects containing image pull secret names that will be applied to each service account.
     # This can be used to reference image pull secrets if using a custom consul or consul-k8s-control-plane Docker image.
@@ -302,7 +302,7 @@ consul:
     # connect-injected sidecar proxies and mesh, terminating, and ingress gateways.
     # See https://www.consul.io/docs/connect/proxies/envoy for full compatibility matrix between Consul and Envoy.
     # @default: envoyproxy/envoy-alpine:<latest supported version>
-    imageEnvoy: "envoyproxy/envoy-alpine:v1.18.4"
+    imageEnvoy: "docker.io/envoyproxy/envoy-alpine:v1.18.4"
     # Configuration for running this Helm chart on the Red Hat OpenShift platform.
     # This Helm chart currently supports OpenShift v4.x+.
     openshift:

--- a/charts/mla/grafana/README.md
+++ b/charts/mla/grafana/README.md
@@ -196,7 +196,7 @@ This version requires Helm >= 3.1.0.
 | `downloadDashboards.env`                  | Environment variables to be passed to the `download-dashboards` container | `{}`                        |
 | `downloadDashboards.envFromSecret`        | Name of a Kubernetes secret (must be manually created in the same namespace) containing values to be added to the environment. Can be templated | `""` |
 | `downloadDashboards.resources`            | Resources of `download-dashboards` container  | `{}`                                                    |
-| `downloadDashboardsImage.repository`      | Curl docker image repo                        | `curlimages/curl`                                       |
+| `downloadDashboardsImage.repository`      | Curl docker image repo                        | `docker.io/curlimages/curl`                             |
 | `downloadDashboardsImage.tag`             | Curl docker image tag                         | `7.73.0`                                                |
 | `downloadDashboardsImage.sha`             | Curl docker image sha (optional)              | `""`                                                    |
 | `downloadDashboardsImage.pullPolicy`      | Curl docker image pull policy                 | `IfNotPresent`                                          |

--- a/charts/mla/grafana/test/config.yaml.out
+++ b/charts/mla/grafana/test/config.yaml.out
@@ -312,7 +312,7 @@ spec:
             - name: storage
               mountPath: "/var/lib/grafana"
         - name: download-dashboards
-          image: "curlimages/curl:7.85.0"
+          image: "docker.io/curlimages/curl:7.85.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh -x /etc/grafana/download_dashboards.sh" ]
@@ -326,7 +326,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.1.5"
+          image: "docker.io/grafana/grafana:9.1.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config
@@ -408,7 +408,7 @@ spec:
   serviceAccountName: release-name-grafana-test
   containers:
     - name: release-name-test
-      image: "bats/bats:v1.4.1"
+      image: "docker.io/bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/mla/grafana/test/config.yaml.out
+++ b/charts/mla/grafana/test/config.yaml.out
@@ -302,7 +302,7 @@ spec:
         runAsUser: 472
       initContainers:
         - name: init-chown-data
-          image: "busybox:1.31.1"
+          image: "docker.io/library/busybox:1.31.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: false

--- a/charts/mla/grafana/test/default.yaml.out
+++ b/charts/mla/grafana/test/default.yaml.out
@@ -302,7 +302,7 @@ spec:
         runAsUser: 472
       initContainers:
         - name: init-chown-data
-          image: "busybox:1.31.1"
+          image: "docker.io/library/busybox:1.31.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: false
@@ -408,7 +408,7 @@ spec:
   serviceAccountName: release-name-grafana-test
   containers:
     - name: release-name-test
-      image: "bats/bats:v1.4.1"
+      image: "docker.io/bats/bats:v1.4.1"
       imagePullPolicy: "IfNotPresent"
       command: ["/opt/bats/bin/bats", "-t", "/tests/run.sh"]
       volumeMounts:

--- a/charts/mla/grafana/test/default.yaml.out
+++ b/charts/mla/grafana/test/default.yaml.out
@@ -312,7 +312,7 @@ spec:
             - name: storage
               mountPath: "/var/lib/grafana"
         - name: download-dashboards
-          image: "curlimages/curl:7.85.0"
+          image: "docker.io/curlimages/curl:7.85.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh -x /etc/grafana/download_dashboards.sh" ]
@@ -326,7 +326,7 @@ spec:
       enableServiceLinks: true
       containers:
         - name: grafana
-          image: "grafana/grafana:9.1.5"
+          image: "docker.io/grafana/grafana:9.1.5"
           imagePullPolicy: IfNotPresent
           volumeMounts:
             - name: config

--- a/charts/mla/grafana/values.yaml
+++ b/charts/mla/grafana/values.yaml
@@ -81,7 +81,7 @@ grafana:
   ##
   # schedulerName: "default-scheduler"
   image:
-    repository: grafana/grafana
+    repository: docker.io/grafana/grafana
     # Overrides the Grafana image tag whose default is the chart appVersion
     tag: ""
     sha: ""
@@ -95,7 +95,7 @@ grafana:
     #   - myRegistrKeySecretName
   testFramework:
     enabled: true
-    image: "bats/bats"
+    image: "docker.io/bats/bats"
     tag: "v1.4.1"
     imagePullPolicy: IfNotPresent
     securityContext: {}
@@ -124,7 +124,7 @@ grafana:
   ## Assign a PriorityClassName to pods if set
   # priorityClassName:
   downloadDashboardsImage:
-    repository: curlimages/curl
+    repository: docker.io/curlimages/curl
     tag: 7.85.0
     sha: ""
     pullPolicy: IfNotPresent
@@ -309,7 +309,7 @@ grafana:
     ## initChownData container image
     ##
     image:
-      repository: busybox
+      repository: docker.io/library/busybox
       tag: "1.31.1"
       sha: ""
       pullPolicy: IfNotPresent

--- a/charts/mla/loki-distributed/test/config.yaml.out
+++ b/charts/mla/loki-distributed/test/config.yaml.out
@@ -1190,7 +1190,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m
@@ -1286,7 +1286,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m
@@ -1382,7 +1382,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m
@@ -1478,7 +1478,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m

--- a/charts/mla/loki-distributed/test/default.yaml.out
+++ b/charts/mla/loki-distributed/test/default.yaml.out
@@ -1190,7 +1190,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m
@@ -1286,7 +1286,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m
@@ -1382,7 +1382,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m
@@ -1478,7 +1478,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: memcached
-          image: docker.io/memcached:1.6.7-alpine
+          image: docker.io/library/memcached:1.6.7-alpine
           imagePullPolicy: IfNotPresent
           args:
             - -I 32m

--- a/charts/mla/loki-distributed/values.yaml
+++ b/charts/mla/loki-distributed/values.yaml
@@ -1063,7 +1063,7 @@ loki-distributed:
       # -- The Docker registry for the memcached
       registry: docker.io
       # -- Memcached Docker image repository
-      repository: memcached
+      repository: library/memcached
       # -- Memcached Docker image tag
       tag: 1.6.7-alpine
       # -- Memcached Docker image pull policy

--- a/charts/mla/minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
+++ b/charts/mla/minio-lifecycle-mgr/templates/lifecycle-mgr-cronjob.yaml
@@ -26,7 +26,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: minio
-              image: minio/mc
+              image: docker.io/minio/mc:latest
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/charts/mla/minio-lifecycle-mgr/test/config.yaml.out
+++ b/charts/mla/minio-lifecycle-mgr/test/config.yaml.out
@@ -65,7 +65,7 @@ data:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: minio-lifecycle-mgr
@@ -79,7 +79,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: minio
-              image: minio/mc
+              image: docker.io/minio/mc:latest
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/charts/mla/minio-lifecycle-mgr/test/default.yaml.out
+++ b/charts/mla/minio-lifecycle-mgr/test/default.yaml.out
@@ -65,7 +65,7 @@ data:
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: minio-lifecycle-mgr
@@ -79,7 +79,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: minio
-              image: minio/mc
+              image: docker.io/minio/mc:latest
               imagePullPolicy: IfNotPresent
               command:
                 - /bin/sh

--- a/charts/mla/minio/values.yaml
+++ b/charts/mla/minio/values.yaml
@@ -29,10 +29,6 @@ minio:
     repository: docker.io/bskim45/helm-kubectl-jq
     tag: 3.1.0
     pullPolicy: IfNotPresent
-  mcImage:
-    repository: docker.io/minio/mc
-  image:
-    repository: docker.io/minio/minio
   ## minio server mode, i.e. standalone or distributed.
   ## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
   ##

--- a/charts/mla/minio/values.yaml
+++ b/charts/mla/minio/values.yaml
@@ -26,9 +26,13 @@ minio:
   ## process used to create secret for prometheus ServiceMonitor).
   ##
   helmKubectlJqImage:
-    repository: bskim45/helm-kubectl-jq
+    repository: docker.io/bskim45/helm-kubectl-jq
     tag: 3.1.0
     pullPolicy: IfNotPresent
+  mcImage:
+    repository: docker.io/minio/mc
+  image:
+    repository: docker.io/minio/minio
   ## minio server mode, i.e. standalone or distributed.
   ## Distributed Minio ref: https://docs.minio.io/docs/distributed-minio-quickstart-guide
   ##

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -48,7 +48,7 @@ var (
 )
 
 const (
-	envoyImageName = "envoyproxy/envoy"
+	envoyImageName = "docker.io/envoyproxy/envoy"
 )
 
 // DaemonSetCreator returns the function to create and update the Envoy DaemonSet.

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/monitoring"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity"
+	k8sdashboard "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard"
 	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/usersshkeys"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
@@ -151,6 +152,7 @@ func getImagesFromCreators(log logrus.FieldLogger, templateData *resources.Templ
 	deploymentCreators = append(deploymentCreators, vpa.UpdaterDeploymentCreator(config, kubermaticVersions))
 	deploymentCreators = append(deploymentCreators, mla.GatewayDeploymentCreator(templateData, nil))
 	deploymentCreators = append(deploymentCreators, operatingsystemmanager.DeploymentCreator(templateData))
+	deploymentCreators = append(deploymentCreators, k8sdashboard.DeploymentCreator(templateData.RewriteImage))
 
 	if templateData.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 		deploymentCreators = append(deploymentCreators, cloudcontroller.DeploymentCreator(templateData))


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR does two things:
- It restores `kubermatic-installer mirror-images` working on our Helm charts again, because the addition of the MLA charts added a lot of "non-canonical" images that the code cannot process. Being explicit here is better anyway.
- It adds the missing DeploymentCreator for `kubernetesui/metrics-scraper` to `pkg/install/images`, thus now correctly loading that image when mirroring images.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind cleanup
/kind regression
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfixes
installer subcommand `mirror-images` correctly mirrors image `kubernetesui/metrics-scraper` now
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
