### PR TITLE
Upgrade KubeVirt CCM to v0.4.0 and kubevirt.io/api to v0.58.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -112,7 +112,7 @@ require (
 	k8s.io/metrics v0.25.0
 	k8s.io/test-infra v0.0.0-20220912095525-6dee5b631f79
 	k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73
-	kubevirt.io/api v0.56.0
+	kubevirt.io/api v0.58.0
 	kubevirt.io/containerized-data-importer-api v1.54.0
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/controller-tools v0.9.2

--- a/go.sum
+++ b/go.sum
@@ -1944,8 +1944,8 @@ k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e/go.mod h1:jPW/WVKK9YHAvNhRxK0md/
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73 h1:H9TCJUUx+2VA0ZiD9lvtaX8fthFsMoD+Izn93E/hm8U=
 k8s.io/utils v0.0.0-20220823124924-e9cbc92d1a73/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-kubevirt.io/api v0.56.0 h1:BLQ88qkfy1+zZK2+RuZUI8kBTC6QUchmNw8jTyhUCls=
-kubevirt.io/api v0.56.0/go.mod h1:Qp0JL1vT194eyJ4gy6EokSxnuQveo332dCGX3i5nh/A=
+kubevirt.io/api v0.58.0 h1:qeNeRtD6AIJ5WVJuRXajmmXtnrO5dYchy+hpCm6QwhE=
+kubevirt.io/api v0.58.0/go.mod h1:U0CQlZR0JoJCaC+Va0wz4dMOtYDdVywJ98OT1KmOkzI=
 kubevirt.io/containerized-data-importer-api v1.54.0 h1:0nIFScuAQNtD2OHNM3hNyBRrZwgOKIOUlD1JIG0PWxI=
 kubevirt.io/containerized-data-importer-api v1.54.0/go.mod h1:92HiQEyzPoeMiCbgfG5Qe10JQVbtWMZOXucy56dKdGg=
 kubevirt.io/controller-lifecycle-operator-sdk/api v0.0.0-20220329064328-f3cc58c6ed90 h1:QMrd0nKP0BGbnxTqakhDZAUhGKxPiPiN5gSDqKUmGGc=

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	KubeVirtCCMDeploymentName = "kubevirt-cloud-controller-manager"
-	KubeVirtCCMTag            = "v0.2.0"
+	KubeVirtCCMTag            = "v0.4.0"
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
This is part of #10923 and is also needed as a requirement to unblock other KubeVirt topics like #11114 due due to kubevirt api version conflicts.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade KubeVirt CCM to v0.4.0 and kubevirt.io/api to v0.58.0
```
**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
