### PR TITLE
Fix externalcluster kubeconfig not fetched

### DIFF
--- a/pkg/provider/cloud/eks/provider.go
+++ b/pkg/provider/cloud/eks/provider.go
@@ -189,17 +189,6 @@ func GetCredentialsForCluster(cloud *kubermaticv1.ExternalClusterEKSCloudSpec, s
 		}
 	}
 
-	if creds.AssumeRoleExternalID == "" {
-		// AssumeRoleARN is optional
-		if cloud.CredentialsReference == nil {
-			return creds, errors.New("no credentials provided")
-		}
-		creds.AssumeRoleExternalID, err = secretKeySelector(cloud.CredentialsReference, resources.AWSAssumeRoleExternalID)
-		if err != nil {
-			return creds, err
-		}
-	}
-
 	return creds, nil
 }
 


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: Fix externalcluster kubeconfig not fetched by removing duplicate condition for  `AssumeRoleExternalID` as the field is optional

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
