### PR TITLE
Fix metrics scraping configmap prefix for addons

### DIFF
--- a/addons/kube-state-metrics/scrape-config.yaml
+++ b/addons/kube-state-metrics/scrape-config.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-scraping-kube-state-metrics
+  name: monitoring-scraping-kube-state-metrics
   namespace: mla-system
 data:
   custom-scrape-configs.yaml: |+

--- a/addons/node-exporter/scrape-config.yaml
+++ b/addons/node-exporter/scrape-config.yaml
@@ -17,7 +17,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-scraping-node-exporter
+  name: monitoring-scraping-node-exporter
   namespace: mla-system
 data:
   custom-scrape-configs.yaml: |+


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes configmap names for addons: kube-state-metrics and node-exporter so that they work with usercluster's monitoring-agent.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
