### PR TITLE
Extend the web terminal endpoint to implement pod expiration message/refresh

### DIFF
--- a/pkg/handler/websocket/terminal.go
+++ b/pkg/handler/websocket/terminal.go
@@ -85,13 +85,13 @@ type TerminalSession struct {
 //
 // OP          DIRECTION  FIELD(S) USED  DESCRIPTION
 // ---------------------------------------------------------------------
-// stdin       fe->be     Data           Keystrokes/paste buffer
-// resize      fe->be     Rows, Cols     New terminal size
-// refresh     fe->be                    Signal to extend expiration time
-// stdout      be->fe     Data           Output from the process
+// stdin       fe->be     Data           Keystrokes/paste buffer.
+// resize      fe->be     Rows, Cols     New terminal size.
+// refresh     fe->be                    Signal to extend expiration time.
+// stdout      be->fe     Data           Output from the process.
 // toast       be->fe     Data           OOB message to be shown to the user.
-// msg         be->fe     Data           Any necessary message from the backend to the frontend
-// expiration  be->fe     Data           Expiration timestamp in seconds
+// msg         be->fe     Data           Any necessary message from the backend to the frontend.
+// expiration  be->fe     Data           Expiration timestamp in seconds.
 type TerminalMessage struct {
 	Op, Data   string
 	Rows, Cols uint16
@@ -214,7 +214,7 @@ func expirationCheckRoutine(ctx context.Context, clusterClient ctrlruntimeclient
 		expirationTime := time.Unix(expirationTimestamp, 0)
 		remainingExpirationTime := time.Until(expirationTime)
 		if remainingExpirationTime < remainingExpirationTimeForWarning {
-			websocketConn.WriteJSON(TerminalMessage{
+			_ = websocketConn.WriteJSON(TerminalMessage{
 				Op:   "expiration",
 				Data: expirationTimestampStr,
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements the pod expiration refresh handling for the web terminal endpoint.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #10157

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
