### PR TITLE
ensure the KKP Docker image contains our CRDs

### DIFF
--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -90,6 +90,11 @@ if [ -z "${NO_DOCKER_IMAGES:-}" ]; then
   # as it could just be a git hash and we need to ensure a proper semver version
   set_helm_charts_version "${GIT_HEAD_TAG:-v9.9.9-$GIT_HEAD_HASH}" "$KUBERMATICDOCKERTAG"
 
+  # make sure that the main Docker image contains ready made CRDs, as the installer
+  # will take them from the operator chart and not use the compiled-in versions.
+  copy_crds_to_chart
+  set_crds_version_annotation
+
   set -f # prevent globbing, do word splitting
   # shellcheck disable=SC2086
   retry 5 ./hack/release-docker-images.sh $TAGS


### PR DESCRIPTION
**What this PR does / why we need it**:
The KKP dashboard begins to use the KKP installer in its Docker image (https://github.com/kubermatic/dashboard/pull/5088) and it turns out, the installer (by design) installs the master CRDs from the operator Helm chart. This is so that on initial setups, CRDs can be manipulated if necessary.

However our Docker image didn't contain the CRDs inside the chart, so the installer could not install them and would later fail during the installation. This PR fixes that by ensuring the CRDs are present.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
CRDs were missing in the KKP Docker images, making it hard to use the installer in Docker. This was now fixed and the CRDs are available.
```

**Documentation**:
```documentation
NONE
```
