### PR TITLE
Set ownership for kubevirt provider to sig-virt

### DIFF
--- a/pkg/provider/cloud/kubevirt/OWNERS
+++ b/pkg/provider/cloud/kubevirt/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-virtualization
+
+reviewers:
+  - sig-virtualization
+
+labels:
+  - sig/virtualization
+
+options:
+  no_parent_owners: true


### PR DESCRIPTION
**What this PR does / why we need it**:
This relieves dependency of sig-clustermanagement for kubevirt provider development.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Analog to https://github.com/kubermatic/machine-controller/pull/1496

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
