### PR TITLE
Fix membernotfound error

### DIFF
--- a/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller_test.go
@@ -133,7 +133,7 @@ func generateUser(name string, deleted bool) *kubermaticv1.User {
 	if deleted {
 		deleteTime := metav1.NewTime(time.Now())
 		user.DeletionTimestamp = &deleteTime
-		user.Finalizers = append(user.Finalizers, cleanupFinalizer)
+		user.Finalizers = append(user.Finalizers, seedUsersCleanupFinalizer)
 	}
 	return user
 }


### PR DESCRIPTION
**What this PR does / why we need it**: Fix member not found when a respective user doesn't exist
- When a sole user owner with no resources in owned project is set to deletion then project is deleted as user is set as ownerRefereces, which will also delete userprojectbindings
- For any other case this pr will take care of deleting the userprojectbindings to avoid any error

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #8289

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Now userprojectbinding will be deleted if the respecitve user is set for deletion
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
