### PR TITLE
Do not use spot instances (during Black Friday week)

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -110,13 +110,13 @@ func (s *awsScenario) MachineDeployments(ctx context.Context, num int, secrets t
 			OperatingSystem: *osSpec,
 			Cloud: apiv1.NodeCloudSpec{
 				AWS: &apiv1.AWSNodeSpec{
-					InstanceType:         awsInstanceType,
-					VolumeType:           awsVolumeType,
-					VolumeSize:           awsVolumeSize,
-					AvailabilityZone:     *subnet.AvailabilityZone,
-					SubnetID:             *subnet.SubnetId,
-					IsSpotInstance:       pointer.Bool(true),
-					SpotInstanceMaxPrice: pointer.String("0.5"), // USD
+					InstanceType:     awsInstanceType,
+					VolumeType:       awsVolumeType,
+					VolumeSize:       awsVolumeSize,
+					AvailabilityZone: *subnet.AvailabilityZone,
+					SubnetID:         *subnet.SubnetId,
+					IsSpotInstance:   pointer.Bool(false),
+					// SpotInstanceMaxPrice: pointer.String("0.5"), // USD
 				},
 			},
 		}

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -145,7 +145,8 @@ func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, cred
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
-		WithAWS("t3.small", spotMaxPriceUSD)
+		// WithAWS("t3.small", spotMaxPriceUSD)
+		WithAWS("t3.small", nil)
 
 	return &TestJig{
 		ProjectJig: projectJig,


### PR DESCRIPTION
**What this PR does / why we need it**:
AWS capacity is pretty bad. Might be because of Black Friday coming up. Let's try if using on-demand instances is better for our CI tests.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
