### PR TITLE
Remove Cluster.Status.CloudProviderRevision

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -520,11 +520,6 @@ type ClusterStatus struct {
 	// +optional
 	Phase ClusterPhase `json:"phase,omitempty"`
 
-	// CloudMigrationRevision describes the latest version of the migration that has been done
-	// It is used to avoid redundant and potentially costly migrations.
-	// +optional
-	CloudMigrationRevision int `json:"cloudMigrationRevision,omitempty"`
-
 	// InheritedLabels are labels the cluster inherited from the project. They are read-only for users.
 	// +optional
 	InheritedLabels map[string]string `json:"inheritedLabels,omitempty"`

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -187,9 +187,8 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 	}
 
 	testCluster.Status = kubermaticv1.ClusterStatus{
-		UserEmail:              "test@example.com",
-		CloudMigrationRevision: 2,
-		NamespaceName:          clusterNamespace,
+		UserEmail:     "test@example.com",
+		NamespaceName: clusterNamespace,
 		ExtendedHealth: kubermaticv1.ExtendedClusterHealth{
 			Apiserver:                    kubermaticv1.HealthStatusUp,
 			Scheduler:                    kubermaticv1.HealthStatusUp,

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1771,9 +1771,6 @@ spec:
                       description: URL under which the Apiserver is available
                       type: string
                   type: object
-                cloudMigrationRevision:
-                  description: CloudMigrationRevision describes the latest version of the migration that has been done It is used to avoid redundant and potentially costly migrations.
-                  type: integer
                 conditions:
                   additionalProperties:
                     properties:

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -32,7 +32,6 @@ import (
 	osflavors "github.com/gophercloud/gophercloud/openstack/compute/v2/flavors"
 	osprojects "github.com/gophercloud/gophercloud/openstack/identity/v3/projects"
 	ossecuritygroups "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
-	osecuritygrouprules "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/rules"
 	ossubnetpools "github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/subnetpools"
 	osnetworks "github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
 	ossubnets "github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
@@ -41,7 +40,6 @@ import (
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
-	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 )
@@ -675,82 +673,6 @@ func GetSubnets(ctx context.Context, authURL, region, networkID string, credenti
 	}
 
 	return subnets, nil
-}
-
-func (os *Provider) AddICMPRulesIfRequired(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	if cluster.Spec.Cloud.Openstack.SecurityGroups == "" {
-		return nil
-	}
-	sgName := cluster.Spec.Cloud.Openstack.SecurityGroups
-
-	creds, err := GetCredentialsForCluster(cluster.Spec.Cloud, os.secretKeySelector)
-	if err != nil {
-		return err
-	}
-
-	netClient, err := getNetClient(ctx, os.dc.AuthURL, os.dc.Region, creds, os.caBundle)
-	if err != nil {
-		return fmt.Errorf("failed to create a authenticated openstack client: %w", err)
-	}
-
-	// We can only get security groups by ID and can't be sure that what's on the cluster
-	securityGroups, err := getSecurityGroups(netClient, ossecuritygroups.ListOpts{Name: sgName})
-	if err != nil {
-		return fmt.Errorf("failed to list security groups: %w", err)
-	}
-
-	for _, sg := range securityGroups {
-		if err := addICMPRulesToSecurityGroupIfNecessary(cluster, sg, netClient); err != nil {
-			return fmt.Errorf("failed to add rules for ICMP to security group %q: %w", sg.ID, err)
-		}
-	}
-	return nil
-}
-
-func addICMPRulesToSecurityGroupIfNecessary(cluster *kubermaticv1.Cluster, secGroup ossecuritygroups.SecGroup, netClient *gophercloud.ServiceClient) error {
-	var hasIPV4Rule, hasIPV6Rule bool
-	for _, rule := range secGroup.Rules {
-		if rule.Direction == string(osecuritygrouprules.DirIngress) {
-			if rule.EtherType == string(osecuritygrouprules.EtherType4) && rule.Protocol == string(osecuritygrouprules.ProtocolICMP) {
-				hasIPV4Rule = true
-			}
-			if rule.EtherType == string(osecuritygrouprules.EtherType6) && rule.Protocol == string(osecuritygrouprules.ProtocolIPv6ICMP) {
-				hasIPV6Rule = true
-			}
-		}
-	}
-
-	var rulesToCreate []osecuritygrouprules.CreateOpts
-	if !hasIPV4Rule {
-		rulesToCreate = append(rulesToCreate, osecuritygrouprules.CreateOpts{
-			Direction:  osecuritygrouprules.DirIngress,
-			EtherType:  osecuritygrouprules.EtherType4,
-			SecGroupID: secGroup.ID,
-			Protocol:   osecuritygrouprules.ProtocolICMP,
-		})
-		kubermaticlog.Logger.Infow("Adding Openstack ICMP allow rule to cluster", "cluster", cluster.Name)
-	}
-	if !hasIPV6Rule {
-		rulesToCreate = append(rulesToCreate, osecuritygrouprules.CreateOpts{
-			Direction:  osecuritygrouprules.DirIngress,
-			EtherType:  osecuritygrouprules.EtherType6,
-			SecGroupID: secGroup.ID,
-			Protocol:   osecuritygrouprules.ProtocolIPv6ICMP,
-		})
-		kubermaticlog.Logger.Infow("Adding Openstack ICMP6 allow rule to cluster", "cluster", cluster.Name)
-	}
-
-	for _, rule := range rulesToCreate {
-		res := osecuritygrouprules.Create(netClient, rule)
-		if res.Err != nil {
-			return fmt.Errorf("failed to create security group rule: %w", res.Err)
-		}
-		if _, err := res.Extract(); err != nil {
-			return fmt.Errorf("failed to extract result after security group creation: %w", err)
-		}
-	}
-
-	return nil
 }
 
 // ValidateCloudSpecUpdate verifies whether an update of cloud spec is valid and permitted.


### PR DESCRIPTION
**What this PR does / why we need it**:
This gets rid of a field that we do not need anymore. Since the cloud providers were rewritten to be actual reconcilers, they can / have to fix issues anyway and so there is no need for a "remember how much we did already" flag.

If, in the future, we need to store more info, we can use the existing Conditions and just define a new one.

**Which issue(s) this PR fixes**:
Fixes #8921

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Remove unused `Cluster.Status.CloudProviderRevision` field which carried no useful information anymore.
```

**Documentation**:
```documentation
NONE
```
