### PR TITLE
Fix PSP and PDB resources in addons `pod-security-policy`, `aws-node-termination-handler` and `aws-ebs-csi-driver`

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -55,9 +55,11 @@ aws-ebs-csi-driver:
 	mkdir -p csi/aws-ebs
 	cat csi/aws-ebs/_header.txt > $(OUTPUT_FILE)
 	helm --namespace kube-system template aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
+	  --version 2.11.1 \
 	  --set 'controller.k8sTagClusterId=\{{ .Cluster.Name }}' \
 	  --set 'node.securityContext.seccompProfile.type=RuntimeDefault' \
 	  --set 'controller.securityContext.seccompProfile.type=RuntimeDefault' \
+	  --api-versions 'policy/v1/PodDisruptionBudget' \
 	  >> $(OUTPUT_FILE)
 	cat csi/aws-ebs/_footer.txt >> $(OUTPUT_FILE)
 	sed -i 's/public.ecr.aws/{{ Registry "public.ecr.aws" }}/g' $(OUTPUT_FILE)

--- a/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
+++ b/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -17,40 +17,6 @@
 
 {{ if eq .Cluster.CloudProviderName "aws" }}
 ---
-# Source: aws-node-termination-handler/templates/psp.yaml
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: aws-node-termination-handler
-  labels:
-    app.kubernetes.io/name: aws-node-termination-handler
-    app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.16.2"
-    app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.18.2
-  annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
-spec:
-  privileged: false
-  hostIPC: false
-  hostNetwork: true
-  hostPID: false
-  readOnlyRootFilesystem: false
-  allowPrivilegeEscalation: false
-  allowedCapabilities:
-    - '*'
-  fsGroup:
-    rule: RunAsAny
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-    - '*'
----
 # Source: aws-node-termination-handler/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -129,48 +95,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: aws-node-termination-handler
-subjects:
-  - kind: ServiceAccount
-    name: aws-node-termination-handler
-    namespace: kube-system
----
-# Source: aws-node-termination-handler/templates/psp.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: aws-node-termination-handler-psp
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: aws-node-termination-handler
-    app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.16.2"
-    app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.18.2
-rules:
-  - apiGroups: ['policy']
-    resources: ['podsecuritypolicies']
-    verbs:     ['use']
-    resourceNames:
-      - aws-node-termination-handler
----
-# Source: aws-node-termination-handler/templates/psp.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: aws-node-termination-handler-psp
-  namespace: kube-system
-  labels:
-    app.kubernetes.io/name: aws-node-termination-handler
-    app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.16.2"
-    app.kubernetes.io/part-of: aws-node-termination-handler
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.18.2
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: aws-node-termination-handler-psp
 subjects:
   - kind: ServiceAccount
     name: aws-node-termination-handler

--- a/addons/csi/aws-ebs/driver.yaml
+++ b/addons/csi/aws-ebs/driver.yaml
@@ -19,7 +19,7 @@
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 ---
 # Source: aws-ebs-csi-driver/templates/poddisruptionbudget-controller.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: ebs-csi-controller

--- a/addons/pod-security-policy/psp-privileged.yaml
+++ b/addons/pod-security-policy/psp-privileged.yaml
@@ -40,4 +40,4 @@ spec:
     rule: 'RunAsAny'
   fsGroup:
     rule: 'RunAsAny'
-{{ - end }}
+{{- end }}

--- a/addons/pod-security-policy/psp-privileged.yaml
+++ b/addons/pod-security-policy/psp-privileged.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if and (eq .Cluster.Version.Major 1) (le .Cluster.Version.Minor 24) }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -39,3 +40,4 @@ spec:
     rule: 'RunAsAny'
   fsGroup:
     rule: 'RunAsAny'
+{{ - end }}

--- a/addons/pod-security-policy/rbac-kube-system.yaml
+++ b/addons/pod-security-policy/rbac-kube-system.yaml
@@ -39,4 +39,4 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: system:serviceaccounts
-{{ - end }}
+{{- end }}

--- a/addons/pod-security-policy/rbac-kube-system.yaml
+++ b/addons/pod-security-policy/rbac-kube-system.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if and (eq .Cluster.Version.Major 1) (le .Cluster.Version.Minor 24) }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -38,3 +39,4 @@ subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io
     name: system:serviceaccounts
+{{ - end }}

--- a/addons/values-aws-node-termination-handler.yaml
+++ b/addons/values-aws-node-termination-handler.yaml
@@ -25,3 +25,6 @@ podSecurityContext:
 
 nodeSelector:
   k8c.io/aws-spot: aws-node-termination-handler
+
+rbac:
+  pspEnabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:

Pod security policies were removed in Kubernetes 1.25 (https://kubernetes.io/docs/concepts/security/pod-security-policy/). We apply the `pod-security-policy` addon [by default](https://github.com/kubermatic/kubermatic/blob/f890674f0adda5a7e44f70873248cad21ddad092/pkg/defaulting/configuration.go#L918-L923).  This results in error events like the following:

```
failed to reconcile Addon "pod-security-policy": failed to deploy the addon manifests into the cluster: failed to execute '/usr/local/bin/kubectl-1.25 --kubeconfig /tmp/cluster-uqb9ls8ptr-addon-pod-security-policy-kubeconfig apply --prune --filename /tmp/cluster-uqb9ls8ptr-pod-security-policy.yaml --selector kubermatic-addon=pod-security-policy' for addon pod-security-policy of cluster uqb9ls8ptr: exit status 1 role.rbac.authorization.k8s.io/psp:kube-system unchanged rolebinding.rbac.authorization.k8s.io/psp:kube-system unchanged error: resource mapping not found for name: "kubermatic-privileged" namespace: "" from "/tmp/cluster-uqb9ls8ptr-pod-security-policy.yaml": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1" ensure CRDs are installed first
```

Therefore, this PR puts a condition into the addon manifests to make sure we only try to apply resources on Kubernetes 1.24 or lower.

I also found some additional issues with resources that no longer exist in 1.25 in AWS related addons.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* No resources are created for the default addon `pod-security-policy` when applied to Kubernetes 1.25 or higher
* Remove `PodSecurityPolicy` resource from `aws-node-termination-handler` addon
* Ensure `PodDisruptionBudget` resource in `aws-ebs-csi-driver` addon is created via `policy/v1` API
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
