### PR TITLE
fix typos in dualstack e2e tests

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -146,7 +146,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.14-1
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -50,7 +50,6 @@ echodate "Building binaries for $KUBERMATIC_VERSION"
 TEST_NAME="Build Kubermatic binaries"
 
 beforeGoBuild=$(nowms)
-export UIDOCKERTAG="$(get_latest_dashboard_hash "${PULL_BASE_REF:-main}")"
 time retry 1 make build
 pushElapsed kubermatic_go_build_duration_milliseconds $beforeGoBuild
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes two leftover Prowjobs that used an old Docker image and removes the need to get the dashboard's latest Git hash, as all KKP e2e tests are headless and so we never need to know about the dashboard at all.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
