### PR TITLE
Default tag category from seed

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -271,6 +271,9 @@ spec:
           rootPath: ""
           # The name of the storage policy to use for the storage class created in the user cluster.
           storagePolicy: ""
+          # TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+          # and they don't wish KKP to create default generated tag category, upon cluster creation.
+          tagCategoryID: ""
           # A list of VM templates to use for a given operating system. You must
           # define at least one template.
           # See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -254,6 +254,9 @@ spec:
           # classes/dynamic provisioning and for storing virtual machine files in
           # case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
           datastore: ""
+          # DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+          # and they don't wish KKP to create default generated tag category, upon cluster creation.
+          defaultTagCategoryID: ""
           # Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
           endpoint: ""
           # Optional: Infra management user is the user that will be used for everything
@@ -271,9 +274,6 @@ spec:
           rootPath: ""
           # The name of the storage policy to use for the storage class created in the user cluster.
           storagePolicy: ""
-          # TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
-          # and they don't wish KKP to create default generated tag category, upon cluster creation.
-          tagCategoryID: ""
           # A list of VM templates to use for a given operating system. You must
           # define at least one template.
           # See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -271,6 +271,9 @@ spec:
           rootPath: ""
           # The name of the storage policy to use for the storage class created in the user cluster.
           storagePolicy: ""
+          # TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+          # and they don't wish KKP to create default generated tag category, upon cluster creation.
+          tagCategoryID: ""
           # A list of VM templates to use for a given operating system. You must
           # define at least one template.
           # See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -254,6 +254,9 @@ spec:
           # classes/dynamic provisioning and for storing virtual machine files in
           # case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
           datastore: ""
+          # DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+          # and they don't wish KKP to create default generated tag category, upon cluster creation.
+          defaultTagCategoryID: ""
           # Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
           endpoint: ""
           # Optional: Infra management user is the user that will be used for everything
@@ -271,9 +274,6 @@ spec:
           rootPath: ""
           # The name of the storage policy to use for the storage class created in the user cluster.
           storagePolicy: ""
-          # TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
-          # and they don't wish KKP to create default generated tag category, upon cluster creation.
-          tagCategoryID: ""
           # A list of VM templates to use for a given operating system. You must
           # define at least one template.
           # See: https://github.com/kubermatic/machine-controller/blob/master/docs/vsphere.md#template-vms-preparation

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -601,6 +601,9 @@ type DatacenterSpecVSphere struct {
 	InfraManagementUser *VSphereCredentials `json:"infraManagementUser,omitempty"`
 	// Optional: defines if the IPv6 is enabled for the datacenter
 	IPv6Enabled *bool `json:"ipv6Enabled,omitempty"`
+	// TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+	// and they don't wish KKP to create default generated tag category, upon cluster creation.
+	TagCategoryID string `json:"tagCategoryID,omitempty"`
 }
 
 type DatacenterSpecVMwareCloudDirector struct {

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -601,9 +601,9 @@ type DatacenterSpecVSphere struct {
 	InfraManagementUser *VSphereCredentials `json:"infraManagementUser,omitempty"`
 	// Optional: defines if the IPv6 is enabled for the datacenter
 	IPv6Enabled *bool `json:"ipv6Enabled,omitempty"`
-	// TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+	// DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
 	// and they don't wish KKP to create default generated tag category, upon cluster creation.
-	TagCategoryID string `json:"tagCategoryID,omitempty"`
+	DefaultTagCategoryID string `json:"defaultTagCategoryID,omitempty"`
 }
 
 type DatacenterSpecVMwareCloudDirector struct {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -443,6 +443,9 @@ spec:
                               storagePolicy:
                                 description: The name of the storage policy to use for the storage class created in the user cluster.
                                 type: string
+                              tagCategoryID:
+                                description: TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level, and they don't wish KKP to create default generated tag category, upon cluster creation.
+                                type: string
                               templates:
                                 additionalProperties:
                                   type: string

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -423,6 +423,9 @@ spec:
                               datastore:
                                 description: The default Datastore to be used for provisioning volumes using storage classes/dynamic provisioning and for storing virtual machine files in case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
                                 type: string
+                              defaultTagCategoryID:
+                                description: DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level, and they don't wish KKP to create default generated tag category, upon cluster creation.
+                                type: string
                               endpoint:
                                 description: Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
                                 type: string
@@ -442,9 +445,6 @@ spec:
                                 type: string
                               storagePolicy:
                                 description: The name of the storage policy to use for the storage class created in the user cluster.
-                                type: string
-                              tagCategoryID:
-                                description: TagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level, and they don't wish KKP to create default generated tag category, upon cluster creation.
                                 type: string
                               templates:
                                 additionalProperties:

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -301,14 +301,14 @@ func (v *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clou
 		}
 	}
 
-	restSession, err := newRESTSession(ctx, v.dc, username, password, v.caBundle)
-	if err != nil {
-		return fmt.Errorf("failed to create REST client session: %w", err)
-	}
-	defer restSession.Logout(ctx)
-
-	tagManager := tags.NewManager(restSession.Client)
 	if tagCategoryID := spec.VSphere.TagCategoryID; tagCategoryID != "" {
+		restSession, err := newRESTSession(ctx, v.dc, username, password, v.caBundle)
+		if err != nil {
+			return fmt.Errorf("failed to create REST client session: %w", err)
+		}
+		defer restSession.Logout(ctx)
+
+		tagManager := tags.NewManager(restSession.Client)
 		if _, err := tagManager.GetCategory(ctx, tagCategoryID); err != nil {
 			return fmt.Errorf("failed to get tag categories %w", err)
 		}

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -29,6 +29,7 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/session"
+	"github.com/vmware/govmomi/vapi/tags"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/soap"
 
@@ -246,7 +247,11 @@ func GetVMFolders(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere, u
 }
 
 // DefaultCloudSpec adds defaults to the cloud spec.
-func (v *Provider) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (v *Provider) DefaultCloudSpec(_ context.Context, spec *kubermaticv1.CloudSpec) error {
+	if spec.VSphere.TagCategoryID == "" {
+		spec.VSphere.TagCategoryID = v.dc.TagCategoryID
+	}
+
 	return nil
 }
 
@@ -293,6 +298,19 @@ func (v *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clou
 	if ds := spec.VSphere.Datastore; ds != "" {
 		if _, err = session.Finder.Datastore(ctx, ds); err != nil {
 			return fmt.Errorf("failed to get datastore cluster provided by cluste spec %q: %w", ds, err)
+		}
+	}
+
+	restSession, err := newRESTSession(ctx, v.dc, username, password, v.caBundle)
+	if err != nil {
+		return fmt.Errorf("failed to create REST client session: %w", err)
+	}
+	defer restSession.Logout(ctx)
+
+	tagManager := tags.NewManager(restSession.Client)
+	if tagCategoryID := spec.VSphere.TagCategoryID; tagCategoryID != "" {
+		if _, err := tagManager.GetCategory(ctx, tagCategoryID); err != nil {
+			return fmt.Errorf("failed to get tag categories %w", err)
 		}
 	}
 

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -249,7 +249,7 @@ func GetVMFolders(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere, u
 // DefaultCloudSpec adds defaults to the cloud spec.
 func (v *Provider) DefaultCloudSpec(_ context.Context, spec *kubermaticv1.CloudSpec) error {
 	if spec.VSphere.TagCategoryID == "" {
-		spec.VSphere.TagCategoryID = v.dc.TagCategoryID
+		spec.VSphere.TagCategoryID = v.dc.DefaultTagCategoryID
 	}
 
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
KKP 2.21 supported a new feature, where users can create and attach tags to vSphere VMs similar to other cloud providers. This feature however, requires some certain types of vSphere permissions in order to create and use those tags. If users decides not to use any vSphere VM tagging, they are still required, to grant permissions to KKP to manage tags and tag categories, due to some default behaviour that creates those tags categories if they don't exist. 

This PR make it easy for users, to avoid giving permissions to KKP when they choose not to use vSphere tagging, by assigning a pre created tag category that KKP can use, with pre created tags. Those default tags and categories are going to be inherited from the seed, if they are not specified in the user cluster.
    
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Defaulting vSphere tag category from seed, when it is not specified in user cluster 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
