### PR TITLE
update Prometheus to 2.40.2

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: prometheus
 version: v9.9.9-dev
-appVersion: v2.37.0
+appVersion: v2.40.2
 description: Prometheus Monitoring for Kubernetes
 keywords:
   - kubermatic

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -16,7 +16,7 @@ prometheus:
   replicas: 2
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.37.0
+    tag: v2.40.2
     pullPolicy: IfNotPresent
 
   host: ''

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.37.0"
+	tag  = "v2.40.2"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.23.5-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.23.5-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.23.5-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.23.5-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.23.5-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.23.5-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.23.5-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.37.0
+        image: quay.io/prometheus/prometheus:v2.40.2
         livenessProbe:
           failureThreshold: 10
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
As far as I could see, no breaking changes occured between 2.37 and 2.40. But we gain better Kubernetes discovery performance, better performance overall and an improved dark mode theme.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Prometheus to 2.40.2
```

**Documentation**:
```documentation
NONE
```
