### PR TITLE
Stop creating vsphere tags categories unconditionally

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1014,8 +1014,11 @@ type VSphereCloudSpec struct {
 	// This user will be used for everything except cloud provider functionality
 	InfraManagementUser VSphereCredentials `json:"infraManagementUser"`
 
-	// This is category for the machine deployment tags
-	TagCategoryID string `json:"tagCategoryID,omitempty"`
+	// TagCategoryName represents the name of vSphere tag category that will be used to create and attach tags on VMS.
+	TagCategoryName string `json:"tagCategoryName,omitempty"`
+
+	// TagCategoryID represents the category id for the machine deployment tags.
+	TagCategoryID string `json:"tagCategoryName,omitempty"`
 }
 
 // VMwareCloudDirectorCloudSpec specifies access data to VMware Cloud Director cloud.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1018,7 +1018,7 @@ type VSphereCloudSpec struct {
 	TagCategoryName string `json:"tagCategoryName,omitempty"`
 
 	// TagCategoryID represents the category id for the machine deployment tags.
-	TagCategoryID string `json:"tagCategoryName,omitempty"`
+	TagCategoryID string `json:"tagCategoryID,omitempty"`
 }
 
 // VMwareCloudDirectorCloudSpec specifies access data to VMware Cloud Director cloud.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -924,8 +924,8 @@ spec:
                         storagePolicy:
                           description: StoragePolicy to be used for storage provisioning
                           type: string
-                        tagCategoryID:
-                          description: This is category for the machine deployment tags
+                        tagCategoryName:
+                          description: TagCategoryID represents the category id for the machine deployment tags.
                           type: string
                         username:
                           description: Username is the vSphere user name.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -924,8 +924,11 @@ spec:
                         storagePolicy:
                           description: StoragePolicy to be used for storage provisioning
                           type: string
-                        tagCategoryName:
+                        tagCategoryID:
                           description: TagCategoryID represents the category id for the machine deployment tags.
+                          type: string
+                        tagCategoryName:
+                          description: TagCategoryName represents the name of vSphere tag category that will be used to create and attach tags on VMS.
                           type: string
                         username:
                           description: Username is the vSphere user name.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -919,8 +919,8 @@ spec:
                         storagePolicy:
                           description: StoragePolicy to be used for storage provisioning
                           type: string
-                        tagCategoryID:
-                          description: This is category for the machine deployment tags
+                        tagCategoryName:
+                          description: TagCategoryID represents the category id for the machine deployment tags.
                           type: string
                         username:
                           description: Username is the vSphere user name.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -919,8 +919,11 @@ spec:
                         storagePolicy:
                           description: StoragePolicy to be used for storage provisioning
                           type: string
-                        tagCategoryName:
+                        tagCategoryID:
                           description: TagCategoryID represents the category id for the machine deployment tags.
+                          type: string
+                        tagCategoryName:
+                          description: TagCategoryName represents the name of vSphere tag category that will be used to create and attach tags on VMS.
                           type: string
                         username:
                           description: Username is the vSphere user name.

--- a/pkg/provider/cloud/vsphere/category.go
+++ b/pkg/provider/cloud/vsphere/category.go
@@ -19,6 +19,7 @@ package vsphere
 import (
 	"context"
 	"fmt"
+
 	"github.com/vmware/govmomi/vapi/tags"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -171,7 +171,9 @@ func (v *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberma
 			return nil, err
 		}
 	}
-	if cluster.Spec.Cloud.VSphere.TagCategoryID == "" {
+
+	// We only need to fetch/create tag categories only if the user explicitly decides to use on.
+	if cluster.Spec.Cloud.VSphere.TagCategoryID != "" {
 		restSession, err := newRESTSession(ctx, v.dc, username, password, v.caBundle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create REST client session: %w", err)

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -194,7 +194,7 @@ func (v *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberma
 
 		categoryID, err = createTagCategory(ctx, restSession, cluster)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create tag category: %v", err)
+			return nil, fmt.Errorf("failed to create tag category: %w", err)
 		}
 
 		return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -45,7 +45,7 @@ const (
 	// categoryCleanupFinilizer will instruct the deletion of the default category tag.
 	tagCategoryCleanupFinilizer = "kubermatic.k8c.io/cleanup-vsphere-tag-category"
 
-	defaultCategory = "cluster"
+	defaultCategoryPrefix = "kubermatic.k8c.io"
 )
 
 // Provider represents the vsphere provider.
@@ -172,26 +172,31 @@ func (v *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberma
 		}
 	}
 
+	tagCategoryName := cluster.Spec.Cloud.VSphere.TagCategoryName
 	// We only need to fetch/create tag categories only if the user explicitly decides to use on.
-	if cluster.Spec.Cloud.VSphere.TagCategoryID != "" {
+	if tagCategoryName != "" {
 		restSession, err := newRESTSession(ctx, v.dc, username, password, v.caBundle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create REST client session: %w", err)
 		}
 		defer restSession.Logout(ctx)
 
-		// If the user did not specify a tag category, we create an own default for this cluster
-		categoryID, err := createTagCategory(ctx, restSession, cluster)
+		categoryID, err := fetchTagCategory(ctx, restSession, tagCategoryName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create tag category: %w", err)
+			return nil, fmt.Errorf("failed to fetch tag category: %w", err)
 		}
-		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+
+		if categoryID != "" {
+			return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+				cluster.Spec.Cloud.VSphere.TagCategoryID = categoryID
+			})
+		}
+
+		categoryID, err = createTagCategory(ctx, restSession, cluster)
+		return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.AddFinalizer(cluster, tagCategoryCleanupFinilizer)
 			cluster.Spec.Cloud.VSphere.TagCategoryID = categoryID
 		})
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	return cluster, nil

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -193,6 +193,10 @@ func (v *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberma
 		}
 
 		categoryID, err = createTagCategory(ctx, restSession, cluster)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create tag category: %v", err)
+		}
+
 		return update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.AddFinalizer(cluster, tagCategoryCleanupFinilizer)
 			cluster.Spec.Cloud.VSphere.TagCategoryID = categoryID


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, vSphere reconciler in the seed controller manager, creates the tags categories regardless if the user specifies that or not. To create tags and tag categories users need to have some permissions, which they are not allowed to have. Thus, this would lead to failing at creating clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes kubermatic/kubermatic#11349

**What type of PR is this?**
/kind design
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
