### PR TITLE
[release/v2.21] remove docker image digests in addons

### DIFF
--- a/addons/cilium/cilium_v1.11.yaml
+++ b/addons/cilium/cilium_v1.11.yaml
@@ -479,7 +479,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: cilium-agent
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -598,7 +598,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -625,7 +625,7 @@ spec:
         securityContext:
           privileged: true
       - name: apply-sysctl-overwrites
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -651,7 +651,7 @@ spec:
         securityContext:
           privileged: true
       - name: clean-cilium-state
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9@sha256:a732e57cb4881abe4783562bbba0045209ef85542372b44ce61584c887c49878"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.11.9"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -807,7 +807,7 @@ spec:
             topologyKey: kubernetes.io/hostname
       containers:
       - name: cilium-operator
-        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.11.6@sha256:9f6063c7bcaede801a39315ec7c166309f6a6783e98665f6693939cf1701bc17"
+        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.11.6"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/addons/cilium/cilium_v1.12.yaml
+++ b/addons/cilium/cilium_v1.12.yaml
@@ -573,7 +573,7 @@ spec:
     spec:
       containers:
       - name: cilium-agent
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -740,7 +740,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -782,7 +782,7 @@ spec:
               - SYS_CHROOT
               - SYS_PTRACE
       - name: apply-sysctl-overwrites
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -825,7 +825,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -841,7 +841,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2@sha256:986f8b04cfdb35cf714701e58e35da0ee63da2b8a048ab596ccb49de58d5ba36"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.2"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -1031,7 +1031,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.12.2@sha256:00508f78dae5412161fa40ee30069c2802aef20f7bdd20e91423103ba8c0df6e"
+        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.12.2"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/addons/hubble/hubble_v1.11.yaml
+++ b/addons/hubble/hubble_v1.11.yaml
@@ -241,7 +241,7 @@ spec:
             topologyKey: "kubernetes.io/hostname"
       containers:
         - name: hubble-relay
-          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.11.9@sha256:0b2f19895de281e4a416700b17a4dc9b8d3b80eb7b5b65dac173880f5113084e"
+          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.11.9"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -320,7 +320,7 @@ spec:
       serviceAccountName: "hubble-ui"
       containers:
       - name: frontend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"
+        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.9.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -330,7 +330,7 @@ spec:
             mountPath: /etc/nginx/conf.d/default.conf
             subPath: nginx.conf
       - name: backend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"
+        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.9.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: EVENTS_SERVER_PORT
@@ -364,7 +364,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.5@sha256:0c2b71bb3469990e7990e7e26243617aa344b5a69a4ce465740b8577f9d48ab9"
+          image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.5"
           imagePullPolicy: IfNotPresent
           command:
             - "/usr/bin/cilium-certgen"
@@ -406,7 +406,7 @@ spec:
         spec:
           containers:
             - name: certgen
-              image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.5@sha256:0c2b71bb3469990e7990e7e26243617aa344b5a69a4ce465740b8577f9d48ab9"
+              image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.5"
               imagePullPolicy: IfNotPresent
               command:
                 - "/usr/bin/cilium-certgen"

--- a/addons/hubble/hubble_v1.12.yaml
+++ b/addons/hubble/hubble_v1.12.yaml
@@ -50,10 +50,10 @@ data:
     cluster-name: default
     peer-service: "hubble-peer.kube-system.svc.cluster.local:443"
     listen-address: :4245
-    dial-timeout: 
-    retry-timeout: 
-    sort-buffer-len-max: 
-    sort-buffer-drain-timeout: 
+    dial-timeout:
+    retry-timeout:
+    sort-buffer-len-max:
+    sort-buffer-drain-timeout:
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
@@ -232,7 +232,7 @@ spec:
     spec:
       containers:
         - name: hubble-relay
-          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.12.2@sha256:6f3496c28f23542f2645d614c0a9e79e3b0ae2732080da794db41c33e4379e5c"
+          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.12.2"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -256,7 +256,7 @@ spec:
             readOnly: true
           terminationMessagePolicy: FallbackToLogsOnError
       restartPolicy: Always
-      priorityClassName: 
+      priorityClassName:
       serviceAccount: "hubble-relay"
       serviceAccountName: "hubble-relay"
       automountServiceAccountToken: false
@@ -315,12 +315,12 @@ spec:
         fsGroup: 1001
         runAsGroup: 1001
         runAsUser: 1001
-      priorityClassName: 
+      priorityClassName:
       serviceAccount: "hubble-ui"
       serviceAccountName: "hubble-ui"
       containers:
       - name: frontend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.9.2@sha256:d3596efc94a41c6b772b9afe6fe47c17417658956e04c3e2a28d293f2670663e"
+        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.9.2"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -333,7 +333,7 @@ spec:
             mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.9.2@sha256:a3ac4d5b87889c9f7cc6323e86d3126b0d382933bd64f44382a92778b0cde5d7"
+        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.9.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: EVENTS_SERVER_PORT
@@ -371,7 +371,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"
+          image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.8"
           imagePullPolicy: IfNotPresent
           command:
             - "/usr/bin/cilium-certgen"
@@ -413,7 +413,7 @@ spec:
         spec:
           containers:
             - name: certgen
-              image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.8@sha256:4a456552a5f192992a6edcec2febb1c54870d665173a33dc7d876129b199ddbd"
+              image: "{{ Registry "quay.io" }}/cilium/certgen:v0.1.8"
               imagePullPolicy: IfNotPresent
               command:
                 - "/usr/bin/cilium-certgen"


### PR DESCRIPTION
**What this PR does / why we need it**:
#11147 fixed the digest handling proper, but for the existing releases we do not want to backport the rather large change, but instead only just remove the digests. See the linked PR for more details as to why.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Remove digests from Docker images in addon manifests to fix issues with Docker registry mirrors / local registries. KKP 2.22  will restore the digests and properly support them.
```

**Documentation**:
```documentation
NONE
```
