### PR TITLE
KubeVirt cleanup Flavor and PodAffinityPreset

### DIFF
--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -520,10 +520,6 @@ func getGCPProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *ku
 func GetKubevirtProviderConfig(cluster *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*kubevirt.RawConfig, error) {
 	config := &kubevirt.RawConfig{
 		VirtualMachine: kubevirt.VirtualMachine{
-			Flavor: kubevirt.Flavor{
-				Name:    providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.FlavorName},
-				Profile: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.FlavorProfile},
-			},
 			Instancetype: nodeSpec.Cloud.Kubevirt.Instancetype,
 			Preference:   nodeSpec.Cloud.Kubevirt.Preference,
 			Template: kubevirt.Template{
@@ -541,8 +537,6 @@ func GetKubevirtProviderConfig(cluster *kubermaticv1.Cluster, nodeSpec apiv1.Nod
 			DNSConfig: dc.Spec.Kubevirt.DNSConfig.DeepCopy(),
 		},
 		Affinity: kubevirt.Affinity{
-			PodAffinityPreset:     providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.PodAffinityPreset},     //nolint:staticcheck
-			PodAntiAffinityPreset: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.PodAntiAffinityPreset}, //nolint:staticcheck
 			NodeAffinityPreset: kubevirt.NodeAffinityPreset{
 				Type: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Type},
 				Key:  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Key},


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Small cleanup after sig/virtualization did agree that all MD will require a **manual** migration (migration doc will be written part of https://github.com/kubermatic/docs/issues/1261).
Any existing MD that contains:
- Flavor
- PodAffinity/AntiAffinity/Preset
**will have to be manually migrated.**

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11410 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Action required: KubeVirt- Manual migration of existing MD (https://github.com/kubermatic/docs/issues/1261)

```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD (https://github.com/kubermatic/docs/issues/1261)

```
