### PR TITLE
[release/v2.21] Upgrade Anexia CCM to v1.5.0

### DIFF
--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -68,7 +68,7 @@ func anexiaDeploymentCreator(data *resources.TemplateData) reconciling.NamedDepl
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:1.4.3",
+					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:1.5.0",
 					Command: []string{
 						"/app/ccm",
 						"--cloud-provider=anexia",


### PR DESCRIPTION
**What this PR does / why we need it**:

Title says it all, upgrade Anexia CCM to v1.5.0.

Manual backport of #11501 

**What type of PR is this?**
/kind feature
/kind chore

**Documentation**:
```documentation
NONE
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Anexia CCM (cloud-controller-manager) to version 1.5.0
```