### PR TITLE
bump k8s-dns-node-cache to 1.22.13

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -87,7 +87,7 @@ func DaemonSetCreator(imageRewriter registry.ImageRewriter) reconciling.NamedDae
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
-					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.21.1", resources.RegistryK8S))),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.22.13", resources.RegistryK8S))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",


### PR DESCRIPTION
**What this PR does / why we need it**:
This simply bumps the Docker image version. It seems to be compatible with all Kubernetes releases.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update k8s-dns-node-cache to 1.22.13
```

**Documentation**:
```documentation
NONE
```
