### PR TITLE
Fix for tunnelingAgentIP default spec

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -139,6 +139,11 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 	// default cluster networking parameters
 	spec.ClusterNetwork = DefaultClusterNetwork(spec.ClusterNetwork, kubermaticv1.ProviderType(spec.Cloud.ProviderName))
 
+	if spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+		if spec.ClusterNetwork.TunnelingAgentIP == "" {
+			spec.ClusterNetwork.TunnelingAgentIP = resources.DefaultTunnelingAgentIP
+		}
+	}
 	return nil
 }
 

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -137,13 +137,8 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 	}
 
 	// default cluster networking parameters
-	spec.ClusterNetwork = DefaultClusterNetwork(spec.ClusterNetwork, kubermaticv1.ProviderType(spec.Cloud.ProviderName))
+	spec.ClusterNetwork = DefaultClusterNetwork(spec.ClusterNetwork, kubermaticv1.ProviderType(spec.Cloud.ProviderName), spec.ExposeStrategy)
 
-	if spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
-		if spec.ClusterNetwork.TunnelingAgentIP == "" {
-			spec.ClusterNetwork.TunnelingAgentIP = resources.DefaultTunnelingAgentIP
-		}
-	}
 	return nil
 }
 
@@ -183,7 +178,7 @@ func DatacenterForClusterSpec(spec *kubermaticv1.ClusterSpec, seed *kubermaticv1
 	return nil, field.Invalid(field.NewPath("spec", "cloud", "dc"), datacenterName, "invalid datacenter name")
 }
 
-func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConfig, provider kubermaticv1.ProviderType) kubermaticv1.ClusterNetworkingConfig {
+func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConfig, provider kubermaticv1.ProviderType, exposeStrategy kubermaticv1.ExposeStrategy) kubermaticv1.ClusterNetworkingConfig {
 	if specClusterNetwork.IPFamily == "" {
 		if len(specClusterNetwork.Pods.CIDRBlocks) < 2 {
 			// single / no pods CIDR means IPv4-only (IPv6-only is not supported yet and not allowed by cluster validation)
@@ -235,6 +230,12 @@ func DefaultClusterNetwork(specClusterNetwork kubermaticv1.ClusterNetworkingConf
 
 	if specClusterNetwork.DNSDomain == "" {
 		specClusterNetwork.DNSDomain = "cluster.local"
+	}
+
+	if exposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+		if specClusterNetwork.TunnelingAgentIP == "" {
+			specClusterNetwork.TunnelingAgentIP = resources.DefaultTunnelingAgentIP
+		}
 	}
 
 	return specClusterNetwork

--- a/pkg/defaulting/cluster_test.go
+++ b/pkg/defaulting/cluster_test.go
@@ -227,7 +227,7 @@ func TestDefaultClusterNetwork(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			tc.spec.ClusterNetwork = DefaultClusterNetwork(tc.spec.ClusterNetwork, kubermaticv1.ProviderType(tc.spec.Cloud.ProviderName))
+			tc.spec.ClusterNetwork = DefaultClusterNetwork(tc.spec.ClusterNetwork, kubermaticv1.ProviderType(tc.spec.Cloud.ProviderName), tc.spec.ExposeStrategy)
 			assert.Equal(t, tc.expectedChangedSpec, tc.spec)
 		})
 	}


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
This PR sets the tunnelingAgentIP to default IP `192.168.30.10` if it is not set in case of Tunnelling expose strategy

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # [11442](https://github.com/kubermatic/kubermatic/issues/11442)

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes default tunnelingAgentIP for Tunneling expose strategy
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
