### PR TITLE
fix AllowedRegistry ConstraintTemplate OpenAPI schema

### DIFF
--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -155,6 +155,7 @@ func allowedRegistryCTCreatorGetter() reconciling.NamedKubermaticV1ConstraintTem
 						Validation: &constrainttemplatev1.Validation{
 							LegacySchema: pointer.Bool(false),
 							OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+								Type: "object",
 								Properties: map[string]apiextensionsv1.JSONSchemaProps{
 									AllowedRegistryField: {
 										Type: "array",

--- a/pkg/ee/allowed-registry-controller/reconcile_test.go
+++ b/pkg/ee/allowed-registry-controller/reconcile_test.go
@@ -202,6 +202,7 @@ func genConstraintTemplate() *kubermaticv1.ConstraintTemplate {
 				Validation: &constrainttemplatev1.Validation{
 					LegacySchema: pointer.Bool(false),
 					OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+						Type: "object",
 						Properties: map[string]apiextensionsv1.JSONSchemaProps{
 							AllowedRegistryField: {
 								Type: "array",


### PR DESCRIPTION
**What this PR does / why we need it**:
fixes the allowedReigstry ConstraintTemplate OpenApiSchema.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed the issue where AllowedRegistry ConstraintTemplate was not being reconiciled by Gatekeeper because it's `spec.crd` OpenAPI spec was missing a type.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
