### PR TITLE
Deploy KKP API based on the dashboard Docker image

### DIFF
--- a/.prow/api.yaml
+++ b/.prow/api.yaml
@@ -29,6 +29,7 @@ presubmits:
       preset-gce: "true"
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
+      preset-repo-ssh: "true"
       preset-goproxy: "true"
     spec:
       containers:

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -17,7 +17,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
-    dockerRepository: quay.io/kubermatic/kubermatic
+    dockerRepository: quay.io/kubermatic/dashboard
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -17,7 +17,7 @@ spec:
     # DebugLog enables more verbose logging.
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
-    dockerRepository: quay.io/kubermatic/kubermatic-ee
+    dockerRepository: quay.io/kubermatic/dashboard-ee
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -73,6 +73,7 @@ echodate "Building binaries for $KUBERMATIC_VERSION"
 TEST_NAME="Build Kubermatic binaries"
 
 beforeGoBuild=$(nowms)
+export UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF:-main}")"
 time retry 1 make build
 pushElapsed kubermatic_go_build_duration_milliseconds $beforeGoBuild
 

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -242,11 +242,16 @@ func APIDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, workerName 
 				args = append(args, fmt.Sprintf("-worker-name=%s", workerName))
 			}
 
+			tag := versions.UI
+			if cfg.Spec.UI.DockerTag != "" {
+				tag = cfg.Spec.UI.DockerTag
+			}
+
 			d.Spec.Template.Spec.Volumes = volumes
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "api",
-					Image:   cfg.Spec.API.DockerRepository + ":" + versions.Kubermatic,
+					Image:   cfg.Spec.API.DockerRepository + ":" + tag,
 					Command: []string{"kubermatic-api"},
 					Args:    args,
 					Env:     common.ProxyEnvironmentVars(cfg),

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -58,9 +58,10 @@ func UIDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, versions kub
 
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:  "webserver",
-					Image: cfg.Spec.UI.DockerRepository + ":" + tag,
-					Env:   common.ProxyEnvironmentVars(cfg),
+					Name:    "webserver",
+					Image:   cfg.Spec.UI.DockerRepository + ":" + tag,
+					Command: []string{"dashboard"},
+					Env:     common.ProxyEnvironmentVars(cfg),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -549,7 +549,7 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 
 	configCopy.Spec.Auth = auth
 
-	if err := defaultDockerRepo(&configCopy.Spec.API.DockerRepository, DefaultKubermaticImage, "api.dockerRepository", logger); err != nil {
+	if err := defaultDockerRepo(&configCopy.Spec.API.DockerRepository, DefaultDashboardImage, "api.dockerRepository", logger); err != nil {
 		return configCopy, err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As the KKP API was moved to the dashboard, it is now part of the dashboard's Docker image. This PR adjusts the KKP operator to deploy the KKP API with the new Docker image.

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The KKP API is run based on the Dashboard's Docker image now.
```

**Documentation**:
```documentation
NONE
```
