### PR TITLE
Add OSM webhook to mutate MachineDeployments

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -348,6 +348,10 @@ func GetServiceCreators(data *resources.TemplateData) []reconciling.NamedService
 		creators = append(creators, nodeportproxy.FrontLoadBalancerServiceCreator(data))
 	}
 
+	if data.Cluster().Spec.IsOperatingSystemManagerEnabled() {
+		creators = append(creators, operatingsystemmanager.ServiceCreator())
+	}
+
 	return creators
 }
 
@@ -391,6 +395,7 @@ func GetDeploymentCreators(data *resources.TemplateData, enableAPIserverOIDCAuth
 
 	if data.Cluster().Spec.IsOperatingSystemManagerEnabled() {
 		deployments = append(deployments, operatingsystemmanager.DeploymentCreator(data))
+		deployments = append(deployments, operatingsystemmanager.WebhookDeploymentCreator(data))
 	}
 
 	if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
@@ -443,6 +448,13 @@ func (r *Reconciler) GetSecretCreators(data *resources.TemplateData) []reconcili
 	if data.Cluster().Spec.IsKubernetesDashboardEnabled() {
 		creators = append(creators,
 			resources.GetInternalKubeconfigCreator(namespace, resources.KubernetesDashboardKubeconfigSecretName, resources.KubernetesDashboardCertUsername, nil, data, r.log),
+		)
+	}
+
+	if data.Cluster().Spec.IsOperatingSystemManagerEnabled() {
+		creators = append(creators,
+			resources.GetInternalKubeconfigCreator(namespace, resources.OperatingSystemManagerWebhookKubeconfigSecretName, resources.OperatingSystemManagerWebhookCertUsername, nil, data, r.log),
+			operatingsystemmanager.TLSServingCertificateCreator(data),
 		)
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -556,6 +556,7 @@ func (r *reconciler) reconcileClusterRoles(ctx context.Context, data reconcileDa
 
 	if data.operatingSystemManagerEnabled {
 		creators = append(creators, operatingsystemmanager.MachineDeploymentsClusterRoleCreator())
+		creators = append(creators, operatingsystemmanager.WebhookClusterRoleCreator())
 	}
 
 	if err := reconciling.ReconcileClusterRoles(ctx, creators, "", r.Client); err != nil {
@@ -605,6 +606,7 @@ func (r *reconciler) reconcileClusterRoleBindings(ctx context.Context, data reco
 
 	if data.operatingSystemManagerEnabled {
 		creators = append(creators, operatingsystemmanager.MachineDeploymentsClusterRoleBindingCreator())
+		creators = append(creators, operatingsystemmanager.WebhookClusterRoleBindingCreator())
 	}
 
 	if err := reconciling.ReconcileClusterRoleBindings(ctx, creators, "", r.Client); err != nil {
@@ -657,6 +659,10 @@ func (r *reconciler) reconcileMutatingWebhookConfigurations(ctx context.Context,
 	if r.opaIntegration && r.opaEnableMutation {
 		creators = append(creators, gatekeeper.MutatingWebhookConfigurationCreator(r.opaWebhookTimeout))
 	}
+	if data.operatingSystemManagerEnabled {
+		creators = append(creators, operatingsystemmanager.MutatingwebhookConfigurationCreator(data.caCert.Cert, r.namespace))
+	}
+
 	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, creators, "", r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile MutatingWebhookConfigurations: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
@@ -69,8 +69,9 @@ func WebhookClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreat
 			}
 			crb.Subjects = []rbacv1.Subject{
 				{
-					Kind: rbacv1.UserKind,
-					Name: resources.OperatingSystemManagerWebhookCertUsername,
+					Kind:     rbacv1.UserKind,
+					APIGroup: rbacv1.GroupName,
+					Name:     resources.OperatingSystemManagerWebhookCertUsername,
 				},
 			}
 			return crb, nil

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	webhookRoleName        = "kubermatic:machine-controller-webhook"
-	webhookRoleBindingName = "kubermatic:machine-controller-webhook"
+	webhookRoleName        = "kubermatic:operating-system-manager-webhook"
+	webhookRoleBindingName = "kubermatic:operating-system-manager-webhook"
 
 	clusterAPIGroup   = "cluster.k8s.io"
 	clusterAPIVersion = "v1alpha1"

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
@@ -89,8 +89,8 @@ func MutatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace str
 
 			// This only gets set when the APIServer supports it, so carry it over
 			var scope *admissionregistrationv1.ScopeType
-			if len(mutatingWebhookConfiguration.Webhooks) != 2 {
-				mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{}, {}}
+			if len(mutatingWebhookConfiguration.Webhooks) != 1 {
+				mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{}}
 			} else if len(mutatingWebhookConfiguration.Webhooks[0].Rules) > 0 {
 				scope = mutatingWebhookConfiguration.Webhooks[0].Rules[0].Scope
 			}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatingsystemmanager
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	webhookRoleName        = "kubermatic:machine-controller-webhook"
+	webhookRoleBindingName = "kubermatic:machine-controller-webhook"
+
+	clusterAPIGroup   = "cluster.k8s.io"
+	clusterAPIVersion = "v1alpha1"
+)
+
+func WebhookClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
+	return func() (string, reconciling.ClusterRoleCreator) {
+		return webhookRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+			cr.Rules = []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{"operatingsystemmanager.k8c.io"},
+					Resources: []string{"operatingsystemprofiles"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups:     []string{"coordination.k8s.io"},
+					Resources:     []string{"leases"},
+					Verbs:         []string{"create", "update", "get", "list", "watch"},
+					ResourceNames: []string{"operating-system-manager-leader-lock"},
+				},
+			}
+
+			return cr, nil
+		}
+	}
+}
+
+func WebhookClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
+	return func() (string, reconciling.ClusterRoleBindingCreator) {
+		return webhookRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+			crb.RoleRef = rbacv1.RoleRef{
+				Name:     webhookRoleName,
+				Kind:     "ClusterRole",
+				APIGroup: rbacv1.GroupName,
+			}
+			crb.Subjects = []rbacv1.Subject{
+				{
+					Kind: rbacv1.UserKind,
+					Name: resources.OperatingSystemManagerWebhookCertUsername,
+				},
+			}
+			return crb, nil
+		}
+	}
+}
+
+// MutatingwebhookConfigurationCreator returns the MutatingwebhookConfiguration for OSM.
+func MutatingwebhookConfigurationCreator(caCert *x509.Certificate, namespace string) reconciling.NamedMutatingWebhookConfigurationCreatorGetter {
+	return func() (string, reconciling.MutatingWebhookConfigurationCreator) {
+		return resources.OperatingSystemManagerMutatingWebhookConfigurationName, func(mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, error) {
+			failurePolicy := admissionregistrationv1.Fail
+			sideEffects := admissionregistrationv1.SideEffectClassNone
+			mdURL := fmt.Sprintf("https://%s.%s.svc.cluster.local./mutate-v1alpha1-machinedeployment", resources.OperatingSystemManagerWebhookServiceName, namespace)
+			reviewVersions := []string{"v1", "v1beta1"}
+
+			// This only gets set when the APIServer supports it, so carry it over
+			var scope *admissionregistrationv1.ScopeType
+			if len(mutatingWebhookConfiguration.Webhooks) != 2 {
+				mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{}, {}}
+			} else if len(mutatingWebhookConfiguration.Webhooks[0].Rules) > 0 {
+				scope = mutatingWebhookConfiguration.Webhooks[0].Rules[0].Scope
+			}
+
+			mutatingWebhookConfiguration.Webhooks[0].Name = fmt.Sprintf("%s-machinedeployments", resources.OperatingSystemManagerMutatingWebhookConfigurationName)
+			mutatingWebhookConfiguration.Webhooks[0].NamespaceSelector = &metav1.LabelSelector{}
+			mutatingWebhookConfiguration.Webhooks[0].SideEffects = &sideEffects
+			mutatingWebhookConfiguration.Webhooks[0].FailurePolicy = &failurePolicy
+			mutatingWebhookConfiguration.Webhooks[0].AdmissionReviewVersions = reviewVersions
+			mutatingWebhookConfiguration.Webhooks[0].Rules = []admissionregistrationv1.RuleWithOperations{{
+				Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
+				Rule: admissionregistrationv1.Rule{
+					APIGroups:   []string{clusterAPIGroup},
+					APIVersions: []string{clusterAPIVersion},
+					Resources:   []string{"machinedeployments"},
+					Scope:       scope,
+				},
+			}}
+			mutatingWebhookConfiguration.Webhooks[0].ClientConfig = admissionregistrationv1.WebhookClientConfig{
+				URL:      &mdURL,
+				CABundle: triple.EncodeCertPEM(caCert),
+			}
+
+			return mutatingWebhookConfiguration, nil
+		}
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/operating-system-manager/webhook.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	webhookRoleName        = "kubermatic:operating-system-manager-webhook"
-	webhookRoleBindingName = "kubermatic:operating-system-manager-webhook"
+	webhookClusterRoleName        = "kubermatic:operating-system-manager-webhook"
+	webhookClusterRoleBindingName = "kubermatic:operating-system-manager-webhook"
 
 	clusterAPIGroup   = "cluster.k8s.io"
 	clusterAPIVersion = "v1alpha1"
@@ -39,7 +39,7 @@ const (
 
 func WebhookClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 	return func() (string, reconciling.ClusterRoleCreator) {
-		return webhookRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
+		return webhookClusterRoleName, func(cr *rbacv1.ClusterRole) (*rbacv1.ClusterRole, error) {
 			cr.Rules = []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{"operatingsystemmanager.k8c.io"},
@@ -61,9 +61,9 @@ func WebhookClusterRoleCreator() reconciling.NamedClusterRoleCreatorGetter {
 
 func WebhookClusterRoleBindingCreator() reconciling.NamedClusterRoleBindingCreatorGetter {
 	return func() (string, reconciling.ClusterRoleBindingCreator) {
-		return webhookRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+		return webhookClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.RoleRef = rbacv1.RoleRef{
-				Name:     webhookRoleName,
+				Name:     webhookClusterRoleName,
 				Kind:     "ClusterRole",
 				APIGroup: rbacv1.GroupName,
 			}

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -358,6 +358,8 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		resources.OperatingSystemManagerKubeconfigSecretName,
 		resources.KonnectivityKubeconfigSecretName,
 		resources.KonnectivityProxyTLSSecretName,
+		resources.OperatingSystemManagerWebhookKubeconfigSecretName,
+		resources.OperatingSystemManagerWebhookServingCertSecretName,
 	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -52,7 +52,7 @@ var (
 
 const (
 	Name = "machine-controller"
-	// TODO: update to tagged machine-controller version
+	// TODO: update to tagged machine-controller version.
 	Tag = "d41d7d9ce97ff62d7f3629495fce00c355e3ae53"
 )
 

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -52,7 +52,8 @@ var (
 
 const (
 	Name = "machine-controller"
-	Tag  = "5819bb5f27f7cb9f0ca83045de1eb0f5de122af5"
+	// TODO: update to tagged machine-controller version
+	Tag = "d41d7d9ce97ff62d7f3629495fce00c355e3ae53"
 )
 
 type machinecontrollerData interface {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -54,7 +54,8 @@ var (
 
 const (
 	Name = "operating-system-manager"
-	Tag  = "v1.1.1"
+	// TODO: pin to a released version again
+	Tag = "296ee43a51a0aee013f0c6aa98f85493c59db050"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -54,7 +54,7 @@ var (
 
 const (
 	Name = "operating-system-manager"
-	// TODO: pin to a released version again
+	// TODO: pin to a released version again.
 	Tag = "296ee43a51a0aee013f0c6aa98f85493c59db050"
 )
 

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -68,7 +68,7 @@ func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.Named
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
-			volumes := []corev1.Volume{getKubeconfigVolume(), getServingCertVolume(), getCABundleVolume()}
+			volumes := []corev1.Volume{getWebhookKubeconfigVolume(), getServingCertVolume(), getCABundleVolume()}
 			dep.Spec.Template.Spec.Volumes = volumes
 
 			podLabels, err := data.GetPodTemplateLabels(resources.OperatingSystemManagerWebhookDeploymentName, volumes, nil)
@@ -269,6 +269,17 @@ func getCABundleVolume() corev1.Volume {
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: resources.CABundleConfigMapName,
 				},
+			},
+		},
+	}
+}
+
+func getWebhookKubeconfigVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: resources.OperatingSystemManagerWebhookKubeconfigSecretName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: resources.OperatingSystemManagerWebhookKubeconfigSecretName,
 			},
 		},
 	}

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -1,0 +1,275 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package operatingsystemmanager
+
+import (
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/sets"
+	certutil "k8s.io/client-go/util/cert"
+)
+
+var (
+	webhookResourceRequirements = map[string]*corev1.ResourceRequirements{
+		Name: {
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("32Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+			},
+		},
+	}
+)
+
+// WebhookDeploymentCreator returns the function to create and update the operating-system-manager webhook deployment.
+func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.NamedDeploymentCreatorGetter {
+	return func() (string, reconciling.DeploymentCreator) {
+		return resources.OperatingSystemManagerWebhookDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			args := []string{
+				"-logtostderr",
+				"-v", "4",
+				"-namespace", "kube-system",
+			}
+
+			dep.Name = resources.OperatingSystemManagerWebhookDeploymentName
+			dep.Labels = resources.BaseAppLabels(resources.OperatingSystemManagerWebhookDeploymentName, nil)
+			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabels(resources.OperatingSystemManagerWebhookDeploymentName, nil),
+			}
+			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
+
+			volumes := []corev1.Volume{getKubeconfigVolume(), getServingCertVolume(), getCABundleVolume()}
+			dep.Spec.Template.Spec.Volumes = volumes
+
+			podLabels, err := data.GetPodTemplateLabels(resources.OperatingSystemManagerWebhookDeploymentName, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %w", err)
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{Labels: podLabels}
+
+			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
+
+			repository := registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/operating-system-manager"))
+			if r := data.OperatingSystemManagerImageRepository(); r != "" {
+				repository = r
+			}
+
+			tag := Tag
+			if t := data.OperatingSystemManagerImageTag(); t != "" {
+				tag = t
+			}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:    Name,
+					Image:   repository + ":" + tag,
+					Command: []string{"/usr/local/bin/webhook"},
+					Args:    args,
+					Env: []corev1.EnvVar{
+						{
+							Name:  "KUBECONFIG",
+							Value: "/etc/kubernetes/worker-kubeconfig/kubeconfig",
+						},
+					},
+					ReadinessProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(8081),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						FailureThreshold: 3,
+						PeriodSeconds:    10,
+						SuccessThreshold: 1,
+						TimeoutSeconds:   15,
+					},
+					LivenessProbe: &corev1.Probe{
+						FailureThreshold: 8,
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/healthz",
+								Port:   intstr.FromInt(8081),
+								Scheme: corev1.URISchemeHTTPS,
+							},
+						},
+						InitialDelaySeconds: 15,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      resources.OperatingSystemManagerWebhookKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/worker-kubeconfig",
+							ReadOnly:  true,
+						},
+						{
+							Name:      resources.OperatingSystemManagerWebhookServingCertSecretName,
+							MountPath: "/tmp/k8s-webhook-server/serving-certs",
+							ReadOnly:  true,
+						},
+						{
+							Name:      resources.CABundleConfigMapName,
+							MountPath: "/etc/kubernetes/pki/ca-bundle",
+							ReadOnly:  true,
+						},
+					},
+				},
+			}
+			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, webhookResourceRequirements, nil, dep.Annotations)
+			if err != nil {
+				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
+			}
+
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name), "Machine,cluster.k8s.io/v1alpha1")
+			if err != nil {
+				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
+			}
+			dep.Spec.Template.Spec = *wrappedPodSpec
+
+			return dep, nil
+		}
+	}
+}
+
+// ServiceCreator returns the function to reconcile the DNS service.
+func ServiceCreator() reconciling.NamedServiceCreatorGetter {
+	return func() (string, reconciling.ServiceCreator) {
+		return resources.OperatingSystemManagerWebhookServiceName, func(se *corev1.Service) (*corev1.Service, error) {
+			se.Name = resources.OperatingSystemManagerWebhookServiceName
+			se.Labels = resources.BaseAppLabels(resources.OperatingSystemManagerWebhookDeploymentName, nil)
+
+			se.Spec.Type = corev1.ServiceTypeClusterIP
+			se.Spec.Selector = map[string]string{
+				resources.AppLabelKey: resources.OperatingSystemManagerWebhookDeploymentName,
+			}
+			se.Spec.Ports = []corev1.ServicePort{
+				{
+					Name:       "",
+					Port:       443,
+					Protocol:   corev1.ProtocolTCP,
+					TargetPort: intstr.FromInt(9443),
+				},
+			}
+
+			return se, nil
+		}
+	}
+}
+
+type tlsServingCertCreatorData interface {
+	GetRootCA() (*triple.KeyPair, error)
+	Cluster() *kubermaticv1.Cluster
+}
+
+// TLSServingCertificateCreator returns a function to create/update the secret with the operating-system-manager-webhook tls certificate.
+func TLSServingCertificateCreator(data tlsServingCertCreatorData) reconciling.NamedSecretCreatorGetter {
+	return func() (string, reconciling.SecretCreator) {
+		return resources.OperatingSystemManagerWebhookServingCertSecretName, func(se *corev1.Secret) (*corev1.Secret, error) {
+			if se.Data == nil {
+				se.Data = map[string][]byte{}
+			}
+
+			ca, err := data.GetRootCA()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get root ca: %w", err)
+			}
+
+			commonName := fmt.Sprintf("%s.%s.svc.cluster.local.", resources.OperatingSystemManagerWebhookServiceName, data.Cluster().Status.NamespaceName)
+			altNames := certutil.AltNames{
+				DNSNames: []string{
+					resources.OperatingSystemManagerWebhookServiceName,
+					fmt.Sprintf("%s.%s", resources.OperatingSystemManagerWebhookServiceName, data.Cluster().Status.NamespaceName),
+					commonName,
+					fmt.Sprintf("%s.%s.svc", resources.OperatingSystemManagerWebhookServiceName, data.Cluster().Status.NamespaceName),
+					fmt.Sprintf("%s.%s.svc.", resources.OperatingSystemManagerWebhookServiceName, data.Cluster().Status.NamespaceName),
+				},
+			}
+
+			if b, exists := se.Data[resources.OperatingSystemManagerWebhookServingCertCertKeyName]; exists {
+				certs, err := certutil.ParseCertsPEM(b)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse certificate (key=%s) from existing secret: %w", resources.OperatingSystemManagerWebhookServingCertCertKeyName, err)
+				}
+				if resources.IsServerCertificateValidForAllOf(certs[0], commonName, altNames, ca.Cert) {
+					return se, nil
+				}
+			}
+
+			newKP, err := triple.NewServerKeyPair(ca,
+				commonName,
+				resources.OperatingSystemManagerWebhookServiceName,
+				data.Cluster().Status.NamespaceName,
+				"",
+				nil,
+				// For some reason the name the APIServer validates against must be in the SANs, having it as CN is not enough
+				[]string{commonName})
+			if err != nil {
+				return nil, fmt.Errorf("failed to generate serving cert: %w", err)
+			}
+
+			se.Data[resources.OperatingSystemManagerWebhookServingCertCertKeyName] = triple.EncodeCertPEM(newKP.Cert)
+			se.Data[resources.OperatingSystemManagerWebhookServingCertKeyKeyName] = triple.EncodePrivateKeyPEM(newKP.Key)
+			// Include the CA for simplicity
+			se.Data[resources.CACertSecretKey] = triple.EncodeCertPEM(ca.Cert)
+
+			return se, nil
+		}
+	}
+}
+
+func getServingCertVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: resources.OperatingSystemManagerWebhookServingCertSecretName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: resources.OperatingSystemManagerWebhookServingCertSecretName,
+			},
+		},
+	}
+}
+
+func getCABundleVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: resources.CABundleConfigMapName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: resources.CABundleConfigMapName,
+				},
+			},
+		},
+	}
+}

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -58,6 +58,8 @@ func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.Named
 				"-logtostderr",
 				"-v", "4",
 				"-namespace", "kube-system",
+				"-health-probe-bind-address", "0.0.0.0:8081",
+				"-metrics-bind-address", "0.0.0.0:8080",
 			}
 
 			dep.Name = resources.OperatingSystemManagerWebhookDeploymentName
@@ -105,7 +107,7 @@ func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.Named
 					ReadinessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/healthz",
+								Path:   "/readyz",
 								Port:   intstr.FromInt(8081),
 								Scheme: corev1.URISchemeHTTPS,
 							},

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -62,10 +62,12 @@ func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.Named
 
 			dep.Name = resources.OperatingSystemManagerWebhookDeploymentName
 			dep.Labels = resources.BaseAppLabels(resources.OperatingSystemManagerWebhookDeploymentName, nil)
+
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: resources.BaseAppLabels(resources.OperatingSystemManagerWebhookDeploymentName, nil),
 			}
+
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
 			volumes := []corev1.Volume{getWebhookKubeconfigVolume(), getServingCertVolume(), getCABundleVolume()}
@@ -112,8 +114,9 @@ func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.Named
 					ReadinessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path: "/readyz",
-								Port: intstr.FromInt(8081),
+								Path:   "/readyz",
+								Port:   intstr.FromInt(8081),
+								Scheme: corev1.URISchemeHTTP,
 							},
 						},
 						FailureThreshold: 3,
@@ -125,8 +128,9 @@ func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.Named
 						FailureThreshold: 8,
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path: "/healthz",
-								Port: intstr.FromInt(8081),
+								Path:   "/healthz",
+								Port:   intstr.FromInt(8081),
+								Scheme: corev1.URISchemeHTTP,
 							},
 						},
 						InitialDelaySeconds: 15,

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -155,7 +155,7 @@ func WebhookDeploymentCreator(data operatingSystemManagerData) reconciling.Named
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name), "Machine,cluster.k8s.io/v1alpha1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.NewString(Name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -166,9 +166,9 @@ const (
 	// OperatingSystemManagerWebhookServingCertSecretName is the name for the operating-system-manager webhook TLS server certificate secret.
 	OperatingSystemManagerWebhookServingCertSecretName = "operating-system-manager-webhook-serving-cert"
 	// OperatingSystemManagerWebhookServingCertCertKeyName is the name for the key that contains the cert.
-	OperatingSystemManagerWebhookServingCertCertKeyName = "cert.pem"
+	OperatingSystemManagerWebhookServingCertCertKeyName = "tls.crt"
 	// OperatingSystemManagerWebhookServingCertCertKeyName is the name for the key that contains the private key.
-	OperatingSystemManagerWebhookServingCertKeyKeyName = "key.pem"
+	OperatingSystemManagerWebhookServingCertKeyKeyName = "tls.key"
 	// PrometheusApiserverClientCertificateSecretName is the name for the secret containing the client certificate used by prometheus to access the apiserver.
 	PrometheusApiserverClientCertificateSecretName = "prometheus-apiserver-certificate"
 	// ClusterAutoscalerKubeconfigSecretName is the name of the kubeconfig secret used for

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -65,6 +65,10 @@ const (
 	SchedulerDeploymentName = "scheduler"
 	// OperatingSystemManagerDeploymentName is the name for the operating-system-manager deployment.
 	OperatingSystemManagerDeploymentName = "operating-system-manager"
+	// OperatingSystemManagerWebhookDeploymentName is the name for the operating-system-manager webhook deployment.
+	OperatingSystemManagerWebhookDeploymentName = "operating-system-manager-webhook"
+	// OperatingSystemManagerWebhookServiceName is the name for the operating-system-manager webhook service.
+	OperatingSystemManagerWebhookServiceName = "operating-system-manager-webhook"
 	// MachineControllerDeploymentName is the name for the machine-controller deployment.
 	MachineControllerDeploymentName = "machine-controller"
 	// MachineControllerWebhookDeploymentName is the name for the machine-controller webhook deployment.
@@ -146,6 +150,8 @@ const (
 	ControllerManagerKubeconfigSecretName = "controllermanager-kubeconfig"
 	// OperatingSystemManagerKubeconfigSecretName is the name for the secret containing the kubeconfig used by the osm.
 	OperatingSystemManagerKubeconfigSecretName = "operatingsystemmanager-kubeconfig"
+	// OperatingSystemManagerKubeconfigSecretName is the name for the secret containing the kubeconfig used by the osm webhook.
+	OperatingSystemManagerWebhookKubeconfigSecretName = "operatingsystemmanager-webhook-kubeconfig"
 	// MachineControllerKubeconfigSecretName is the name for the secret containing the kubeconfig used by the machinecontroller.
 	MachineControllerKubeconfigSecretName = "machinecontroller-kubeconfig"
 	// CloudControllerManagerKubeconfigSecretName is the name for the secret containing the kubeconfig used by the external cloud provider.
@@ -157,6 +163,12 @@ const (
 	MachineControllerWebhookServingCertCertKeyName = "cert.pem"
 	// MachineControllerWebhookServingCertKeyKeyName is the name for the key that contains the key.
 	MachineControllerWebhookServingCertKeyKeyName = "key.pem"
+	// OperatingSystemManagerWebhookServingCertSecretName is the name for the operating-system-manager webhook TLS server certificate secret.
+	OperatingSystemManagerWebhookServingCertSecretName = "operating-system-manager-webhook-serving-cert"
+	// OperatingSystemManagerWebhookServingCertCertKeyName is the name for the key that contains the cert.
+	OperatingSystemManagerWebhookServingCertCertKeyName = "cert.pem"
+	// OperatingSystemManagerWebhookServingCertCertKeyName is the name for the key that contains the private key.
+	OperatingSystemManagerWebhookServingCertKeyKeyName = "key.pem"
 	// PrometheusApiserverClientCertificateSecretName is the name for the secret containing the client certificate used by prometheus to access the apiserver.
 	PrometheusApiserverClientCertificateSecretName = "prometheus-apiserver-certificate"
 	// ClusterAutoscalerKubeconfigSecretName is the name of the kubeconfig secret used for
@@ -260,6 +272,8 @@ const (
 
 	// OperatingSystemManagerCertUsername is the name of the user coming from kubeconfig cert.
 	OperatingSystemManagerCertUsername = "operating-system-manager"
+	// OperatingSystemManagerWebhookCertUsername is the name of the user coming from the kubeconfig cert.
+	OperatingSystemManagerWebhookCertUsername = "operating-system-manager-webhook"
 	// MachineControllerCertUsername is the name of the user coming from kubeconfig cert.
 	MachineControllerCertUsername = "machine-controller"
 	// KubeStateMetricsCertUsername is the name of the user coming from kubeconfig cert.
@@ -452,6 +466,8 @@ const (
 	// MachineControllerMutatingWebhookConfigurationName is the name of the machine-controllers mutating webhook
 	// configuration.
 	MachineControllerMutatingWebhookConfigurationName = "machine-controller.kubermatic.io"
+	// MachineControllerMutatingWebhookConfigurationName is the name of OSM's mutating webhook configuration.
+	OperatingSystemManagerMutatingWebhookConfigurationName = "operating-system-manager.kubermatic.io"
 
 	// GatekeeperValidatingWebhookConfigurationName is the name of the gatekeeper validating webhook
 	// configuration.

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-node-kubelet-feature-gates","CSIMigrationAWS=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-node-kubelet-feature-gates","CSIMigrationAWS=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-node-kubelet-feature-gates","CSIMigrationAWS=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.23.5-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.23.5-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.23.5-operating-system-manager.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-operating-system-manager.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:5819bb5f27f7cb9f0ca83045de1eb0f5de122af5
+        image: quay.io/kubermatic/machine-controller:d41d7d9ce97ff62d7f3629495fce00c355e3ae53
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,112 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: operating-system-manager-webhook
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: operating-system-manager-webhook
+        ca-bundle-configmap-revision: "123456"
+        cluster: de-test-01
+        operating-system-manager-webhook-serving-cert-secret-revision: "123456"
+        operatingsystemmanager-webhook-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - -endpoint
+        - https://apiserver-external.cluster-de-test-01.svc.cluster.local./healthz
+        - -insecure
+        - -retries
+        - "100"
+        - -retry-wait
+        - "2"
+        - -timeout
+        - "1"
+        - -command
+        - '{"command":"/usr/local/bin/webhook","args":["-logtostderr","-v","4","-namespace","kube-system"]}'
+        command:
+        - /http-prober-bin/http-prober
+        env:
+        - name: KUBECONFIG
+          value: /etc/kubernetes/worker-kubeconfig/kubeconfig
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
+        livenessProbe:
+          failureThreshold: 8
+          httpGet:
+            path: /healthz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        name: operating-system-manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
+        resources:
+          limits:
+            cpu: 100m
+            memory: 512Mi
+          requests:
+            cpu: 10m
+            memory: 32Mi
+        volumeMounts:
+        - mountPath: /etc/kubernetes/worker-kubeconfig
+          name: operatingsystemmanager-webhook-kubeconfig
+          readOnly: true
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: operating-system-manager-webhook-serving-cert
+          readOnly: true
+        - mountPath: /etc/kubernetes/pki/ca-bundle
+          name: ca-bundle
+          readOnly: true
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      imagePullSecrets:
+      - name: dockercfg
+      initContainers:
+      - command:
+        - /bin/cp
+        - /usr/local/bin/http-prober
+        - /http-prober-bin/http-prober
+        image: quay.io/kubermatic/http-prober:v0.3.3
+        name: copy-http-prober
+        resources: {}
+        volumeMounts:
+        - mountPath: /http-prober-bin
+          name: http-prober-bin
+      volumes:
+      - name: operatingsystemmanager-webhook-kubeconfig
+        secret:
+          secretName: operatingsystemmanager-webhook-kubeconfig
+      - name: operating-system-manager-webhook-serving-cert
+        secret:
+          secretName: operating-system-manager-webhook-serving-cert
+      - configMap:
+          name: ca-bundle
+        name: ca-bundle
+      - emptyDir: {}
+        name: http-prober-bin
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.1
+        image: quay.io/kubermatic/operating-system-manager:296ee43a51a0aee013f0c6aa98f85493c59db050
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-aws-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-aws-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-azure-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-bringyourown-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-digitalocean-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-gcp-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-gcp-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-gcp-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-openstack-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.23.5-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.23.5-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.24.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.24.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/fixtures/service-vsphere-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.25.0-operating-system-manager-webhook.yaml
@@ -1,0 +1,19 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: operating-system-manager-webhook
+  name: operating-system-manager-webhook
+  namespace: cluster-de-test-01
+spec:
+  ports:
+  - name: webhook-server
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: operating-system-manager-webhook
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -486,6 +486,13 @@ func TestLoadFiles(t *testing.T) {
 							&corev1.Secret{
 								ObjectMeta: metav1.ObjectMeta{
 									ResourceVersion: "123456",
+									Name:            resources.OperatingSystemManagerWebhookKubeconfigSecretName,
+									Namespace:       cluster.Status.NamespaceName,
+								},
+							},
+							&corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									ResourceVersion: "123456",
 									Name:            resources.OpenVPNServerCertificatesSecretName,
 									Namespace:       cluster.Status.NamespaceName,
 								},
@@ -550,6 +557,13 @@ func TestLoadFiles(t *testing.T) {
 								ObjectMeta: metav1.ObjectMeta{
 									ResourceVersion: "123456",
 									Name:            resources.MachineControllerWebhookServingCertSecretName,
+									Namespace:       cluster.Status.NamespaceName,
+								},
+							},
+							&corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									ResourceVersion: "123456",
+									Name:            resources.OperatingSystemManagerWebhookServingCertSecretName,
 									Namespace:       cluster.Status.NamespaceName,
 								},
 							},

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -156,9 +156,9 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				args = append(args, "-owner-email", email)
 			}
 
-			if data.Cluster().Spec.DebugLog {
-				args = append(args, "-log-debug=true")
-			}
+			//if data.Cluster().Spec.DebugLog {
+			args = append(args, "-log-debug=true")
+			//}
 
 			if data.IsKonnectivityEnabled() {
 				args = append(args, "-konnectivity-enabled=true")

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -156,9 +156,9 @@ func DeploymentCreator(data userclusterControllerData) reconciling.NamedDeployme
 				args = append(args, "-owner-email", email)
 			}
 
-			//if data.Cluster().Spec.DebugLog {
-			args = append(args, "-log-debug=true")
-			//}
+			if data.Cluster().Spec.DebugLog {
+				args = append(args, "-log-debug=true")
+			}
 
 			if data.IsKonnectivityEnabled() {
 				args = append(args, "-konnectivity-enabled=true")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR incorporates https://github.com/kubermatic/machine-controller/pull/1428 and https://github.com/kubermatic/operating-system-manager/pull/227 into KKP. Essentially, the functionality to annotate default OSPs to `MachineDeployments` moved from MC to OSM, and as such the OSM webhook needs to be integrated.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Move mutation to add default OSP annotations to `MachineDeployments` to a new operating-system-manager webhook
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
