### PR TITLE
Migrate old initial-md annotations on cluster templates during reconcilitation

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -3,3 +3,4 @@ iam
 keypair
 shouldnot
 uptodate
+nd

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -91,6 +91,8 @@ presubmits:
               cpu: 2
 
   - name: pre-kubermatic-dualstack-e2e-aws
+    # TODO: Mark them as required, remove optional flag, when the test are functional again.
+    optional: true
     run_if_changed: ".*(cilium|canal|dualstack|addon|cni|provider|machine|webhook|.prow|go.mod|proxy|network).*"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"

--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -224,6 +224,7 @@ func clusterTemplateSynchronizerFactoryCreator(ctrlCtx *controllerContext) seedc
 	return func(ctx context.Context, masterMgr manager.Manager, seedManagerMap map[string]manager.Manager) (string, error) {
 		return clustertemplatesynchronizer.ControllerName, clustertemplatesynchronizer.Add(
 			masterMgr,
+			ctrlCtx.seedsGetter,
 			seedManagerMap,
 			ctrlCtx.log,
 		)

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -18,12 +18,15 @@ package clustertemplatesynchronizer
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	nodedeploymentmigration "k8c.io/kubermatic/v2/pkg/controller/shared/nodedeployment-migration"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
+	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
@@ -49,6 +52,7 @@ const (
 
 type reconciler struct {
 	log          *zap.SugaredLogger
+	seedsGetter  provider.SeedsGetter
 	masterClient ctrlruntimeclient.Client
 	seedClients  kuberneteshelper.SeedClientMap
 	recorder     record.EventRecorder
@@ -56,12 +60,14 @@ type reconciler struct {
 
 func Add(
 	masterMgr manager.Manager,
+	seedsGetter provider.SeedsGetter,
 	seedManagers map[string]manager.Manager,
 	log *zap.SugaredLogger,
 ) error {
 	log = log.Named(ControllerName)
 	r := &reconciler{
 		log:          log,
+		seedsGetter:  seedsGetter,
 		masterClient: masterMgr.GetClient(),
 		seedClients:  kuberneteshelper.SeedClientMap{},
 		recorder:     masterMgr.GetEventRecorderFor(ControllerName),
@@ -117,6 +123,14 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
+	// In KKP 2.22, initial-machinedeployments were changed from NodeDeployments to actual
+	// MachineDeployments; in order to eventually be able to remove the NodeDedeployment codebase,
+	// existing annotations need to be migrated.
+	// This code can be removed in KKP 2.23+.
+	if err := r.migrateInitialMachineDeployment(ctx, log, clusterTemplate); err != nil {
+		return fmt.Errorf("failed to migrate initial-machinedeployment annotation: %w", err)
+	}
+
 	clusterTemplateReconcilerFactorys := []reconciling.NamedClusterTemplateReconcilerFactory{
 		clusterTemplateReconcilerFactory(clusterTemplate),
 	}
@@ -138,6 +152,57 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		return fmt.Errorf("reconciled cluster template: %s: %w", clusterTemplate.Name, err)
 	}
 	return nil
+}
+
+func (r *reconciler) migrateInitialMachineDeployment(ctx context.Context, log *zap.SugaredLogger, clusterTemplate *kubermaticv1.ClusterTemplate) error {
+	request := clusterTemplate.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation]
+	if request == "" {
+		return nil
+	}
+
+	datacenter, err := r.getTargetDatacenter(clusterTemplate)
+	if err != nil {
+		return err
+	}
+
+	cluster := &kubermaticv1.Cluster{
+		ObjectMeta: clusterTemplate.ObjectMeta,
+		Spec:       clusterTemplate.Spec,
+	}
+
+	machineDeployment, migrated, err := nodedeploymentmigration.ParseNodeOrMachineDeployment(cluster, datacenter, request)
+	if err != nil {
+		return err
+	}
+
+	if !migrated {
+		return nil
+	}
+
+	encoded, err := json.Marshal(machineDeployment)
+	if err != nil {
+		return fmt.Errorf("cannot marshal initial machine deployment: %w", err)
+	}
+	clusterTemplate.Annotations[kubermaticv1.InitialMachineDeploymentRequestAnnotation] = string(encoded)
+
+	return r.masterClient.Update(ctx, clusterTemplate)
+}
+
+func (r *reconciler) getTargetDatacenter(clusterTemplate *kubermaticv1.ClusterTemplate) (*kubermaticv1.Datacenter, error) {
+	seeds, err := r.seedsGetter()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list seeds: %w", err)
+	}
+
+	for _, seed := range seeds {
+		for key, dc := range seed.Spec.Datacenters {
+			if key == clusterTemplate.Spec.Cloud.DatacenterName {
+				return &dc, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("there is no datacenter named %q", clusterTemplate.Spec.Cloud.DatacenterName)
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, template *kubermaticv1.ClusterTemplate) error {

--- a/pkg/controller/shared/nodedeployment-migration/api/types.go
+++ b/pkg/controller/shared/nodedeployment-migration/api/types.go
@@ -24,14 +24,14 @@ import (
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
 )
 
-// NodeDeployment represents a set of worker nodes that is part of a cluster
+// NodeDeployment represents a set of worker nodes that is part of a cluster.
 type NodeDeployment struct {
 	apiv1.ObjectMeta `json:",inline"`
 
 	Spec NodeDeploymentSpec `json:"spec"`
 }
 
-// NodeDeploymentSpec node deployment specification
+// NodeDeploymentSpec node deployment specification.
 type NodeDeploymentSpec struct {
 	// required: true
 	Replicas int32 `json:"replicas"`
@@ -44,7 +44,7 @@ type NodeDeploymentSpec struct {
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
 }
 
-// NodeSpec node specification
+// NodeSpec node specification.
 type NodeSpec struct {
 	// required: true
 	Cloud NodeCloudSpec `json:"cloud"`
@@ -90,21 +90,21 @@ type OperatingSystemSpec struct {
 	RockyLinux  *RockyLinuxSpec  `json:"rockylinux,omitempty"`
 }
 
-// UbuntuSpec ubuntu specific settings
+// UbuntuSpec ubuntu specific settings.
 type UbuntuSpec struct {
-	// do a dist-upgrade on boot and reboot it required afterwards
+	// do a dist-upgrade on boot and reboot it required afterwards.
 	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
 }
 
 // CentOSSpec contains CentOS specific settings.
 type CentOSSpec struct {
-	// do a dist-upgrade on boot and reboot it required afterwards
+	// do a dist-upgrade on boot and reboot it required afterwards.
 	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
 }
 
-// FlatcarSpec contains Flatcar Linux specific settings
+// FlatcarSpec contains Flatcar Linux specific settings.
 type FlatcarSpec struct {
-	// disable flatcar linux auto-update feature
+	// disable flatcar linux auto-update feature.
 	DisableAutoUpdate bool `json:"disableAutoUpdate"`
 
 	// ProvisioningUtility specifies the type of provisioning utility, allowed values are cloud-init and ignition.
@@ -112,34 +112,34 @@ type FlatcarSpec struct {
 	flatcar.ProvisioningUtility `json:"provisioningUtility,omitempty"`
 }
 
-// SLESSpec contains SLES specific settings
+// SLESSpec contains SLES specific settings.
 type SLESSpec struct {
-	// do a dist-upgrade on boot and reboot it required afterwards
+	// do a dist-upgrade on boot and reboot it required afterwards.
 	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
 }
 
-// RHELSpec contains rhel specific settings
+// RHELSpec contains rhel specific settings.
 type RHELSpec struct {
-	// do a dist-upgrade on boot and reboot it required afterwards
+	// do a dist-upgrade on boot and reboot it required afterwards.
 	DistUpgradeOnBoot               bool   `json:"distUpgradeOnBoot"`
 	RHELSubscriptionManagerUser     string `json:"rhelSubscriptionManagerUser,omitempty"`
 	RHELSubscriptionManagerPassword string `json:"rhelSubscriptionManagerPassword,omitempty"`
 	RHSMOfflineToken                string `json:"rhsmOfflineToken,omitempty"`
 }
 
-// RockyLinuxSpec contains rocky-linux specific settings
+// RockyLinuxSpec contains rocky-linux specific settings.
 type RockyLinuxSpec struct {
-	// do a dist-upgrade on boot and reboot it required afterwards
+	// do a dist-upgrade on boot and reboot it required afterwards.
 	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
 }
 
-// AmazonLinuxSpec amazon linux specific settings
+// AmazonLinuxSpec amazon linux specific settings.
 type AmazonLinuxSpec struct {
-	// do a dist-upgrade on boot and reboot it required afterwards
+	// do a dist-upgrade on boot and reboot it required afterwards.
 	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
 }
 
-// NodeVersionInfo node version information
+// NodeVersionInfo node version information.
 type NodeVersionInfo struct {
 	Kubelet string `json:"kubelet"`
 }
@@ -151,24 +151,24 @@ type TaintSpec struct {
 	Effect string `json:"effect"`
 }
 
-// DigitaloceanNodeSpec digitalocean node settings
+// DigitaloceanNodeSpec digitalocean node settings.
 type DigitaloceanNodeSpec struct {
-	// droplet size slug
+	// droplet size slug.
 	// required: true
 	Size string `json:"size"`
-	// enable backups for the droplet
+	// enable backups for the droplet.
 	Backups bool `json:"backups"`
 	// DEPRECATED
 	// IPv6 is enabled automatically based on IP Family of the cluster so setting this field is not needed.
 	// enable ipv6 for the droplet
 	IPv6 bool `json:"ipv6"`
-	// enable monitoring for the droplet
+	// enable monitoring for the droplet.
 	Monitoring bool `json:"monitoring"`
-	// additional droplet tags
+	// additional droplet tags.
 	Tags []string `json:"tags"`
 }
 
-// HetznerNodeSpec Hetzner node settings
+// HetznerNodeSpec Hetzner node settings.
 type HetznerNodeSpec struct {
 	// server type
 	// required: true
@@ -178,40 +178,40 @@ type HetznerNodeSpec struct {
 	Network string `json:"network"`
 }
 
-// AzureNodeSpec describes settings for an Azure node
+// AzureNodeSpec describes settings for an Azure node.
 type AzureNodeSpec struct {
-	// VM size
+	// VM size.
 	// required: true
 	Size string `json:"size"`
-	// should the machine have a publicly accessible IP address
+	// should the machine have a publicly accessible IP address.
 	// required: false
 	AssignPublicIP bool `json:"assignPublicIP"`
-	// Additional metadata to set
+	// Additional metadata to set.
 	// required: false
 	Tags map[string]string `json:"tags,omitempty"`
-	// OS disk size in GB
+	// OS disk size in GB.
 	// required: false
 	OSDiskSize int32 `json:"osDiskSize"`
-	// Data disk size in GB
+	// Data disk size in GB.
 	// required: false
 	DataDiskSize int32 `json:"dataDiskSize"`
-	// Zones represents the availability zones for azure vms
+	// Zones represents the availability zones for azure vms.
 	// required: false
 	Zones []string `json:"zones"`
-	// ImageID represents the ID of the image that should be used to run the node
+	// ImageID represents the ID of the image that should be used to run the node.
 	// required: false
 	ImageID string `json:"imageID"`
 	// AssignAvailabilitySet is used to check if an availability set should be created and assigned to the cluster.
 	AssignAvailabilitySet bool `json:"assignAvailabilitySet"`
 }
 
-// VSphereNodeSpec VSphere node settings
+// VSphereNodeSpec VSphere node settings.
 type VSphereNodeSpec struct {
 	CPUs       int    `json:"cpus"`
 	Memory     int    `json:"memory"`
 	DiskSizeGB *int64 `json:"diskSizeGB,omitempty"`
 	Template   string `json:"template"`
-	// Additional metadata to set
+	// Additional metadata to set.
 	// required: false
 	Tags []VSphereTag `json:"tags,omitempty"`
 }
@@ -224,24 +224,24 @@ type VSphereTag struct {
 	CategoryID string `json:"categoryID,omitempty"`
 }
 
-// OpenstackNodeSpec openstack node settings
+// OpenstackNodeSpec openstack node settings.
 type OpenstackNodeSpec struct {
-	// instance flavor
+	// instance flavor.
 	// required: true
 	Flavor string `json:"flavor"`
-	// image to use
+	// image to use.
 	// required: true
 	Image string `json:"image"`
-	// Additional metadata to set
+	// Additional metadata to set.
 	// required: false
 	Tags map[string]string `json:"tags,omitempty"`
-	// Defines whether floating ip should be used
+	// Defines whether floating ip should be used.
 	// required: false
 	UseFloatingIP bool `json:"useFloatingIP,omitempty"`
-	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor
+	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor.
 	// required: false
 	RootDiskSizeGB *int `json:"diskSize"`
-	// if not set, the default AZ from the Datacenter spec will be used
+	// if not set, the default AZ from the Datacenter spec will be used.
 	// required: false
 	AvailabilityZone string `json:"availabilityZone"`
 	// Period of time to check for instance ready status, i.e. 10s/1m
@@ -255,9 +255,9 @@ type OpenstackNodeSpec struct {
 	ServerGroup string `json:"serverGroup"`
 }
 
-// AWSNodeSpec aws specific node settings
+// AWSNodeSpec aws specific node settings.
 type AWSNodeSpec struct {
-	// instance type. for example: t2.micro
+	// instance type. for example: t2.micro.
 	// required: true
 	InstanceType string `json:"instanceType"`
 	// size of the volume in gb. Only one volume will be created
@@ -299,17 +299,17 @@ type AWSNodeSpec struct {
 	AssumeRoleExternalID string `json:"assumeRoleExternalID"`
 }
 
-// PacketNodeSpec specifies packet specific node settings
+// PacketNodeSpec specifies packet specific node settings.
 type PacketNodeSpec struct {
 	// InstanceType denotes the plan to which the device will be provisioned.
 	// required: true
 	InstanceType string `json:"instanceType"`
-	// additional instance tags
+	// additional instance tags.
 	// required: false
 	Tags []string `json:"tags"`
 }
 
-// GCPNodeSpec gcp specific node settings
+// GCPNodeSpec gcp specific node settings.
 type GCPNodeSpec struct {
 	Zone        string            `json:"zone"`
 	MachineType string            `json:"machineType"`
@@ -321,7 +321,7 @@ type GCPNodeSpec struct {
 	CustomImage string            `json:"customImage"`
 }
 
-// KubevirtNodeSpec kubevirt specific node settings
+// KubevirtNodeSpec kubevirt specific node settings.
 type KubevirtNodeSpec struct {
 	// FlavorName states name of the virtual-machine flavor.
 	//
@@ -357,17 +357,17 @@ type KubevirtNodeSpec struct {
 	// PrimaryDiskSize states the size of the provisioned pvc per node.
 	// required: true
 	PrimaryDiskSize string `json:"primaryDiskSize"`
-	// SecondaryDisks contains list of secondary-disks
+	// SecondaryDisks contains list of secondary-disks.
 	SecondaryDisks []SecondaryDisks `json:"secondaryDisks"`
-	// PodAffinityPreset describes pod affinity scheduling rules
+	// PodAffinityPreset describes pod affinity scheduling rules.
 	//
-	// Deprecated: in favor of topology spread constraints
+	// Deprecated: in favor of topology spread constraints.
 	PodAffinityPreset string `json:"podAffinityPreset"`
-	// PodAntiAffinityPreset describes pod anti-affinity scheduling rules
+	// PodAntiAffinityPreset describes pod anti-affinity scheduling rules.
 	//
 	// Deprecated: in favor of topology spread constraints
 	PodAntiAffinityPreset string `json:"podAntiAffinityPreset"`
-	// NodeAffinityPreset describes node affinity scheduling rules
+	// NodeAffinityPreset describes node affinity scheduling rules.
 	NodeAffinityPreset NodeAffinityPreset `json:"nodeAffinityPreset"`
 	// TopologySpreadConstraints describes topology spread constraints for VMs.
 	TopologySpreadConstraints []TopologySpreadConstraint `json:"topologySpreadConstraints"`
@@ -389,12 +389,12 @@ type TopologySpreadConstraint struct {
 	MaxSkew int `json:"maxSkew"`
 	// TopologyKey is the key of infra-node labels.
 	TopologyKey string `json:"topologyKey"`
-	// WhenUnsatisfiable indicates how to deal with a VM if it doesn't satisfy
+	// WhenUnsatisfiable indicates how to deal with a VM if it doesn't satisfy.
 	// the spread constraint.
 	WhenUnsatisfiable string `json:"whenUnsatisfiable"`
 }
 
-// AlibabaNodeSpec alibaba specific node settings
+// AlibabaNodeSpec alibaba specific node settings.
 type AlibabaNodeSpec struct {
 	InstanceType            string            `json:"instanceType"`
 	DiskSize                string            `json:"diskSize"`
@@ -405,7 +405,7 @@ type AlibabaNodeSpec struct {
 	ZoneID                  string            `json:"zoneID"`
 }
 
-// AnexiaDiskConfig defines a single disk for a node at anexia
+// AnexiaDiskConfig defines a single disk for a node at anexia.
 type AnexiaDiskConfig struct {
 	// Disks configures this disk of each node will have.
 	// required: true
@@ -417,9 +417,9 @@ type AnexiaDiskConfig struct {
 	PerformanceType *string `json:"performanceType,omitempty"`
 }
 
-// AnexiaNodeSpec anexia specific node settings
+// AnexiaNodeSpec anexia specific node settings.
 type AnexiaNodeSpec struct {
-	// VlanID Instance vlanID
+	// VlanID Instance vlanID.
 	// required: true
 	VlanID string `json:"vlanID"`
 	// TemplateID instance template
@@ -442,7 +442,7 @@ type AnexiaNodeSpec struct {
 	Disks []AnexiaDiskConfig `json:"disks"`
 }
 
-// NutanixNodeSpec nutanix specific node settings
+// NutanixNodeSpec nutanix specific node settings.
 type NutanixNodeSpec struct {
 	SubnetName     string            `json:"subnetName"`
 	ImageName      string            `json:"imageName"`
@@ -454,7 +454,7 @@ type NutanixNodeSpec struct {
 	DiskSize       *int64            `json:"diskSize"`
 }
 
-// VMwareCloudDirectorNodeSpec VMware Cloud Director node settings
+// VMwareCloudDirectorNodeSpec VMware Cloud Director node settings.
 type VMwareCloudDirectorNodeSpec struct {
 	CPUs             int                  `json:"cpus"`
 	CPUCores         int                  `json:"cpuCores"`
@@ -467,7 +467,7 @@ type VMwareCloudDirectorNodeSpec struct {
 	IPAllocationMode vcd.IPAllocationMode `json:"ipAllocationMode,omitempty"`
 	VApp             string               `json:"vapp,omitempty"`
 	Network          string               `json:"network,omitempty"`
-	// Additional metadata to set
+	// Additional metadata to set.
 	// required: false
 	Metadata map[string]string `json:"metadata,omitempty"`
 }

--- a/pkg/controller/shared/nodedeployment-migration/api/types.go
+++ b/pkg/controller/shared/nodedeployment-migration/api/types.go
@@ -1,0 +1,473 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	kubevirtv1 "kubevirt.io/api/core/v1"
+
+	vcd "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vmwareclouddirector/types"
+	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
+	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
+)
+
+// NodeDeployment represents a set of worker nodes that is part of a cluster
+type NodeDeployment struct {
+	apiv1.ObjectMeta `json:",inline"`
+
+	Spec NodeDeploymentSpec `json:"spec"`
+}
+
+// NodeDeploymentSpec node deployment specification
+type NodeDeploymentSpec struct {
+	// required: true
+	Replicas int32 `json:"replicas"`
+	// required: true
+	Template NodeSpec `json:"template"`
+	// required: false
+	Paused *bool `json:"paused,omitempty"`
+	// Only supported for nodes with Kubernetes 1.23 or less.
+	// required: false
+	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
+}
+
+// NodeSpec node specification
+type NodeSpec struct {
+	// required: true
+	Cloud NodeCloudSpec `json:"cloud"`
+	// required: true
+	OperatingSystem OperatingSystemSpec `json:"operatingSystem"`
+	// required: false
+	SSHUserName string `json:"sshUserName,omitempty"`
+	// required: true
+	Versions NodeVersionInfo `json:"versions,omitempty"`
+	// Map of string keys and values that can be used to organize and categorize (scope and select) objects.
+	// It will be applied to Nodes allowing users run their apps on specific Node using labelSelector.
+	// required: false
+	Labels map[string]string `json:"labels,omitempty"`
+	// List of taints to set on new nodes
+	Taints []TaintSpec `json:"taints,omitempty"`
+}
+
+// NodeCloudSpec represents the collection of cloud provider specific settings. Only one must be set at a time.
+type NodeCloudSpec struct {
+	Digitalocean        *DigitaloceanNodeSpec        `json:"digitalocean,omitempty"`
+	AWS                 *AWSNodeSpec                 `json:"aws,omitempty"`
+	Azure               *AzureNodeSpec               `json:"azure,omitempty"`
+	Openstack           *OpenstackNodeSpec           `json:"openstack,omitempty"`
+	Packet              *PacketNodeSpec              `json:"packet,omitempty"`
+	Hetzner             *HetznerNodeSpec             `json:"hetzner,omitempty"`
+	VSphere             *VSphereNodeSpec             `json:"vsphere,omitempty"`
+	GCP                 *GCPNodeSpec                 `json:"gcp,omitempty"`
+	Kubevirt            *KubevirtNodeSpec            `json:"kubevirt,omitempty"`
+	Alibaba             *AlibabaNodeSpec             `json:"alibaba,omitempty"`
+	Anexia              *AnexiaNodeSpec              `json:"anexia,omitempty"`
+	Nutanix             *NutanixNodeSpec             `json:"nutanix,omitempty"`
+	VMwareCloudDirector *VMwareCloudDirectorNodeSpec `json:"vmwareclouddirector,omitempty"`
+}
+
+// OperatingSystemSpec represents the collection of os specific settings. Only one must be set at a time.
+type OperatingSystemSpec struct {
+	Ubuntu      *UbuntuSpec      `json:"ubuntu,omitempty"`
+	AmazonLinux *AmazonLinuxSpec `json:"amzn2,omitempty"`
+	CentOS      *CentOSSpec      `json:"centos,omitempty"`
+	SLES        *SLESSpec        `json:"sles,omitempty"`
+	RHEL        *RHELSpec        `json:"rhel,omitempty"`
+	Flatcar     *FlatcarSpec     `json:"flatcar,omitempty"`
+	RockyLinux  *RockyLinuxSpec  `json:"rockylinux,omitempty"`
+}
+
+// UbuntuSpec ubuntu specific settings
+type UbuntuSpec struct {
+	// do a dist-upgrade on boot and reboot it required afterwards
+	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
+}
+
+// CentOSSpec contains CentOS specific settings.
+type CentOSSpec struct {
+	// do a dist-upgrade on boot and reboot it required afterwards
+	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
+}
+
+// FlatcarSpec contains Flatcar Linux specific settings
+type FlatcarSpec struct {
+	// disable flatcar linux auto-update feature
+	DisableAutoUpdate bool `json:"disableAutoUpdate"`
+
+	// ProvisioningUtility specifies the type of provisioning utility, allowed values are cloud-init and ignition.
+	// Defaults to ignition.
+	flatcar.ProvisioningUtility `json:"provisioningUtility,omitempty"`
+}
+
+// SLESSpec contains SLES specific settings
+type SLESSpec struct {
+	// do a dist-upgrade on boot and reboot it required afterwards
+	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
+}
+
+// RHELSpec contains rhel specific settings
+type RHELSpec struct {
+	// do a dist-upgrade on boot and reboot it required afterwards
+	DistUpgradeOnBoot               bool   `json:"distUpgradeOnBoot"`
+	RHELSubscriptionManagerUser     string `json:"rhelSubscriptionManagerUser,omitempty"`
+	RHELSubscriptionManagerPassword string `json:"rhelSubscriptionManagerPassword,omitempty"`
+	RHSMOfflineToken                string `json:"rhsmOfflineToken,omitempty"`
+}
+
+// RockyLinuxSpec contains rocky-linux specific settings
+type RockyLinuxSpec struct {
+	// do a dist-upgrade on boot and reboot it required afterwards
+	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
+}
+
+// AmazonLinuxSpec amazon linux specific settings
+type AmazonLinuxSpec struct {
+	// do a dist-upgrade on boot and reboot it required afterwards
+	DistUpgradeOnBoot bool `json:"distUpgradeOnBoot"`
+}
+
+// NodeVersionInfo node version information
+type NodeVersionInfo struct {
+	Kubelet string `json:"kubelet"`
+}
+
+// TaintSpec defines a node taint.
+type TaintSpec struct {
+	Key    string `json:"key"`
+	Value  string `json:"value"`
+	Effect string `json:"effect"`
+}
+
+// DigitaloceanNodeSpec digitalocean node settings
+type DigitaloceanNodeSpec struct {
+	// droplet size slug
+	// required: true
+	Size string `json:"size"`
+	// enable backups for the droplet
+	Backups bool `json:"backups"`
+	// DEPRECATED
+	// IPv6 is enabled automatically based on IP Family of the cluster so setting this field is not needed.
+	// enable ipv6 for the droplet
+	IPv6 bool `json:"ipv6"`
+	// enable monitoring for the droplet
+	Monitoring bool `json:"monitoring"`
+	// additional droplet tags
+	Tags []string `json:"tags"`
+}
+
+// HetznerNodeSpec Hetzner node settings
+type HetznerNodeSpec struct {
+	// server type
+	// required: true
+	Type string `json:"type"`
+	// network name
+	// required: false
+	Network string `json:"network"`
+}
+
+// AzureNodeSpec describes settings for an Azure node
+type AzureNodeSpec struct {
+	// VM size
+	// required: true
+	Size string `json:"size"`
+	// should the machine have a publicly accessible IP address
+	// required: false
+	AssignPublicIP bool `json:"assignPublicIP"`
+	// Additional metadata to set
+	// required: false
+	Tags map[string]string `json:"tags,omitempty"`
+	// OS disk size in GB
+	// required: false
+	OSDiskSize int32 `json:"osDiskSize"`
+	// Data disk size in GB
+	// required: false
+	DataDiskSize int32 `json:"dataDiskSize"`
+	// Zones represents the availability zones for azure vms
+	// required: false
+	Zones []string `json:"zones"`
+	// ImageID represents the ID of the image that should be used to run the node
+	// required: false
+	ImageID string `json:"imageID"`
+	// AssignAvailabilitySet is used to check if an availability set should be created and assigned to the cluster.
+	AssignAvailabilitySet bool `json:"assignAvailabilitySet"`
+}
+
+// VSphereNodeSpec VSphere node settings
+type VSphereNodeSpec struct {
+	CPUs       int    `json:"cpus"`
+	Memory     int    `json:"memory"`
+	DiskSizeGB *int64 `json:"diskSizeGB,omitempty"`
+	Template   string `json:"template"`
+	// Additional metadata to set
+	// required: false
+	Tags []VSphereTag `json:"tags,omitempty"`
+}
+
+// VSphereTag represents vsphere tag.
+type VSphereTag struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+	// CategoryID when empty the default category will be used.
+	CategoryID string `json:"categoryID,omitempty"`
+}
+
+// OpenstackNodeSpec openstack node settings
+type OpenstackNodeSpec struct {
+	// instance flavor
+	// required: true
+	Flavor string `json:"flavor"`
+	// image to use
+	// required: true
+	Image string `json:"image"`
+	// Additional metadata to set
+	// required: false
+	Tags map[string]string `json:"tags,omitempty"`
+	// Defines whether floating ip should be used
+	// required: false
+	UseFloatingIP bool `json:"useFloatingIP,omitempty"`
+	// if set, the rootDisk will be a volume. If not, the rootDisk will be on ephemeral storage and its size will be derived from the flavor
+	// required: false
+	RootDiskSizeGB *int `json:"diskSize"`
+	// if not set, the default AZ from the Datacenter spec will be used
+	// required: false
+	AvailabilityZone string `json:"availabilityZone"`
+	// Period of time to check for instance ready status, i.e. 10s/1m
+	// required: false
+	InstanceReadyCheckPeriod string `json:"instanceReadyCheckPeriod"`
+	// Max time to wait for the instance to be ready, i.e. 10s/1m
+	// required: false
+	InstanceReadyCheckTimeout string `json:"instanceReadyCheckTimeout"`
+	// UUID of the server group, used to configure affinity or anti-affinity of the VM instances relative to hypervisor
+	// required: false
+	ServerGroup string `json:"serverGroup"`
+}
+
+// AWSNodeSpec aws specific node settings
+type AWSNodeSpec struct {
+	// instance type. for example: t2.micro
+	// required: true
+	InstanceType string `json:"instanceType"`
+	// size of the volume in gb. Only one volume will be created
+	// required: true
+	VolumeSize int32 `json:"diskSize"`
+	// type of the volume. for example: gp2, io1, st1, sc1, standard
+	// required: true
+	VolumeType string `json:"volumeType"`
+	// ami to use. Will be defaulted to a ami for your selected operating system and region. Only set this when you know what you do.
+	AMI string `json:"ami"`
+	// additional instance tags
+	Tags map[string]string `json:"tags"`
+	// Availability zone in which to place the node. It is coupled with the subnet to which the node will belong.
+	AvailabilityZone string `json:"availabilityZone"`
+	// The VPC subnet to which the node shall be connected.
+	SubnetID string `json:"subnetID"`
+	// This flag controls a property of the AWS instance. When set the AWS instance will get a public IP address
+	// assigned during launch overriding a possible setting in the used AWS subnet.
+	// required: false
+	AssignPublicIP *bool `json:"assignPublicIP"`
+	// IsSpotInstance indicates whether the created machine is an aws ec2 spot instance or on-demand ec2 instance.
+	IsSpotInstance *bool `json:"isSpotInstance"`
+	// SpotInstanceMaxPrice is the maximum price you are willing to pay per instance hour. Your instance runs when
+	// your maximum price is greater than the Spot Price.
+	SpotInstanceMaxPrice *string `json:"spotInstanceMaxPrice"`
+	// SpotInstancePersistentRequest ensures that your request will be submitted every time your Spot Instance is terminated.
+	SpotInstancePersistentRequest *bool `json:"spotInstancePersistentRequest"`
+	// SpotInstanceInterruptionBehavior sets the interruption behavior for the spot instance when capacity is no longer
+	// available at the price you specified, if there is no capacity, or if a constraint cannot be met. Charges for EBS
+	// volume storage apply when an instance is stopped.
+	SpotInstanceInterruptionBehavior *string `json:"spotInstanceInterruptionBehavior"`
+	// AssumeRoleARN defines the ARN for an IAM role that should be assumed when handling resources on AWS. It will be used
+	// to acquire temporary security credentials using an STS AssumeRole API operation whenever creating an AWS session.
+	// required: false
+	AssumeRoleARN string `json:"assumeRoleARN"`
+	// AssumeRoleExternalID is an arbitrary string that may be needed when calling the STS AssumeRole API operation.
+	// Using an external ID can help to prevent the "confused deputy problem".
+	// required: false
+	AssumeRoleExternalID string `json:"assumeRoleExternalID"`
+}
+
+// PacketNodeSpec specifies packet specific node settings
+type PacketNodeSpec struct {
+	// InstanceType denotes the plan to which the device will be provisioned.
+	// required: true
+	InstanceType string `json:"instanceType"`
+	// additional instance tags
+	// required: false
+	Tags []string `json:"tags"`
+}
+
+// GCPNodeSpec gcp specific node settings
+type GCPNodeSpec struct {
+	Zone        string            `json:"zone"`
+	MachineType string            `json:"machineType"`
+	DiskSize    int64             `json:"diskSize"`
+	DiskType    string            `json:"diskType"`
+	Preemptible bool              `json:"preemptible"`
+	Labels      map[string]string `json:"labels"`
+	Tags        []string          `json:"tags"`
+	CustomImage string            `json:"customImage"`
+}
+
+// KubevirtNodeSpec kubevirt specific node settings
+type KubevirtNodeSpec struct {
+	// FlavorName states name of the virtual-machine flavor.
+	//
+	// Deprecated. In favor of Instancetype and Preference.
+	FlavorName string `json:"flavorName"`
+	// FlavorProfile states name of virtual-machine profile.
+	//
+	// Deprecated. In favor of Instancetype and Preference.
+	FlavorProfile string `json:"flavorProfile"`
+	// Instancetype provide a way to define a set of resource, performance and other runtime characteristics,
+	// allowing users to reuse these definitions across multiple VirtualMachines.
+	// Anything provided within an instancetype cannot be overridden within the VirtualMachine.
+	Instancetype *kubevirtv1.InstancetypeMatcher `json:"instancetype"`
+	// Preference are like Instancetype defining runtime characteristics. But unlike Instancetypes,
+	// Preferences only represent the preferred values and as such can be overridden by values in the VirtualMachine.
+	Preference *kubevirtv1.PreferenceMatcher `json:"preference"`
+	// CPUs states how many cpus the kubevirt node will have.
+	// required: true
+	CPUs string `json:"cpus"`
+	// Memory states the memory that kubevirt node will have.
+	// required: true
+	Memory string `json:"memory"`
+
+	// PrimaryDiskOSImage states the source from which the imported image will be downloaded.
+	// This field contains:
+	// - a URL to download an Os Image from a HTTP source.
+	// - a DataVolume Name as source for DataVolume cloning.
+	// required: true
+	PrimaryDiskOSImage string `json:"primaryDiskOSImage"`
+	// PrimaryDiskStorageClassName states the storage class name for the provisioned PVCs.
+	// required: true
+	PrimaryDiskStorageClassName string `json:"primaryDiskStorageClassName"`
+	// PrimaryDiskSize states the size of the provisioned pvc per node.
+	// required: true
+	PrimaryDiskSize string `json:"primaryDiskSize"`
+	// SecondaryDisks contains list of secondary-disks
+	SecondaryDisks []SecondaryDisks `json:"secondaryDisks"`
+	// PodAffinityPreset describes pod affinity scheduling rules
+	//
+	// Deprecated: in favor of topology spread constraints
+	PodAffinityPreset string `json:"podAffinityPreset"`
+	// PodAntiAffinityPreset describes pod anti-affinity scheduling rules
+	//
+	// Deprecated: in favor of topology spread constraints
+	PodAntiAffinityPreset string `json:"podAntiAffinityPreset"`
+	// NodeAffinityPreset describes node affinity scheduling rules
+	NodeAffinityPreset NodeAffinityPreset `json:"nodeAffinityPreset"`
+	// TopologySpreadConstraints describes topology spread constraints for VMs.
+	TopologySpreadConstraints []TopologySpreadConstraint `json:"topologySpreadConstraints"`
+}
+
+type SecondaryDisks struct {
+	Size             string `json:"size"`
+	StorageClassName string `json:"storageClassName"`
+}
+
+type NodeAffinityPreset struct {
+	Type   string
+	Key    string
+	Values []string
+}
+
+type TopologySpreadConstraint struct {
+	// MaxSkew describes the degree to which VMs may be unevenly distributed.
+	MaxSkew int `json:"maxSkew"`
+	// TopologyKey is the key of infra-node labels.
+	TopologyKey string `json:"topologyKey"`
+	// WhenUnsatisfiable indicates how to deal with a VM if it doesn't satisfy
+	// the spread constraint.
+	WhenUnsatisfiable string `json:"whenUnsatisfiable"`
+}
+
+// AlibabaNodeSpec alibaba specific node settings
+type AlibabaNodeSpec struct {
+	InstanceType            string            `json:"instanceType"`
+	DiskSize                string            `json:"diskSize"`
+	DiskType                string            `json:"diskType"`
+	VSwitchID               string            `json:"vSwitchID"`
+	InternetMaxBandwidthOut string            `json:"internetMaxBandwidthOut"`
+	Labels                  map[string]string `json:"labels"`
+	ZoneID                  string            `json:"zoneID"`
+}
+
+// AnexiaDiskConfig defines a single disk for a node at anexia
+type AnexiaDiskConfig struct {
+	// Disks configures this disk of each node will have.
+	// required: true
+	Size int64 `json:"size"`
+
+	// PerformanceType configures the performance type this disks of each node will have.
+	// Known values are something like "ENT3" or "HPC2".
+	// required: false
+	PerformanceType *string `json:"performanceType,omitempty"`
+}
+
+// AnexiaNodeSpec anexia specific node settings
+type AnexiaNodeSpec struct {
+	// VlanID Instance vlanID
+	// required: true
+	VlanID string `json:"vlanID"`
+	// TemplateID instance template
+	// required: true
+	TemplateID string `json:"templateID"`
+	// CPUs states how many cpus the node will have.
+	// required: true
+	CPUs int `json:"cpus"`
+	// Memory states the memory that node will have.
+	// required: true
+	Memory int64 `json:"memory"`
+
+	// DiskSize states the disk size that node will have.
+	// Deprecated: please use the new Disks attribute instead.
+	// required: false
+	DiskSize *int64 `json:"diskSize"`
+
+	// Disks configures the disks each node will have.
+	// required: false
+	Disks []AnexiaDiskConfig `json:"disks"`
+}
+
+// NutanixNodeSpec nutanix specific node settings
+type NutanixNodeSpec struct {
+	SubnetName     string            `json:"subnetName"`
+	ImageName      string            `json:"imageName"`
+	Categories     map[string]string `json:"categories"`
+	CPUs           int64             `json:"cpus"`
+	CPUCores       *int64            `json:"cpuCores"`
+	CPUPassthrough *bool             `json:"cpuPassthrough"`
+	MemoryMB       int64             `json:"memoryMB"`
+	DiskSize       *int64            `json:"diskSize"`
+}
+
+// VMwareCloudDirectorNodeSpec VMware Cloud Director node settings
+type VMwareCloudDirectorNodeSpec struct {
+	CPUs             int                  `json:"cpus"`
+	CPUCores         int                  `json:"cpuCores"`
+	MemoryMB         int                  `json:"memoryMB"`
+	DiskSizeGB       *int64               `json:"diskSizeGB,omitempty"`
+	DiskIOPS         *int64               `json:"diskIOPS,omitempty"`
+	Template         string               `json:"template"`
+	Catalog          string               `json:"catalog"`
+	StorageProfile   string               `json:"storageProfile"`
+	IPAllocationMode vcd.IPAllocationMode `json:"ipAllocationMode,omitempty"`
+	VApp             string               `json:"vapp,omitempty"`
+	Network          string               `json:"network,omitempty"`
+	// Additional metadata to set
+	// required: false
+	Metadata map[string]string `json:"metadata,omitempty"`
+}

--- a/pkg/controller/shared/nodedeployment-migration/machine/common.go
+++ b/pkg/controller/shared/nodedeployment-migration/machine/common.go
@@ -1,0 +1,771 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+
+	alibaba "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/alibaba/types"
+	anexiaProvider "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia"
+	anexia "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
+	aws "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/aws/types"
+	azure "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/azure/types"
+	digitalocean "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/digitalocean/types"
+	equinixmetal "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/equinixmetal/types"
+	gce "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/gce/types"
+	hetzner "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/hetzner/types"
+	kubevirt "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/kubevirt/types"
+	nutanix "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/nutanix/types"
+	openstack "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/openstack/types"
+	vcd "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vmwareclouddirector/types"
+	vsphere "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"github.com/kubermatic/machine-controller/pkg/userdata/amzn2"
+	"github.com/kubermatic/machine-controller/pkg/userdata/centos"
+	"github.com/kubermatic/machine-controller/pkg/userdata/flatcar"
+	"github.com/kubermatic/machine-controller/pkg/userdata/rhel"
+	"github.com/kubermatic/machine-controller/pkg/userdata/rockylinux"
+	"github.com/kubermatic/machine-controller/pkg/userdata/sles"
+	"github.com/kubermatic/machine-controller/pkg/userdata/ubuntu"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/controller/shared/nodedeployment-migration/api"
+	nutanixprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/nutanix"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
+)
+
+func getOsName(nodeSpec apiv1.NodeSpec) (providerconfig.OperatingSystem, error) {
+	if nodeSpec.OperatingSystem.CentOS != nil {
+		return providerconfig.OperatingSystemCentOS, nil
+	}
+	if nodeSpec.OperatingSystem.Ubuntu != nil {
+		return providerconfig.OperatingSystemUbuntu, nil
+	}
+	if nodeSpec.OperatingSystem.SLES != nil {
+		return providerconfig.OperatingSystemSLES, nil
+	}
+	if nodeSpec.OperatingSystem.RHEL != nil {
+		return providerconfig.OperatingSystemRHEL, nil
+	}
+	if nodeSpec.OperatingSystem.Flatcar != nil {
+		return providerconfig.OperatingSystemFlatcar, nil
+	}
+	if nodeSpec.OperatingSystem.RockyLinux != nil {
+		return providerconfig.OperatingSystemRockyLinux, nil
+	}
+	if nodeSpec.OperatingSystem.AmazonLinux != nil {
+		return providerconfig.OperatingSystemAmazonLinux2, nil
+	}
+
+	return "", errors.New("unknown operating system")
+}
+
+func EncodeAsRawExtension(providerConfig interface{}) (*runtime.RawExtension, error) {
+	ext := &runtime.RawExtension{}
+	b, err := json.Marshal(providerConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	ext.Raw = b
+	return ext, nil
+}
+
+func GetAWSProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*aws.RawConfig, error) {
+	osName, err := getOsName(nodeSpec)
+	if err != nil {
+		return nil, err
+	}
+	ami := dc.Spec.AWS.Images[osName]
+	if nodeSpec.Cloud.AWS.AMI != "" {
+		ami = nodeSpec.Cloud.AWS.AMI
+	}
+
+	spotConfig := &aws.SpotInstanceConfig{}
+	if nodeSpec.Cloud.AWS.IsSpotInstance != nil && *nodeSpec.Cloud.AWS.IsSpotInstance {
+		if nodeSpec.Cloud.AWS.SpotInstanceMaxPrice != nil {
+			spotConfig.MaxPrice = providerconfig.ConfigVarString{Value: *nodeSpec.Cloud.AWS.SpotInstanceMaxPrice}
+		}
+
+		if nodeSpec.Cloud.AWS.SpotInstancePersistentRequest != nil {
+			spotConfig.PersistentRequest = providerconfig.ConfigVarBool{Value: nodeSpec.Cloud.AWS.SpotInstancePersistentRequest}
+		}
+
+		if nodeSpec.Cloud.AWS.SpotInstanceInterruptionBehavior != nil {
+			spotConfig.InterruptionBehavior = providerconfig.ConfigVarString{Value: *nodeSpec.Cloud.AWS.SpotInstanceInterruptionBehavior}
+		}
+	}
+
+	config := &aws.RawConfig{
+		// If the node spec doesn't provide a subnet ID, AWS will just pick the AZ's default subnet.
+		SubnetID:             providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.SubnetID},
+		VpcID:                providerconfig.ConfigVarString{Value: c.Spec.Cloud.AWS.VPCID},
+		SecurityGroupIDs:     []providerconfig.ConfigVarString{{Value: c.Spec.Cloud.AWS.SecurityGroupID}},
+		Region:               providerconfig.ConfigVarString{Value: dc.Spec.AWS.Region},
+		AvailabilityZone:     providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.AvailabilityZone},
+		InstanceProfile:      providerconfig.ConfigVarString{Value: c.Spec.Cloud.AWS.InstanceProfileName},
+		InstanceType:         providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.InstanceType},
+		DiskType:             providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.VolumeType},
+		DiskSize:             nodeSpec.Cloud.AWS.VolumeSize,
+		AMI:                  providerconfig.ConfigVarString{Value: ami},
+		AssignPublicIP:       nodeSpec.Cloud.AWS.AssignPublicIP,
+		IsSpotInstance:       nodeSpec.Cloud.AWS.IsSpotInstance,
+		SpotInstanceConfig:   spotConfig,
+		AssumeRoleARN:        providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.AssumeRoleARN},
+		AssumeRoleExternalID: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.AWS.AssumeRoleExternalID},
+		EBSVolumeEncrypted:   providerconfig.ConfigVarBool{Value: pointer.Bool(false)},
+	}
+	if config.DiskType.Value == "" {
+		config.DiskType.Value = string(ec2types.VolumeTypeGp2)
+	}
+	if config.DiskSize == 0 {
+		config.DiskSize = 25
+	}
+
+	config.Tags = map[string]string{}
+	for key, value := range nodeSpec.Cloud.AWS.Tags {
+		config.Tags[key] = value
+	}
+	config.Tags["kubernetes.io/cluster/"+c.Name] = ""
+	config.Tags["system/cluster"] = c.Name
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		config.Tags["system/project"] = projectID
+	}
+
+	return config, nil
+}
+
+func getAWSProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetAWSProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetAzureProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*azure.RawConfig, error) {
+	config := &azure.RawConfig{
+		Location:              providerconfig.ConfigVarString{Value: dc.Spec.Azure.Location},
+		ResourceGroup:         providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.ResourceGroup},
+		VNetResourceGroup:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetResourceGroup},
+		VMSize:                providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.Size},
+		OSDiskSize:            nodeSpec.Cloud.Azure.OSDiskSize,
+		DataDiskSize:          nodeSpec.Cloud.Azure.DataDiskSize,
+		VNetName:              providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.VNetName},
+		SubnetName:            providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SubnetName},
+		RouteTableName:        providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.RouteTableName},
+		AvailabilitySet:       providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.AvailabilitySet},
+		AssignAvailabilitySet: c.Spec.Cloud.Azure.AssignAvailabilitySet,
+		SecurityGroupName:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.Azure.SecurityGroup},
+		Zones:                 nodeSpec.Cloud.Azure.Zones,
+		ImageID:               providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Azure.ImageID},
+
+		// https://github.com/kubermatic/kubermatic/issues/5013#issuecomment-580357280
+		AssignPublicIP: providerconfig.ConfigVarBool{Value: pointer.Bool(nodeSpec.Cloud.Azure.AssignPublicIP)},
+	}
+	config.Tags = map[string]string{}
+	for key, value := range nodeSpec.Cloud.Azure.Tags {
+		config.Tags[key] = value
+	}
+	config.Tags["KubernetesCluster"] = c.Name
+	config.Tags["system-cluster"] = c.Name
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		config.Tags["system-project"] = projectID
+	}
+
+	return config, nil
+}
+
+func getAzureProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetAzureProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	if nodeSpec.Cloud.Azure.AssignPublicIP && c.Spec.Cloud.Azure.LoadBalancerSKU == kubermaticv1.AzureStandardLBSKU {
+		config.PublicIPSKU = pointer.String("standard")
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetVSphereProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*vsphere.RawConfig, error) {
+	var datastore = ""
+	// If `DatastoreCluster` is not specified we use either the Datastore
+	// specified at `Cluster` or the one specified at `Datacenter` level.
+	if c.Spec.Cloud.VSphere.DatastoreCluster == "" {
+		datastore = defaultIfEmpty(c.Spec.Cloud.VSphere.Datastore, dc.Spec.VSphere.DefaultDatastore)
+	}
+
+	config := &vsphere.RawConfig{
+		TemplateVMName:   providerconfig.ConfigVarString{Value: nodeSpec.Cloud.VSphere.Template},
+		VMNetName:        providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.VMNetName},
+		CPUs:             int32(nodeSpec.Cloud.VSphere.CPUs),
+		MemoryMB:         int64(nodeSpec.Cloud.VSphere.Memory),
+		DiskSizeGB:       nodeSpec.Cloud.VSphere.DiskSizeGB,
+		Datacenter:       providerconfig.ConfigVarString{Value: dc.Spec.VSphere.Datacenter},
+		Datastore:        providerconfig.ConfigVarString{Value: datastore},
+		DatastoreCluster: providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.DatastoreCluster},
+		Cluster:          providerconfig.ConfigVarString{Value: dc.Spec.VSphere.Cluster},
+		Folder:           providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.Folder},
+		AllowInsecure:    providerconfig.ConfigVarBool{Value: pointer.Bool(dc.Spec.VSphere.AllowInsecure)},
+		ResourcePool:     providerconfig.ConfigVarString{Value: c.Spec.Cloud.VSphere.ResourcePool},
+	}
+
+	config.Tags = []vsphere.Tag{}
+	for _, tag := range nodeSpec.Cloud.VSphere.Tags {
+		vsphereTag := vsphere.Tag{
+			Description: tag.Description,
+			Name:        tag.Name,
+			CategoryID:  tag.CategoryID,
+		}
+		// Set default category if empty
+		if tag.CategoryID == "" {
+			vsphereTag.CategoryID = c.Spec.Cloud.VSphere.TagCategoryID
+		}
+		config.Tags = append(config.Tags, vsphereTag)
+	}
+
+	return config, nil
+}
+
+func getVSphereProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetVSphereProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetVMwareCloudDirectorProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*vcd.RawConfig, error) {
+	catalogName := defaultIfEmpty(nodeSpec.Cloud.VMwareCloudDirector.Catalog, dc.Spec.VMwareCloudDirector.DefaultCatalog)
+	storageProfile := defaultIfEmpty(nodeSpec.Cloud.VMwareCloudDirector.StorageProfile, dc.Spec.VMwareCloudDirector.DefaultStorageProfile)
+
+	config := &vcd.RawConfig{
+		VApp:             providerconfig.ConfigVarString{Value: c.Spec.Cloud.VMwareCloudDirector.VApp},
+		Template:         providerconfig.ConfigVarString{Value: nodeSpec.Cloud.VMwareCloudDirector.Template},
+		Catalog:          providerconfig.ConfigVarString{Value: catalogName},
+		Network:          providerconfig.ConfigVarString{Value: c.Spec.Cloud.VMwareCloudDirector.OVDCNetwork},
+		CPUs:             int64(nodeSpec.Cloud.VMwareCloudDirector.CPUs),
+		CPUCores:         int64(nodeSpec.Cloud.VMwareCloudDirector.CPUCores),
+		MemoryMB:         int64(nodeSpec.Cloud.VMwareCloudDirector.MemoryMB),
+		IPAllocationMode: nodeSpec.Cloud.VMwareCloudDirector.IPAllocationMode,
+		AllowInsecure:    providerconfig.ConfigVarBool{Value: pointer.Bool(dc.Spec.VMwareCloudDirector.AllowInsecure)},
+	}
+
+	if storageProfile != "" {
+		config.StorageProfile = &storageProfile
+	}
+
+	if nodeSpec.Cloud.VMwareCloudDirector.DiskIOPS != nil && *nodeSpec.Cloud.VMwareCloudDirector.DiskIOPS >= 0 {
+		config.DiskIOPS = nodeSpec.Cloud.VMwareCloudDirector.DiskIOPS
+	}
+
+	if nodeSpec.Cloud.VMwareCloudDirector.DiskSizeGB != nil && *nodeSpec.Cloud.VMwareCloudDirector.DiskSizeGB > 4 {
+		config.DiskSizeGB = nodeSpec.Cloud.VMwareCloudDirector.DiskSizeGB
+	}
+
+	if nodeSpec.Cloud.VMwareCloudDirector.Metadata != nil {
+		config.Metadata = &nodeSpec.Cloud.VMwareCloudDirector.Metadata
+	}
+
+	return config, nil
+}
+
+func getVMwareCloudDirectorProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetVMwareCloudDirectorProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetOpenstackProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*openstack.RawConfig, error) {
+	config := &openstack.RawConfig{
+		Image:                     providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.Image},
+		Flavor:                    providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.Flavor},
+		AvailabilityZone:          providerconfig.ConfigVarString{Value: dc.Spec.Openstack.AvailabilityZone},
+		Region:                    providerconfig.ConfigVarString{Value: dc.Spec.Openstack.Region},
+		IdentityEndpoint:          providerconfig.ConfigVarString{Value: dc.Spec.Openstack.AuthURL},
+		Network:                   providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.Network},
+		Subnet:                    providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.SubnetID},
+		SecurityGroups:            []providerconfig.ConfigVarString{{Value: c.Spec.Cloud.Openstack.SecurityGroups}},
+		InstanceReadyCheckPeriod:  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckPeriod},
+		InstanceReadyCheckTimeout: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.InstanceReadyCheckTimeout},
+		TrustDevicePath:           providerconfig.ConfigVarBool{Value: pointer.Bool(false)},
+		ServerGroup:               providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.ServerGroup},
+	}
+
+	if nodeSpec.Cloud.Openstack.UseFloatingIP || dc.Spec.Openstack.EnforceFloatingIP {
+		config.FloatingIPPool = providerconfig.ConfigVarString{Value: c.Spec.Cloud.Openstack.FloatingIPPool}
+	}
+
+	if nodeSpec.Cloud.Openstack.RootDiskSizeGB != nil && *nodeSpec.Cloud.Openstack.RootDiskSizeGB > 0 {
+		config.RootDiskSizeGB = nodeSpec.Cloud.Openstack.RootDiskSizeGB
+	}
+
+	if dc.Spec.Openstack.TrustDevicePath != nil {
+		config.TrustDevicePath = providerconfig.ConfigVarBool{Value: dc.Spec.Openstack.TrustDevicePath}
+	}
+
+	// Use the nodeDeployment spec AvailabilityZone if set, otherwise we stick to the default from the datacenter
+	if nodeSpec.Cloud.Openstack.AvailabilityZone != "" {
+		config.AvailabilityZone = providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Openstack.AvailabilityZone}
+	}
+
+	config.Tags = map[string]string{}
+	for key, value := range nodeSpec.Cloud.Openstack.Tags {
+		config.Tags[key] = value
+	}
+	config.Tags["kubernetes-cluster"] = c.Name
+	config.Tags["system-cluster"] = c.Name
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		config.Tags["system-project"] = projectID
+	}
+
+	return config, nil
+}
+
+func getOpenstackProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetOpenstackProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetHetznerProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*hetzner.RawConfig, error) {
+	network := nodeSpec.Cloud.Hetzner.Network
+	// fall back to network defined in cluster spec
+	if network == "" {
+		network = c.Spec.Cloud.Hetzner.Network
+	}
+	// fall back to network defined in datacenter spec
+	if network == "" {
+		network = dc.Spec.Hetzner.Network
+	}
+
+	networks := []providerconfig.ConfigVarString{}
+
+	if network != "" {
+		networks = append(networks, providerconfig.ConfigVarString{Value: network})
+	}
+
+	config := &hetzner.RawConfig{
+		Datacenter: providerconfig.ConfigVarString{Value: dc.Spec.Hetzner.Datacenter},
+		Location:   providerconfig.ConfigVarString{Value: dc.Spec.Hetzner.Location},
+		Networks:   networks,
+		ServerType: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Hetzner.Type},
+	}
+
+	return config, nil
+}
+
+func getHetznerProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetHetznerProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetDigitaloceanProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*digitalocean.RawConfig, error) {
+	config := &digitalocean.RawConfig{
+		Region:            providerconfig.ConfigVarString{Value: dc.Spec.Digitalocean.Region},
+		Backups:           providerconfig.ConfigVarBool{Value: pointer.Bool(nodeSpec.Cloud.Digitalocean.Backups)},
+		IPv6:              providerconfig.ConfigVarBool{Value: pointer.Bool(nodeSpec.Cloud.Digitalocean.IPv6)},
+		Monitoring:        providerconfig.ConfigVarBool{Value: pointer.Bool(nodeSpec.Cloud.Digitalocean.Monitoring)},
+		Size:              providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Digitalocean.Size},
+		PrivateNetworking: providerconfig.ConfigVarBool{Value: pointer.Bool(true)},
+	}
+
+	tags := sets.NewString(nodeSpec.Cloud.Digitalocean.Tags...)
+	tags.Insert("kubernetes", fmt.Sprintf("kubernetes-cluster-%s", c.Name), fmt.Sprintf("system-cluster-%s", c.Name))
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		tags.Insert(fmt.Sprintf("system-project-%s", projectID))
+	}
+
+	config.Tags = make([]providerconfig.ConfigVarString, len(tags.List()))
+	for i, tag := range tags.List() {
+		config.Tags[i].Value = tag
+	}
+
+	return config, nil
+}
+
+func getDigitaloceanProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetDigitaloceanProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetPacketProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*equinixmetal.RawConfig, error) {
+	config := &equinixmetal.RawConfig{
+		InstanceType: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Packet.InstanceType},
+	}
+
+	tags := sets.NewString(nodeSpec.Cloud.Packet.Tags...)
+	tags.Insert("kubernetes", fmt.Sprintf("kubernetes-cluster-%s", c.Name), fmt.Sprintf("system/cluster:%s", c.Name))
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		tags.Insert(fmt.Sprintf("system/project:%s", projectID))
+	}
+	config.Tags = make([]providerconfig.ConfigVarString, len(tags.List()))
+	for i, tag := range tags.List() {
+		config.Tags[i].Value = tag
+	}
+
+	var facilities = sets.String{}
+	if dc.Spec.Packet.Facilities != nil {
+		facilities = sets.NewString(dc.Spec.Packet.Facilities...)
+		config.Facilities = make([]providerconfig.ConfigVarString, len(facilities.List()))
+		for i, facility := range facilities.List() {
+			config.Facilities[i].Value = facility
+		}
+	}
+
+	if len(facilities) < 1 && dc.Spec.Packet.Metro == "" {
+		return nil, errors.New("equinixmetal metro or facilities must be specified")
+	}
+
+	config.Metro.Value = dc.Spec.Packet.Metro
+
+	return config, nil
+}
+
+func getPacketProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetPacketProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetGCPProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*gce.CloudProviderSpec, error) {
+	config := &gce.CloudProviderSpec{
+		Zone:                  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.GCP.Zone},
+		MachineType:           providerconfig.ConfigVarString{Value: nodeSpec.Cloud.GCP.MachineType},
+		DiskSize:              nodeSpec.Cloud.GCP.DiskSize,
+		DiskType:              providerconfig.ConfigVarString{Value: nodeSpec.Cloud.GCP.DiskType},
+		Preemptible:           providerconfig.ConfigVarBool{Value: pointer.Bool(nodeSpec.Cloud.GCP.Preemptible)},
+		Network:               providerconfig.ConfigVarString{Value: c.Spec.Cloud.GCP.Network},
+		Subnetwork:            providerconfig.ConfigVarString{Value: c.Spec.Cloud.GCP.Subnetwork},
+		AssignPublicIPAddress: &providerconfig.ConfigVarBool{Value: pointer.Bool(true)},
+		CustomImage:           providerconfig.ConfigVarString{Value: nodeSpec.Cloud.GCP.CustomImage},
+		MultiZone:             providerconfig.ConfigVarBool{Value: pointer.Bool(false)},
+		Regional:              providerconfig.ConfigVarBool{Value: pointer.Bool(false)},
+	}
+
+	tags := sets.NewString(nodeSpec.Cloud.GCP.Tags...)
+	tags.Insert(fmt.Sprintf("kubernetes-cluster-%s", c.Name), fmt.Sprintf("system-cluster-%s", c.Name))
+	projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		tags.Insert(fmt.Sprintf("system-project-%s", projectID))
+	}
+	config.Tags = tags.List()
+
+	config.Labels = map[string]string{}
+	for key, value := range nodeSpec.Cloud.GCP.Labels {
+		config.Labels[key] = value
+	}
+
+	return config, nil
+}
+
+func getGCPProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetGCPProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetKubevirtProviderConfig(cluster *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*kubevirt.RawConfig, error) {
+	config := &kubevirt.RawConfig{
+		ClusterName: providerconfig.ConfigVarString{Value: cluster.Name},
+		VirtualMachine: kubevirt.VirtualMachine{
+			Instancetype: nodeSpec.Cloud.Kubevirt.Instancetype,
+			Preference:   nodeSpec.Cloud.Kubevirt.Preference,
+			Template: kubevirt.Template{
+				CPUs:   providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.CPUs},
+				Memory: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.Memory},
+				PrimaryDisk: kubevirt.PrimaryDisk{
+					Disk: kubevirt.Disk{
+						Size:             providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.PrimaryDiskSize},
+						StorageClassName: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.PrimaryDiskStorageClassName},
+					},
+					OsImage: providerconfig.ConfigVarString{Value: extractKubeVirtOsImageURLOrDataVolumeNsName(cluster.Status.NamespaceName, nodeSpec.Cloud.Kubevirt.PrimaryDiskOSImage)},
+				},
+			},
+			DNSPolicy: providerconfig.ConfigVarString{Value: dc.Spec.Kubevirt.DNSPolicy},
+			DNSConfig: dc.Spec.Kubevirt.DNSConfig.DeepCopy(),
+		},
+		Affinity: kubevirt.Affinity{
+			NodeAffinityPreset: kubevirt.NodeAffinityPreset{
+				Type: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Type},
+				Key:  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Key},
+			},
+		},
+	}
+	config.VirtualMachine.Template.SecondaryDisks = make([]kubevirt.SecondaryDisks, 0, len(nodeSpec.Cloud.Kubevirt.SecondaryDisks))
+	for _, sd := range nodeSpec.Cloud.Kubevirt.SecondaryDisks {
+		secondaryDisk := kubevirt.SecondaryDisks{Disk: kubevirt.Disk{
+			Size:             providerconfig.ConfigVarString{Value: sd.Size},
+			StorageClassName: providerconfig.ConfigVarString{Value: sd.StorageClassName},
+		}}
+		config.VirtualMachine.Template.SecondaryDisks = append(config.VirtualMachine.Template.SecondaryDisks, secondaryDisk)
+	}
+	config.Affinity.NodeAffinityPreset.Values = make([]providerconfig.ConfigVarString, 0, len(nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Values))
+	for _, val := range nodeSpec.Cloud.Kubevirt.NodeAffinityPreset.Values {
+		config.Affinity.NodeAffinityPreset.Values = append(config.Affinity.NodeAffinityPreset.Values, providerconfig.ConfigVarString{Value: val})
+	}
+	config.TopologySpreadConstraints = make([]kubevirt.TopologySpreadConstraint, 0, len(nodeSpec.Cloud.Kubevirt.TopologySpreadConstraints))
+	for _, tsc := range nodeSpec.Cloud.Kubevirt.TopologySpreadConstraints {
+		constraint := kubevirt.TopologySpreadConstraint{
+			MaxSkew:           providerconfig.ConfigVarString{Value: strconv.Itoa(tsc.MaxSkew)},
+			TopologyKey:       providerconfig.ConfigVarString{Value: tsc.TopologyKey},
+			WhenUnsatisfiable: providerconfig.ConfigVarString{Value: tsc.WhenUnsatisfiable},
+		}
+		config.TopologySpreadConstraints = append(config.TopologySpreadConstraints, constraint)
+	}
+	return config, nil
+}
+
+func extractKubeVirtOsImageURLOrDataVolumeNsName(namespace string, osImage string) string {
+	// config.VirtualMachine.Template.PrimaryDisk.OsImage.Value contains:
+	// - a URL
+	// - or a DataVolume name
+	// If config.VirtualMachine.Template.PrimaryDisk.OsImage.Value is a DataVolume, we need to add the namespace prefix
+	if _, err := url.ParseRequestURI(osImage); err == nil {
+		return osImage
+	}
+	// It's a DataVolume
+	// If it's already a ns/name keep it.
+	if nameSpaceAndName := strings.Split(osImage, "/"); len(nameSpaceAndName) >= 2 {
+		return osImage
+	}
+	return fmt.Sprintf("%s/%s", namespace, osImage)
+}
+
+func getKubevirtProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetKubevirtProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetAlibabaProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*alibaba.RawConfig, error) {
+	config := &alibaba.RawConfig{
+		InstanceType:            providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Alibaba.InstanceType},
+		DiskSize:                providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Alibaba.DiskSize},
+		DiskType:                providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Alibaba.DiskType},
+		VSwitchID:               providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Alibaba.VSwitchID},
+		RegionID:                providerconfig.ConfigVarString{Value: dc.Spec.Alibaba.Region},
+		InternetMaxBandwidthOut: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Alibaba.InternetMaxBandwidthOut},
+		ZoneID:                  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Alibaba.ZoneID},
+	}
+
+	config.Labels = map[string]string{}
+	for key, value := range nodeSpec.Cloud.Alibaba.Labels {
+		config.Labels[key] = value
+	}
+
+	return config, nil
+}
+
+func getAlibabaProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetAlibabaProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetAnexiaProviderConfig(_ *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*anexia.RawConfig, error) {
+	config := &anexia.RawConfig{
+		VlanID:     providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Anexia.VlanID},
+		TemplateID: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Anexia.TemplateID},
+		CPUs:       nodeSpec.Cloud.Anexia.CPUs,
+		Memory:     int(nodeSpec.Cloud.Anexia.Memory),
+		DiskSize:   int(*nodeSpec.Cloud.Anexia.DiskSize),
+		LocationID: providerconfig.ConfigVarString{Value: dc.Spec.Anexia.LocationID},
+	}
+
+	if nodeSpec.Cloud.Anexia.DiskSize != nil {
+		config.DiskSize = int(*nodeSpec.Cloud.Anexia.DiskSize)
+	}
+
+	if diskcount := len(nodeSpec.Cloud.Anexia.Disks); diskcount > 0 {
+		config.Disks = make([]anexia.RawDisk, diskcount)
+
+		for diskIndex, diskConfig := range nodeSpec.Cloud.Anexia.Disks {
+			config.Disks[diskIndex].Size = int(diskConfig.Size)
+
+			if diskConfig.PerformanceType != nil {
+				config.Disks[diskIndex].PerformanceType.Value = *diskConfig.PerformanceType
+			}
+		}
+	}
+
+	if config.DiskSize >= 0 && len(config.Disks) > 0 {
+		return nil, anexiaProvider.ErrConfigDiskSizeAndDisks
+	}
+
+	return config, nil
+}
+
+func getAnexiaProviderSpec(nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetAnexiaProviderConfig(nil, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func GetNutanixProviderConfig(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*nutanix.RawConfig, error) {
+	config := &nutanix.RawConfig{
+		SubnetName: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Nutanix.SubnetName},
+		ImageName:  providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Nutanix.ImageName},
+
+		Categories: nodeSpec.Cloud.Nutanix.Categories,
+
+		CPUs:           nodeSpec.Cloud.Nutanix.CPUs,
+		CPUCores:       nodeSpec.Cloud.Nutanix.CPUCores,
+		CPUPassthrough: nodeSpec.Cloud.Nutanix.CPUPassthrough,
+
+		MemoryMB: nodeSpec.Cloud.Nutanix.MemoryMB,
+		DiskSize: nodeSpec.Cloud.Nutanix.DiskSize,
+	}
+
+	if c.Spec.Cloud.Nutanix.ProjectName != "" && c.Spec.Cloud.Nutanix.ProjectName != nutanixprovider.DefaultProject {
+		config.ProjectName = &providerconfig.ConfigVarString{Value: c.Spec.Cloud.Nutanix.ProjectName}
+	}
+
+	config.Categories = map[string]string{}
+	for key, value := range nodeSpec.Cloud.Nutanix.Categories {
+		config.Categories[key] = value
+	}
+
+	config.Categories[nutanixprovider.ClusterCategoryName] = nutanixprovider.CategoryValue(c.Name)
+
+	if projectID, ok := c.Labels[kubermaticv1.ProjectIDLabelKey]; ok {
+		config.Categories[nutanixprovider.ProjectCategoryName] = projectID
+	}
+
+	return config, nil
+}
+
+func getNutanixProviderSpec(c *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter) (*runtime.RawExtension, error) {
+	config, err := GetNutanixProviderConfig(c, nodeSpec, dc)
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func getCentOSOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtension, error) {
+	return EncodeAsRawExtension(centos.Config{
+		DistUpgradeOnBoot: nodeSpec.OperatingSystem.CentOS.DistUpgradeOnBoot,
+	})
+}
+
+func getUbuntuOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtension, error) {
+	return EncodeAsRawExtension(ubuntu.Config{
+		DistUpgradeOnBoot: nodeSpec.OperatingSystem.Ubuntu.DistUpgradeOnBoot,
+	})
+}
+
+func getSLESOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtension, error) {
+	return EncodeAsRawExtension(sles.Config{
+		DistUpgradeOnBoot: nodeSpec.OperatingSystem.SLES.DistUpgradeOnBoot,
+	})
+}
+
+func getRHELOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtension, error) {
+	return EncodeAsRawExtension(rhel.Config{
+		DistUpgradeOnBoot:               nodeSpec.OperatingSystem.RHEL.DistUpgradeOnBoot,
+		RHELSubscriptionManagerUser:     nodeSpec.OperatingSystem.RHEL.RHELSubscriptionManagerUser,
+		RHELSubscriptionManagerPassword: nodeSpec.OperatingSystem.RHEL.RHELSubscriptionManagerPassword,
+		RHSMOfflineToken:                nodeSpec.OperatingSystem.RHEL.RHSMOfflineToken,
+	})
+}
+
+func getFlatcarOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtension, error) {
+	config := flatcar.Config{
+		DisableAutoUpdate: nodeSpec.OperatingSystem.Flatcar.DisableAutoUpdate,
+		// We manage Flatcar updates via the CoreOS update operator which requires locksmithd
+		// to be disabled: https://github.com/coreos/container-linux-update-operator#design
+		DisableLocksmithD: true,
+
+		ProvisioningUtility: flatcar.Ignition,
+	}
+	// Force cloud-init on Anexia since it doesn't have support for ignition
+	if nodeSpec.Cloud.Anexia != nil {
+		config.ProvisioningUtility = flatcar.CloudInit
+	}
+
+	return EncodeAsRawExtension(config)
+}
+
+func getRockyLinuxOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtension, error) {
+	return EncodeAsRawExtension(rockylinux.Config{
+		DistUpgradeOnBoot: nodeSpec.OperatingSystem.RockyLinux.DistUpgradeOnBoot,
+	})
+}
+
+func getAmazonLinuxOperatingSystemSpec(nodeSpec apiv1.NodeSpec) (*runtime.RawExtension, error) {
+	return EncodeAsRawExtension(amzn2.Config{
+		DistUpgradeOnBoot: nodeSpec.OperatingSystem.AmazonLinux.DistUpgradeOnBoot,
+	})
+}
+
+// defaultIfEmpty returns the given value if not empty or the default value
+// otherwise.
+func defaultIfEmpty(value, defaultValue string) string {
+	if value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/pkg/controller/shared/nodedeployment-migration/machine/machinedeployment.go
+++ b/pkg/controller/shared/nodedeployment-migration/machine/machinedeployment.go
@@ -1,0 +1,412 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package machine
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	semverlib "github.com/Masterminds/semver/v3"
+
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"github.com/kubermatic/machine-controller/pkg/cloudprovider/util"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	apiv1 "k8c.io/kubermatic/v2/pkg/controller/shared/nodedeployment-migration/api"
+	"k8c.io/kubermatic/v2/pkg/validation/nodeupdate"
+	osmresources "k8c.io/operating-system-manager/pkg/controllers/osc/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// Deployment returns a Machine Deployment object for the given Node Deployment spec.
+func Deployment(cluster *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermaticv1.Datacenter, keys []*kubermaticv1.UserSSHKey) (*clusterv1alpha1.MachineDeployment, error) {
+	md := &clusterv1alpha1.MachineDeployment{}
+
+	if nd.Name != "" {
+		md.Name = nd.Name
+	} else {
+		// GenerateName can be set only if Name is empty to avoid confusing error:
+		// https://github.com/kubernetes/kubernetes/issues/32220
+		md.GenerateName = fmt.Sprintf("%s-worker-", cluster.Name)
+	}
+
+	// Add Annotations to Machine Deployment
+	md.Annotations = nd.Annotations
+
+	osp := getOperatingSystemProfile(nd, dc)
+	if osp != "" {
+		if md.Annotations == nil {
+			md.Annotations = make(map[string]string)
+		}
+		md.Annotations[osmresources.MachineDeploymentOSPAnnotation] = osp
+	}
+
+	md.Namespace = metav1.NamespaceSystem
+	md.Finalizers = []string{metav1.FinalizerDeleteDependents}
+
+	md.Spec.Selector.MatchLabels = map[string]string{
+		"machine": fmt.Sprintf("md-%s-%s", cluster.Name, rand.String(10)),
+	}
+	md.Spec.Template.Labels = md.Spec.Selector.MatchLabels
+	md.Spec.Template.Spec.Labels = nd.Spec.Template.Labels
+	if md.Spec.Template.Spec.Labels == nil {
+		md.Spec.Template.Spec.Labels = make(map[string]string)
+	}
+	md.Spec.Template.Spec.Labels["system/cluster"] = cluster.Name
+	projectID, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
+	if ok {
+		md.Spec.Template.Spec.Labels["system/project"] = projectID
+	}
+
+	var taints []corev1.Taint
+	for _, taint := range nd.Spec.Template.Taints {
+		taints = append(taints, corev1.Taint{
+			Value:  taint.Value,
+			Key:    taint.Key,
+			Effect: corev1.TaintEffect(taint.Effect),
+		})
+	}
+	md.Spec.Template.Spec.Taints = taints
+
+	// Create a copy to avoid changing the ND when changing the MD
+	replicas := nd.Spec.Replicas
+	md.Spec.Replicas = &replicas
+
+	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet
+
+	// Deprecated: This is not supported for 1.24 and higher and is blocked by
+	// Validate for 1.24+. Can be removed once 1.23 support is dropped.
+	if nd.Spec.DynamicConfig != nil && *nd.Spec.DynamicConfig {
+		kubeletVersion, err := semverlib.NewVersion(nd.Spec.Template.Versions.Kubelet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kubelet version: %w", err)
+		}
+
+		md.Spec.Template.Spec.ConfigSource = &corev1.NodeConfigSource{
+			ConfigMap: &corev1.ConfigMapNodeConfigSource{
+				Namespace:        metav1.NamespaceSystem,
+				Name:             fmt.Sprintf("kubelet-config-%d.%d", kubeletVersion.Major(), kubeletVersion.Minor()),
+				KubeletConfigKey: "kubelet",
+			},
+		}
+	}
+
+	if len(cluster.Spec.MachineNetworks) > 0 {
+		// TODO(mrIncompetent): Rename this finalizer to not contain the word "kubermatic" (For whitelabeling purpose)
+		md.Spec.Template.Annotations = map[string]string{
+			"machine-controller.kubermatic.io/initializers": "ipam",
+		}
+	}
+
+	if nd.Spec.Paused != nil {
+		md.Spec.Paused = *nd.Spec.Paused
+	}
+
+	config, err := getProviderConfig(cluster, nd, dc, keys)
+	if err != nil {
+		return nil, err
+	}
+
+	err = getProviderOS(config, nd)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := json.Marshal(config)
+	if err != nil {
+		return nil, err
+	}
+
+	md.Spec.Template.Spec.ProviderSpec.Value = &runtime.RawExtension{Raw: b}
+
+	return md, nil
+}
+
+//gocyclo:ignore
+func getProviderConfig(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermaticv1.Datacenter, keys []*kubermaticv1.UserSSHKey) (*providerconfig.Config, error) {
+	config := providerconfig.Config{}
+	config.SSHPublicKeys = make([]string, len(keys))
+	for i, key := range keys {
+		config.SSHPublicKeys[i] = key.Spec.PublicKey
+	}
+
+	var (
+		cloudExt *runtime.RawExtension
+		err      error
+	)
+
+	switch {
+	case nd.Spec.Template.Cloud.AWS != nil && dc.Spec.AWS != nil:
+		config.CloudProvider = providerconfig.CloudProviderAWS
+		cloudExt, err = getAWSProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Azure != nil && dc.Spec.Azure != nil:
+		config.CloudProvider = providerconfig.CloudProviderAzure
+		cloudExt, err = getAzureProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.VSphere != nil && dc.Spec.VSphere != nil:
+		config.CloudProvider = providerconfig.CloudProviderVsphere
+		cloudExt, err = getVSphereProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Openstack != nil && dc.Spec.Openstack != nil:
+		config.CloudProvider = providerconfig.CloudProviderOpenstack
+		cloudExt, err = getOpenstackProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Hetzner != nil && dc.Spec.Hetzner != nil:
+		config.CloudProvider = providerconfig.CloudProviderHetzner
+		cloudExt, err = getHetznerProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Digitalocean != nil && dc.Spec.Digitalocean != nil:
+		config.CloudProvider = providerconfig.CloudProviderDigitalocean
+		cloudExt, err = getDigitaloceanProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Packet != nil && dc.Spec.Packet != nil:
+		config.CloudProvider = providerconfig.CloudProviderPacket
+		cloudExt, err = getPacketProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.GCP != nil && dc.Spec.GCP != nil:
+		config.CloudProvider = providerconfig.CloudProviderGoogle
+		cloudExt, err = getGCPProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Kubevirt != nil && dc.Spec.Kubevirt != nil:
+		config.CloudProvider = providerconfig.CloudProviderKubeVirt
+		cloudExt, err = getKubevirtProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Alibaba != nil && dc.Spec.Alibaba != nil:
+		config.CloudProvider = providerconfig.CloudProviderAlibaba
+		cloudExt, err = getAlibabaProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Anexia != nil && dc.Spec.Anexia != nil:
+		config.CloudProvider = providerconfig.CloudProviderAnexia
+		cloudExt, err = getAnexiaProviderSpec(nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.Nutanix != nil && dc.Spec.Nutanix != nil:
+		config.CloudProvider = providerconfig.CloudProviderNutanix
+		cloudExt, err = getNutanixProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	case nd.Spec.Template.Cloud.VMwareCloudDirector != nil && dc.Spec.VMwareCloudDirector != nil:
+		config.CloudProvider = providerconfig.CloudProviderVMwareCloudDirector
+		cloudExt, err = getVMwareCloudDirectorProviderSpec(c, nd.Spec.Template, dc)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, errors.New("unknown cloud provider or cloud provider mismatch between node and datacenter")
+	}
+	config.CloudProviderSpec = *cloudExt
+
+	if config.Network == nil {
+		config.Network = &providerconfig.NetworkConfig{}
+	}
+
+	switch {
+	case c.IsIPv4Only():
+		config.Network.IPFamily = util.IPv4
+	case c.IsIPv6Only():
+		config.Network.IPFamily = util.IPv6
+	case c.IsDualStack():
+		config.Network.IPFamily = util.DualStack
+	default:
+		config.Network.IPFamily = util.Unspecified
+	}
+
+	return &config, nil
+}
+
+func getOperatingSystemProfile(nd *apiv1.NodeDeployment, dc *kubermaticv1.Datacenter) string {
+	if dc.Spec.DefaultOperatingSystemProfiles == nil {
+		return ""
+	}
+
+	// OS specifics
+	switch {
+	case nd.Spec.Template.OperatingSystem.Ubuntu != nil:
+		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemUbuntu]
+	case nd.Spec.Template.OperatingSystem.CentOS != nil:
+		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemCentOS]
+	case nd.Spec.Template.OperatingSystem.SLES != nil:
+		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemSLES]
+	case nd.Spec.Template.OperatingSystem.RHEL != nil:
+		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemRHEL]
+	case nd.Spec.Template.OperatingSystem.Flatcar != nil:
+		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemFlatcar]
+	case nd.Spec.Template.OperatingSystem.RockyLinux != nil:
+		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemRockyLinux]
+	case nd.Spec.Template.OperatingSystem.AmazonLinux != nil:
+		return dc.Spec.DefaultOperatingSystemProfiles[providerconfig.OperatingSystemAmazonLinux2]
+	default:
+		return ""
+	}
+}
+
+func getProviderOS(config *providerconfig.Config, nd *apiv1.NodeDeployment) error {
+	var (
+		err   error
+		osExt *runtime.RawExtension
+	)
+
+	// OS specifics
+	switch {
+	case nd.Spec.Template.OperatingSystem.Ubuntu != nil:
+		config.OperatingSystem = providerconfig.OperatingSystemUbuntu
+		osExt, err = getUbuntuOperatingSystemSpec(nd.Spec.Template)
+		if err != nil {
+			return err
+		}
+	case nd.Spec.Template.OperatingSystem.CentOS != nil:
+		config.OperatingSystem = providerconfig.OperatingSystemCentOS
+		osExt, err = getCentOSOperatingSystemSpec(nd.Spec.Template)
+		if err != nil {
+			return err
+		}
+	case nd.Spec.Template.OperatingSystem.SLES != nil:
+		config.OperatingSystem = providerconfig.OperatingSystemSLES
+		osExt, err = getSLESOperatingSystemSpec(nd.Spec.Template)
+		if err != nil {
+			return err
+		}
+	case nd.Spec.Template.OperatingSystem.RHEL != nil:
+		config.OperatingSystem = providerconfig.OperatingSystemRHEL
+		osExt, err = getRHELOperatingSystemSpec(nd.Spec.Template)
+		if err != nil {
+			return err
+		}
+	case nd.Spec.Template.OperatingSystem.Flatcar != nil:
+		config.OperatingSystem = providerconfig.OperatingSystemFlatcar
+		osExt, err = getFlatcarOperatingSystemSpec(nd.Spec.Template)
+		if err != nil {
+			return err
+		}
+	case nd.Spec.Template.OperatingSystem.RockyLinux != nil:
+		config.OperatingSystem = providerconfig.OperatingSystemRockyLinux
+		osExt, err = getRockyLinuxOperatingSystemSpec(nd.Spec.Template)
+		if err != nil {
+			return err
+		}
+	case nd.Spec.Template.OperatingSystem.AmazonLinux != nil:
+		config.OperatingSystem = providerconfig.OperatingSystemAmazonLinux2
+		osExt, err = getAmazonLinuxOperatingSystemSpec(nd.Spec.Template)
+		if err != nil {
+			return err
+		}
+	default:
+		return errors.New("no machine os was provided")
+	}
+	config.OperatingSystemSpec = *osExt
+
+	return nil
+}
+
+// Validate if the node deployment structure fulfills certain requirements. It returns node deployment with updated
+// kubelet version if it wasn't specified.
+func Validate(nd *apiv1.NodeDeployment, controlPlaneVersion *semverlib.Version) (*apiv1.NodeDeployment, error) {
+	if nd.Spec.Template.Cloud.Openstack == nil &&
+		nd.Spec.Template.Cloud.Digitalocean == nil &&
+		nd.Spec.Template.Cloud.AWS == nil &&
+		nd.Spec.Template.Cloud.Hetzner == nil &&
+		nd.Spec.Template.Cloud.VSphere == nil &&
+		nd.Spec.Template.Cloud.Azure == nil &&
+		nd.Spec.Template.Cloud.Packet == nil &&
+		nd.Spec.Template.Cloud.GCP == nil &&
+		nd.Spec.Template.Cloud.Kubevirt == nil &&
+		nd.Spec.Template.Cloud.Alibaba == nil &&
+		nd.Spec.Template.Cloud.Anexia == nil &&
+		nd.Spec.Template.Cloud.Nutanix == nil &&
+		nd.Spec.Template.Cloud.VMwareCloudDirector == nil {
+		return nil, fmt.Errorf("node deployment needs to have cloud provider data")
+	}
+
+	var (
+		kubeletVersion *semverlib.Version
+		err            error
+	)
+
+	if nd.Spec.Template.Versions.Kubelet != "" {
+		kubeletVersion, err = semverlib.NewVersion(nd.Spec.Template.Versions.Kubelet)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse kubelet version: %w", err)
+		}
+
+		if err = nodeupdate.EnsureVersionCompatible(controlPlaneVersion, kubeletVersion); err != nil {
+			return nil, err
+		}
+	} else {
+		kubeletVersion = controlPlaneVersion
+	}
+
+	nd.Spec.Template.Versions.Kubelet = kubeletVersion.String()
+
+	constraint124, err := semverlib.NewConstraint(">= 1.24")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse 1.24 constraint: %w", err)
+	}
+
+	if nd.Spec.DynamicConfig != nil && *nd.Spec.DynamicConfig && constraint124.Check(kubeletVersion) {
+		return nil, errors.New("dynamic config cannot be configured for Kubernetes 1.24 or higher")
+	}
+
+	// The default
+	allowedTaintEffects := sets.NewString(
+		string(corev1.TaintEffectNoExecute),
+		string(corev1.TaintEffectNoSchedule),
+		string(corev1.TaintEffectPreferNoSchedule),
+	)
+	for _, taint := range nd.Spec.Template.Taints {
+		if taint.Key == "" {
+			return nil, errors.New("taint key must be set")
+		}
+		if taint.Value == "" {
+			return nil, errors.New("taint value must be set")
+		}
+		if !allowedTaintEffects.Has(taint.Effect) {
+			return nil, fmt.Errorf("taint effect '%s' not allowed. Allowed: %s", taint.Effect, strings.Join(allowedTaintEffects.List(), ", "))
+		}
+	}
+
+	return nd, nil
+}

--- a/pkg/controller/shared/nodedeployment-migration/machinedeployment.json
+++ b/pkg/controller/shared/nodedeployment-migration/machinedeployment.json
@@ -1,0 +1,72 @@
+{
+   "metadata": {
+      "name": "elastic-yalow",
+      "namespace": "kube-system",
+      "creationTimestamp": null,
+      "annotations": {
+         "k8c.io/operating-system-profile": "osp-ubuntu"
+      },
+      "finalizers": [
+         "foregroundDeletion"
+      ]
+   },
+   "spec": {
+      "replicas": 2,
+      "selector": {
+         "matchLabels": {
+            "machine": "md-b6zskbf5x9-4hk6kgwwb9"
+         }
+      },
+      "template": {
+         "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+               "machine": "md-b6zskbf5x9-4hk6kgwwb9"
+            }
+         },
+         "spec": {
+            "metadata": {
+               "creationTimestamp": null,
+               "labels": {
+                  "system/cluster": "b6zskbf5x9"
+               }
+            },
+            "providerSpec": {
+               "value": {
+                  "sshPublicKeys": [],
+                  "caPublicKey": "",
+                  "cloudProvider": "hetzner",
+                  "cloudProviderSpec": {
+                     "token": "",
+                     "serverType": "cx21",
+                     "datacenter": "nbg1-dc3",
+                     "image": "",
+                     "location": "",
+                     "placementGroupPrefix": "",
+                     "networks": [
+                        "dev"
+                     ],
+                     "firewalls": null
+                  },
+                  "operatingSystem": "ubuntu",
+                  "operatingSystemSpec": {
+                     "distUpgradeOnBoot": false
+                  },
+                  "network": {
+                     "cidr": "",
+                     "gateway": "",
+                     "dns": {
+                        "servers": null
+                     },
+                     "ipFamily": "IPv4"
+                  }
+               }
+            },
+            "versions": {
+               "kubelet": ""
+            }
+         }
+      }
+   },
+   "status": {}
+}

--- a/pkg/controller/shared/nodedeployment-migration/migrate.go
+++ b/pkg/controller/shared/nodedeployment-migration/migrate.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedeploymentmigration
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/shared/nodedeployment-migration/api"
+	"k8c.io/kubermatic/v2/pkg/controller/shared/nodedeployment-migration/machine"
+)
+
+func ParseNodeOrMachineDeployment(cluster *kubermaticv1.Cluster, datacenter *kubermaticv1.Datacenter, encoded string) (machineDeployment *clusterv1alpha1.MachineDeployment, migrated bool, err error) {
+	if len(encoded) == 0 {
+		return nil, false, nil
+	}
+
+	machineDeployment = &clusterv1alpha1.MachineDeployment{}
+	if err := json.Unmarshal([]byte(encoded), machineDeployment); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal string as MachineDeployment: %w", err)
+	}
+
+	// looks like we found an already migrated machine deployment :)
+	if machineDeployment.Name != "" {
+		return machineDeployment, false, nil
+	}
+
+	nodeDeployment := &api.NodeDeployment{}
+	if err := json.Unmarshal([]byte(encoded), nodeDeployment); err != nil {
+		return nil, false, fmt.Errorf("failed to unmarshal string as NodeDeployment: %w", err)
+	}
+
+	if nodeDeployment.Name == "" {
+		return nil, false, errors.New("string is neither a valid MachineDeployment nor a valid NodeDeployment")
+	}
+
+	machineDeployment, err = machine.Deployment(cluster, nodeDeployment, datacenter, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to convert NodeDeployment: %w", err)
+	}
+
+	return machineDeployment, true, nil
+}

--- a/pkg/controller/shared/nodedeployment-migration/migrate_test.go
+++ b/pkg/controller/shared/nodedeployment-migration/migrate_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodedeploymentmigration
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/test/generator"
+)
+
+var (
+	datacenter = &kubermaticv1.Datacenter{
+		Spec: kubermaticv1.DatacenterSpec{
+			Alibaba: &kubermaticv1.DatacenterSpecAlibaba{
+				Region: "test",
+			},
+			Hetzner: &kubermaticv1.DatacenterSpecHetzner{
+				Datacenter: "dummy",
+			},
+		},
+	}
+)
+
+func TestParseNodeDeployment(t *testing.T) {
+	body, err := os.ReadFile("nodedeployment.json")
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	cluster := generator.GenCluster("test", "test", "projectName", time.Now(), func(c *kubermaticv1.Cluster) {
+		c.Spec.Cloud.ProviderName = string(kubermaticv1.AlibabaCloudProvider)
+		c.Spec.Cloud.Fake = nil
+		c.Spec.Cloud.Alibaba = &kubermaticv1.AlibabaCloudSpec{}
+	})
+
+	md, migrated, err := ParseNodeOrMachineDeployment(cluster, datacenter, string(body))
+	if err != nil {
+		t.Fatalf("Failed to parse body: %v", err)
+	}
+
+	if !migrated {
+		t.Fatal("Expected migrated to be true, but got false.")
+	}
+
+	if expected := "trusting-wiles"; md.Name != expected {
+		t.Fatalf("Expected name to be %q, but got %q", expected, md.Name)
+	}
+}
+
+func TestParseMachineDeployment(t *testing.T) {
+	body, err := os.ReadFile("machinedeployment.json")
+	if err != nil {
+		t.Fatalf("Failed to read file: %v", err)
+	}
+
+	cluster := generator.GenCluster("test", "test", "projectName", time.Now(), func(c *kubermaticv1.Cluster) {
+		c.Spec.Cloud.ProviderName = string(kubermaticv1.HetznerCloudProvider)
+		c.Spec.Cloud.Fake = nil
+		c.Spec.Cloud.Hetzner = &kubermaticv1.HetznerCloudSpec{}
+	})
+
+	md, migrated, err := ParseNodeOrMachineDeployment(cluster, datacenter, string(body))
+	if err != nil {
+		t.Fatalf("Failed to parse body: %v", err)
+	}
+
+	if migrated {
+		t.Fatal("Expected migrated to be faalse, but got true.")
+	}
+
+	if expected := "elastic-yalow"; md.Name != expected {
+		t.Fatalf("Expected name to be %q, but got %q", expected, md.Name)
+	}
+}

--- a/pkg/controller/shared/nodedeployment-migration/nodedeployment.json
+++ b/pkg/controller/shared/nodedeployment-migration/nodedeployment.json
@@ -1,0 +1,40 @@
+{
+   "name": "trusting-wiles",
+   "creationTimestamp": "0001-01-01T00:00:00Z",
+   "spec": {
+      "replicas": 1,
+      "template": {
+         "cloud": {
+            "alibaba": {
+               "instanceType": "ecs.ic5.large",
+               "diskSize": "40",
+               "diskType": "cloud",
+               "vSwitchID": "vsw-xxxxxx",
+               "internetMaxBandwidthOut": "10",
+               "labels": null,
+               "zoneID": "eu-central-1a"
+            }
+         },
+         "operatingSystem": {
+            "ubuntu": {
+               "distUpgradeOnBoot": false
+            }
+         },
+         "versions": {
+            "kubelet": ""
+         },
+         "labels": {
+            "k1": "v1",
+            "k2": "v2"
+         },
+         "taints": [
+            {
+               "key": "k1",
+               "value": "v1",
+               "effect": "NoSchedule"
+            }
+         ]
+      }
+   },
+   "status": {}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
In #11339 we removed the old NodeDeployment handling, assuming that during the KKP 2.22 installations we could simply check for new Cluster objects that still have an old annotation and reject the installation. Since the annotation is only temporary, this should fix itself and once all initial-md annotations are gone, an upgrade would be possible.

However that doesn't work for ClusterTemplates, which still permanently encoded old NodeDeployments. This PR therefore brings back the necessary code for converting NodeDeployments into MachineDeployments and extends the cluster-template-synchronizer controller to automatically migrate annotations during its reconciliation loop. Doing it in the loop makes the whole migration work for those who do not use the kubermatic-installer :)

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
