### PR TITLE
Pass cluster name to KubeVirt CCM

### DIFF
--- a/pkg/resources/cloudcontroller.go
+++ b/pkg/resources/cloudcontroller.go
@@ -108,7 +108,7 @@ func MigrationToExternalCloudControllerSupported(dc *kubermaticv1.Datacenter, cl
 // for the cloud provider.
 func ExternalCloudControllerClusterName(cloudSpec *kubermaticv1.CloudSpec) bool {
 	switch kubermaticv1.ProviderType(cloudSpec.ProviderName) {
-	case kubermaticv1.OpenstackCloudProvider, kubermaticv1.AzureCloudProvider, kubermaticv1.AWSCloudProvider:
+	case kubermaticv1.OpenstackCloudProvider, kubermaticv1.AzureCloudProvider, kubermaticv1.AWSCloudProvider, kubermaticv1.KubevirtCloudProvider:
 		return true
 	default:
 		return false

--- a/pkg/webhook/cluster/mutation/mutator_test.go
+++ b/pkg/webhook/cluster/mutation/mutator_test.go
@@ -693,6 +693,7 @@ func TestMutator(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeLocalDNSCacheEnabled", true),
 				jsonpatch.NewOperation("add", "/spec/clusterNetwork/nodeCidrMaskSizeIPv4", float64(24)),
 				jsonpatch.NewOperation("add", "/spec/features/externalCloudProvider", true),
+				jsonpatch.NewOperation("add", "/spec/features/ccmClusterName", true),
 				jsonpatch.NewOperation("replace", "/spec/cloud/providerName", string(kubermaticv1.KubevirtCloudProvider)),
 			),
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR the KubeVirt CCM is getting cluster-name as a parameter so the CCM can use this as a selector on the LoadBalancer Services it creates. See: https://github.com/kubevirt/cloud-provider-kubevirt#prerequisites

See also: https://github.com/kubermatic/kubermatic/issues/10923

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Special notes to the reviewer**:
Docs PR will come with the final PR on this Repo when we bump the MC version also using the cluster-name to label created VMs.

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
