### PR TITLE
[release/v2.21] Update metering

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -59,7 +59,7 @@ const (
 )
 
 func getMeteringImage(overwriter registry.WithOverwriteFunc) string {
-	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v1.0.0"
+	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v1.0.1"
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates metering to new patch release. 

This includes: 

```release-note
Update metering to version 1.0.1
* Add average-used-cpu-millicores to Cluster and Namespace reports
* Add average-available-cpu-millicores add average-cluster-machines field to Cluster reports
* Fix a bug that causes wrong values if metric is not continuously present for the aggregation window
```

**Documentation**:

```documentation
https://github.com/kubermatic/docs/pull/1239
```


Manual backport of:
https://github.com/kubermatic/kubermatic/pull/11282
