### PR TITLE
[release/v2.21] Update OpenStack Cinder CSI to v1.24.5, v1.23.4, and v1.22.2

### DIFF
--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -20,13 +20,13 @@
 {{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
-{{ $version = "v1.23.0"}}
+{{ $version = "v1.23.4"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.0"}}
+{{ $version = "v1.24.5"}}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 ---

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -20,15 +20,14 @@
 {{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
-{{ $version = "v1.23.0"}}
+{{ $version = "v1.23.4"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.0"}}
+{{ $version = "v1.24.5"}}
 {{ end }}
-
 {{ if not (eq $version "UNSUPPORTED") }}
 ---
 kind: DaemonSet


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry-pick of #11454 to the `release/v2.21` branch.

Update OpenStack Cinder CSI to v1.24.5, v1.23.4, and v1.22.2.

**Which issue(s) this PR fixes**:

xref #11123 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update OpenStack Cinder CSI to v1.24.5, v1.23.4, and v1.22.2
```

**Documentation**:
```documentation
NONE
```