### PR TITLE
Update OpenStack Cinder CSI to v1.24.5 and v1.25.3

### DIFF
--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -17,16 +17,16 @@
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
 {{ $version = "v1.23.4"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.3"}}
+{{ $version = "v1.24.5"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.0"}}
+{{ $version = "v1.25.3"}}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 ---
@@ -110,7 +110,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.6.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.7.0" }}'
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -17,18 +17,17 @@
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
 {{ $version = "v1.23.4"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.3"}}
+{{ $version = "v1.24.5"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.0"}}
+{{ $version = "v1.25.3"}}
 {{ end }}
-
 {{ if not (eq $version "UNSUPPORTED") }}
 ---
 kind: DaemonSet
@@ -54,7 +53,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.1" }}'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -78,7 +77,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.6.0" }}'
+          image: '{{ Image "registry.k8s.io/sig-storage/livenessprobe:v2.7.0" }}'
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update OpenStack Cinder CSI to v1.24.5 and v1.25.3.

**Which issue(s) this PR fixes**:

xref #11123 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update OpenStack Cinder CSI to v1.24.5 and v1.25.3
```

**Documentation**:
```documentation
NONE
```