### PR TITLE
bump nginx-ingress to 1.5.1

### DIFF
--- a/charts/nginx-ingress-controller/Chart.lock
+++ b/charts/nginx-ingress-controller/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: ingress-nginx
   repository: https://kubernetes.github.io/ingress-nginx
-  version: 4.3.0
-digest: sha256:885a8f2d9b543232a4a9974edfe4204c7f4b9b36031ce38243d58b635fa878b8
-generated: "2022-10-06T17:21:49.913698958+02:00"
+  version: 4.4.0
+digest: sha256:38caeea0a19ac742be4dae3ec0cd68572d5d4b0204467a6a7e3c81a708da6fd5
+generated: "2022-11-23T10:49:02.713871768+01:00"

--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: nginx-ingress-controller
 version: v9.9.9-dev
-appVersion: 1.4.0
+appVersion: 1.5.1
 description: nginx-ingress-controller
 keywords:
   - kubermatic
@@ -30,5 +30,5 @@ maintainers:
 dependencies:
   - name: ingress-nginx
     repository: https://kubernetes.github.io/ingress-nginx
-    version: 4.3.0
+    version: 4.4.0
     alias: nginx

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -4,10 +4,10 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -26,10 +26,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,10 +42,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -59,10 +59,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -143,10 +143,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -164,10 +164,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -231,7 +231,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - ingress-controller-leader
+      - nginx-ingress-leader
     verbs:
       - get
       - update
@@ -246,7 +246,7 @@ rules:
     resources:
       - leases
     resourceNames:
-      - ingress-controller-leader
+      - nginx-ingress-leader
     verbs:
       - get
       - update
@@ -277,10 +277,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -300,10 +300,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -326,10 +326,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -354,10 +354,10 @@ metadata:
   annotations:
     helm.sh/resource-policy: "keep"
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -389,10 +389,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -420,7 +420,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "registry.k8s.io/ingress-nginx/controller:v1.4.0@sha256:34ee929b111ffc7aa426ffd409af44da48e5a0eea1eb2207994d9e0c0882d143"
+          image: "registry.k8s.io/ingress-nginx/controller:v1.5.1@sha256:4ba73c697770664c1e00e9f968de14e08f606ff961c76e5d7033a4a9c593c629"
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -430,7 +430,7 @@ spec:
           args:
             - /nginx-ingress-controller
             - --publish-service=$(POD_NAMESPACE)/nginx-ingress-controller
-            - --election-id=ingress-controller-leader
+            - --election-id=nginx-ingress-leader
             - --controller-class=k8s.io/ingress-nginx
             - --ingress-class=nginx
             - --configmap=$(POD_NAMESPACE)/nginx-ingress-controller
@@ -531,10 +531,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -549,10 +549,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -590,10 +590,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -607,10 +607,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -632,10 +632,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -658,10 +658,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -684,10 +684,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -710,10 +710,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -722,10 +722,10 @@ spec:
     metadata:
       name: nginx-ingress-admission-create
       labels:
-        helm.sh/chart: nginx-4.3.0
+        helm.sh/chart: nginx-4.4.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.5.1"
         app.kubernetes.io/part-of: nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -744,7 +744,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
+          securityContext: 
             allowPrivilegeEscalation: false
       restartPolicy: OnFailure
       serviceAccountName: nginx-ingress-admission
@@ -765,10 +765,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -777,10 +777,10 @@ spec:
     metadata:
       name: nginx-ingress-admission-patch
       labels:
-        helm.sh/chart: nginx-4.3.0
+        helm.sh/chart: nginx-4.4.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.5.1"
         app.kubernetes.io/part-of: nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -801,7 +801,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
+          securityContext: 
             allowPrivilegeEscalation: false
       restartPolicy: OnFailure
       serviceAccountName: nginx-ingress-admission

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -4,10 +4,10 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -26,10 +26,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,10 +42,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -59,10 +59,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -143,10 +143,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -164,10 +164,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -231,7 +231,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - ingress-controller-leader
+      - nginx-ingress-leader
     verbs:
       - get
       - update
@@ -246,7 +246,7 @@ rules:
     resources:
       - leases
     resourceNames:
-      - ingress-controller-leader
+      - nginx-ingress-leader
     verbs:
       - get
       - update
@@ -277,10 +277,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -300,10 +300,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -326,10 +326,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -354,10 +354,10 @@ metadata:
   annotations:
     helm.sh/resource-policy: "keep"
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -389,10 +389,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -420,7 +420,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "registry.k8s.io/ingress-nginx/controller:v1.4.0@sha256:34ee929b111ffc7aa426ffd409af44da48e5a0eea1eb2207994d9e0c0882d143"
+          image: "registry.k8s.io/ingress-nginx/controller:v1.5.1@sha256:4ba73c697770664c1e00e9f968de14e08f606ff961c76e5d7033a4a9c593c629"
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -430,7 +430,7 @@ spec:
           args:
             - /nginx-ingress-controller
             - --publish-service=$(POD_NAMESPACE)/nginx-ingress-controller
-            - --election-id=ingress-controller-leader
+            - --election-id=nginx-ingress-leader
             - --controller-class=k8s.io/ingress-nginx
             - --ingress-class=nginx
             - --configmap=$(POD_NAMESPACE)/nginx-ingress-controller
@@ -531,10 +531,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -549,10 +549,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -590,10 +590,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -607,10 +607,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -632,10 +632,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -658,10 +658,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -684,10 +684,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -710,10 +710,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -722,10 +722,10 @@ spec:
     metadata:
       name: nginx-ingress-admission-create
       labels:
-        helm.sh/chart: nginx-4.3.0
+        helm.sh/chart: nginx-4.4.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.5.1"
         app.kubernetes.io/part-of: nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -744,7 +744,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
+          securityContext: 
             allowPrivilegeEscalation: false
       restartPolicy: OnFailure
       serviceAccountName: nginx-ingress-admission
@@ -765,10 +765,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -777,10 +777,10 @@ spec:
     metadata:
       name: nginx-ingress-admission-patch
       labels:
-        helm.sh/chart: nginx-4.3.0
+        helm.sh/chart: nginx-4.4.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.5.1"
         app.kubernetes.io/part-of: nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -801,7 +801,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
+          securityContext: 
             allowPrivilegeEscalation: false
       restartPolicy: OnFailure
       serviceAccountName: nginx-ingress-admission

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -4,10 +4,10 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -26,10 +26,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,10 +42,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -59,10 +59,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -143,10 +143,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -164,10 +164,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -231,7 +231,7 @@ rules:
     resources:
       - configmaps
     resourceNames:
-      - ingress-controller-leader
+      - nginx-ingress-leader
     verbs:
       - get
       - update
@@ -246,7 +246,7 @@ rules:
     resources:
       - leases
     resourceNames:
-      - ingress-controller-leader
+      - nginx-ingress-leader
     verbs:
       - get
       - update
@@ -277,10 +277,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -300,10 +300,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -326,10 +326,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -354,10 +354,10 @@ metadata:
   annotations:
     helm.sh/resource-policy: "keep"
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -389,10 +389,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -420,7 +420,7 @@ spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "registry.k8s.io/ingress-nginx/controller:v1.4.0@sha256:34ee929b111ffc7aa426ffd409af44da48e5a0eea1eb2207994d9e0c0882d143"
+          image: "registry.k8s.io/ingress-nginx/controller:v1.5.1@sha256:4ba73c697770664c1e00e9f968de14e08f606ff961c76e5d7033a4a9c593c629"
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -430,7 +430,7 @@ spec:
           args:
             - /nginx-ingress-controller
             - --publish-service=$(POD_NAMESPACE)/nginx-ingress-controller
-            - --election-id=ingress-controller-leader
+            - --election-id=nginx-ingress-leader
             - --controller-class=k8s.io/ingress-nginx
             - --ingress-class=nginx
             - --configmap=$(POD_NAMESPACE)/nginx-ingress-controller
@@ -531,10 +531,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -549,10 +549,10 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -590,10 +590,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -607,10 +607,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -632,10 +632,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -658,10 +658,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -684,10 +684,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade,post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -710,10 +710,10 @@ metadata:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -722,10 +722,10 @@ spec:
     metadata:
       name: nginx-ingress-admission-create
       labels:
-        helm.sh/chart: nginx-4.3.0
+        helm.sh/chart: nginx-4.4.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.5.1"
         app.kubernetes.io/part-of: nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -744,7 +744,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
+          securityContext: 
             allowPrivilegeEscalation: false
       restartPolicy: OnFailure
       serviceAccountName: nginx-ingress-admission
@@ -765,10 +765,10 @@ metadata:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
   labels:
-    helm.sh/chart: nginx-4.3.0
+    helm.sh/chart: nginx-4.4.0
     app.kubernetes.io/name: nginx
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "1.4.0"
+    app.kubernetes.io/version: "1.5.1"
     app.kubernetes.io/part-of: nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -777,10 +777,10 @@ spec:
     metadata:
       name: nginx-ingress-admission-patch
       labels:
-        helm.sh/chart: nginx-4.3.0
+        helm.sh/chart: nginx-4.4.0
         app.kubernetes.io/name: nginx
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "1.4.0"
+        app.kubernetes.io/version: "1.5.1"
         app.kubernetes.io/part-of: nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -801,7 +801,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          securityContext:
+          securityContext: 
             allowPrivilegeEscalation: false
       restartPolicy: OnFailure
       serviceAccountName: nginx-ingress-admission


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates nginx to the latest available version. This supposedly fixes a number of CVEs: https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.5.1

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update nginx-ingress to 1.5.1
```

**Documentation**:
```documentation
NONE
```
