### PR TITLE
Add network policy to allow only egress to k8s api server from the web terminal pod

### DIFF
--- a/pkg/handler/routes_v1_websocket.go
+++ b/pkg/handler/routes_v1_websocket.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/handler/auth"
 	handlercommon "k8c.io/kubermatic/v2/pkg/handler/common"
 	"k8c.io/kubermatic/v2/pkg/handler/middleware"
@@ -80,7 +81,7 @@ var upgrader = websocket.Upgrader{
 
 type WebsocketSettingsWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn)
 type WebsocketUserWriter func(ctx context.Context, providers watcher.Providers, ws *websocket.Conn, userEmail string)
-type WebsocketTerminalWriter func(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string)
+type WebsocketTerminalWriter func(ctx context.Context, ws *websocket.Conn, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster)
 
 const (
 	maxNumberOfTerminalActiveConnectionsPerUser = 5
@@ -298,7 +299,7 @@ func getTerminalWatchHandler(writer WebsocketTerminalWriter, providers watcher.P
 			return
 		}
 
-		writer(ctx, ws, client, k8sClient, cfg, userEmailID)
+		writer(ctx, ws, client, k8sClient, cfg, userEmailID, cluster)
 	}
 }
 

--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -51,6 +51,7 @@ import (
 const (
 	END_OF_TRANSMISSION    = "\u0004"
 	timeout                = 2 * time.Minute
+	appName                = "webterminal"
 	webTerminalStorage     = "web-terminal-storage"
 	podLifetime            = 30 * time.Minute
 	expirationTimestampKey = "ExpirationTimestamp"
@@ -163,35 +164,35 @@ func (t TerminalSession) Toast(p string) error {
 	return nil
 }
 
-func appName(userEmailID string) string {
-	return fmt.Sprintf("webterminal-%s", userEmailID)
+func userAppName(userEmailID string) string {
+	return fmt.Sprintf("%s-%s", appName, userEmailID)
 }
 
 // startProcess is called by terminal session creation.
 // Executed cmd in the container specified in request and connects it up with the ptyHandler (a session).
 func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClient kubernetes.Interface, cfg *rest.Config, userEmailID string, cluster *kubermaticv1.Cluster, cmd []string, ptyHandler PtyHandler, websocketConn *websocket.Conn) error {
-	appName := appName(userEmailID)
+	userAppName := userAppName(userEmailID)
 
 	// check if WEB terminal Pod exists, if not create
 	pod := &corev1.Pod{}
 	if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{
 		Namespace: metav1.NamespaceSystem,
-		Name:      appName,
+		Name:      userAppName,
 	}, pod); err != nil {
 		if !apierrors.IsNotFound(err) {
 			return err
 		}
 		// create Configmap, NetworkPolicy and Pod if not found
-		if err := client.Create(ctx, genWebTerminalConfigMap(appName)); err != nil {
+		if err := client.Create(ctx, genWebTerminalConfigMap(userAppName)); err != nil {
 			if !apierrors.IsAlreadyExists(err) {
 				return err
 			}
-			err := client.Update(ctx, genWebTerminalConfigMap(appName))
+			err := client.Update(ctx, genWebTerminalConfigMap(userAppName))
 			if err != nil {
 				return err
 			}
 		}
-		webTerminalNetworkPolicy, err := genWebTerminalNetworkPolicy(appName, cluster)
+		webTerminalNetworkPolicy, err := genWebTerminalNetworkPolicy(userAppName, cluster)
 		if err != nil {
 			return err
 		}
@@ -204,7 +205,7 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 				return err
 			}
 		}
-		if err := client.Create(ctx, genWebTerminalPod(appName, userEmailID)); err != nil {
+		if err := client.Create(ctx, genWebTerminalPod(userAppName, userEmailID)); err != nil {
 			return err
 		}
 	}
@@ -213,7 +214,7 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 		pod := &corev1.Pod{}
 		if err := client.Get(ctx, ctrlruntimeclient.ObjectKey{
 			Namespace: metav1.NamespaceSystem,
-			Name:      appName,
+			Name:      userAppName,
 		}, pod); err != nil {
 			return false
 		}
@@ -238,7 +239,7 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 
 	req := k8sClient.CoreV1().RESTClient().Post().
 		Resource("pods").
-		Name(appName).
+		Name(userAppName).
 		Namespace(metav1.NamespaceSystem).
 		SubResource("exec")
 
@@ -269,12 +270,12 @@ func startProcess(ctx context.Context, client ctrlruntimeclient.Client, k8sClien
 	return nil
 }
 
-func genWebTerminalConfigMap(appName string) *corev1.ConfigMap {
+func genWebTerminalConfigMap(userAppName string) *corev1.ConfigMap {
 	expirationTime := time.Now().Add(podLifetime)
 
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      appName,
+			Name:      userAppName,
 			Namespace: metav1.NamespaceSystem,
 			Labels: map[string]string{
 				"app": appName,
@@ -286,7 +287,7 @@ func genWebTerminalConfigMap(appName string) *corev1.ConfigMap {
 	}
 }
 
-func genWebTerminalNetworkPolicy(appName string, cluster *kubermaticv1.Cluster) (*networkingv1.NetworkPolicy, error) {
+func genWebTerminalNetworkPolicy(userAppName string, cluster *kubermaticv1.Cluster) (*networkingv1.NetworkPolicy, error) {
 	dnsPort := intstr.FromInt(53)
 	apiServicePort := intstr.FromInt(443)
 	protoUdp := corev1.ProtocolUDP
@@ -302,7 +303,7 @@ func genWebTerminalNetworkPolicy(appName string, cluster *kubermaticv1.Cluster) 
 	// block all ingress and allow only egress to the API server
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      appName,
+			Name:      userAppName,
 			Namespace: metav1.NamespaceSystem,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
@@ -372,9 +373,9 @@ func genWebTerminalNetworkPolicy(appName string, cluster *kubermaticv1.Cluster) 
 	}, nil
 }
 
-func genWebTerminalPod(appName, userEmailID string) *corev1.Pod {
+func genWebTerminalPod(userAppName, userEmailID string) *corev1.Pod {
 	pod := &corev1.Pod{}
-	pod.Name = appName
+	pod.Name = userAppName
 	pod.Namespace = metav1.NamespaceSystem
 	pod.Labels = map[string]string{
 		"app": appName,
@@ -384,7 +385,7 @@ func genWebTerminalPod(appName, userEmailID string) *corev1.Pod {
 	pod.Spec.InitContainers = []corev1.Container{}
 	pod.Spec.Containers = []corev1.Container{
 		{
-			Name:    appName,
+			Name:    userAppName,
 			Image:   resources.RegistryQuay + "/kubermatic/web-terminal:0.2.0",
 			Command: []string{"/bin/bash", "-c", "--"},
 			Args:    []string{"while true; do sleep 30; done;"},


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a security improvement PR to block network access to the web terminal pod.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11021

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
