### PR TITLE
bump cert-manager to 1.10.1

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: cert-manager
 version: v9.9.9-dev
-appVersion: v1.9.1
+appVersion: v1.10.1
 description: A Helm chart for cert-manager
 keywords:
   - kubermatic
@@ -31,4 +31,4 @@ maintainers:
 dependencies:
   - repository: https://charts.jetstack.io
     name: cert-manager
-    version: 1.9.1
+    version: 1.10.1

--- a/charts/cert-manager/test/default.yaml.out
+++ b/charts/cert-manager/test/default.yaml.out
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,9 +27,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -43,9 +43,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-config.yaml
 apiVersion: v1
@@ -70,9 +70,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -104,9 +104,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -132,9 +132,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -160,9 +160,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -197,9 +197,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -237,9 +237,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -299,9 +299,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -338,9 +338,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -362,9 +362,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -389,9 +389,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -411,9 +411,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -439,9 +439,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -457,9 +457,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -479,9 +479,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -501,9 +501,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,9 +523,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -545,9 +545,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -567,9 +567,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -589,9 +589,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -611,9 +611,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -633,9 +633,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -655,9 +655,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -680,9 +680,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -708,9 +708,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -731,9 +731,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -758,9 +758,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -783,9 +783,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -807,9 +807,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -831,9 +831,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 spec:
   type: ClusterIP
   ports:
@@ -857,9 +857,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 spec:
   type: ClusterIP
   ports:
@@ -883,9 +883,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 spec:
   replicas: 1
   selector:
@@ -900,16 +900,18 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.9.1"
+        app.kubernetes.io/version: "v1.10.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.9.1
+        helm.sh/chart: cert-manager-v1.10.1
     spec:
       serviceAccountName: release-name-cert-manager-cainjector
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.9.1"
+        - name: cert-manager-cainjector
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.10.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -921,6 +923,9 @@ spec:
                 fieldPath: metadata.namespace
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
       nodeSelector:
         kubernetes.io/os: linux
 ---
@@ -935,9 +940,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 spec:
   replicas: 1
   selector:
@@ -952,9 +957,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.9.1"
+        app.kubernetes.io/version: "v1.10.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.9.1
+        helm.sh/chart: cert-manager-v1.10.1
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -963,9 +968,11 @@ spec:
       serviceAccountName: release-name-cert-manager
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v1.9.1"
+        - name: cert-manager-controller
+          image: "quay.io/jetstack/cert-manager-controller:v1.10.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -977,6 +984,9 @@ spec:
             protocol: TCP
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -996,9 +1006,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 spec:
   replicas: 1
   selector:
@@ -1013,27 +1023,35 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.9.1"
+        app.kubernetes.io/version: "v1.10.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.9.1
+        helm.sh/chart: cert-manager-v1.10.1
     spec:
       serviceAccountName: release-name-cert-manager-webhook
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-webhook:v1.9.1"
+        - name: cert-manager-webhook
+          image: "quay.io/jetstack/cert-manager-webhook:v1.10.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --secure-port=10250
           - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
           - --dynamic-serving-ca-secret-name=release-name-cert-manager-webhook-ca
-          - --dynamic-serving-dns-names=release-name-cert-manager-webhook,release-name-cert-manager-webhook.default,release-name-cert-manager-webhook.default.svc
+          - --dynamic-serving-dns-names=release-name-cert-manager-webhook
+          - --dynamic-serving-dns-names=release-name-cert-manager-webhook.$(POD_NAMESPACE)
+          - --dynamic-serving-dns-names=release-name-cert-manager-webhook.$(POD_NAMESPACE).svc
+          
           ports:
           - name: https
             protocol: TCP
             containerPort: 10250
+          - name: healthcheck
+            protocol: TCP
+            containerPort: 6080
           livenessProbe:
             httpGet:
               path: /livez
@@ -1056,6 +1074,9 @@ spec:
             failureThreshold: 3
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -1074,9 +1095,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1117,9 +1138,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1175,9 +1196,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/startupapicheck-rbac.yaml
 # create certificate role
@@ -1191,9 +1212,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1214,9 +1235,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1241,9 +1262,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.9.1"
+    app.kubernetes.io/version: "v1.10.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.9.1
+    helm.sh/chart: cert-manager-v1.10.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1257,17 +1278,19 @@ spec:
         app.kubernetes.io/name: startupapicheck
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "startupapicheck"
-        app.kubernetes.io/version: "v1.9.1"
+        app.kubernetes.io/version: "v1.10.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.9.1
+        helm.sh/chart: cert-manager-v1.10.1
     spec:
       restartPolicy: OnFailure
       serviceAccountName: release-name-cert-manager-startupapicheck
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
-        - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-ctl:v1.9.1"
+        - name: cert-manager-startupapicheck
+          image: "quay.io/jetstack/cert-manager-ctl:v1.10.1"
           imagePullPolicy: IfNotPresent
           args:
           - check
@@ -1275,5 +1298,8 @@ spec:
           - --wait=1m
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
       nodeSelector:
         kubernetes.io/os: linux

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/iam v1.18.23
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.1
 	github.com/aws/smithy-go v1.13.4
-	github.com/cert-manager/cert-manager v1.10.0
+	github.com/cert-manager/cert-manager v1.10.1
 	github.com/cilium/cilium v1.12.3 // need 1.12.x because 1.11.x is incompatible with k8s 1.24
 	github.com/coreos/locksmith v0.6.2
 	github.com/cristim/ec2-instances-info v0.0.0-20220804141719-da3da500d587

--- a/go.sum
+++ b/go.sum
@@ -215,8 +215,8 @@ github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInq
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0 h1:t/LhUZLVitR1Ow2YOnduCsavhwFUklBMoGVYUCqmCqk=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cert-manager/cert-manager v1.10.0 h1:qWMM2nqt3pyCVKTWoS645PORJpK5XvtE0iImk9qTPsc=
-github.com/cert-manager/cert-manager v1.10.0/go.mod h1:xKakpUDYRHgUry/DkvcCCgQDRSwVSeSXTlw7slT+AYo=
+github.com/cert-manager/cert-manager v1.10.1 h1:/x2dJzUB3TzwiqDcOwg/ug4X8UtOu/s0vUuDaalrgvM=
+github.com/cert-manager/cert-manager v1.10.1/go.mod h1:xKakpUDYRHgUry/DkvcCCgQDRSwVSeSXTlw7slT+AYo=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054 h1:uH66TXeswKn5PW5zdZ39xEwfS9an067BirqA+P4QaLI=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=


### PR DESCRIPTION
**What this PR does / why we need it**:
What it says on the tin. No breaking changes according to the [changelog](https://github.com/cert-manager/cert-manager/releases/tag/v1.10.0).

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update cert-manager to 1.10.1
```

**Documentation**:
```documentation
NONE
```
