### PR TITLE
Implementation of network-interface-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export GO111MODULE = on
 export KUBERMATIC_EDITION ?= ce
 DOCKER_REPO ?= quay.io/kubermatic
 REPO = $(DOCKER_REPO)/kubermatic$(shell [ "$(KUBERMATIC_EDITION)" != "ce" ] && echo "-$(KUBERMATIC_EDITION)" )
-CMD ?= $(filter-out OWNERS nodeport-proxy kubeletdnat-controller, $(notdir $(wildcard ./cmd/*)))
+CMD ?= $(filter-out OWNERS nodeport-proxy kubeletdnat-controller network-interface-manager, $(notdir $(wildcard ./cmd/*)))
 GOBUILDFLAGS ?= -v
 GOOS ?= $(shell go env GOOS)
 GIT_VERSION = $(shell git describe --tags --always)

--- a/cmd/network-interface-manager/Dockerfile
+++ b/cmd/network-interface-manager/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.13
+LABEL maintainer="support@kubermatic.com"
+
+COPY ./_build/network-interface-manager /usr/local/bin/network-interface-manager
+

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -1,0 +1,34 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.io/golang:1.19.3 as builder
+
+# import the GOPROXY variable from Buildah via an arg and then use
+# that arg to define the environment variable later on
+ARG GOPROXY=
+ARG GOCACHE=
+ARG KUBERMATIC_EDITION=ce
+
+ENV GOPROXY=$GOPROXY
+ENV GOCACHE=$GOCACHE
+ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
+
+WORKDIR /go/src/k8c.io/kubermatic
+COPY . .
+RUN make -C ./cmd/network-interface-manager build
+
+FROM docker.io/alpine:3.13
+LABEL maintainer="support@kubermatic.com"
+
+COPY --from=builder /go/src/k8c.io/kubermatic/cmd/network-interface-manager/_build/network-interface-manager /usr/local/bin/network-interface-manager

--- a/cmd/network-interface-manager/Makefile
+++ b/cmd/network-interface-manager/Makefile
@@ -14,11 +14,10 @@
 
 DOCKER_REPO ?= "quay.io/kubermatic"
 GOOS ?= $(shell go env GOOS)
-GOARCH ?= $(shell go env GOARCH)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -v -o ./_build/network-interface-manager .
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/network-interface-manager .
 
 .PHONY: docker
 docker: build

--- a/cmd/network-interface-manager/Makefile
+++ b/cmd/network-interface-manager/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_REPO ?= "quay.io/kubermatic"
+GOOS ?= $(shell go env GOOS)
+GOARCH ?= $(shell go env GOARCH)
+
+.PHONY: build
+build:
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -v -o ./_build/network-interface-manager .
+
+.PHONY: docker
+docker: build
+	docker build -t $(DOCKER_REPO)/network-interface-manager:$(TAG) .
+
+.PHONY: clean
+clean:
+	rm -fr _build/

--- a/cmd/network-interface-manager/main.go
+++ b/cmd/network-interface-manager/main.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"time"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+)
+
+const (
+	SCOPE_HOST = 254
+)
+
+func main() {
+	var (
+		mode   string
+		ifName string
+		ifAddr string
+	)
+
+	var link *netlink.Dummy
+	var err error
+	logOpts := kubermaticlog.NewDefaultOptions()
+	logOpts.AddFlags(flag.CommandLine)
+
+	flag.StringVar(&mode, "mode", "", "Start mode for the process, it can be init or probe")
+	flag.StringVar(&ifName, "if", "", "Name of the network interface to be created or managed, eg: envoyagent")
+	flag.StringVar(&ifAddr, "addr", "", "Network Interface address")
+	flag.Parse()
+
+	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
+	log := rawLog.Sugar()
+
+	// 'init' mode is for init containers
+	if mode == "init" {
+		link, err = createInterface(ifName)
+		if err != nil {
+			log.Fatalf("Failed to create link: %v", err)
+			return
+		}
+		err = addAddressToInterface(link, ifAddr)
+		if err != nil {
+			log.Fatalf("Failed to add address to link: %v", err)
+		}
+		return
+	}
+
+	// 'probe' mode is for side-car containers.
+	if mode == "probe" {
+		ticker := time.NewTicker(time.Second * 10).C
+		for {
+			<-ticker
+			link, err = checkInterfaceExists(ifName)
+			if err != nil {
+				link, _ = createInterface(ifName)
+			}
+
+			err = checkIfAddrExists(link, ifAddr)
+			if err != nil {
+				_ = addAddressToInterface(link, ifAddr)
+			}
+		}
+	}
+}
+
+// Creates a dummy link, equalent to "ip link add envoyagent type dummy".
+func createInterface(ifName string) (*netlink.Dummy, error) {
+	link := &netlink.Dummy{LinkAttrs: netlink.LinkAttrs{Name: ifName}}
+
+	err := netlink.LinkAdd(link)
+	if err != nil {
+		return link, fmt.Errorf("could not add %s: %w", link.Name, err)
+	}
+	log.Printf("Interface %s created", ifName)
+
+	return link, nil
+}
+
+// Adds address to the link, equalent to "ip addr add ...".
+func addAddressToInterface(link *netlink.Dummy, ifAddr string) error {
+	addr := &netlink.Addr{IPNet: &net.IPNet{
+		IP:   net.ParseIP(ifAddr),
+		Mask: net.CIDRMask(32, 32),
+	}}
+	addr.Scope = SCOPE_HOST
+
+	err := netlink.AddrAdd(link, addr)
+	if err != nil {
+		return fmt.Errorf("failed to add address to interface %s, error: %w", link.Name, err)
+	}
+	return err
+}
+
+func checkInterfaceExists(ifName string) (*netlink.Dummy, error) {
+	link, err := netlink.LinkByName(ifName)
+	linkDummy := &netlink.Dummy{LinkAttrs: *link.Attrs()}
+	return linkDummy, err
+}
+
+func checkIfAddrExists(link *netlink.Dummy, ifAddr string) error {
+	addrs, err := netlink.AddrList(link, unix.AF_INET)
+	if err != nil {
+		return fmt.Errorf("no addresses configured for interface %s: %w", link.Name, err)
+	}
+
+	for _, addr := range addrs {
+		err = errors.New("address not present")
+		if addr.IPNet.IP.String() == ifAddr {
+			err = nil
+			break
+		}
+	}
+
+	return err
+}

--- a/cmd/network-interface-manager/main.go
+++ b/cmd/network-interface-manager/main.go
@@ -104,6 +104,7 @@ func createInterface(ifName string) (*netlink.Dummy, error) {
 
 // Adds address to the link, equalent to "ip addr add ...".
 func addAddressToInterface(link *netlink.Dummy, ifAddr string) error {
+	var err error
 	addr := &netlink.Addr{IPNet: &net.IPNet{
 		IP:   net.ParseIP(ifAddr),
 		Mask: net.CIDRMask(32, 32),
@@ -111,7 +112,7 @@ func addAddressToInterface(link *netlink.Dummy, ifAddr string) error {
 	addr.Scope = SCOPE_HOST
 
 	// Check for configured addresses and remove them
-	addrs, err := netlink.AddrList(link, unix.AF_INET)
+	addrs, _ := netlink.AddrList(link, unix.AF_INET)
 	if len(addrs) > 0 {
 		for _, val := range addrs {
 			err = netlink.AddrDel(link, &val)

--- a/go.mod
+++ b/go.mod
@@ -319,7 +319,7 @@ require (
 	golang.org/x/mod v0.7.0 // indirect
 	golang.org/x/net v0.2.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
-	golang.org/x/sys v0.2.0 // indirect
+	golang.org/x/sys v0.2.0
 	golang.org/x/term v0.2.0 // indirect
 	golang.org/x/text v0.4.0 // indirect
 	golang.org/x/time v0.0.0-20220922220347-f3bd1da661af // indirect
@@ -340,8 +340,6 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
-
-require github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 
 require github.com/vishvananda/netlink v1.1.1-0.20220125195016-0639e7e787ba
 

--- a/go.mod
+++ b/go.mod
@@ -340,3 +340,9 @@ require (
 	sigs.k8s.io/kustomize/kyaml v0.13.9 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
+
+require github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
+
+require github.com/vishvananda/netlink v1.1.1-0.20220125195016-0639e7e787ba
+
+require github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1076,6 +1076,11 @@ github.com/vektah/gqlparser/v2 v2.2.0 h1:bAc3slekAAJW6sZTi07aGq0OrfaCjj4jxARAaC7
 github.com/vektah/gqlparser/v2 v2.2.0/go.mod h1:i3mQIGIrbK2PD1RrCeMTlVbkF2FJ6WkU1KJlJlC+3F4=
 github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
 github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
+github.com/vishvananda/netlink v1.1.1-0.20220125195016-0639e7e787ba h1:MU5oPE25XZhDS8Z0xFG0/1ERBEu5rZIw62TImubLusU=
+github.com/vishvananda/netlink v1.1.1-0.20220125195016-0639e7e787ba/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
+github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 h1:gga7acRE695APm9hlsSMoOoE65U4/TcqNj90mc69Rlg=
+github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware/go-vcloud-director/v2 v2.16.0 h1:2KxPI3jDPV4ZpYU6odYcMiyKyXK589Hg5cRdnnOU5Gw=
 github.com/vmware/go-vcloud-director/v2 v2.16.0/go.mod h1:DgfzOh0u9J70FFOC2Qwy4iCjPoktg6SDdEguNi0z0H0=
 github.com/vmware/govmomi v0.29.0 h1:SHJQ7DUc4fltFZv16znJNGHR1/XhiDK5iKxm2OqwkuU=
@@ -1390,6 +1395,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1400,6 +1406,7 @@ golang.org/x/sys v0.0.0-20200515095857-1151b9dac4a9/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/hack/README.md
+++ b/hack/README.md
@@ -47,6 +47,7 @@ Builds and pushes all KKP Docker images:
 * quay.io/kubermatic/kubeletdnat-controller
 * quay.io/kubermatic/user-ssh-keys-agent
 * quay.io/kubermatic/etcd-launcher
+* quay.io/kubermatic/network-interface-manager
 
 The images are tagged with all arguments given to the script, i.e
 `./release-docker-images.sh foo bar` will tag `kubermatic:foo` and

--- a/hack/ci/setup-kubermatic-backups-in-kind.sh
+++ b/hack/ci/setup-kubermatic-backups-in-kind.sh
@@ -91,6 +91,15 @@ beforeDockerBuild=$(nowms)
   time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
   time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
+(
+  echodate "Building network-interface-manager image"
+  TEST_NAME="Build network-interface-manager Docker image"
+  cd cmd/network-interface-manager
+  make build
+  IMAGE_NAME="quay.io/kubermatic/network-interface-manager:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
 
 pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
 echodate "Successfully built and loaded all images"

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -105,6 +105,15 @@ beforeDockerBuild=$(nowms)
   time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
   time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
+(
+  echodate "Building network-interface-manager image"
+  TEST_NAME="Build network-interface-manager Docker image"
+  cd cmd/network-interface-manager
+  make build
+  IMAGE_NAME="quay.io/kubermatic/network-interface-manager:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
 
 pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
 echodate "Successfully built and loaded all images"

--- a/hack/ci/setup-kubermatic-mla-in-kind.sh
+++ b/hack/ci/setup-kubermatic-mla-in-kind.sh
@@ -93,6 +93,15 @@ beforeDockerBuild=$(nowms)
   time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
   time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
+(
+  echodate "Building network-interface-manager image"
+  TEST_NAME="Build network-interface-manager Docker image"
+  cd cmd/network-interface-manager
+  make build
+  IMAGE_NAME="quay.io/kubermatic/network-interface-manager:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
 
 pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
 echodate "Successfully built and loaded all images"

--- a/hack/ci/upload-gocache.sh
+++ b/hack/ci/upload-gocache.sh
@@ -80,6 +80,10 @@ echodate "Building binaries"
   cd pkg/test/clusterexposer/cmd
   go build --tags "$KUBERMATIC_EDITION" -v .
 )
+(
+  TEST_NAME="Building network interface manager"
+  make -C cmd/network-interface-manager build
+)
 
 TEST_NAME="Build tests"
 echodate "Building tests"

--- a/hack/local/run-kubermatic-kind.sh
+++ b/hack/local/run-kubermatic-kind.sh
@@ -140,6 +140,15 @@ beforeDockerBuild=$(nowms)
   time retry 5 docker build -t "${IMAGE_NAME}" -f cmd/etcd-launcher/Dockerfile .
   time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
+(
+  echodate "Building network-interface-manager image"
+  TEST_NAME="Build network-interface-manager Docker image"
+  cd cmd/network-interface-manager
+  make build
+  IMAGE_NAME="quay.io/kubermatic/network-interface-manager:$KUBERMATIC_VERSION"
+  time retry 5 docker build -t "${IMAGE_NAME}" .
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+)
 
 pushElapsed kubermatic_docker_build_duration_milliseconds $beforeDockerBuild
 echodate "Successfully built and loaded all images"

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -38,6 +38,7 @@ function patch_kubermatic_domain {
 DOCKER_REPO="${DOCKER_REPO:-quay.io/kubermatic}"
 GOOS="${GOOS:-linux}"
 TAG="$(git rev-parse HEAD)"
+FAKE_TAG="v0.0.0-test"
 KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kubermatic}"
 KUBECONFIG="${KUBECONFIG:-"${HOME}/.kube/config"}"
 KUBERMATIC_EDITION="${KUBERMATIC_EDITION:-ce}"
@@ -82,6 +83,14 @@ make -C cmd/kubeletdnat-controller docker \
 make -C addons docker \
   DOCKER_REPO="${DOCKER_REPO}" \
   TAG="${TAG}"
+make -C cmd/network-interface-manager docker \
+  GOOS="${GOOS}" \
+  DOCKER_REPO="${DOCKER_REPO}" \
+  TAG="${TAG}"
+make -C cmd/network-interface-manager docker \
+  GOOS="${GOOS}" \
+  DOCKER_REPO="${DOCKER_REPO}" \
+  TAG="${FAKE_TAG}"
 
 # the installer should be built for the target platform.
 rm _build/kubermatic-installer
@@ -96,6 +105,8 @@ time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "${KIN
 time kind load docker-image "${DOCKER_REPO}/addons:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/kubermatic${REPOSUFFIX}:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/kubeletdnat-controller:${TAG}" --name "${KIND_CLUSTER_NAME}"
+time kind load docker-image "${DOCKER_REPO}/network-interface-manager:${TAG}" --name "${KIND_CLUSTER_NAME}"
+time kind load docker-image "${DOCKER_REPO}/network-interface-manager:${FAKE_TAG}" --name "${KIND_CLUSTER_NAME}"
 
 # This is just used as a const
 # NB: The CE requires Seeds to be named this way

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -87,6 +87,7 @@ make -C cmd/network-interface-manager docker \
   GOOS="${GOOS}" \
   DOCKER_REPO="${DOCKER_REPO}" \
   TAG="${TAG}"
+# image with FAKE TAG v0.0.0-test is used by envoy-agent pod in ExposeStrategyTunneling test case
 make -C cmd/network-interface-manager docker \
   GOOS="${GOOS}" \
   DOCKER_REPO="${DOCKER_REPO}" \
@@ -106,6 +107,7 @@ time kind load docker-image "${DOCKER_REPO}/addons:${TAG}" --name "${KIND_CLUSTE
 time kind load docker-image "${DOCKER_REPO}/kubermatic${REPOSUFFIX}:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/kubeletdnat-controller:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/network-interface-manager:${TAG}" --name "${KIND_CLUSTER_NAME}"
+# load network-interface-manager with FAKE TAG 'v0.0.0-test' which is used in ExposeStrategyTunneling test case
 time kind load docker-image "${DOCKER_REPO}/network-interface-manager:${FAKE_TAG}" --name "${KIND_CLUSTER_NAME}"
 
 # This is just used as a const

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -179,9 +179,10 @@ func getContainers(versions kubermatic.Versions, imageRewriter registry.ImageRew
 			},
 		},
 		{
-			Name:    resources.EnvoyAgentAssignAddressContainerName,
-			Image:   image,
-			Command: []string{"sh", "-c", fmt.Sprintf("network-interface-manager -mode probe -if envoyagent -addr %s", ip.String())},
+			Name:            resources.EnvoyAgentAssignAddressContainerName,
+			Image:           image,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"sh", "-c", fmt.Sprintf("network-interface-manager -mode probe -if envoyagent -addr %s", ip.String())},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -130,24 +130,10 @@ func getInitContainers(ip net.IP, versions kubermatic.Versions, imageRewriter re
 	// interface in a loop.
 	return []corev1.Container{
 		{
-			Name:    resources.EnvoyAgentCreateInterfaceInitContainerName,
-			Image:   image,
-			Command: []string{"sh", "-c", "ip link add envoyagent type dummy || true"},
-			SecurityContext: &corev1.SecurityContext{
-				Capabilities: &corev1.Capabilities{
-					Add: []corev1.Capability{
-						"NET_ADMIN",
-					},
-					Drop: []corev1.Capability{
-						"all",
-					},
-				},
-			},
-		},
-		{
-			Name:    resources.EnvoyAgentAssignAddressInitContainerName,
-			Image:   image,
-			Command: []string{"sh", "-c", fmt.Sprintf("ip addr add %s/32 dev envoyagent scope host || true", ip.String())},
+			Name:  resources.EnvoyAgentCreateInterfaceInitContainerName,
+			Image: image,
+			// Command: []string{"sh", "-c", "ip link add envoyagent type dummy || true"},
+			Command: []string{"sh", "-c", fmt.Sprintf("network-interface-manager -mode init -if envoyagent -addr %s", ip.String())},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{

--- a/pkg/defaulting/images_ce.go
+++ b/pkg/defaulting/images_ce.go
@@ -35,4 +35,7 @@ const (
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"
+
+	// DefaultNetworkInterfaceManagerImage defines the default Docker repository containing the network interface manager image.
+	DefaultNetworkInterfaceManagerImage = "quay.io/kubermatic/network-interface-manager"
 )

--- a/pkg/defaulting/images_ee.go
+++ b/pkg/defaulting/images_ee.go
@@ -35,4 +35,7 @@ const (
 
 	// DefaultKubernetesAddonImage defines the default Docker repository containing the Kubernetes addons.
 	DefaultKubernetesAddonImage = "quay.io/kubermatic/addons"
+
+	// DefaultNetworkInterfaceManagerImage defines the default Docker repository containing the network interface manager image.
+	DefaultNetworkInterfaceManagerImage = "quay.io/kubermatic/network-interface-manager"
 )

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -422,6 +422,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		WithKubermaticImage(defaulting.DefaultKubermaticImage).
 		WithEtcdLauncherImage(defaulting.DefaultEtcdLauncherImage).
 		WithDnatControllerImage(defaulting.DefaultDNATControllerImage).
+		WithNetworkIntfMgrImage(defaulting.DefaultNetworkInterfaceManagerImage).
 		WithBackupPeriod(20 * time.Minute).
 		WithFailureDomainZoneAntiaffinity(false).
 		WithVersions(kubermaticVersions).

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -77,6 +77,7 @@ type TemplateData struct {
 	kubermaticImage                  string
 	etcdLauncherImage                string
 	dnatControllerImage              string
+	networkIntfMgrImage              string
 	machineControllerImageTag        string
 	machineControllerImageRepository string
 	backupSchedule                   time.Duration
@@ -184,6 +185,11 @@ func (td *TemplateDataBuilder) WithEtcdLauncherImage(image string) *TemplateData
 
 func (td *TemplateDataBuilder) WithDnatControllerImage(image string) *TemplateDataBuilder {
 	td.data.dnatControllerImage = image
+	return td
+}
+
+func (td *TemplateDataBuilder) WithNetworkIntfMgrImage(image string) *TemplateDataBuilder {
+	td.data.networkIntfMgrImage = image
 	return td
 }
 
@@ -470,6 +476,10 @@ func (d *TemplateData) KubermaticDockerTag() string {
 
 func (d *TemplateData) DNATControllerImage() string {
 	return registry.Must(d.RewriteImage(d.dnatControllerImage))
+}
+
+func (d *TemplateData) NetworkIntfMgrImage() string {
+	return registry.Must(d.RewriteImage(d.networkIntfMgrImage))
 }
 
 func (d *TemplateData) BackupSchedule() time.Duration {

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -332,3 +332,64 @@ func TestDNATControllerImage(t *testing.T) {
 		})
 	}
 }
+
+func TestNetworkInterfaceManagerImage(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		templateData            *TemplateData
+		wantNetworkIntfMgrImage string
+	}{
+		{
+			name: "default image",
+			templateData: &TemplateData{
+				networkIntfMgrImage: "quay.io/kubermatic/network-interface-manager",
+			},
+			wantNetworkIntfMgrImage: "quay.io/kubermatic/network-interface-manager",
+		},
+		{
+			name: "default image with overwrite registry",
+			templateData: &TemplateData{
+				networkIntfMgrImage: "quay.io/kubermatic/network-interface-manager",
+				OverwriteRegistry:   "custom-registry.kubermatic.io",
+			},
+			wantNetworkIntfMgrImage: "custom-registry.kubermatic.io/kubermatic/network-interface-manager",
+		},
+		{
+			name: "custom image with 2 parts",
+			templateData: &TemplateData{
+				networkIntfMgrImage: "kubermatic/network-interface-manager",
+			},
+			wantNetworkIntfMgrImage: "docker.io/kubermatic/network-interface-manager",
+		},
+		{
+			name: "custom image with 2 parts with overwrite registry",
+			templateData: &TemplateData{
+				networkIntfMgrImage: "kubermatic/network-interface-manager",
+				OverwriteRegistry:   "custom-registry.kubermatic.io",
+			},
+			wantNetworkIntfMgrImage: "custom-registry.kubermatic.io/kubermatic/network-interface-manager",
+		},
+		{
+			name: "custom image with 4 parts",
+			templateData: &TemplateData{
+				networkIntfMgrImage: "registry.kubermatic.io/images/kubermatic/network-interface-manager",
+			},
+			wantNetworkIntfMgrImage: "registry.kubermatic.io/images/kubermatic/network-interface-manager",
+		},
+		{
+			name: "custom image with 4 parts with overwrite registry",
+			templateData: &TemplateData{
+				networkIntfMgrImage: "registry.kubermatic.io/images/kubermatic/network-interface-manager",
+				OverwriteRegistry:   "custom-registry.kubermatic.io",
+			},
+			wantNetworkIntfMgrImage: "custom-registry.kubermatic.io/images/kubermatic/network-interface-manager",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if img := tc.templateData.NetworkIntfMgrImage(); img != tc.wantNetworkIntfMgrImage {
+				t.Errorf("want network-interface-manager image %q, but got %q", tc.wantNetworkIntfMgrImage, img)
+			}
+		})
+	}
+}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -740,7 +740,7 @@ const (
 	EnvoyAgentConfigFileName                   = "envoy.yaml"
 	EnvoyAgentDaemonSetName                    = "envoy-agent"
 	EnvoyAgentCreateInterfaceInitContainerName = "create-dummy-interface"
-	EnvoyAgentAssignAddressInitContainerName   = "assign-address"
+	EnvoyAgentAssignAddressContainerName       = "assign-address"
 	EnvoyAgentDeviceSetupImage                 = "kubermatic/network-interface-manager"
 	// Default tunneling agent IP address.
 	DefaultTunnelingAgentIP = "192.168.30.10"

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -741,7 +741,7 @@ const (
 	EnvoyAgentDaemonSetName                    = "envoy-agent"
 	EnvoyAgentCreateInterfaceInitContainerName = "create-dummy-interface"
 	EnvoyAgentAssignAddressInitContainerName   = "assign-address"
-	EnvoyAgentDeviceSetupImage                 = "kubermatic/kubeletdnat-controller"
+	EnvoyAgentDeviceSetupImage                 = "kubermatic/network-interface-manager"
 	// Default tunneling agent IP address.
 	DefaultTunnelingAgentIP = "192.168.30.10"
 )

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -746,6 +746,7 @@ func TestLoadFiles(t *testing.T) {
 						WithKubermaticImage("quay.io/kubermatic/kubermatic").
 						WithEtcdLauncherImage("quay.io/kubermatic/etcd-launcher").
 						WithDnatControllerImage("quay.io/kubermatic/kubeletdnat-controller").
+						WithNetworkIntfMgrImage("quay.io/kubermatic/network-interface-manager").
 						WithVersions(kubermaticVersions).
 						Build()
 


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
Implements network-interface-manager for creating and monitoring dummy network interface required by the envoy-agent. This is used as an init and side-car container in envoy-agent pod which is required for Tunnelling expose strategy.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # [7123](https://github.com/kubermatic/kubermatic/issues/7123)

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Implemented network-interface-manager for enhancing Tunnelling expose strategy reliability
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
