### PR TITLE
Add support for Kubernetes 1.25.4, 1.24.8, and 1.23.14

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.24.6
+    default: v1.24.8
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -540,27 +540,33 @@ spec:
       - from: 1.23.*
         to: 1.23.*
       - automatic: true
-        from: '>= 1.23.0, < 1.23.12'
-        to: 1.23.12
+        from: '>= 1.23.0, < 1.23.14'
+        to: 1.23.14
       - from: 1.23.*
         to: 1.24.*
       - from: 1.24.*
         to: 1.24.*
       - automatic: true
-        from: '>= 1.24.0, < 1.24.6'
-        to: 1.24.6
+        from: '>= 1.24.0, < 1.24.8'
+        to: 1.24.8
       - from: 1.24.*
         to: 1.25.*
       - from: 1.25.*
         to: 1.25.*
+      - automatic: true
+        from: '>= 1.25.0, < 1.25.4'
+        to: 1.25.4
     # Versions lists the available versions.
     versions:
       - v1.23.6
       - v1.23.9
       - v1.23.12
+      - v1.23.14
       - v1.24.3
       - v1.24.6
+      - v1.24.8
       - v1.25.2
+      - v1.25.4
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.24.6
+    default: v1.24.8
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -540,27 +540,33 @@ spec:
       - from: 1.23.*
         to: 1.23.*
       - automatic: true
-        from: '>= 1.23.0, < 1.23.12'
-        to: 1.23.12
+        from: '>= 1.23.0, < 1.23.14'
+        to: 1.23.14
       - from: 1.23.*
         to: 1.24.*
       - from: 1.24.*
         to: 1.24.*
       - automatic: true
-        from: '>= 1.24.0, < 1.24.6'
-        to: 1.24.6
+        from: '>= 1.24.0, < 1.24.8'
+        to: 1.24.8
       - from: 1.24.*
         to: 1.25.*
       - from: 1.25.*
         to: 1.25.*
+      - automatic: true
+        from: '>= 1.25.0, < 1.25.4'
+        to: 1.25.4
     # Versions lists the available versions.
     versions:
       - v1.23.6
       - v1.23.9
       - v1.23.12
+      - v1.23.14
       - v1.24.3
       - v1.24.6
+      - v1.24.8
       - v1.25.2
+      - v1.25.4
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,17 +216,27 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.24.6"),
+		Default: semver.NewSemverOrDie("v1.24.8"),
+		// NB: We keep all patch releases that we supported, even if there's
+		// an auto-upgrade rule in place. That's because removing a patch
+		// release from this slice can break reconciliation loop for clusters
+		// running that version, and it might take some time to upgrade all
+		// the clusters in large KKP installations.
+		// Dashboard hides version that are not supported any longer from the
+		// cluster creation/upgrade page.
 		Versions: []semver.Semver{
 			// Kubernetes 1.23
 			newSemver("v1.23.6"),
 			newSemver("v1.23.9"),
 			newSemver("v1.23.12"),
+			newSemver("v1.23.14"),
 			// Kubernetes 1.24
 			newSemver("v1.24.3"),
 			newSemver("v1.24.6"),
+			newSemver("v1.24.8"),
 			// Kubernetes 1.25
 			newSemver("v1.25.2"),
+			newSemver("v1.25.4"),
 		},
 		Updates: []kubermaticv1.Update{
 			{
@@ -245,8 +255,10 @@ var (
 				// Auto-upgrade because of CVEs:
 				// - CVE-2022-3172 (fixed >= 1.23.11)
 				// - CVE-2021-25749 (fixed >= 1.23.11)
-				From:      ">= 1.23.0, < 1.23.12",
-				To:        "1.23.12",
+				// - CVE-2022-3162 (fixed >= 1.23.14)
+				// - CVE-2022-3294 (fixed >= 1.23.14)
+				From:      ">= 1.23.0, < 1.23.14",
+				To:        "1.23.14",
 				Automatic: pointer.Bool(true),
 			},
 			{
@@ -264,8 +276,10 @@ var (
 				// Auto-upgrade because of CVEs:
 				// - CVE-2022-3172 (fixed >= 1.24.5)
 				// - CVE-2021-25749 (fixed >= 1.24.5)
-				From:      ">= 1.24.0, < 1.24.6",
-				To:        "1.24.6",
+				// - CVE-2022-3162 (fixed >= 1.24.8)
+				// - CVE-2022-3294 (fixed >= 1.24.8)
+				From:      ">= 1.24.0, < 1.24.8",
+				To:        "1.24.8",
 				Automatic: pointer.Bool(true),
 			},
 			{
@@ -278,6 +292,14 @@ var (
 				// Allow to change to any patch version
 				From: "1.25.*",
 				To:   "1.25.*",
+			},
+			{
+				// Auto-upgrade because of CVEs:
+				// - CVE-2022-3162 (fixed >= 1.25.4)
+				// - CVE-2022-3294 (fixed >= 1.25.4)
+				From:      ">= 1.25.0, < 1.25.4",
+				To:        "1.25.4",
+				Automatic: pointer.Bool(true),
 			},
 		},
 		ProviderIncompatibilities: []kubermaticv1.Incompatibility{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for Kubernetes 1.25.4, 1.24.8, and 1.23.14. Those Kubernetes patch releases include fixes for two CVEs: CVE-2022-3162 and CVE-2022-3294. Therefore, this PR also adds auto-upgrade rules from previous patch releases to the latest ones.

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add support for Kubernetes 1.25.4, 1.24.8, and 1.23.14. Those Kubernetes patch releases fix CVE-2022-3162 and CVE-2022-3294, both in kube-apiserver:
  - [CVE-2022-3162: Unauthorized read of Custom Resources](https://groups.google.com/g/kubernetes-announce/c/oR2PUBiODNA/m/tShPgvpUDQAJ)
  - [CVE-2022-3294: Node address isn't always verified when proxying](https://groups.google.com/g/kubernetes-announce/c/eR0ghAXy2H8/m/sCuQQZlVDQAJ)
We strongly recommend upgrading to those Kubernetes patch releases as soon as possible.
```

**Documentation**:
```documentation
NONE
```