### PR TITLE
Disable promtail sidecar to set fs.inotify.max_user_instances

### DIFF
--- a/charts/logging/promtail/test/default.yaml.out
+++ b/charts/logging/promtail/test/default.yaml.out
@@ -406,16 +406,6 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: promtail
-      initContainers:
-        - name: init
-          image: "docker.io/library/busybox:1.33"
-          imagePullPolicy: IfNotPresent
-          command:
-            - sh
-            - -c
-            - sysctl -w fs.inotify.max_user_instances=256
-          securityContext:
-            privileged: true
       securityContext:
         runAsGroup: 0
         runAsUser: 0

--- a/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
@@ -406,16 +406,6 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: promtail
-      initContainers:
-        - name: init
-          image: "docker.io/library/busybox:1.33"
-          imagePullPolicy: IfNotPresent
-          command:
-            - sh
-            - -c
-            - sysctl -w fs.inotify.max_user_instances=256
-          securityContext:
-            privileged: true
       securityContext:
         runAsGroup: 0
         runAsUser: 0

--- a/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
@@ -406,16 +406,6 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       serviceAccountName: promtail
-      initContainers:
-        - name: init
-          image: "docker.io/library/busybox:1.33"
-          imagePullPolicy: IfNotPresent
-          command:
-            - sh
-            - -c
-            - sysctl -w fs.inotify.max_user_instances=256
-          securityContext:
-            privileged: true
       securityContext:
         runAsGroup: 0
         runAsUser: 0

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -18,7 +18,7 @@ promtail:
   deploymentStrategy: RollingUpdate
 
   initContainer:
-    enabled: true
+    enabled: false
     fsInotifyMaxUserInstances: 256
     image:
       repository: library/busybox


### PR DESCRIPTION
**What this PR does / why we need it**:
This sidecar was enabled all the way back in #7506. Since https://github.com/kubermatic/machine-controller/pull/1214, we set a significantly higher value for `fs.inotify.max_user_instances` (`8192`) in nodes bootrapped via MC and OSM.

As such, we should disable the sidecar that sets it to `256` only, which was an improvement back then, but is now "downgrading" nodes.

I'd like to keep this PR open until we've figured out if recent instability in CI can be attributed to this limitation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disable promtail initContainer that was overriding system `fs.inotify.max_user_instances` configuration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
