### PR TITLE
update node_exporter to 1.4.0

### DIFF
--- a/charts/monitoring/node-exporter/Chart.yaml
+++ b/charts/monitoring/node-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: node-exporter
 version: v9.9.9-dev
-appVersion: v1.3.1
+appVersion: v1.4.0
 description: Prometheus Node Exporter for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/node-exporter/values.yaml
+++ b/charts/monitoring/node-exporter/values.yaml
@@ -15,7 +15,7 @@
 nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
-    tag: v1.3.1
+    tag: v1.4.0
   resources:
     requests:
       cpu: 50m
@@ -27,7 +27,7 @@ nodeExporter:
   rbacProxy:
     image:
       repository: quay.io/brancz/kube-rbac-proxy
-      tag: v0.12.0
+      tag: v0.13.1
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/prometheus/node_exporter/releases/tag/v1.4.0 contains no breaking change, neither does https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.13.1, so this should be a safe upgrade.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update node_exporter to 1.4.0
```

**Documentation**:
```documentation
NONE
```
