### PR TITLE
[release/v2.20] Use optimistic locking when managing finalizer `kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids`

### DIFF
--- a/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
@@ -213,7 +213,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 	oldCluster := cluster.DeepCopy()
 	if !kubernetes.HasFinalizer(cluster, UserSSHKeysClusterIDsCleanupFinalizer) {
 		kubernetes.AddFinalizer(cluster, UserSSHKeysClusterIDsCleanupFinalizer)
-		if err := seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
+		if err := seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFromWithOptions(oldCluster, ctrlruntimeclient.MergeFromWithOptimisticLock{})); err != nil {
 			return fmt.Errorf("failed adding %s finalizer: %w", UserSSHKeysClusterIDsCleanupFinalizer, err)
 		}
 	}

--- a/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkeyssynchronizer/controller.go
@@ -192,7 +192,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, requ
 		if kubernetes.HasFinalizer(cluster, UserSSHKeysClusterIDsCleanupFinalizer) {
 			oldCluster := cluster.DeepCopy()
 			kubernetes.RemoveFinalizer(cluster, UserSSHKeysClusterIDsCleanupFinalizer)
-			if err := seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster)); err != nil {
+			if err := seedClient.Patch(ctx, cluster, ctrlruntimeclient.MergeFromWithOptions(oldCluster, ctrlruntimeclient.MergeFromWithOptimisticLock{})); err != nil {
 				return fmt.Errorf("failed removing %s finalizer: %w", UserSSHKeysClusterIDsCleanupFinalizer, err)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP 2.21 and later use optimistic locking for adding finalizers to make sure we never override finalizers set up by other controllers. Some of that logic was backported to 2.20 with #10543. It seems the UserSSHKeys finalizer was either missed or out of scope for the previous PR.

We've observed at least one event where finalizers were overridden by this code, so we should fix it and ship the fix ASAP.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding finalizer `kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids` to `Cluster` resources can no longer remove other finalizers
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
