### PR TITLE
Fix rendering error of the metallb addon causing missing L2Advertisement

### DIFF
--- a/addons/metallb/01_address-pools.yaml
+++ b/addons/metallb/01_address-pools.yaml
@@ -34,7 +34,7 @@ spec:
   {{- end }}
 {{- end }}
 
-{{- if and (index .Cluster.Network.IPAMAllocations "metallb-ipv4") (index .Cluster.Network.IPAMAllocations "metallb-ipv6") }}
+{{- if and (index .Cluster.Network.IPAMAllocations "metallb-ipv4").Type (index .Cluster.Network.IPAMAllocations "metallb-ipv6").Type }}
 ---
 apiVersion: metallb.io/v1beta1
 kind: IPAddressPool


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Fixes rendering error of the metallb addon causing the missing `L2Advertisement` CR in the rendered manifest.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix rendering error of the metallb addon causing missing L2Advertisement
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
