### PR TITLE
skip vsphere tests if $VSPHERE_E2E_DISABLED is not empty

### DIFF
--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -78,11 +78,21 @@ elif [[ $provider == "vsphere" ]]; then
   EXTRA_ARGS="-vsphere-username=${VSPHERE_E2E_USERNAME}
     -vsphere-password=${VSPHERE_E2E_PASSWORD}
     -vsphere-kkp-datacenter=vsphere-ger"
+
+  if [ -n "${VSPHERE_E2E_DISABLED:-}" ]; then
+    echodate "\$VSPHERE_E2E_DISABLED is not empty, skipping tests."
+    exit 0
+  fi
 elif [[ $provider == "kubevirt" ]]; then
   tmpFile="$(mktemp)"
   echo "$KUBEVIRT_E2E_TESTS_KUBECONFIG" > "$tmpFile"
   EXTRA_ARGS="-kubevirt-kubeconfig=$tmpFile
     -kubevirt-kkp-datacenter=kubevirt-europe-west3-c"
+
+  if [ -n "${KUBEVIRT_E2E_DISABLED:-}" ]; then
+    echodate "\$KUBEVIRT_E2E_DISABLED is not empty, skipping tests."
+    exit 0
+  fi
 elif [[ $provider == "alibaba" ]]; then
   EXTRA_ARGS="-alibaba-access-key-id=${ALIBABA_E2E_TESTS_KEY_ID}
     -alibaba-secret-access-key=${ALIBABA_E2E_TESTS_SECRET}
@@ -104,6 +114,11 @@ elif [[ $provider == "vmwareclouddirector" ]]; then
     -vmware-cloud-director-vdc=${VCD_VDC}
     -vmware-cloud-director-ovdc-network=${VCD_OVDC_NETWORK}
     -vmware-cloud-director-kkp-datacenter=vmware-cloud-director-ger"
+
+  if [ -n "${VCD_E2E_DISABLED:-}" ]; then
+    echodate "\$VCD_E2E_DISABLED is not empty, skipping tests."
+    exit 0
+  fi
 fi
 
 # in periodic jobs, we run multiple scenarios (e.g. testing azure in 1.21 and 1.22),

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -73,6 +73,11 @@ export METAL_PROJECT_ID="${METAL_PROJECT_ID:-$(vault kv get -field=METAL_PROJECT
 export VSPHERE_E2E_USERNAME="${VSPHERE_E2E_USERNAME:-$(vault kv get -field=username dev/e2e-vsphere)}"
 export VSPHERE_E2E_PASSWORD="${VSPHERE_E2E_PASSWORD:-$(vault kv get -field=password dev/e2e-vsphere)}"
 
+if [ "$PROVIDER" == "vsphere" ] && [ -n "${VSPHERE_E2E_DISABLED:-}" ]; then
+  echodate "\$VSPHERE_E2E_DISABLED is not empty, skipping tests."
+  exit 0
+fi
+
 echodate "Successfully got secrets from Vault"
 echodate "Running dualstack tests..."
 

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -97,5 +97,11 @@ echodate "Running integration tests..."
 # * Prefixing them with `./` as that's needed by `go test` as well
 for file in $(grep --files-with-matches --recursive --extended-regexp '//go:build.+integration' cmd/ pkg/ | xargs dirname | sort -u); do
   echodate "Testing package ${file}..."
+
+  if [[ "$file" =~ .*vsphere.* ]] && [ -n "${VSPHERE_E2E_DISABLED:-}" ]; then
+    echodate "\$VSPHERE_E2E_DISABLED is not empty, skipping tests."
+    continue
+  fi
+
   go_test $(echo $file | sed 's/\//_/g') -tags "integration,${KUBERMATIC_EDITION:-ce}" -race ./${file} -v
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes use of the new environment variables that can be globally set in order to disable certain providers. Some providers have proven to be extremely flaky and to have a tendency to block everything.

This new mechanism gives us great power, but also great responsibility that we must not forget to turn a provider back on after some time...

For the record, I kind of hate this (it's similar to https://github.com/kubermatic/kubermatic/blob/main/hack/ci/deploy.sh#L41-L63 just without the TTL mechanism), but it's the least worst solution right now. And easy to undo if and when we have something better.

/kind flake

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
