### PR TITLE
 assign public ip to node in azure cluster jig 

### DIFF
--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -162,7 +162,7 @@ presubmits:
               memory: 4Gi
               cpu: 2
 
-  - name: pre-kubermatic-dualstack-e2e-azure
+  - name: pre-kubermatic-dualstack-e2e-azure-canal
     optional: true
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -181,7 +181,43 @@ presubmits:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
             - name: CNI
-              value: canal,cilium
+              value: canal
+            - name: PROVIDER
+              value: azure
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pre-kubermatic-dualstack-e2e-azure-cilium
+    optional: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
+          imagePullPolicy: Always
+          command:
+            - "./hack/ci/run-dualstack-e2e-test.sh"
+          env:
+            - name: CNI
+              value: cilium
             - name: PROVIDER
               value: azure
             - name: KUBERMATIC_EDITION

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -434,7 +434,7 @@ func (j *ClusterJig) Delete(ctx context.Context, synchronous bool) error {
 	if synchronous {
 		log.Info("Waiting for cluster to be gone...")
 
-		err = wait.PollLog(ctx, log, 20*time.Second, 10*time.Minute, func() (transient error, terminal error) {
+		err = wait.PollLog(ctx, log, 20*time.Second, 30*time.Minute, func() (transient error, terminal error) {
 			c := &kubermaticv1.Cluster{}
 			err := j.client.Get(ctx, types.NamespacedName{Name: j.clusterName}, c)
 

--- a/pkg/test/e2e/jig/machine.go
+++ b/pkg/test/e2e/jig/machine.go
@@ -194,7 +194,10 @@ func (j *MachineJig) WithAWS(instanceType string, spotMaxPriceUSD *string) *Mach
 func (j *MachineJig) WithAzure(vmSize string) *MachineJig {
 	t := true
 	return j.WithProviderSpec(azuretypes.RawConfig{
-		VMSize:         providerconfig.ConfigVarString{Value: vmSize},
+		VMSize: providerconfig.ConfigVarString{Value: vmSize},
+		// From Azure VM there is no IPv6-only route to the internet
+		// unless the VM has a globally routable IPv6 address.
+		// We set this to make IPv6 egress work in dualstack tests.
 		AssignPublicIP: providerconfig.ConfigVarBool{Value: &t},
 	})
 }

--- a/pkg/test/e2e/jig/machine.go
+++ b/pkg/test/e2e/jig/machine.go
@@ -192,8 +192,10 @@ func (j *MachineJig) WithAWS(instanceType string, spotMaxPriceUSD *string) *Mach
 }
 
 func (j *MachineJig) WithAzure(vmSize string) *MachineJig {
+	t := true
 	return j.WithProviderSpec(azuretypes.RawConfig{
-		VMSize: providerconfig.ConfigVarString{Value: vmSize},
+		VMSize:         providerconfig.ConfigVarString{Value: vmSize},
+		AssignPublicIP: providerconfig.ConfigVarBool{Value: &t},
 	})
 }
 

--- a/pkg/test/e2e/jig/machine.go
+++ b/pkg/test/e2e/jig/machine.go
@@ -192,13 +192,12 @@ func (j *MachineJig) WithAWS(instanceType string, spotMaxPriceUSD *string) *Mach
 }
 
 func (j *MachineJig) WithAzure(vmSize string) *MachineJig {
-	t := true
 	return j.WithProviderSpec(azuretypes.RawConfig{
 		VMSize: providerconfig.ConfigVarString{Value: vmSize},
 		// From Azure VM there is no IPv6-only route to the internet
 		// unless the VM has a globally routable IPv6 address.
 		// We set this to make IPv6 egress work in dualstack tests.
-		AssignPublicIP: providerconfig.ConfigVarBool{Value: &t},
+		AssignPublicIP: providerconfig.ConfigVarBool{Value: pointer.Bool(true)},
 	})
 }
 

--- a/pkg/test/e2e/jig/project.go
+++ b/pkg/test/e2e/jig/project.go
@@ -146,7 +146,6 @@ func (j *ProjectJig) Delete(ctx context.Context, synchronous bool) error {
 
 		err := wait.PollLog(ctx, log, 5*time.Second, 10*time.Minute, func() (transient error, terminal error) {
 			project := &kubermaticv1.Project{}
-
 			err := j.client.Get(ctx, types.NamespacedName{Name: j.projectName}, project)
 			if err == nil {
 				return errors.New("project still exists"), nil

--- a/pkg/test/e2e/jig/project.go
+++ b/pkg/test/e2e/jig/project.go
@@ -144,7 +144,7 @@ func (j *ProjectJig) Delete(ctx context.Context, synchronous bool) error {
 	if synchronous {
 		log.Info("Waiting for project to be gone...")
 
-		err := wait.PollLog(ctx, log, 5*time.Second, 10*time.Minute, func() (transient error, terminal error) {
+		err := wait.PollLog(ctx, log, 5*time.Second, 30*time.Minute, func() (transient error, terminal error) {
 			project := &kubermaticv1.Project{}
 			err := j.client.Get(ctx, types.NamespacedName{Name: j.projectName}, project)
 			if err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Assign public IP to nodes for egress tests to work. 
Increase timeout for cluster, project deletion wait.  Current timeouts are are not enough for Azure. 
Split the test by CNI so the test that passes doesn't have to run again and there is smaller chance of overall test timing out.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
