### PR TITLE
[release/v2.19] Remove `pre-kubermatic-ccm-migration-e2e` prow job

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1362,38 +1362,6 @@ presubmits:
             memory: 6Gi
 
   #########################################################
-  # external ccm migration e2e tests
-  #########################################################
-
-  - name: pre-kubermatic-ccm-migration-e2e
-    run_if_changed: "(pkg/|.prow.yaml)"
-    decorate: true
-    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
-    labels:
-      preset-openstack: "true"
-      preset-docker-pull: "true"
-      preset-docker-push: "true"
-      preset-kind-volume-mounts: "true"
-      preset-goproxy: "true"
-    spec:
-      containers:
-        - image: quay.io/kubermatic/build:go-1.17-node-16-kind-0.11-5
-          env:
-            - name: KUBERMATIC_EDITION
-              value: ce
-          command:
-            - ./hack/run-ccm-migration-e2e-test-in-kind.sh
-          # docker-in-docker needs privileged mode
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              memory: 4Gi
-              cpu: 3.5
-            limits:
-              memory: 4Gi
-
-  #########################################################
   # misc
   #########################################################
 


### PR DESCRIPTION
**What this PR does / why we need it**:
CCM migration tests pre-2.21 are in a somewhat weird state and as far we know do not test properly for what we want to have tested. This removes the `pre-kubermatic-ccm-migration-e2e` prow job from `release/v2.19` so it doesn't block further backport efforts.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
