### PR TITLE
monitoring: add alerts on usercluster etcd database size

### DIFF
--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -119,6 +119,33 @@ groups:
     labels:
       severity: warning
 
+  - alert: EtcdDatabaseQuotaLowSpace
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+    expr: |
+      (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+    for: 10m
+    labels:
+      severity: critical
+
+  - alert: EtcdExcessiveDatabaseGrowth
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+    expr: |
+      predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+    for: 10m
+    labels:
+      severity: warning
+
+  - alert: EtcdDatabaseHighFragmentationRatio
+    annotations:
+      message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+    expr: |
+      (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+    for: 10m
+    labels:
+      severity: warning
+
   - record: job:etcd_server_has_leader:sum
     expr: sum(etcd_server_has_leader)
     labels:

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-aws-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.23.5-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.23.5-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.23.5-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.25.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.23.5-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.23.5-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.24.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-gcp-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.25.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.23.5-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.23.5-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus.yaml
@@ -355,6 +355,33 @@ data:
         labels:
           severity: warning
 
+      - alert: EtcdDatabaseQuotaLowSpace
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size exceeds the defined quota on etcd instance {{ $labels.instance }}, please defrag or increase the quota as the writes to etcd will be disabled when it is full.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_bytes[5m]) / last_over_time(etcd_server_quota_backend_bytes[5m]))*100 > 95
+        for: 10m
+        labels:
+          severity: critical
+
+      - alert: EtcdExcessiveDatabaseGrowth
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": Predicting running out of disk space in the next four hours, based on write observations within the past four hours on etcd instance {{ $labels.instance }}, please check as it might be disruptive.'
+        expr: |
+          predict_linear(etcd_mvcc_db_total_size_in_bytes[4h], 4*60*60) > etcd_server_quota_backend_bytes
+        for: 10m
+        labels:
+          severity: warning
+
+      - alert: EtcdDatabaseHighFragmentationRatio
+        annotations:
+          message: 'Etcd cluster "{{ $labels.job }}": database size in use on instance {{ $labels.instance }} is {{ $value | humanizePercentage }} of the actual allocated disk space, please run defragmentation (e.g. etcdctl defrag) to retrieve the unused fragmented disk space.'
+        expr: |
+          (last_over_time(etcd_mvcc_db_total_size_in_use_in_bytes[5m]) / last_over_time(etcd_mvcc_db_total_size_in_bytes[5m])) < 0.5
+        for: 10m
+        labels:
+          severity: warning
+
       - record: job:etcd_server_has_leader:sum
         expr: sum(etcd_server_has_leader)
         labels:


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds alerts on high etcd database usage based on the [official etcd mixin](https://github.com/etcd-io/etcd/blob/main/contrib/mixin/mixin.libsonnet).
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11462 

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
monitoring: added etcd database size alerts: EtcdDatabaseQuotaLowSpace, EtcdExcessiveDatabaseGrowth, EtcdDatabaseHighFragmentationRatio.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
