### PR TITLE
[release/v2.19] Add RBAC role creation that was accidentally removed in #11117

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -1242,17 +1242,17 @@ func (c *resourcesController) ensureRBACForEtcdLauncher(ctx context.Context, cli
 	if err := c.ensureRBACRoleBindingForEtcdLauncher(ctx, metaObject, kubermaticv1.EtcdRestoreKindName); err != nil {
 		return fmt.Errorf("failed to sync etcd restore RBAC ClusterRoleBinding for %s resource for %s cluster provider: %v", rmapping, c.providerName, err)
 	}
-	if err := c.ensureRBACRoleBindingForEtcdLauncher(ctx, cluster, "Secret"); err != nil {
-		return fmt.Errorf("failed to sync etcd restore RBAC RoleBinding for %s resource for %s cluster provider: %w", rmapping, c.providerName, err)
+	if err := c.ensureRBACRoleForEtcdLauncher(ctx, metaObject, "secrets", "", "Secret"); err != nil {
+		return fmt.Errorf("failed to sync etcd restore RBAC Role for %s resource for %s cluster provider in namespace %s: %w", rmapping, c.providerName, metaObject.GetNamespace(), err)
+	}
+	if err := c.ensureRBACRoleBindingForEtcdLauncher(ctx, metaObject, "Secret"); err != nil {
+		return fmt.Errorf("failed to sync etcd restore RBAC RoleBinding for %s resource for %s cluster provider: %v", rmapping, c.providerName, err)
 	}
 	if err := c.ensureRBACRoleForEtcdLauncher(ctx, cluster, "pods", "", "Pod"); err != nil {
 		return fmt.Errorf("failed to sync etcd restore RBAC Role for %s resource for %s cluster provider: %w", rmapping, c.providerName, err)
 	}
 	if err := c.ensureRBACRoleBindingForEtcdLauncher(ctx, cluster, "Pod"); err != nil {
 		return fmt.Errorf("failed to sync etcd restore RBAC RoleBinding for %s resource for %s cluster provider: %w", rmapping, c.providerName, err)
-	}
-	if err := c.ensureRBACRoleBindingForEtcdLauncher(ctx, metaObject, "Secret"); err != nil {
-		return fmt.Errorf("failed to sync etcd restore RBAC ClusterRoleBinding for %s resource for %s cluster provider: %v", rmapping, c.providerName, err)
 	}
 	if err := c.ensureRBACRoleForEtcdLauncher(ctx, metaObject, "statefulsets", "apps", "StatefulSet"); err != nil {
 		return fmt.Errorf("failed to sync etcd launcher RBAC Role for %s resource for %s cluster provider in namespace %s, due to = %v", rmapping, c.providerName, metaObject.GetNamespace(), err)


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a regression introduced in #11117. The PR accidentally removed the RBAC role generation call for etcd-launcher based restores (compare to #11116 which did not change the same line).

This resulted in error messages like the one below when trying to restore a backup:

```
User \"system:serviceaccount:cluster-<ID>:etcd-launcher\" cannot get resource \"secrets\" in API group \"\" in the namespace \"cluster-<ID>\": RBAC: role.rbac.authorization.k8s.io \"kubermatic:secret:sa-etcd-launcher\" not found"
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix regression that no longer created `Role` kubermatic:secret:sa-etcd-launcher for etcd-launcher-based restores
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
