### PR TITLE
Add externalclusters in kubermaticwebhook clusterrole

### DIFF
--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -76,6 +76,11 @@ func WebhookClusterRoleCreator(cfg *kubermaticv1.KubermaticConfiguration) reconc
 					Resources: []string{"clustertemplates", "projects", "ipamallocations", "resourcequotas"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				{
+					APIGroups: []string{"kubermatic.k8c.io"},
+					Resources: []string{"externalclusters"},
+					Verbs:     []string{"get", "list"},
+				},
 			}
 
 			return r, nil

--- a/pkg/validation/user.go
+++ b/pkg/validation/user.go
@@ -112,7 +112,7 @@ func ValidateUserDelete(ctx context.Context,
 			return err
 		}
 		if hasExtClusters {
-			return fmt.Errorf("operation not permitted!: user project %s has resources, clusters or externalclusters", project.Name)
+			return fmt.Errorf("operation not permitted!: user project %s has resources i.e., externalclusters", project.Name)
 		}
 
 		// if project has clusters on any seed
@@ -130,7 +130,7 @@ func ValidateUserDelete(ctx context.Context,
 				return err
 			}
 			if hasClusters {
-				return fmt.Errorf("operation not permitted!: user project %s has resources, clusters or externalclusters", project.Name)
+				return fmt.Errorf("operation not permitted!: user project %s has resources i.e., clusters", project.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**:  Fixes rbac rules for the kubermatic-webhook so that it can interact with externalclusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
