### PR TITLE
Use t3a.small for spot instance machines and move to eu-west-1 in e2e tests

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	awsInstanceType = "t3.small"
+	awsInstanceType = "t3a.small"
 	awsVolumeType   = "gp2"
 	awsVolumeSize   = 100
 )

--- a/hack/ci/run-cilium-e2e-test.sh
+++ b/hack/ci/run-cilium-e2e-test.sh
@@ -50,6 +50,6 @@ echodate "Successfully got secrets for dev from Vault"
 echodate "Running Cilium tests..."
 
 go_test cilium_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium \
-  -aws-kkp-datacenter aws-eu-central-1a
+  -aws-kkp-datacenter aws-eu-west-1a
 
 echodate "Cilium tests done."

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -46,7 +46,7 @@ if [[ $provider == "anexia" ]]; then
 elif [[ $provider == "aws" ]]; then
   EXTRA_ARGS="-aws-access-key-id=${AWS_E2E_TESTS_KEY_ID}
     -aws-secret-access-key=${AWS_E2E_TESTS_SECRET}
-    -aws-kkp-datacenter=aws-eu-central-1a"
+    -aws-kkp-datacenter=aws-eu-west-1a"
 elif [[ $provider == "packet" ]]; then
   maxDuration=90
   EXTRA_ARGS="-packet-api-key=${PACKET_API_KEY}

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -81,7 +81,7 @@ go_test dualstack_e2e -race -timeout 90m -tags "dualstack,$KUBERMATIC_EDITION" -
   -provider "${PROVIDER:-}" \
   -os "${OSNAMES:-all}" \
   -alibaba-kkp-datacenter alibaba-eu-central-1a \
-  -aws-kkp-datacenter aws-eu-central-1a \
+  -aws-kkp-datacenter aws-eu-west-1a \
   -azure-kkp-datacenter azure-westeurope \
   -digitalocean-kkp-datacenter do-fra1 \
   -equinix-kkp-datacenter packet-am \

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -51,6 +51,6 @@ echodate "Successfully got secrets for dev from Vault"
 echodate "Running Konnectivity tests..."
 
 go_test konnectivity_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity \
-  -aws-kkp-datacenter aws-eu-central-1a
+  -aws-kkp-datacenter aws-eu-west-1a
 
 echodate "Konnectivity tests done."

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -65,6 +65,12 @@ spec:
       spec:
         aws:
           region: eu-central-1
+    aws-eu-west-1a:
+      location: EU (Ireland)
+      country: IE
+      spec:
+        aws:
+          region: eu-west-1
     hetzner-hel1:
       location: Helsinki 1 DC 6
       country: DE

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -66,7 +66,7 @@ azure)
 aws)
   # default version is 1.23, but AWS CCM requires 1.24, so we must explicitly
   # ask for a 1.24.x cluster
-  EXTRA_ARGS="-aws-kkp-datacenter=aws-eu-central-1a -cluster-version=1.24"
+  EXTRA_ARGS="-aws-kkp-datacenter=aws-eu-west-1a -cluster-version=1.24"
   ;;
 esac
 

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -79,7 +79,7 @@ aws)
   AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)}"
   extraArgs="-aws-access-key-id=$AWS_ACCESS_KEY_ID
     -aws-secret-access-key=$AWS_SECRET_ACCESS_KEY
-    -aws-kkp-datacenter=aws-eu-central-1a"
+    -aws-kkp-datacenter=aws-eu-west-1a"
   ;;
 
 azure)

--- a/pkg/test/e2e/jig/machine.go
+++ b/pkg/test/e2e/jig/machine.go
@@ -671,7 +671,7 @@ func (j *MachineJig) enrichAWSProviderSpec(cluster *kubermaticv1.Cluster, datace
 	}
 
 	if awsConfig.InstanceType.Value == "" {
-		awsConfig.InstanceType.Value = "t3.small"
+		awsConfig.InstanceType.Value = "t3a.small"
 	}
 
 	if awsConfig.VpcID.Value == "" {

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -145,7 +145,7 @@ func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, cred
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
-		WithAWS("t3.small", spotMaxPriceUSD)
+		WithAWS("t3a.small", spotMaxPriceUSD)
 
 	return &TestJig{
 		ProjectJig: projectJig,


### PR DESCRIPTION
**What this PR does / why we need it**:
Seems that `t3.small` is having capacity issues in AWS Frankfurt. This PR updates the machine type to `t3a.small`, let's see if that helps.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
