### PR TITLE
[release/v2.19] Update OpenStack Cinder CSI to v1.22.2

### DIFF
--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -23,7 +23,7 @@
 {{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 
 ---

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -23,7 +23,7 @@
 {{ $version = "v1.21.0"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.22" }}
-{{ $version = "v1.22.0"}}
+{{ $version = "v1.22.2"}}
 {{ end }}
 
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual cherry-pick of #11454 to the `release/v2.19` branch.

Update OpenStack Cinder CSI to v1.22.2.

**Which issue(s) this PR fixes**:

xref #11123 

**What type of PR is this?**

/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update OpenStack Cinder CSI to v1.22.2.
```

**Documentation**:
```documentation
NONE
```