### PR TITLE
[release/v2.21] Fix panic in cluster webhook (#11236)

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -163,7 +163,11 @@ func ValidateNewClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec,
 		allErrs = append(allErrs, errs...)
 	}
 
-	if cloudProvider != nil {
+	// The cloudProvider is built based on the *datacenter*, but does not necessarily match the CloudSpec.
+	// To prevent a cloud provider to accidentally access nil fields, we check here again that the datacenter
+	// type, providerName and provider data all match before calling the provider's validation logic.
+	// No error needs to be reported here if there's a mismatch, as ValidateClusterSpec() already reported one.
+	if cloudProvider != nil && validateDatacenterMatchesProvider(spec.Cloud, dc) == nil {
 		if err := cloudProvider.ValidateCloudSpec(ctx, spec.Cloud); err != nil {
 			// Just using spec.Cloud for the error leads to a Go-representation of the struct being printed in
 			// the error message, which looks awful an is not helpful. However any other encoding (e.g. JSON)
@@ -549,6 +553,28 @@ func ValidateCloudChange(newSpec, oldSpec kubermaticv1.CloudSpec) error {
 	return nil
 }
 
+func validateDatacenterMatchesProvider(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter) error {
+	clusterCloudProvider, err := provider.ClusterCloudProviderName(spec)
+	if err != nil {
+		return fmt.Errorf("could not determine cluster cloud provider: %w", err)
+	}
+
+	dcCloudProvider, err := provider.DatacenterCloudProviderName(&dc.Spec)
+	if err != nil {
+		return fmt.Errorf("could not determine datacenter cloud provider: %w", err)
+	}
+
+	if clusterCloudProvider != dcCloudProvider {
+		return fmt.Errorf("expected datacenter provider to be %q, but got %q", clusterCloudProvider, dcCloudProvider)
+	}
+
+	if spec.ProviderName != dcCloudProvider {
+		return fmt.Errorf("expected providerName to be %q, but got %q", dcCloudProvider, spec.ProviderName)
+	}
+
+	return nil
+}
+
 // ValidateCloudSpec validates if the cloud spec is valid
 // If this is not called from within another validation
 // routine, parentFieldPath can be nil.
@@ -574,20 +600,8 @@ func ValidateCloudSpec(spec kubermaticv1.CloudSpec, dc *kubermaticv1.Datacenter,
 	}
 
 	if dc != nil {
-		clusterCloudProvider, err := provider.ClusterCloudProviderName(spec)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, fmt.Sprintf("could not determine cluster cloud provider: %v", err)))
-		}
-
-		dcCloudProvider, err := provider.DatacenterCloudProviderName(&dc.Spec)
-		if err != nil {
-			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, fmt.Sprintf("could not determine datacenter cloud provider: %v", err)))
-		}
-
-		// this should never happen, unless the caller did the wrong thing
-		// (i.e. user input should never lead to this place)
-		if clusterCloudProvider != dcCloudProvider {
-			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, fmt.Sprintf("expected datacenter provider to be %q, but got %q", clusterCloudProvider, dcCloudProvider)))
+		if err := validateDatacenterMatchesProvider(spec, dc); err != nil {
+			allErrs = append(allErrs, field.Invalid(parentFieldPath, nil, err.Error()))
 		}
 	}
 

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -84,6 +84,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: true,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:  "some-project",
 					Username: "some-user",
@@ -99,6 +100,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: true,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					ProjectID: "some-project",
 					Username:  "some-user",
@@ -114,6 +116,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:  "some-project",
 					Username: "some-user",
@@ -129,6 +132,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:        "some-project",
 					Username:       "some-user",
@@ -143,6 +147,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{
 					Token: "a-token",
 				},
@@ -160,7 +165,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: true,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
-				ProviderName:   "openstack",
+				ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:        "some-project",
 					Username:       "some-user",
@@ -175,7 +180,7 @@ func TestValidateCloudSpec(t *testing.T) {
 			valid: false,
 			spec: kubermaticv1.CloudSpec{
 				DatacenterName: "some-datacenter",
-				ProviderName:   "closedstack",
+				ProviderName:   "closedstack", // *giggle*
 				Openstack: &kubermaticv1.OpenstackCloudSpec{
 					Project:        "some-project",
 					Username:       "some-user",

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -203,7 +203,8 @@ func TestHandle(t *testing.T) {
 				Labels: map[string]string{
 					kubermaticv1.ProjectIDLabelKey: project1.Name,
 				},
-				ExposeStrategy: "Tunneling",
+				ExposeStrategy:    "NodePort",
+				CloudProviderName: string(kubermaticv1.DigitaloceanCloudProvider),
 				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
 					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
 					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
@@ -1773,6 +1774,7 @@ func TestHandle(t *testing.T) {
 type rawClusterGen struct {
 	Name                  string
 	Namespace             string
+	CloudProviderName     string
 	Labels                map[string]string
 	ExposeStrategy        string
 	EnableUserSSHKey      *bool
@@ -1822,6 +1824,10 @@ func (r rawClusterGen) Build() kubermaticv1.Cluster {
 			ComponentsOverride:    r.ComponentSettings,
 			CNIPlugin:             r.CNIPlugin,
 		},
+	}
+
+	if r.CloudProviderName != "" {
+		c.Spec.Cloud.ProviderName = r.CloudProviderName
 	}
 
 	return c

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -58,7 +58,6 @@ func init() {
 // kube-apiserver *before* the admission webhook is called. So for example this function
 // ensures that an empty nodeport range fails, but in reality, this never happens
 // because of the mutating webhook.
-//
 func TestHandle(t *testing.T) {
 	seed := kubermaticv1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
@@ -1811,6 +1810,7 @@ func (r rawClusterGen) Build() kubermaticv1.Cluster {
 			Version:           *version,
 			Cloud: kubermaticv1.CloudSpec{
 				DatacenterName: datacenterName,
+				ProviderName:   string(kubermaticv1.HetznerCloudProvider),
 				Hetzner: &kubermaticv1.HetznerCloudSpec{
 					Token: "thisis.reallyreallyfake",
 				},

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -760,6 +760,7 @@ func (r rawTemplateGen) Build() kubermaticv1.ClusterTemplate {
 			Version:           *version,
 			Cloud: kubermaticv1.CloudSpec{
 				DatacenterName: datacenterName,
+				ProviderName:   string(kubermaticv1.HetznerCloudProvider),
 				Hetzner: &kubermaticv1.HetznerCloudSpec{
 					Token: "thisis.reallyreallyfake",
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #11236.

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix kubermatic-webhook panic on providerName mismatch from CloudSpec.
```

**Documentation**:
```documentation
NONE
```
