### PR TITLE
Check error directly instead of calling isNotFound(err) in Azure provider

### DIFF
--- a/pkg/provider/cloud/azure/availability_set.go
+++ b/pkg/provider/cloud/azure/availability_set.go
@@ -43,9 +43,10 @@ func reconcileAvailabilitySet(ctx context.Context, clients *ClientSet, location 
 		return nil, err
 	}
 
-	// if we found an availability set, we can check for the ownership tag to determine
-	// if the referenced availability set is owned by this cluster and should be reconciled
-	if !isNotFound(err) && !hasOwnershipTag(availabilitySet.Tags, cluster) {
+	// if we found an availability set (no error), we can check for the ownership tag to determine
+	// if the referenced availability set is owned by this cluster and should be reconciled. We return
+	// early if the availability set is not owned by us.
+	if err == nil && !hasOwnershipTag(availabilitySet.Tags, cluster) {
 		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.AvailabilitySet = cluster.Spec.Cloud.Azure.AvailabilitySet
 		})

--- a/pkg/provider/cloud/azure/resource_group.go
+++ b/pkg/provider/cloud/azure/resource_group.go
@@ -47,10 +47,11 @@ func reconcileResourceGroup(ctx context.Context, clients *ClientSet, location st
 		return nil, err
 	}
 
+	// if the request returned no error, it means the resource group already exists and we can return early.
 	// usually, we check for ownership tags here and then compare attributes of interest to a target representation
 	// of the resource. Since there is nothing in the resource group we could compare to eventually reconcile, we
 	// skip all of that and return early if we found a resource group during our API call earlier.
-	if !isNotFound(err) {
+	if err == nil {
 		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.ResourceGroup = cluster.Spec.Cloud.Azure.ResourceGroup
 			// this is a special case; because we cannot determine if a resource group was created by

--- a/pkg/provider/cloud/azure/route_table.go
+++ b/pkg/provider/cloud/azure/route_table.go
@@ -47,10 +47,11 @@ func reconcileRouteTable(ctx context.Context, clients *ClientSet, location strin
 		return nil, err
 	}
 
+	// if the request returned no error, it means the route table already exists and we can return early.
 	// usually, we check for ownership tags here and then compare attributes of interest to a target representation
 	// of the resource. Since there is nothing in the route table we could compare to eventually reconcile (the subnet setting
 	// you see later on is ineffective), we skip all of that and return early if we found a route table during our API call earlier.
-	if !isNotFound(err) {
+	if err == nil {
 		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.RouteTableName = cluster.Spec.Cloud.Azure.RouteTableName
 			// this is a special case; because we cannot determine if a route table was created by

--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -46,9 +46,10 @@ func reconcileSecurityGroup(ctx context.Context, clients *ClientSet, location st
 		return nil, err
 	}
 
-	// if we found a security group, we can check for the ownership tag to determine
-	// if the referenced security group is owned by this cluster and should be reconciled
-	if !isNotFound(err) && !hasOwnershipTag(securityGroup.Tags, cluster) {
+	// if we found a security group (no error), we can check for the ownership tag to determine
+	// if the referenced security group is owned by this cluster and should be reconciled. We return
+	// early in this condition if the security group is not owned by us.
+	if err == nil && !hasOwnershipTag(securityGroup.Tags, cluster) {
 		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SecurityGroup = cluster.Spec.Cloud.Azure.SecurityGroup
 		})

--- a/pkg/provider/cloud/azure/subnet.go
+++ b/pkg/provider/cloud/azure/subnet.go
@@ -50,7 +50,7 @@ func reconcileSubnet(ctx context.Context, clients *ClientSet, location string, c
 
 	vnet, err := clients.Networks.Get(ctx, resourceGroup, cluster.Spec.Cloud.Azure.VNetName, nil)
 	if err != nil && !isNotFound(err) {
-		return cluster, err
+		return nil, err
 	}
 
 	routeTable, err := clients.RouteTables.Get(ctx, cluster.Spec.Cloud.Azure.ResourceGroup, cluster.Spec.Cloud.Azure.RouteTableName, nil)
@@ -66,8 +66,8 @@ func reconcileSubnet(ctx context.Context, clients *ClientSet, location string, c
 	// since subnets are sub-resources of VNETs and don't have tags themselves
 	// we can only guess KKP ownership based on the VNET ownership tag. If the
 	// VNET isn't owned by KKP, we should not try to reconcile subnets and
-	// return early
-	if !isNotFound(err) && !hasOwnershipTag(vnet.Tags, cluster) {
+	// return early.
+	if err == nil && !hasOwnershipTag(vnet.Tags, cluster) {
 		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.SubnetName = cluster.Spec.Cloud.Azure.SubnetName
 		})

--- a/pkg/provider/cloud/azure/vnet.go
+++ b/pkg/provider/cloud/azure/vnet.go
@@ -51,9 +51,10 @@ func reconcileVNet(ctx context.Context, clients *ClientSet, location string, clu
 		return cluster, err
 	}
 
-	// if we found a VNET, we can check for the ownership tag to determine
-	// if the referenced VNET is owned by this cluster and should be reconciled
-	if !isNotFound(err) && !hasOwnershipTag(vnet.Tags, cluster) {
+	// if we found a VNET (no error), we can check for the ownership tag to determine
+	// if the referenced VNET is owned by this cluster and should be reconciled. We return
+	// early if the vnet is not owned by us.
+	if err == nil && !hasOwnershipTag(vnet.Tags, cluster) {
 		return update(ctx, cluster.Name, func(updatedCluster *kubermaticv1.Cluster) {
 			updatedCluster.Spec.Cloud.Azure.VNetName = cluster.Spec.Cloud.Azure.VNetName
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
@moadqassem and I were looking at some code in the Azure provider and were under the impression that the if conditions were broken. However, after some analysis, it turns out it's fine insofar that it does the correct thing. The reason it does is counter-intuitive though (`isNotFound(err)` will always return `false` if `err` is `nil`). Here is what I wrote:

> 1. an error that is not "404" is returned: it will be caught by if err != nil && !isNotFound(err) .
> 2. an error is returned and it's 404: it will ignore the two if conditions if err != nil && !isNotFound(err)and !isNotFound(err) and skip past them into ensuring the resource group exists.
> 3. no error is returned, meaning the resource group exists. It will NOT be caught by if err != nil && !isNotFound(err) since err is nil, BUT !isNotFound(err) will return true because isNotFound always returns a false on a nil error.

This PR replaces `if !isNotFound(err)` in a couple of places where `err` is guaranteed to be `nil` in the scenarios that the if conditions are wrapping. It also clarifies the comments around this a bit.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
