### PR TITLE
[release/v2.19] monitoring: rename etcd metrics graduated by v3.4.0

### DIFF
--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: 1.5.8
+version: 1.5.9
 appVersion: 8.1.2
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/etcd-overview.json
@@ -464,7 +464,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(job:etcd_debugging_mvcc_db_total_size_in_bytes:clone) by (cluster)",
+          "expr": "sum(job:etcd_mvcc_db_total_size_in_bytes:clone) by (cluster)",
           "format": "time_series",
           "hide": false,
           "interval": "$interval",
@@ -1073,7 +1073,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(job:etcd_debugging_mvcc_txn_total:rate5m) by (cluster)",
+          "expr": "sum(job:etcd_mvcc_txn_total:rate5m) by (cluster)",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1169,7 +1169,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(job:etcd_debugging_mvcc_put_total:rate5m) by (cluster)",
+          "expr": "sum(job:etcd_mvcc_put_total:rate5m) by (cluster)",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1265,7 +1265,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(job:etcd_debugging_mvcc_range_total:rate5m) by (cluster)",
+          "expr": "sum(job:etcd_mvcc_range_total:rate5m) by (cluster)",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1361,7 +1361,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(job:etcd_debugging_mvcc_delete_total:rate5m) by (cluster)",
+          "expr": "sum(job:etcd_mvcc_delete_total:rate5m) by (cluster)",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,

--- a/charts/monitoring/grafana/dashboards/kubernetes/etcd.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/etcd.json
@@ -456,7 +456,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "job:etcd_debugging_mvcc_db_total_size_in_bytes:clone{cluster=\"$cluster\"}",
+          "expr": "job:etcd_mvcc_db_total_size_in_bytes:clone{cluster=\"$cluster\"}",
           "format": "time_series",
           "hide": false,
           "interval": "$interval",
@@ -1291,7 +1291,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "job:etcd_debugging_mvcc_txn_total:rate5m{cluster=\"$cluster\"}",
+          "expr": "job:etcd_mvcc_txn_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1387,7 +1387,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "job:etcd_debugging_mvcc_put_total:rate5m{cluster=\"$cluster\"}",
+          "expr": "job:etcd_mvcc_put_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1483,7 +1483,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "job:etcd_debugging_mvcc_range_total:rate5m{cluster=\"$cluster\"}",
+          "expr": "job:etcd_mvcc_range_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,
@@ -1579,7 +1579,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "job:etcd_debugging_mvcc_delete_total:rate5m{cluster=\"$cluster\"}",
+          "expr": "job:etcd_mvcc_delete_total:rate5m{cluster=\"$cluster\"}",
           "format": "time_series",
           "interval": "$interval",
           "intervalFactor": 1,

--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -73,8 +73,8 @@ groups:
     labels:
       kubermatic: federate
 
-  - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-    expr: etcd_debugging_mvcc_db_total_size_in_bytes
+  - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+    expr: etcd_mvcc_db_total_size_in_bytes
     labels:
       kubermatic: federate
 
@@ -123,18 +123,18 @@ groups:
     labels:
       kubermatic: federate
 
-  - record: job:etcd_debugging_mvcc_delete_total:rate5m
-    expr: rate(etcd_debugging_mvcc_delete_total[5m])
+  - record: job:etcd_mvcc_delete_total:rate5m
+    expr: rate(etcd_mvcc_delete_total[5m])
     labels:
       kubermatic: federate
 
-  - record: job:etcd_debugging_mvcc_put_total:rate5m
-    expr: rate(etcd_debugging_mvcc_put_total[5m])
+  - record: job:etcd_mvcc_put_total:rate5m
+    expr: rate(etcd_mvcc_put_total[5m])
     labels:
       kubermatic: federate
 
-  - record: job:etcd_debugging_mvcc_range_total:rate5m
-    expr: rate(etcd_debugging_mvcc_range_total[5m])
+  - record: job:etcd_mvcc_range_total:rate5m
+    expr: rate(etcd_mvcc_range_total[5m])
     labels:
       kubermatic: federate
 
@@ -143,8 +143,8 @@ groups:
     labels:
       kubermatic: federate
 
-  - record: job:etcd_debugging_mvcc_txn_total:rate5m
-    expr: rate(etcd_debugging_mvcc_txn_total[5m])
+  - record: job:etcd_mvcc_txn_total:rate5m
+    expr: rate(etcd_mvcc_txn_total[5m])
     labels:
       kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.20.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.21.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.22.1-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.20.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.21.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.22.1-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.20.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.21.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.22.1-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.20.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.21.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.22.1-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus-externalCloudProvider.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.20.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus-externalCloudProvider.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.21.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus-externalCloudProvider.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.22.1-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus-externalCloudProvider.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.20.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus-externalCloudProvider.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.21.0-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus-externalCloudProvider.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.22.1-prometheus.yaml
@@ -283,8 +283,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_db_total_size_in_bytes:clone
-        expr: etcd_debugging_mvcc_db_total_size_in_bytes
+      - record: job:etcd_mvcc_db_total_size_in_bytes:clone
+        expr: etcd_mvcc_db_total_size_in_bytes
         labels:
           kubermatic: federate
 
@@ -333,18 +333,18 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_delete_total:rate5m
-        expr: rate(etcd_debugging_mvcc_delete_total[5m])
+      - record: job:etcd_mvcc_delete_total:rate5m
+        expr: rate(etcd_mvcc_delete_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_put_total:rate5m
-        expr: rate(etcd_debugging_mvcc_put_total[5m])
+      - record: job:etcd_mvcc_put_total:rate5m
+        expr: rate(etcd_mvcc_put_total[5m])
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_range_total:rate5m
-        expr: rate(etcd_debugging_mvcc_range_total[5m])
+      - record: job:etcd_mvcc_range_total:rate5m
+        expr: rate(etcd_mvcc_range_total[5m])
         labels:
           kubermatic: federate
 
@@ -353,8 +353,8 @@ data:
         labels:
           kubermatic: federate
 
-      - record: job:etcd_debugging_mvcc_txn_total:rate5m
-        expr: rate(etcd_debugging_mvcc_txn_total[5m])
+      - record: job:etcd_mvcc_txn_total:rate5m
+        expr: rate(etcd_mvcc_txn_total[5m])
         labels:
           kubermatic: federate
 


### PR DESCRIPTION
**What this PR does / why we need it**:
manual cherry-pick of #11434 
With release 3.4.0 of etcd, some metrics were renamed from `etcd_debugging_mvcc_` prefix to `etcd_mvcc_`. This change follows up by rewriting some recording rules and queries inside grafana dashboards.

covered metrics:
* `etcd_mvcc_db_total_size_in_bytes`
* `etcd_mvcc_delete_total`
* `etcd_mvcc_put_total`
* `etcd_mvcc_range_total`
* `etcd_mvcc_txn_total`

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11428 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix missing etcd metrics in Grafana etcd dashboards and master/seed Prometheus by renaming to: `etcd_mvcc_db_total_size_in_bytes`, `etcd_mvcc_delete_total`, `etcd_mvcc_put_total`, `etcd_mvcc_range_total`, `etcd_mvcc_txn_total`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
