### PR TITLE
[release/v2.21] Defaulting tag categoryID in vSphere user cluster from seed

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -25536,6 +25536,11 @@
           "type": "string",
           "x-go-name": "DefaultDatastore"
         },
+        "defaultTagCategoryID": {
+          "description": "DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,\nand they don't wish KKP to create default generated tag category, upon cluster creation.",
+          "type": "string",
+          "x-go-name": "DefaultTagCategoryID"
+        },
         "endpoint": {
           "description": "Endpoint URL to use, including protocol, for example \"https://vcenter.example.com\".",
           "type": "string",

--- a/docs/zz_generated.seed.yaml
+++ b/docs/zz_generated.seed.yaml
@@ -233,6 +233,9 @@ spec:
           # classes/dynamic provisioning and for storing virtual machine files in
           # case no `Datastore` or `DatastoreCluster` is provided at Cluster level.
           datastore: ""
+          # DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+          # and they don't wish KKP to create default generated tag category, upon cluster creation.
+          defaultTagCategoryID: ""
           # Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
           endpoint: ""
           # Optional: Infra management user is the user that will be used for everything

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -580,6 +580,9 @@ type DatacenterSpecVSphere struct {
 	InfraManagementUser *VSphereCredentials `json:"infraManagementUser,omitempty"`
 	// Optional: defines if the IPv6 is enabled for the datacenter
 	IPv6Enabled *bool `json:"ipv6Enabled,omitempty"`
+	// DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+	// and they don't wish KKP to create default generated tag category, upon cluster creation.
+	DefaultTagCategoryID string `json:"defaultTagCategoryID,omitempty"`
 }
 
 type DatacenterSpecVMwareCloudDirector struct {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -503,6 +503,13 @@ spec:
                                 and for storing virtual machine files in case no `Datastore`
                                 or `DatastoreCluster` is provided at Cluster level.
                               type: string
+                            defaultTagCategoryID:
+                              description: DefaultTagCategoryID is the tag category
+                                id that will be used as default, if users don't specify
+                                it on a cluster level, and they don't wish KKP to
+                                create default generated tag category, upon cluster
+                                creation.
+                              type: string
                             endpoint:
                               description: Endpoint URL to use, including protocol,
                                 for example "https://vcenter.example.com".

--- a/pkg/test/e2e/utils/apiclient/models/datacenter_spec_v_sphere.go
+++ b/pkg/test/e2e/utils/apiclient/models/datacenter_spec_v_sphere.go
@@ -35,6 +35,10 @@ type DatacenterSpecVSphere struct {
 	// The name of the storage policy to use for the storage class created in the user cluster.
 	DefaultStoragePolicy string `json:"storagePolicy,omitempty"`
 
+	// DefaultTagCategoryID is the tag category id that will be used as default, if users don't specify it on a cluster level,
+	// and they don't wish KKP to create default generated tag category, upon cluster creation.
+	DefaultTagCategoryID string `json:"defaultTagCategoryID,omitempty"`
+
 	// Endpoint URL to use, including protocol, for example "https://vcenter.example.com".
 	Endpoint string `json:"endpoint,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/11411 to the release/v2.21 branch.

Defaulting tagCategoryID in vSphere user clusters, if the field was empty.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Defaulting vSphere tag category from seed, when it is not specified in user cluster 
```

**Documentation**:
Defaulting tag category in seed objects [PR](https://github.com/kubermatic/docs/pull/1266)

<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
