### PR TITLE
Switch AWS account for E2E tests

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -135,7 +135,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-vault: "true"

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -53,7 +53,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -88,7 +88,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -124,7 +124,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -166,7 +166,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -207,7 +207,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -246,7 +246,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -285,7 +285,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -324,7 +324,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -363,7 +363,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -402,7 +402,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -441,7 +441,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -480,7 +480,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -521,7 +521,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -562,7 +562,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -603,7 +603,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -644,7 +644,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -837,7 +837,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -18,7 +18,7 @@ presubmits:
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow/)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -62,7 +62,7 @@ presubmits:
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow/)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -106,7 +106,7 @@ presubmits:
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow/)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -151,7 +151,7 @@ presubmits:
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow/)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
@@ -197,7 +197,7 @@ presubmits:
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow/)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws: "true"
+      preset-aws-e2e-kkp: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"

--- a/hack/ci/run-cilium-e2e-test.sh
+++ b/hack/ci/run-cilium-e2e-test.sh
@@ -43,8 +43,8 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 echodate "Getting secrets from Vault"
 retry 5 vault_ci_login
 
-export AWS_ACCESS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws)
-export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws)
+export AWS_ACCESS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws-kkp)
+export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)
 
 echodate "Successfully got secrets for dev from Vault"
 echodate "Running Cilium tests..."

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -46,8 +46,8 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 echodate "Getting secrets from Vault"
 retry 5 vault_ci_login
 
-export AWS_ACCESS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws)
-export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws)
+export AWS_ACCESS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws-kkp)
+export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)
 
 export AZURE_TENANT_ID="${AZURE_TENANT_ID:-$(vault kv get -field=tenantID dev/e2e-azure)}"
 export AZURE_SUBSCRIPTION_ID="${AZURE_SUBSCRIPTION_ID:-$(vault kv get -field=subscriptionID dev/e2e-azure)}"

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -43,8 +43,8 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 echodate "Getting secrets from Vault"
 retry 5 vault_ci_login
 
-export AWS_ACCESS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws)
-export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws)
+export AWS_ACCESS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws-kkp)
+export AWS_SECRET_ACCESS_KEY=$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)
 
 echodate "Successfully got secrets for dev from Vault"
 

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -75,8 +75,8 @@ anexia)
   ;;
 
 aws)
-  AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$(vault kv get -field=accessKeyID dev/e2e-aws)}"
-  AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(vault kv get -field=secretAccessKey dev/e2e-aws)}"
+  AWS_ACCESS_KEY_ID="${AWS_ACCESS_KEY_ID:-$(vault kv get -field=accessKeyID dev/e2e-aws-kkp)}"
+  AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)}"
   extraArgs="-aws-access-key-id=$AWS_ACCESS_KEY_ID
     -aws-secret-access-key=$AWS_SECRET_ACCESS_KEY
     -aws-kkp-datacenter=aws-eu-central-1a"

--- a/pkg/test/dualstack/README.md
+++ b/pkg/test/dualstack/README.md
@@ -1,0 +1,10 @@
+# Dualstack E2E Tests
+
+## AWS Preconditions
+
+To make the E2E tests work on AWS, the following steps need to be taken:
+
+* See https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/networking/dual-stack/#aws
+* The VPC and Subnets must have IPv6 CIDRs assigned.
+* The default route table needs to have an entry for the VPC's IPv6 CIDR.
+* An egress-only internet gateway must be created.

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -216,7 +216,7 @@ func (a aws) NodeSpec() models.NodeCloudSpec {
 			IsSpotInstance:                false,
 			SpotInstanceMaxPrice:          "",
 			SpotInstancePersistentRequest: false,
-			SubnetID:                      "subnet-01d796b6b81cab01c",
+			SubnetID:                      "subnet-0373d73f016db25c7",
 			VolumeSize:                    pointer.Int32(64),
 			VolumeType:                    pointer.String("standard"),
 		},
@@ -234,7 +234,7 @@ func (a aws) CloudSpec() models.CloudSpec {
 			RouteTableID:            "",
 			SecretAccessKey:         os.Getenv("AWS_SECRET_ACCESS_KEY"),
 			SecurityGroupID:         "",
-			VPCID:                   "vpc-819f62e9",
+			VPCID:                   "vpc-05dba8c3284fc2836",
 		},
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
To aid in cleaning up and to share fewer credentials, all AWS-based e2e activity from KKP should be moved to its own AWS account.

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
