### PR TITLE
Properly check condition array length for GKE status before accessing it

### DIFF
--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -402,7 +402,7 @@ func GetMDStatusMessage(np *container.NodePool) string {
 	}
 	statusMessage = np.StatusMessage
 	if statusMessage == "" {
-		if np.Conditions != nil && len(np.Conditions) > 0 {
+		if np.Conditions != nil && len(np.Conditions) > 1 {
 			statusMessage = np.Conditions[1].Message
 		}
 	}
@@ -449,7 +449,7 @@ func GetStatusMessage(gkeCluster *container.Cluster) string {
 	}
 	statusMessage = gkeCluster.StatusMessage
 	if statusMessage == "" {
-		if gkeCluster.Conditions != nil && len(gkeCluster.Conditions) > 0 {
+		if gkeCluster.Conditions != nil && len(gkeCluster.Conditions) > 1 {
 			statusMessage = gkeCluster.Conditions[1].Message
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, the master-controller-manager is failing in dev with an index out of bounds error for this code. That is not surprising given that the if condition did not properly check if there are _at least two_ conditions before attempting to index the second element.

I don't know if this is the proper fix since I'm not sure how the conditions on these API resources work (if there's only one condition, should it be ignored? is there something specific about the second element condition?), but at least this code should no longer result in an out-of-bounds panic.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

 Please let @imharshita review this given she knows the context of this code better.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note bugfixes
Prevent index out-of-bounds issue when querying GKE external cluster status
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
