### PR TITLE
do not require go-openapi just to handle aggregate errors

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -27,7 +27,6 @@ allowlist:
   - ISC
 
 exceptions:
-  - github.com/ajeddeloh/go-json # Since it's a fork, https://github.com/golang/go/blob/master/LICENSE
   - github.com/cristim/ec2-instances-info # Public domain: https://github.com/cristim/ec2-instances-info/blob/master/LICENSE.
   - github.com/cristim/ec2-instances-info/data # MIT: https://github.com/powdahound/ec2instances.info/blob/master/LICENSE.
   - github.com/acomagu/bufpipe # MIT: https://github.com/acomagu/bufpipe/blob/master/LICENSE (used by go-git)
@@ -38,15 +37,5 @@ exceptions:
   - github.com/hashicorp/go-version # MPL-2.0
   - github.com/hashicorp/golang-lru # MPL-2.0
   - github.com/hashicorp/golang-lru/simplelru # MPL-2.0
-  - github.com/hashicorp/hcl # MPL-2.0
-  - github.com/hashicorp/hcl/hcl/ast # MPL-2.0
-  - github.com/hashicorp/hcl/hcl/parser # MPL-2.0
-  - github.com/hashicorp/hcl/hcl/printer # MPL-2.0
-  - github.com/hashicorp/hcl/hcl/scanner # MPL-2.0
-  - github.com/hashicorp/hcl/hcl/strconv # MPL-2.0
-  - github.com/hashicorp/hcl/hcl/token # MPL-2.0
-  - github.com/hashicorp/hcl/json/parser # MPL-2.0
-  - github.com/hashicorp/hcl/json/scanner # MPL-2.0
-  - github.com/hashicorp/hcl/json/token # MPL-2.0
   - github.com/yvasiyarov/go-metrics # BSD-2-Clause-Views required for https://github.com/distribution/distribution (used by Helm)
   - github.com/bugsnag/osext # Zlib required for https://github.com/distribution/distribution (used by Helm)

--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3
-	github.com/go-openapi/errors v0.20.3
 	github.com/go-test/deep v1.0.8
 	github.com/gobuffalo/flect v0.3.0
 	github.com/google/go-cmp v0.5.9

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,6 @@ github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/zapr v1.2.3 h1:a9vnzlIBPQBBkeaR9IuMUfmVOrQlkoC4YfPoFkX3T7A=
 github.com/go-logr/zapr v1.2.3/go.mod h1:eIauM6P8qSvTw5o2ez6UEAfGjQKrxQTl5EoK+Qa2oG4=
-github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
-github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
 github.com/go-openapi/jsonpointer v0.19.5/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/go-openapi/errors"
 	"go.uber.org/zap"
 
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -31,6 +30,7 @@ import (
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
@@ -166,7 +166,7 @@ func (r *Reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	}
 
 	if len(errs) > 0 {
-		return nil, errors.CompositeValidationError(errs...)
+		return nil, utilerrors.NewAggregate(errs)
 	}
 
 	if err := r.removeAnnotation(ctx, cluster); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We already have a package that can handle multiple errors and that package does not pretent that those errors are all validation related. So I think we can just use one over the other, as ultimately the aggregated errors are just logged and nothing depends on them being a go-openapi Composite Error.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
