### PR TITLE
[release/v2.19] bump Dex to 2.35.3 (#11413)

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: oauth
-version: 1.6.1
-appVersion: v2.30.0
+version: 1.6.2
+appVersion: v2.35.3
 description: Dex
 keywords:
 - kubermatic

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -14,8 +14,8 @@
 
 dex:
   image:
-    repository: "docker.io/dexidp/dex"
-    tag: "v2.30.0"
+    repository: "ghcr.io/dexidp/dex"
+    tag: "v2.35.3"
   replicas: 2
   # this options allows setting custom envvars in the dex container
   # this list is directly handed to the container spec


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #11413 because of the security issues that were fixed in Dex 2.35+.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Dex to 2.35.3
```

**Documentation**:
```documentation
NONE
```
