### PR TITLE
Kubevirt fix wrong HostPort in the csi-driver

### DIFF
--- a/pkg/resources/csi/kubevirt/deployment.go
+++ b/pkg/resources/csi/kubevirt/deployment.go
@@ -88,7 +88,6 @@ func ControllerDeploymentCreator(data *resources.TemplateData) reconciling.Named
 			if err != nil {
 				return nil, err
 			}
-			d.Spec.Template.Spec.HostNetwork = true
 			d.Spec.Template.Spec.ServiceAccountName = resources.KubeVirtCSIServiceAccountName
 			d.Spec.Template.Spec.Tolerations = []corev1.Toleration{
 				{
@@ -116,7 +115,6 @@ func ControllerDeploymentCreator(data *resources.TemplateData) reconciling.Named
 						{
 							Name:          "healthz",
 							ContainerPort: 10301,
-							HostPort:      10301,
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Thanks to some flaky e2e kubevirt tests in the CI, I figured out that the `csi-controller` does not need a HostPort.
It was a mistake introduced by the split of the CSI driver deployment ticket.
This PR fixes this error.
No cherry-pick needed, it's a 2.22 introduced error.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11435 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
