### PR TITLE
Revert "Add support for Kubernetes 1.25.4, 1.24.8, and 1.23.14 (#11340)"

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.24.8
+    default: v1.24.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -540,33 +540,27 @@ spec:
       - from: 1.23.*
         to: 1.23.*
       - automatic: true
-        from: '>= 1.23.0, < 1.23.14'
-        to: 1.23.14
+        from: '>= 1.23.0, < 1.23.12'
+        to: 1.23.12
       - from: 1.23.*
         to: 1.24.*
       - from: 1.24.*
         to: 1.24.*
       - automatic: true
-        from: '>= 1.24.0, < 1.24.8'
-        to: 1.24.8
+        from: '>= 1.24.0, < 1.24.6'
+        to: 1.24.6
       - from: 1.24.*
         to: 1.25.*
       - from: 1.25.*
         to: 1.25.*
-      - automatic: true
-        from: '>= 1.25.0, < 1.25.4'
-        to: 1.25.4
     # Versions lists the available versions.
     versions:
       - v1.23.6
       - v1.23.9
       - v1.23.12
-      - v1.23.14
       - v1.24.3
       - v1.24.6
-      - v1.24.8
       - v1.25.2
-      - v1.25.4
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.24.8
+    default: v1.24.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -540,33 +540,27 @@ spec:
       - from: 1.23.*
         to: 1.23.*
       - automatic: true
-        from: '>= 1.23.0, < 1.23.14'
-        to: 1.23.14
+        from: '>= 1.23.0, < 1.23.12'
+        to: 1.23.12
       - from: 1.23.*
         to: 1.24.*
       - from: 1.24.*
         to: 1.24.*
       - automatic: true
-        from: '>= 1.24.0, < 1.24.8'
-        to: 1.24.8
+        from: '>= 1.24.0, < 1.24.6'
+        to: 1.24.6
       - from: 1.24.*
         to: 1.25.*
       - from: 1.25.*
         to: 1.25.*
-      - automatic: true
-        from: '>= 1.25.0, < 1.25.4'
-        to: 1.25.4
     # Versions lists the available versions.
     versions:
       - v1.23.6
       - v1.23.9
       - v1.23.12
-      - v1.23.14
       - v1.24.3
       - v1.24.6
-      - v1.24.8
       - v1.25.2
-      - v1.25.4
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,27 +216,17 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.24.8"),
-		// NB: We keep all patch releases that we supported, even if there's
-		// an auto-upgrade rule in place. That's because removing a patch
-		// release from this slice can break reconciliation loop for clusters
-		// running that version, and it might take some time to upgrade all
-		// the clusters in large KKP installations.
-		// Dashboard hides version that are not supported any longer from the
-		// cluster creation/upgrade page.
+		Default: semver.NewSemverOrDie("v1.24.6"),
 		Versions: []semver.Semver{
 			// Kubernetes 1.23
 			newSemver("v1.23.6"),
 			newSemver("v1.23.9"),
 			newSemver("v1.23.12"),
-			newSemver("v1.23.14"),
 			// Kubernetes 1.24
 			newSemver("v1.24.3"),
 			newSemver("v1.24.6"),
-			newSemver("v1.24.8"),
 			// Kubernetes 1.25
 			newSemver("v1.25.2"),
-			newSemver("v1.25.4"),
 		},
 		Updates: []kubermaticv1.Update{
 			{
@@ -255,10 +245,8 @@ var (
 				// Auto-upgrade because of CVEs:
 				// - CVE-2022-3172 (fixed >= 1.23.11)
 				// - CVE-2021-25749 (fixed >= 1.23.11)
-				// - CVE-2022-3162 (fixed >= 1.23.14)
-				// - CVE-2022-3294 (fixed >= 1.23.14)
-				From:      ">= 1.23.0, < 1.23.14",
-				To:        "1.23.14",
+				From:      ">= 1.23.0, < 1.23.12",
+				To:        "1.23.12",
 				Automatic: pointer.Bool(true),
 			},
 			{
@@ -276,10 +264,8 @@ var (
 				// Auto-upgrade because of CVEs:
 				// - CVE-2022-3172 (fixed >= 1.24.5)
 				// - CVE-2021-25749 (fixed >= 1.24.5)
-				// - CVE-2022-3162 (fixed >= 1.24.8)
-				// - CVE-2022-3294 (fixed >= 1.24.8)
-				From:      ">= 1.24.0, < 1.24.8",
-				To:        "1.24.8",
+				From:      ">= 1.24.0, < 1.24.6",
+				To:        "1.24.6",
 				Automatic: pointer.Bool(true),
 			},
 			{
@@ -292,14 +278,6 @@ var (
 				// Allow to change to any patch version
 				From: "1.25.*",
 				To:   "1.25.*",
-			},
-			{
-				// Auto-upgrade because of CVEs:
-				// - CVE-2022-3162 (fixed >= 1.25.4)
-				// - CVE-2022-3294 (fixed >= 1.25.4)
-				From:      ">= 1.25.0, < 1.25.4",
-				To:        "1.25.4",
-				Automatic: pointer.Bool(true),
 			},
 		},
 		ProviderIncompatibilities: []kubermaticv1.Incompatibility{


### PR DESCRIPTION
This reverts commit e1cec63f6d0db3b2b8ceb396d3cf0b565d9325f4.

**What this PR does / why we need it**:
With https://github.com/kubermatic/kubermatic/pull/11340 we updated the supported k8s versions but we missed out on updating those fields in the KKP API https://github.com/kubermatic/dashboard/blob/main/pkg/defaulting/configuration.go#L218. So the API endpoints were returning the old values for supported Kubernetes versions on the dashboard.

Due to this mismatch, we were unable to create clusters on dev:
```
admission webhook "clusters.kubermatic.io" denied the request: version: Unsupported value: "1.24.6": supported values: "1.23.14", "1.24.8", "1.25.4"
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
