### PR TITLE
Improvements for network-interface-manager and Change TunnelingAgentIP default value

### DIFF
--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -100,7 +100,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	c := controllerRunOptions{
 		featureGates: features.FeatureGate{},
 		// Default IP used by tunneling agents
-		tunnelingAgentIP: flagopts.IPValue{IP: net.ParseIP("192.168.30.10")},
+		tunnelingAgentIP: flagopts.IPValue{IP: net.ParseIP("100.64.30.10")},
 	}
 
 	var (

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/util/flagopts"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -100,7 +101,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	c := controllerRunOptions{
 		featureGates: features.FeatureGate{},
 		// Default IP used by tunneling agents
-		tunnelingAgentIP: flagopts.IPValue{IP: net.ParseIP("100.64.30.10")},
+		tunnelingAgentIP: flagopts.IPValue{IP: net.ParseIP(resources.DefaultTunnelingAgentIP)},
 	}
 
 	var (

--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -71,7 +71,7 @@ if $(echo ${CLUSTER_RAW} | jq -r '.spec.clusterNetwork.konnectivityEnabled'); th
   else
     KONNECTIVITY_SERVER_PORT="$(echo ${CLUSTER_RAW} | jq -r '.status.address.port')"
     KONNECTIVITY_SERVER_HOST="konnectivity-server.$(echo ${CLUSTER_RAW} | jq -r '.status.address.externalName')"
-    ARGS="$ARGS -tunneling-agent-ip=192.168.30.10"
+    ARGS="$ARGS -tunneling-agent-ip=100.64.30.10"
   fi
   ARGS="$ARGS -konnectivity-enabled=true"
   ARGS="$ARGS -konnectivity-server-host=${KONNECTIVITY_SERVER_HOST}"
@@ -82,7 +82,7 @@ else
     OPENVPN_SERVER_PORT="$(echo ${OPENVPN_SERVER_SERVICE_RAW} | jq -r '.spec.ports[0].nodePort')"
   else
     OPENVPN_SERVER_PORT="$(echo ${OPENVPN_SERVER_SERVICE_RAW} | jq -r '.spec.ports[0].port')"
-    ARGS="$ARGS -tunneling-agent-ip=192.168.30.10"
+    ARGS="$ARGS -tunneling-agent-ip=100.64.30.10"
   fi
   ARGS="$ARGS -openvpn-server-port=${OPENVPN_SERVER_PORT}"
 fi

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -741,7 +741,7 @@ const (
 	EnvoyAgentAssignAddressContainerName       = "assign-address"
 	EnvoyAgentDeviceSetupImage                 = "kubermatic/network-interface-manager"
 	// Default tunneling agent IP address.
-	DefaultTunnelingAgentIP = "192.168.30.10"
+	DefaultTunnelingAgentIP = "100.64.30.10"
 )
 
 const (

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -25,6 +25,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
@@ -71,7 +72,7 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 			return cs
 		}).
 		WithPatch(func(cs *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
-			cs.ClusterNetwork.TunnelingAgentIP = "100.64.30.10"
+			cs.ClusterNetwork.TunnelingAgentIP = resources.DefaultTunnelingAgentIP
 			return cs
 		})
 

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -71,7 +71,7 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 			return cs
 		}).
 		WithPatch(func(cs *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
-			cs.ClusterNetwork.TunnelingAgentIP = "192.168.30.10"
+			cs.ClusterNetwork.TunnelingAgentIP = "100.64.30.10"
 			return cs
 		})
 


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
This PR addresses two points related to feature [7125](https://github.com/kubermatic/kubermatic/issues/7125):
1. Change the TunnelingAgentIP default value from `192.168.30.10` to `100.64.30.10` 
2. Command line args and error handling in network-interface-manager 

<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # 

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
Change the Tunneling agent interface default IP from 192.168.30.10 to 100.64.30.10
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
