### PR TITLE
Remove VM network from vSphere integration tests and increase test timeouts

### DIFF
--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -57,6 +57,7 @@ openstack)
   EXTRA_ARGS="-openstack-kkp-datacenter=syseleven-dbl1"
   ;;
 vsphere)
+  TIMEOUT=45m
   EXTRA_ARGS="-vsphere-kkp-datacenter=vsphere-ger"
   ;;
 azure)

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -146,7 +146,8 @@ vsphere)
   VSPHERE_PASSWORD="${VSPHERE_PASSWORD:-$(vault kv get -field=password dev/vsphere)}"
   extraArgs="-vsphere-username=$VSPHERE_USERNAME
     -vsphere-password=$VSPHERE_PASSWORD
-    -vsphere-kkp-datacenter=vsphere-ger"
+    -vsphere-kkp-datacenter=vsphere-ger
+    -node-ready-timeout=30m"
   ;;
 
 *)

--- a/pkg/provider/cloud/vsphere/network_test.go
+++ b/pkg/provider/cloud/vsphere/network_test.go
@@ -36,12 +36,6 @@ func TestGetPossibleVMNetworks(t *testing.T) {
 			name: "get all networks",
 			expectedNetworkInfos: []NetworkInfo{
 				{
-					AbsolutePath: fmt.Sprintf("/%s/network/VM Network", vSphereDatacenter),
-					RelativePath: "VM Network",
-					Type:         "Network",
-					Name:         "VM Network",
-				},
-				{
 					AbsolutePath: fmt.Sprintf("/%s/network/Management", vSphereDatacenter),
 					RelativePath: "Management",
 					Type:         "DistributedVirtualPortgroup",


### PR DESCRIPTION
**What this PR does / why we need it**:
This network got removed from our vSphere with intent. We need to adjust the integration tests to not expect it anymore.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
