### PR TITLE
[release/v2.20] Update OpenStack Cinder CSI to v1.23.4 and v1.22.2

### DIFF
--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -23,10 +23,10 @@
 {{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
-{{ $version = "v1.23.0"}}
+{{ $version = "v1.23.4"}}
 {{ end }}
 
 ---

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -23,10 +23,10 @@
 {{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
-{{ $version = "v1.23.0"}}
+{{ $version = "v1.23.4"}}
 {{ end }}
 
 ---

--- a/addons/csi/openstack/snapshot-controller.yaml
+++ b/addons/csi/openstack/snapshot-controller.yaml
@@ -137,6 +137,9 @@ spec:
         app: snapshot-controller
     spec:
       serviceAccount: snapshot-controller
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: snapshot-controller
           image: k8s.gcr.io/sig-storage/snapshot-controller:v4.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry-pick of #11454 to the `release/v2.20` branch.

Update OpenStack Cinder CSI to v1.23.4 and v1.22.2.

**Which issue(s) this PR fixes**:

xref #11123 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update OpenStack Cinder CSI to v1.23.4 and v1.22.2
```

**Documentation**:
```documentation
NONE
```