### PR TITLE
[release/v2.21] Bump KubeVirt CSI driver operator version

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -338,7 +338,7 @@ spec:
             - /manager
           args:
             - --leader-elect
-          image: quay.io/kubermatic/kubevirt-csi-driver-operator:v0.1.1
+          image: quay.io/kubermatic/kubevirt-csi-driver-operator:v0.1.3
           imagePullPolicy: Always
           name: manager
           securityContext:


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumps KubeVirt CSI driver operator version to v0.1.3.
The operator in that version has frozen dependencies.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump KubeVirt CSI driver operator version to v0.1.3
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
