### PR TITLE
Fix panic in cluster webhook

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -589,12 +589,12 @@ func ValidateCloudChange(newSpec, oldSpec kubermaticv1.CloudSpec) error {
 func validateDatacenterMatchesProvider(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) error {
 	clusterCloudProvider, err := kubermaticv1helper.ClusterCloudProviderName(spec)
 	if err != nil {
-		return fmt.Errorf("could not determine cluster cloud provider: %v", err)
+		return fmt.Errorf("could not determine cluster cloud provider: %w", err)
 	}
 
 	dcCloudProvider, err := kubermaticv1helper.DatacenterCloudProviderName(&dc.Spec)
 	if err != nil {
-		return fmt.Errorf("could not determine datacenter cloud provider: %v", err)
+		return fmt.Errorf("could not determine datacenter cloud provider: %w", err)
 	}
 
 	if clusterCloudProvider != dcCloudProvider {

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -179,7 +179,11 @@ func ValidateNewClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec,
 		allErrs = append(allErrs, errs...)
 	}
 
-	if cloudProvider != nil {
+	// The cloudProvider is built based on the *datacenter*, but does not necessarily match the CloudSpec.
+	// To prevent a cloud provider to accidentally access nil fields, we check here again that the datacenter
+	// type, providerName and provider data all match before calling the provider's validation logic.
+	// No error needs to be reported here if there's a mismatch, as ValidateClusterSpec() already reported one.
+	if cloudProvider != nil && validateDatacenterMatchesProvider(spec.Cloud, dc) == nil {
 		if err := cloudProvider.ValidateCloudSpec(ctx, spec.Cloud); err != nil {
 			// Just using spec.Cloud for the error leads to a Go-representation of the struct being printed in
 			// the error message, which looks awful an is not helpful. However any other encoding (e.g. JSON)
@@ -582,6 +586,28 @@ func ValidateCloudChange(newSpec, oldSpec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
+func validateDatacenterMatchesProvider(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) error {
+	clusterCloudProvider, err := kubermaticv1helper.ClusterCloudProviderName(spec)
+	if err != nil {
+		return fmt.Errorf("could not determine cluster cloud provider: %v", err)
+	}
+
+	dcCloudProvider, err := kubermaticv1helper.DatacenterCloudProviderName(&dc.Spec)
+	if err != nil {
+		return fmt.Errorf("could not determine datacenter cloud provider: %v", err)
+	}
+
+	if clusterCloudProvider != dcCloudProvider {
+		return fmt.Errorf("expected datacenter provider to be %q, but got %q", clusterCloudProvider, dcCloudProvider)
+	}
+
+	if spec.ProviderName != dcCloudProvider {
+		return fmt.Errorf("expected providerName to be %q, but got %q", dcCloudProvider, spec.ProviderName)
+	}
+
+	return nil
+}
+
 // ValidateCloudSpec validates if the cloud spec is valid
 // If this is not called from within another validation
 // routine, parentFieldPath can be nil.
@@ -607,20 +633,8 @@ func ValidateCloudSpec(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter,
 	}
 
 	if dc != nil {
-		clusterCloudProvider, err := kubermaticv1helper.ClusterCloudProviderName(spec)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, fmt.Sprintf("could not determine cluster cloud provider: %v", err)))
-		}
-
-		dcCloudProvider, err := kubermaticv1helper.DatacenterCloudProviderName(&dc.Spec)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, fmt.Sprintf("could not determine datacenter cloud provider: %v", err)))
-		}
-
-		// this should never happen, unless the caller did the wrong thing
-		// (i.e. user input should never lead to this place)
-		if clusterCloudProvider != dcCloudProvider {
-			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, fmt.Sprintf("expected datacenter provider to be %q, but got %q", clusterCloudProvider, dcCloudProvider)))
+		if err := validateDatacenterMatchesProvider(spec, dc); err != nil {
+			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, err.Error()))
 		}
 	}
 

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -84,6 +84,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: true,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:  "some-project",
 					Username: "some-user",
@@ -99,6 +100,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: true,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					ProjectID: "some-project",
 					Username:  "some-user",
@@ -114,6 +116,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:  "some-project",
 					Username: "some-user",
@@ -129,6 +132,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:        "some-project",
 					Username:       "some-user",
@@ -143,6 +147,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
 					Token: "a-token",
 				},
@@ -160,7 +165,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: true,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
-				ProviderName:   "openstack",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:        "some-project",
 					Username:       "some-user",
@@ -175,7 +180,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
-				ProviderName:   "closedstack",
+				ProviderName:   "closedstack", // *giggle*
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:        "some-project",
 					Username:       "some-user",

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -202,7 +202,8 @@ func TestHandle(t *testing.T) {
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
 				},
-				ExposeStrategy: "Tunneling",
+				ExposeStrategy:    "NodePort",
+				CloudProviderName: string(kubermaticv1.DigitaloceanCloudProvider),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
 					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
 					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
@@ -1772,6 +1773,7 @@ func TestHandle(t *testing.T) {
 type rawClusterGen struct {
 	Name                  string
 	Namespace             string
+	CloudProviderName     string
 	Labels                map[string]string
 	ExposeStrategy        string
 	EnableUserSSHKey      *bool
@@ -1823,6 +1825,10 @@ func (r rawClusterGen) Build() kubermaticv1.Cluster {
 			ComponentsOverride:    r.ComponentSettings,
 			CNIPlugin:             r.CNIPlugin,
 		},
+	}
+
+	if r.CloudProviderName != "" {
+		c.Spec.Cloud.ProviderName = r.CloudProviderName
 	}
 
 	return c


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a fun and kinda sad PR. The original issue was this panic in the kubermatic-webhook:

```
2022/10/26 18:26:24 http: panic serving 10.44.42.8:54636: runtime error: invalid memory address or nil pointer dereference
goroutine 291516 [running]:
net/http.(*conn).serve.func1()
        net/http/server.go:1850 +0xbf
panic({0x3573800, 0x6307230})
        runtime/panic.go:890 +0x262
k8c.io/kubermatic/v2/pkg/provider/cloud/aws.GetCredentialsForCluster({{0xc002774ed0, 0x11}, {0xc001d10f70, 0xc}, 0x0, 0xc0013c57e8, 0x0, 0x0, 0x0, 0x0, ...}, ...)
        k8c.io/kubermatic/v2/pkg/provider/cloud/aws/api.go:145 +0x20
k8c.io/kubermatic/v2/pkg/provider/cloud/aws.(*AmazonEC2).getClientSet(0xc0013c5d58, {0x4374c68, 0xc001cd5da0}, {{0xc002774ed0, 0x11}, {0xc001d10f70, 0xc}, 0x0, 0xc0013c57e8, 0x0, ...})
        k8c.io/kubermatic/v2/pkg/provider/cloud/aws/provider.go:76 +0x9b
k8c.io/kubermatic/v2/pkg/provider/cloud/aws.(*AmazonEC2).ValidateCloudSpec(0xc000217b00?, {0x4374c68, 0xc001cd5da0}, {{0xc002774ed0, 0x11}, {0xc001d10f70, 0xc}, 0x0, 0xc0013c57e8, 0x0, ...})
        k8c.io/kubermatic/v2/pkg/provider/cloud/aws/provider.go:95 +0x78
k8c.io/kubermatic/v2/pkg/validation.ValidateNewClusterSpec({0x4374c68, 0xc001cd5da0}, 0xc000b82108, 0xc000b82000?, {0x4376e80, 0xc0013c5d58}, 0x4372800?, 0xc0006373b0?, 0x0)
        k8c.io/kubermatic/v2/pkg/validation/cluster.go:183 +0x1ae
k8c.io/kubermatic/v2/pkg/webhook/cluster/validation.(*validator).ValidateCreate(0xc000651cc0, {0x4374c68, 0xc001cd5da0}, {0x43603b0?, 0xc000b82000})
        k8c.io/kubermatic/v2/pkg/webhook/cluster/validation/validation.go:96 +0x155
```

This happens when a Cluster object is submitted with the providerName _not_ matching the given spec _OR_ a datacenter that does not match the spec. Even though this does cause an error, it does not prevent the provider validation itself (because we do not want to sift through the spec errors to find some that looks like "provider name does not match something"). However the providers rightfully expect that if their `ValidateClusterSpec` is called, a proper cluster is given. At least I think this is something we can and should guarantee in the `CloudProvider` interface implicitly (maybe not? maybe each provider should add more nil checks?).

So this PR adds some code to only perform provider validation if the name matches correctly.

Now for the fun part: We already _seemingly_ had a unit test for that. This unit test passed always, but not because of the reason we thought. In fact, it returns

> === RUN   TestHandle/Create_cluster_with_invalid_provider_name
>    validation_test.go:1763: exposeStrategy: Forbidden: cannot create cluster with Tunneling expose strategy because the TunnelingExposeStrategy feature gate is not enabled

Ooops. The cluster is invalid, but for the wrong reason. So this PR also extends the tests a bit to make sure we actually generate a broken cluster object. This was the fun part.

Now the sad part: For the unit tests, it doesn't matter, as in unit tests we do not set the `cloudProvider` in the webhook, because we do not want AWS API calls to happen in the background. This is the reason that the new, fixed tests do not cause a panic (if my webhook patch were missing). So the unit test still correctly checks the provider name mismatch (it now correctly gets the error `cloud.providerName: Invalid value: "digitalocean": expected providerName to be "hetzner"`), but it will _not_ ensure that the provider would panic and so does not validate that the new check is in place. I do not see a nice way to improve this in the unit test. That's the sad part.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix kubermatic-webhook panic on providerName mismatch from CloudSpec.
```

**Documentation**:
```documentation
NONE
```
