### PR TITLE
Fix for cluster with MLA not being terminated after project deletion

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -187,6 +187,14 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 		return nil, fmt.Errorf("failed to create Grafana client: %w", err)
 	}
 
+	mlaDisabled := !cluster.Spec.MLA.LoggingEnabled && !cluster.Spec.MLA.MonitoringEnabled
+	if !cluster.DeletionTimestamp.IsZero() || mlaDisabled {
+		if err := r.handleDeletion(ctx, cluster, grafanaClient); err != nil {
+			return nil, fmt.Errorf("handling deletion: %w", err)
+		}
+		return nil, nil
+	}
+
 	project := &kubermaticv1.Project{}
 	err = r.Get(ctx, types.NamespacedName{Name: projectID}, project)
 	if err != nil {
@@ -214,14 +222,6 @@ func (r *datasourceGrafanaController) reconcile(ctx context.Context, cluster *ku
 	}
 	// set header from the very beginning so all other calls will be within this organization
 	grafanaClient.SetOrgIDHeader(org.ID)
-
-	mlaDisabled := !cluster.Spec.MLA.LoggingEnabled && !cluster.Spec.MLA.MonitoringEnabled
-	if !cluster.DeletionTimestamp.IsZero() || mlaDisabled {
-		if err := r.handleDeletion(ctx, cluster, grafanaClient); err != nil {
-			return nil, fmt.Errorf("handling deletion: %w", err)
-		}
-		return nil, nil
-	}
 
 	if err := kubernetes.TryAddFinalizer(ctx, r, cluster, mlaFinalizer); err != nil {
 		return nil, fmt.Errorf("failed to add finalizer: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR anticipates the deletion handling in the MLA datasource Grafana controller, as the k8s Project resource is lacking the necessary annotation with the Grafana organization ID when in "Terminating" state, which was causing an error and returning before removing the cluster finalizer.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11081

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
