### PR TITLE
Label-dependent tests

### DIFF
--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -38,6 +38,11 @@ echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 
 EXTRA_ARGS=""
 provider="${PROVIDER:-aws}"
 maxDuration=60 # in minutes
+
+if provider_disabled $provider; then
+  exit 0
+fi
+
 if [[ $provider == "anexia" ]]; then
   EXTRA_ARGS="-anexia-token=${ANEXIA_TOKEN}
     -anexia-template-id=${ANEXIA_TEMPLATE_ID}
@@ -78,21 +83,11 @@ elif [[ $provider == "vsphere" ]]; then
   EXTRA_ARGS="-vsphere-username=${VSPHERE_E2E_USERNAME}
     -vsphere-password=${VSPHERE_E2E_PASSWORD}
     -vsphere-kkp-datacenter=vsphere-ger"
-
-  if [ -n "${VSPHERE_E2E_DISABLED:-}" ]; then
-    echodate "\$VSPHERE_E2E_DISABLED is not empty, skipping tests."
-    exit 0
-  fi
 elif [[ $provider == "kubevirt" ]]; then
   tmpFile="$(mktemp)"
   echo "$KUBEVIRT_E2E_TESTS_KUBECONFIG" > "$tmpFile"
   EXTRA_ARGS="-kubevirt-kubeconfig=$tmpFile
     -kubevirt-kkp-datacenter=kubevirt-europe-west3-c"
-
-  if [ -n "${KUBEVIRT_E2E_DISABLED:-}" ]; then
-    echodate "\$KUBEVIRT_E2E_DISABLED is not empty, skipping tests."
-    exit 0
-  fi
 elif [[ $provider == "alibaba" ]]; then
   EXTRA_ARGS="-alibaba-access-key-id=${ALIBABA_E2E_TESTS_KEY_ID}
     -alibaba-secret-access-key=${ALIBABA_E2E_TESTS_SECRET}
@@ -114,11 +109,6 @@ elif [[ $provider == "vmwareclouddirector" ]]; then
     -vmware-cloud-director-vdc=${VCD_VDC}
     -vmware-cloud-director-ovdc-network=${VCD_OVDC_NETWORK}
     -vmware-cloud-director-kkp-datacenter=vmware-cloud-director-ger"
-
-  if [ -n "${VCD_E2E_DISABLED:-}" ]; then
-    echodate "\$VCD_E2E_DISABLED is not empty, skipping tests."
-    exit 0
-  fi
 fi
 
 # in periodic jobs, we run multiple scenarios (e.g. testing azure in 1.21 and 1.22),

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -73,8 +73,7 @@ export METAL_PROJECT_ID="${METAL_PROJECT_ID:-$(vault kv get -field=METAL_PROJECT
 export VSPHERE_E2E_USERNAME="${VSPHERE_E2E_USERNAME:-$(vault kv get -field=username dev/e2e-vsphere)}"
 export VSPHERE_E2E_PASSWORD="${VSPHERE_E2E_PASSWORD:-$(vault kv get -field=password dev/e2e-vsphere)}"
 
-if [ "$PROVIDER" == "vsphere" ] && [ -n "${VSPHERE_E2E_DISABLED:-}" ]; then
-  echodate "\$VSPHERE_E2E_DISABLED is not empty, skipping tests."
+if provider_disabled $PROVIDER; then
   exit 0
 fi
 

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -510,3 +510,47 @@ safebase64() {
   echo "$value" | base64 -w0
   echo
 }
+
+pr_has_label() {
+  if [ -z "${REPO_OWNER:-}" ] || [ -z "${REPO_NAME:-}" ] || [ -z "${PULL_NUMBER:-}" ]; then
+    echo "PR check only works on CI."
+    return 1
+  fi
+
+  matched=$(curl \
+    --header "Accept: application/vnd.github+json" \
+    --silent \
+    --fail \
+    https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls/$PULL_NUMBER |
+    jq --arg labelName "$1" '.labels[] | select(.name == $labelName)')
+
+  [ -n "$matched" ]
+}
+
+provider_disabled() {
+  # e.g. "VSPHERE_E2E_DISABLED"
+  local disableEnv="${1^^}_E2E_DISABLED"
+  local labelName="test/require-$1"
+
+  # tests can be globally disabled by having a special environment
+  # variable injected via the Prow preset; if they are not disabled,
+  # we are done here.
+  if [ -z "${!disableEnv:-}" ]; then
+    return 1
+  fi
+
+  # Even if tests are disabled, they can be forcefully re-enabled
+  # (e.g. if provider X is disabled for all tests until a certain
+  # pull requests fixes some underlying issue and for that certain
+  # PR we want to run the tests regardless).
+  # Importantly, one cannot use labels to _disable_ any tests, only
+  # _re-enable_ them.
+
+  if pr_has_label "$labelName"; then
+    echodate "\$$disableEnv is set, but PR has $labelName label, so tests will not be disabled."
+    return 1
+  fi
+
+  echodate "\$$disableEnv is set, tests will be disabled. Apply the label $labelName to this PR to forcefully enable the tests."
+  return 0
+}

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -23,6 +23,10 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
+if provider_disabled $PROVIDER; then
+  exit 0
+fi
+
 export GIT_HEAD_HASH="$(git rev-parse HEAD)"
 export KUBERMATIC_VERSION="${GIT_HEAD_HASH}"
 
@@ -59,11 +63,6 @@ openstack)
 vsphere)
   TIMEOUT=45m
   EXTRA_ARGS="-vsphere-kkp-datacenter=vsphere-ger"
-
-  if [ -n "${VSPHERE_E2E_DISABLED:-}" ]; then
-    echodate "\$VSPHERE_E2E_DISABLED is not empty, skipping tests."
-    exit 0
-  fi
   ;;
 azure)
   TIMEOUT=45m

--- a/hack/run-integration-tests.sh
+++ b/hack/run-integration-tests.sh
@@ -98,8 +98,7 @@ echodate "Running integration tests..."
 for file in $(grep --files-with-matches --recursive --extended-regexp '//go:build.+integration' cmd/ pkg/ | xargs dirname | sort -u); do
   echodate "Testing package ${file}..."
 
-  if [[ "$file" =~ .*vsphere.* ]] && [ -n "${VSPHERE_E2E_DISABLED:-}" ]; then
-    echodate "\$VSPHERE_E2E_DISABLED is not empty, skipping tests."
+  if [[ "$file" =~ .*vsphere.* ]] && provider_disabled vsphere; then
     continue
   fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Disabling all tests for a provider is nice, but it's hard to prove that a follow up PR actually fixes an underlying issue (which could lead to us re-enabling the provider again).

To make it easier for a PR to "opt-in" into a certain provider, I added a hack onto of the existing hack that simply uses the labels on the PR to make that decision. If a `test/require-[provider]` label is set, the disabling via the Prow preset has no effect.

**What type of PR is this?**
/kind flake

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
