### PR TITLE
Use AWS spot instances in E2E tests

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	awsInstanceType = "t2.medium"
+	awsInstanceType = "t3.medium"
 	awsVolumeType   = "gp2"
 	awsVolumeSize   = 100
 )

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -156,11 +156,13 @@ func (s *awsScenario) NodeDeployments(ctx context.Context, replicas int, secrets
 				Template: &apimodels.NodeSpec{
 					Cloud: &apimodels.NodeCloudSpec{
 						Aws: &apimodels.AWSNodeSpec{
-							InstanceType:     &instanceType,
-							VolumeType:       &volumeType,
-							VolumeSize:       &volumeSize,
-							AvailabilityZone: subnets[0].AvailabilityZone,
-							SubnetID:         subnets[0].ID,
+							InstanceType:         &instanceType,
+							VolumeType:           &volumeType,
+							VolumeSize:           &volumeSize,
+							AvailabilityZone:     subnets[0].AvailabilityZone,
+							SubnetID:             subnets[0].ID,
+							IsSpotInstance:       true,
+							SpotInstanceMaxPrice: "0.5", // USD
 						},
 					},
 					Versions: &apimodels.NodeVersionInfo{
@@ -175,11 +177,13 @@ func (s *awsScenario) NodeDeployments(ctx context.Context, replicas int, secrets
 				Template: &apimodels.NodeSpec{
 					Cloud: &apimodels.NodeCloudSpec{
 						Aws: &apimodels.AWSNodeSpec{
-							InstanceType:     &instanceType,
-							VolumeType:       &volumeType,
-							VolumeSize:       &volumeSize,
-							AvailabilityZone: subnets[1].AvailabilityZone,
-							SubnetID:         subnets[1].ID,
+							InstanceType:         &instanceType,
+							VolumeType:           &volumeType,
+							VolumeSize:           &volumeSize,
+							AvailabilityZone:     subnets[1].AvailabilityZone,
+							SubnetID:             subnets[1].ID,
+							IsSpotInstance:       true,
+							SpotInstanceMaxPrice: "0.5", // USD
 						},
 					},
 					Versions: &apimodels.NodeVersionInfo{
@@ -194,11 +198,13 @@ func (s *awsScenario) NodeDeployments(ctx context.Context, replicas int, secrets
 				Template: &apimodels.NodeSpec{
 					Cloud: &apimodels.NodeCloudSpec{
 						Aws: &apimodels.AWSNodeSpec{
-							InstanceType:     &instanceType,
-							VolumeType:       &volumeType,
-							VolumeSize:       &volumeSize,
-							AvailabilityZone: subnets[2].AvailabilityZone,
-							SubnetID:         subnets[2].ID,
+							InstanceType:         &instanceType,
+							VolumeType:           &volumeType,
+							VolumeSize:           &volumeSize,
+							AvailabilityZone:     subnets[2].AvailabilityZone,
+							SubnetID:             subnets[2].ID,
+							IsSpotInstance:       true,
+							SpotInstanceMaxPrice: "0.5", // USD
 						},
 					},
 					Versions: &apimodels.NodeVersionInfo{
@@ -279,11 +285,13 @@ func (s *awsScenario) MachineDeployments(ctx context.Context, num int, secrets t
 			OperatingSystem: *osSpec,
 			Cloud: apiv1.NodeCloudSpec{
 				AWS: &apiv1.AWSNodeSpec{
-					InstanceType:     awsInstanceType,
-					VolumeType:       awsVolumeType,
-					VolumeSize:       awsVolumeSize,
-					AvailabilityZone: *subnet.AvailabilityZone,
-					SubnetID:         *subnet.SubnetId,
+					InstanceType:         awsInstanceType,
+					VolumeType:           awsVolumeType,
+					VolumeSize:           awsVolumeSize,
+					AvailabilityZone:     *subnet.AvailabilityZone,
+					SubnetID:             *subnet.SubnetId,
+					IsSpotInstance:       pointer.Bool(true),
+					SpotInstanceMaxPrice: pointer.String("0.5"), // USD
 				},
 			},
 		}

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	awsInstanceType = "t3.medium"
+	awsInstanceType = "t3.small"
 	awsVolumeType   = "gp2"
 	awsVolumeSize   = 100
 )

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -209,16 +209,15 @@ var _ clusterSpec = aws{}
 func (a aws) NodeSpec() models.NodeCloudSpec {
 	return models.NodeCloudSpec{
 		Aws: &models.AWSNodeSpec{
-			AMI:                           "",
-			AssignPublicIP:                true,
-			AvailabilityZone:              "eu-central-1b",
-			InstanceType:                  pointer.String("t3a.small"),
-			IsSpotInstance:                false,
-			SpotInstanceMaxPrice:          "",
-			SpotInstancePersistentRequest: false,
-			SubnetID:                      "subnet-0373d73f016db25c7",
-			VolumeSize:                    pointer.Int32(64),
-			VolumeType:                    pointer.String("standard"),
+			AMI:                  "",
+			AssignPublicIP:       true,
+			AvailabilityZone:     "eu-central-1b",
+			InstanceType:         pointer.String("t3a.small"),
+			IsSpotInstance:       true,
+			SpotInstanceMaxPrice: "0.5",
+			SubnetID:             "subnet-0373d73f016db25c7",
+			VolumeSize:           pointer.Int32(64),
+			VolumeType:           pointer.String("standard"),
 		},
 	}
 }

--- a/pkg/test/e2e/ccm-migration/providers/aws.go
+++ b/pkg/test/e2e/ccm-migration/providers/aws.go
@@ -38,6 +38,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -198,11 +199,13 @@ func (c *AWSCredentialsType) GenerateProviderSpec(ctx context.Context, cluster *
 		},
 		Cloud: apiv1.NodeCloudSpec{
 			AWS: &apiv1.AWSNodeSpec{
-				InstanceType:     "t2.medium",
-				VolumeType:       "gp2",
-				VolumeSize:       100,
-				AvailabilityZone: *subnet.AvailabilityZone,
-				SubnetID:         *subnet.SubnetId,
+				InstanceType:         "t2.medium",
+				VolumeType:           "gp2",
+				VolumeSize:           100,
+				AvailabilityZone:     *subnet.AvailabilityZone,
+				SubnetID:             *subnet.SubnetId,
+				IsSpotInstance:       pointer.Bool(true),
+				SpotInstanceMaxPrice: pointer.String("0.5"), // USD
 			},
 		},
 	}

--- a/pkg/test/e2e/ccm-migration/providers/aws.go
+++ b/pkg/test/e2e/ccm-migration/providers/aws.go
@@ -199,7 +199,7 @@ func (c *AWSCredentialsType) GenerateProviderSpec(ctx context.Context, cluster *
 		},
 		Cloud: apiv1.NodeCloudSpec{
 			AWS: &apiv1.AWSNodeSpec{
-				InstanceType:         "t2.medium",
+				InstanceType:         "t3.small",
 				VolumeType:           "gp2",
 				VolumeSize:           100,
 				AvailabilityZone:     *subnet.AvailabilityZone,

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -441,7 +442,7 @@ func createUserCluster(
 	masterClient ctrlruntimeclient.Client,
 	proxyMode string,
 ) (ctrlruntimeclient.Client, func(), *zap.SugaredLogger, error) {
-	testJig := jig.NewAWSCluster(masterClient, log, accessKeyID, secretAccessKey, 2)
+	testJig := jig.NewAWSCluster(masterClient, log, accessKeyID, secretAccessKey, 2, pointer.String("0.5"))
 	testJig.ProjectJig.WithHumanReadableName(projectName)
 	testJig.ClusterJig.
 		WithTestName("cilium").

--- a/pkg/test/e2e/jig/machine.go
+++ b/pkg/test/e2e/jig/machine.go
@@ -131,10 +131,18 @@ func (j *MachineJig) WithClusterClient(client ctrlruntimeclient.Client) *Machine
 	return j
 }
 
-func (j *MachineJig) WithAWS(instanceType string) *MachineJig {
-	return j.WithProviderSpec(awstypes.RawConfig{
+func (j *MachineJig) WithAWS(instanceType string, spotMaxPriceUSD *string) *MachineJig {
+	cfg := awstypes.RawConfig{
 		InstanceType: providerconfig.ConfigVarString{Value: instanceType},
-	})
+	}
+
+	if spotMaxPriceUSD != nil {
+		cfg.SpotInstanceConfig = &awstypes.SpotInstanceConfig{
+			MaxPrice: providerconfig.ConfigVarString{Value: *spotMaxPriceUSD},
+		}
+	}
+
+	return j.WithProviderSpec(cfg)
 }
 
 func (j *MachineJig) WithHetzner(instanceSize string) *MachineJig {

--- a/pkg/test/e2e/jig/machine.go
+++ b/pkg/test/e2e/jig/machine.go
@@ -137,6 +137,7 @@ func (j *MachineJig) WithAWS(instanceType string, spotMaxPriceUSD *string) *Mach
 	}
 
 	if spotMaxPriceUSD != nil {
+		cfg.IsSpotInstance = pointer.Bool(true)
 		cfg.SpotInstanceConfig = &awstypes.SpotInstanceConfig{
 			MaxPrice: providerconfig.ConfigVarString{Value: *spotMaxPriceUSD},
 		}

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -96,7 +96,7 @@ func (j *TestJig) WaitForHealthyControlPlane(ctx context.Context, timeout time.D
 	return errors.New("no cluster created yet")
 }
 
-func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, accessKeyID, secretAccessKey string, replicas int) *TestJig {
+func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, accessKeyID, secretAccessKey string, replicas int, spotMaxPriceUSD *string) *TestJig {
 	projectJig := NewProjectJig(client, log)
 
 	clusterJig := NewClusterJig(client, log).
@@ -114,7 +114,7 @@ func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, acce
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
-		WithAWS("t3.small")
+		WithAWS("t3.small", spotMaxPriceUSD)
 
 	return &TestJig{
 		ProjectJig: projectJig,

--- a/pkg/test/e2e/konnectivity/konnectivity_test.go
+++ b/pkg/test/e2e/konnectivity/konnectivity_test.go
@@ -364,7 +364,7 @@ func createUserCluster(
 	log *zap.SugaredLogger,
 	masterClient ctrlruntimeclient.Client,
 ) (*kubermaticv1.Cluster, ctrlruntimeclient.Client, *rest.Config, func(), *zap.SugaredLogger, error) {
-	testJig := jig.NewAWSCluster(masterClient, log, accessKeyID, secretAccessKey, 1)
+	testJig := jig.NewAWSCluster(masterClient, log, accessKeyID, secretAccessKey, 1, pointer.String("0.5"))
 	testJig.ProjectJig.WithHumanReadableName(projectName)
 	testJig.ClusterJig.WithKonnectivity(true).WithTestName("konnectivity")
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is to reduce the costs for our E2E tests. The max price has been set relatively high (currently we experience values around 0.2) to make sure the tests remain somewhat stable.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
