### PR TITLE
Adding TunnelingAgentIP to ClusterNetworkingConfig

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -809,6 +809,9 @@ type ClusterNetworkingConfig struct {
 
 	// KonnectivityEnabled enables konnectivity for controlplane to node network communication.
 	KonnectivityEnabled *bool `json:"konnectivityEnabled,omitempty"`
+
+	// TunnelingAgentIP is the address used by the tunneling agents
+	TunnelingAgentIP string `json:"tunnelingAgentIP,omitempty"`
 }
 
 // MachineNetworkingConfig specifies the networking parameters used for IPAM.

--- a/pkg/controller/seed-controller-manager/kubernetes/address.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/address.go
@@ -45,7 +45,7 @@ func (r *Reconciler) syncAddress(ctx context.Context, log *zap.SugaredLogger, cl
 	b := address.NewModifiersBuilder(log)
 	// we only need providing the agentIP if the Tunneling strategy is used.
 	if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
-		b.TunnelingAgentIP(r.tunnelingAgentIP)
+		b.TunnelingAgentIP(cluster.Spec.ClusterNetwork.TunnelingAgentIP)
 	}
 	modifiers, err := b.
 		Cluster(cluster).

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1013,6 +1013,9 @@ spec:
                       required:
                         - cidrBlocks
                       type: object
+                    tunnelingAgentIP:
+                      description: TunnelingAgentIP is the address used by the tunneling agents
+                      type: string
                   required:
                     - dnsDomain
                     - pods

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1008,6 +1008,9 @@ spec:
                       required:
                         - cidrBlocks
                       type: object
+                    tunnelingAgentIP:
+                      description: TunnelingAgentIP is the address used by the tunneling agents
+                      type: string
                   required:
                     - dnsDomain
                     - pods

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -724,6 +724,8 @@ const (
 	EnvoyAgentCreateInterfaceInitContainerName = "create-dummy-interface"
 	EnvoyAgentAssignAddressInitContainerName   = "assign-address"
 	EnvoyAgentDeviceSetupImage                 = "kubermatic/kubeletdnat-controller"
+	// Default tunneling agent IP address.
+	DefaultTunnelingAgentIP = "192.168.30.10"
 )
 
 const (

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -69,6 +69,10 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 		WithPatch(func(cs *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
 			cs.ComponentsOverride.Apiserver.EndpointReconcilingDisabled = pointer.Bool(true)
 			return cs
+		}).
+		WithPatch(func(cs *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
+			cs.ClusterNetwork.TunnelingAgentIP = "192.168.30.10"
+			return cs
 		})
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForNothing)

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -74,6 +74,8 @@ const (
 
 // ValidateClusterSpec validates the given cluster spec. If this is not called from within another validation
 // routine, parentFieldPath can be nil.
+//
+//gocyclo:ignore
 func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datacenter, enabledFeatures features.FeatureGate, versionManager *version.Manager, parentFieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -118,6 +120,11 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 	// Validate APIServerAllowedIPRanges for LoadBalancer expose strategy
 	if spec.ExposeStrategy != kubermaticv1.ExposeStrategyLoadBalancer && spec.APIServerAllowedIPRanges != nil {
 		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("APIServerAllowedIPRanges"), "Access control for API server is supported only for LoadBalancer expose strategy"))
+	}
+
+	// Validate TunnelingAgentIP for Tunneling Expose strategy
+	if spec.ExposeStrategy != kubermaticv1.ExposeStrategyTunneling && spec.ClusterNetwork.TunnelingAgentIP != "" {
+		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("TunnelingAgentIP"), "Tunneling agent IP can be configured only for Tunneling Expose strategy"))
 	}
 
 	// External CCM is not supported for all providers and all Kubernetes versions.


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
Adds TunnelingAgentIP field to ClusterNetworkingConfig which is part of clusterSpec. This is required to customise the tunnelling agent IP as part of feature [7125](https://github.com/kubermatic/kubermatic/issues/7125)
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # [11261](https://github.com/kubermatic/kubermatic/issues/11261)

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add TunnelingAgentIP into ClusterNetwork part of the cluster API
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
