### PR TITLE
Prohibit cloud provider specific configurations in default Cluster Templates

### DIFF
--- a/pkg/webhook/clustertemplate/validation/validation.go
+++ b/pkg/webhook/clustertemplate/validation/validation.go
@@ -80,25 +80,18 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object) error {
 	}
 
 	var errs field.ErrorList
-
-	scope, ok := template.Labels["scope"]
-
-	// we only validate ClusterTemplates that are not labeled as scope=seed
-	if !ok || scope != kubermaticv1.SeedTemplateScope {
-		datacenter, cloudProvider, err := v.buildValidationDependencies(ctx, &template.Spec)
-		if err != nil {
-			return err
-		}
-
-		config, configErr := v.configGetter(ctx)
-		if configErr != nil {
-			return configErr
-		}
-
-		versionManager := version.NewFromConfiguration(config)
-
-		errs = validation.ValidateClusterTemplate(ctx, template, datacenter, cloudProvider, v.features, versionManager, nil)
+	datacenter, cloudProvider, err := v.buildValidationDependencies(ctx, &template.Spec)
+	if err != nil {
+		return err
 	}
+
+	config, configErr := v.configGetter(ctx)
+	if configErr != nil {
+		return configErr
+	}
+
+	versionManager := version.NewFromConfiguration(config)
+	errs = validation.ValidateClusterTemplate(ctx, template, datacenter, cloudProvider, v.features, versionManager, nil)
 
 	return errs.ToAggregate()
 }


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
This PR adds validations to forbid users from adding cloud provider specific configurations in the default cluster templates. Cloud provider settings tie a user to a particular data center. Defaulting for such a configuration can be more troublesome than beneficial. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11396

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ACTION REQUIRED: Cloud provider specific configurations are prohibited from seed-scoped default cluster templates; for existing seed-scoped default cluster templates these settings should be removed manually.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1269
```
