### PR TITLE
[release/v2.19] Use `registry.k8s.io` instead of `k8s.gcr.io` for Kubernetes upstream images

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -173,7 +173,7 @@ spec:
         app: cluster-autoscaler
     spec:
       containers:
-      - image: '{{ Registry "k8s.gcr.io" }}/autoscaling/cluster-autoscaler:{{ $version }}'
+      - image: '{{ Registry "registry.k8s.io" }}/autoscaling/cluster-autoscaler:{{ $version }}'
         name: cluster-autoscaler
         command:
         - /cluster-autoscaler

--- a/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
+++ b/addons/csi/hetzner/hcloud-csi-1.6.0.yaml
@@ -138,7 +138,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.2.1'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.2.1'
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi
@@ -148,7 +148,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-resizer
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.2.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.2.0'
           volumeMounts:
             - name: socket-dir
               mountPath: /run/csi
@@ -158,7 +158,7 @@ spec:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
         - name: csi-provisioner
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.2.2'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.2.2'
           args:
             - --feature-gates=Topology=true
             - --default-fstype=ext4
@@ -214,7 +214,7 @@ spec:
             allowPrivilegeEscalation: true
         - name: liveness-probe
           imagePullPolicy: Always
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0'
           volumeMounts:
             - mountPath: /run/csi
               name: socket-dir
@@ -260,7 +260,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-node-driver-registrar
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.2.0'
           args:
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi.hetzner.cloud/socket
           env:
@@ -322,7 +322,7 @@ spec:
             periodSeconds: 2
         - name: liveness-probe
           imagePullPolicy: Always
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.3.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.3.0'
           volumeMounts:
             - mountPath: /run/csi
               name: plugin-dir

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -64,7 +64,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.1.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -76,7 +76,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-provisioner
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v2.1.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v2.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -89,7 +89,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: csi-snapshotter
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-snapshotter:v2.1.3'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-snapshotter:v2.1.3'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -101,7 +101,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: csi-resizer
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.1.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.1.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
@@ -114,7 +114,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: liveness-probe
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.4.0'
           args:
             - "--csi-address=$(ADDRESS)"
           env:

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -50,7 +50,7 @@ spec:
       hostNetwork: true
       containers:
         - name: node-driver-registrar
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v1.3.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v1.3.0'
           args:
             - "--csi-address=$(ADDRESS)"
             - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
@@ -74,7 +74,7 @@ spec:
             - name: registration-dir
               mountPath: /registration
         - name: liveness-probe
-          image: '{{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0'
+          image: '{{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.4.0'
           args:
             - --csi-address=/csi/csi.sock
           volumeMounts:

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -260,7 +260,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: csi-attacher
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-attacher:v3.3.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.3.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -275,7 +275,7 @@ spec:
             - mountPath: /csi
               name: socket-dir
         - name: csi-resizer
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-resizer:v1.3.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.3.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -345,7 +345,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.4.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"
@@ -388,7 +388,7 @@ spec:
               name: ca-bundle
               readOnly: true
         - name: csi-provisioner
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-provisioner:v3.0.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.0.0
           args:
             - "--v=4"
             - "--timeout=300s"
@@ -445,7 +445,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: node-driver-registrar
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/csi-node-driver-registrar:v2.3.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.3.0
           args:
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
@@ -534,7 +534,7 @@ spec:
             periodSeconds: 5
             failureThreshold: 3
         - name: liveness-probe
-          image: {{ Registry "k8s.gcr.io" }}/sig-storage/livenessprobe:v2.4.0
+          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.4.0
           args:
             - "--v=4"
             - "--csi-address=/csi/csi.sock"

--- a/addons/kube-proxy/daemonset.yaml
+++ b/addons/kube-proxy/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
       priorityClassName: system-node-critical
       containers:
       - name: kube-proxy
-        image: '{{ Registry "k8s.gcr.io" }}/kube-proxy:v{{ .Cluster.Version }}'
+        image: '{{ Registry "registry.k8s.io" }}/kube-proxy:v{{ .Cluster.Version }}'
         imagePullPolicy: IfNotPresent
         command:
         - /usr/local/bin/kube-proxy

--- a/addons/kube-state-metrics/deployment.yaml
+++ b/addons/kube-state-metrics/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: '{{ Registry "k8s.gcr.io" }}/kube-state-metrics/kube-state-metrics:v2.1.1'
+          image: '{{ Registry "registry.k8s.io" }}/kube-state-metrics/kube-state-metrics:v2.1.1'
           name: kube-state-metrics
           resources:
             limits:

--- a/addons/kubeadm-configmap/kubeadm-configmap.yaml
+++ b/addons/kubeadm-configmap/kubeadm-configmap.yaml
@@ -29,7 +29,7 @@ data:
     apiVersion: kubeadm.k8s.io/v1beta3
     {{- end }}
     certificatesDir: /etc/kubernetes/pki
-    imageRepository: k8s.gcr.io
+    imageRepository: registry.k8s.io
     kind: ClusterConfiguration
     kubernetesVersion: {{ .Cluster.Version }}
   ClusterStatus: |

--- a/addons/metrics-server/metrics-server-deployment.yaml
+++ b/addons/metrics-server/metrics-server-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         emptyDir: {}
       containers:
       - name: metrics-server
-        image: '{{ Registry "k8s.gcr.io" }}/metrics-server-amd64:v0.2.1'
+        image: '{{ Registry "registry.k8s.io" }}/metrics-server-amd64:v0.2.1'
         command:
         - /metrics-server
         - '--source=kubernetes.summary_api:https://kubernetes.default.svc?kubeletHttps=true&kubeletPort=10250&insecure=true'

--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kube-state-metrics
-version: 1.2.2
+version: 1.2.3
 appVersion: v2.2.3
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -14,7 +14,7 @@
 
 kubeStateMetrics:
   image:
-    repository: k8s.gcr.io/kube-state-metrics/kube-state-metrics
+    repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
     tag: v2.2.3
   resources:
     requests:

--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: nginx-ingress-controller
-version: 1.3.5
+version: 1.3.6
 appVersion: 1.0.2
 description: nginx-ingress-controller
 keywords:

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -1,6 +1,6 @@
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
   minAvailable: 1
 ---
@@ -27,7 +27,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,7 +42,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -58,7 +58,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -126,7 +126,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -146,7 +146,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -230,7 +230,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -252,7 +252,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -267,7 +267,7 @@ spec:
       targetPort: metrics
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
@@ -277,7 +277,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -292,7 +292,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
@@ -304,7 +304,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -328,7 +328,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-deployment.yaml
@@ -338,7 +338,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -348,7 +348,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
   replicas: 3
   revisionHistoryLimit: 10
@@ -360,7 +360,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/component: controller
     spec:
       dnsPolicy: ClusterFirst
@@ -478,7 +478,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -495,7 +495,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -535,7 +535,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -551,7 +551,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -575,7 +575,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -600,7 +600,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -625,7 +625,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -650,7 +650,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -661,7 +661,7 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -700,7 +700,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -711,7 +711,7 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -1,12 +1,12 @@
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: controller
   minAvailable: 1
 ---
@@ -27,7 +27,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,7 +42,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -58,7 +58,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -126,7 +126,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -146,7 +146,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -230,7 +230,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -252,7 +252,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -267,7 +267,7 @@ spec:
       targetPort: metrics
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
@@ -277,7 +277,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -292,7 +292,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
@@ -304,7 +304,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -328,7 +328,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-deployment.yaml
@@ -338,7 +338,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -348,7 +348,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: controller
   replicas: 3
   revisionHistoryLimit: 10
@@ -360,13 +360,13 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: controller
     spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "k8s.gcr.io/ingress-nginx/controller:v1.0.5@sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d"
+          image: "registry.k8s.io/ingress-nginx/controller:v1.0.5@sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d"
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -478,7 +478,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -495,7 +495,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -535,7 +535,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -551,7 +551,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -575,7 +575,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -600,7 +600,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -625,7 +625,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -650,7 +650,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -661,14 +661,14 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: create
-          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -700,7 +700,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -711,14 +711,14 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: patch
-          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -1,6 +1,6 @@
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
   minAvailable: 1
 ---
@@ -27,7 +27,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,7 +42,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -58,7 +58,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -126,7 +126,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -146,7 +146,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -230,7 +230,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -252,7 +252,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -267,7 +267,7 @@ spec:
       targetPort: metrics
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
@@ -277,7 +277,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -292,7 +292,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
@@ -304,7 +304,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -328,7 +328,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-deployment.yaml
@@ -338,7 +338,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -348,7 +348,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
   replicas: 3
   revisionHistoryLimit: 10
@@ -360,7 +360,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/component: controller
     spec:
       dnsPolicy: ClusterFirst
@@ -478,7 +478,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -495,7 +495,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -535,7 +535,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -551,7 +551,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -575,7 +575,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -600,7 +600,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -625,7 +625,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -650,7 +650,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -661,7 +661,7 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -700,7 +700,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -711,7 +711,7 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -1,12 +1,12 @@
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: controller
   minAvailable: 1
 ---
@@ -27,7 +27,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,7 +42,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -58,7 +58,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -126,7 +126,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -146,7 +146,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -230,7 +230,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -252,7 +252,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -267,7 +267,7 @@ spec:
       targetPort: metrics
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
@@ -277,7 +277,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -292,7 +292,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
@@ -304,7 +304,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -328,7 +328,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-deployment.yaml
@@ -338,7 +338,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -348,7 +348,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: controller
   replicas: 3
   revisionHistoryLimit: 10
@@ -360,13 +360,13 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: controller
     spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "k8s.gcr.io/ingress-nginx/controller:v1.0.5@sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d"
+          image: "registry.k8s.io/ingress-nginx/controller:v1.0.5@sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d"
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -478,7 +478,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -495,7 +495,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -535,7 +535,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -551,7 +551,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -575,7 +575,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -600,7 +600,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -625,7 +625,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -650,7 +650,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -661,14 +661,14 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: create
-          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -700,7 +700,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -711,14 +711,14 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: patch
-          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -1,6 +1,6 @@
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -6,7 +6,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
   minAvailable: 1
 ---
@@ -27,7 +27,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,7 +42,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -58,7 +58,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -126,7 +126,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -146,7 +146,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -230,7 +230,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -252,7 +252,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -267,7 +267,7 @@ spec:
       targetPort: metrics
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
@@ -277,7 +277,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -292,7 +292,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
@@ -304,7 +304,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -328,7 +328,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-deployment.yaml
@@ -338,7 +338,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -348,7 +348,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/instance: RELEASE-NAME
       app.kubernetes.io/component: controller
   replicas: 3
   revisionHistoryLimit: 10
@@ -360,7 +360,7 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/component: controller
     spec:
       dnsPolicy: ClusterFirst
@@ -478,7 +478,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -495,7 +495,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -535,7 +535,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -551,7 +551,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -575,7 +575,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -600,7 +600,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -625,7 +625,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -650,7 +650,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -661,7 +661,7 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
@@ -700,7 +700,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: RELEASE-NAME
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -711,7 +711,7 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -1,12 +1,12 @@
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-poddisruptionbudget.yaml
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: controller
   minAvailable: 1
 ---
@@ -27,7 +27,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -42,7 +42,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -58,7 +58,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -126,7 +126,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
   name: nginx-ingress
@@ -146,7 +146,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -230,7 +230,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -252,7 +252,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -267,7 +267,7 @@ spec:
       targetPort: metrics
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service-webhook.yaml
@@ -277,7 +277,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -292,7 +292,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-service.yaml
@@ -304,7 +304,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -328,7 +328,7 @@ spec:
       appProtocol: https
   selector:
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: controller
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/controller-deployment.yaml
@@ -338,7 +338,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -348,7 +348,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: nginx
-      app.kubernetes.io/instance: RELEASE-NAME
+      app.kubernetes.io/instance: release-name
       app.kubernetes.io/component: controller
   replicas: 3
   revisionHistoryLimit: 10
@@ -360,13 +360,13 @@ spec:
         prometheus.io/scrape: "true"
       labels:
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: controller
     spec:
       dnsPolicy: ClusterFirst
       containers:
         - name: controller
-          image: "k8s.gcr.io/ingress-nginx/controller:v1.0.5@sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d"
+          image: "registry.k8s.io/ingress-nginx/controller:v1.0.5@sha256:55a1fcda5b7657c372515fe402c3e39ad93aa59f6e4378e82acd99912fe6028d"
           imagePullPolicy: IfNotPresent
           lifecycle: 
             preStop:
@@ -478,7 +478,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -495,7 +495,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -535,7 +535,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -551,7 +551,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -575,7 +575,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -600,7 +600,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -625,7 +625,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -650,7 +650,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -661,14 +661,14 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: create
-          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
           imagePullPolicy: IfNotPresent
           args:
             - create
@@ -700,7 +700,7 @@ metadata:
   labels:
     helm.sh/chart: nginx-4.0.9
     app.kubernetes.io/name: nginx
-    app.kubernetes.io/instance: RELEASE-NAME
+    app.kubernetes.io/instance: release-name
     app.kubernetes.io/version: "1.0.5"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook
@@ -711,14 +711,14 @@ spec:
       labels:
         helm.sh/chart: nginx-4.0.9
         app.kubernetes.io/name: nginx
-        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/instance: release-name
         app.kubernetes.io/version: "1.0.5"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: admission-webhook
     spec:
       containers:
         - name: patch
-          image: "k8s.gcr.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
+          image: "registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.1.1@sha256:64d8c73dca984af206adf9d6d7e46aa550362b1d7a01f3a0a91b20cc67868660"
           imagePullPolicy: IfNotPresent
           args:
             - patch

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -18,6 +18,8 @@ nginx:
   # values for the ingress-nginx chart start below
   # reference: https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml
   controller:
+    image:
+      registry: registry.k8s.io
     hostNetwork: false
     replicaCount: 3
     config: {}
@@ -82,6 +84,8 @@ nginx:
       # in case of azure, can specific a specific IP address for the nginx service
       # loadBalancerIP: ""
     
-    # Temporarily disable the admission webhooks
     admissionWebhooks:
       enabled: true
+      patch:
+        image:
+          registry: registry.k8s.io

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -130,7 +130,7 @@ func getContainers(
 	return []corev1.Container{
 		{
 			Name:            resources.CoreDNSDeploymentName,
-			Image:           fmt.Sprintf("%s/%s", registryWithOverwrite(resources.RegistryK8SGCR), dns.GetCoreDNSImage(clusterVersion)),
+			Image:           fmt.Sprintf("%s/%s", registryWithOverwrite(resources.RegistryK8S), dns.GetCoreDNSImage(clusterVersion)),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			Args: []string{"-conf", "/etc/coredns/Corefile"},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -91,7 +91,7 @@ func DeploymentCreator(registryWithOverwrite registry.WithOverwriteFunc) reconci
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.MetricsServerDeploymentName,
-					Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryK8SGCR), imageName, imageTag),
+					Image:   fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryK8S), imageName, imageTag),
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubelet-insecure-tls",

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -87,7 +87,7 @@ func DaemonSetCreator(registryWithOverwrite registry.WithOverwriteFunc) reconcil
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
-					Image:           fmt.Sprintf("%s/k8s-dns-node-cache:1.15.7", registryWithOverwrite(resources.RegistryK8SGCR)),
+					Image:           fmt.Sprintf("%s/k8s-dns-node-cache:1.15.7", registryWithOverwrite(resources.RegistryK8S)),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -138,7 +138,7 @@ func DeploymentCreator(data *resources.TemplateData, enableOIDCAuthentication bo
 
 			apiserverContainer := &corev1.Container{
 				Name:    resources.ApiserverDeploymentName,
-				Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-apiserver:v" + data.Cluster().Spec.Version.String(),
+				Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-apiserver:v" + data.Cluster().Spec.Version.String(),
 				Command: []string{"/usr/local/bin/kube-apiserver"},
 				Env:     envVars,
 				Args:    flags,

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -146,7 +146,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.ControllerManagerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-controller-manager:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-controller-manager:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/usr/local/bin/kube-controller-manager"},
 					Args:    flags,
 					Env:     envVars,

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -120,7 +120,7 @@ func DeploymentCreator(data deploymentCreatorData) reconciling.NamedDeploymentCr
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  resources.DNSResolverDeploymentName,
-					Image: data.ImageRegistry(resources.RegistryK8SGCR) + "/" + GetCoreDNSImage(data.Cluster().Spec.Version.Semver()),
+					Image: data.ImageRegistry(resources.RegistryK8S) + "/" + GetCoreDNSImage(data.Cluster().Spec.Version.Semver()),
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -85,7 +85,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-state-metrics/kube-state-metrics:" + version,
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-state-metrics/kube-state-metrics:" + version,
 					Command: []string{"/kube-state-metrics"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -111,7 +111,7 @@ func DeploymentCreator(data metricsServerData) reconciling.NamedDeploymentCreato
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    name,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/metrics-server/metrics-server:" + tag,
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/metrics-server/metrics-server:" + tag,
 					Command: []string{"/metrics-server"},
 					Args: []string{
 						"--kubeconfig", "/etc/kubernetes/kubeconfig/kubeconfig",

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -381,6 +381,8 @@ const (
 
 	// RegistryK8SGCR defines the kubernetes specific docker registry at google
 	RegistryK8SGCR = "k8s.gcr.io"
+	// RegistryK8S defines the (new) official registry hosted by the Kubernetes project.
+	RegistryK8S = "registry.k8s.io"
 	// RegistryEUGCR defines the docker registry at google EU
 	RegistryEUGCR = "eu.gcr.io"
 	// RegistryUSGCR defines the docker registry at google US

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -125,7 +125,7 @@ func DeploymentCreator(data *resources.TemplateData) reconciling.NamedDeployment
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.SchedulerDeploymentName,
-					Image:   data.ImageRegistry(resources.RegistryK8SGCR) + "/kube-scheduler:v" + data.Cluster().Spec.Version.String(),
+					Image:   data.ImageRegistry(resources.RegistryK8S) + "/kube-scheduler:v" + data.Cluster().Spec.Version.String(),
 					Command: []string{"/usr/local/bin/kube-scheduler"},
 					Args:    flags,
 					Env: []corev1.EnvVar{

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-apiserver.yaml
@@ -258,7 +258,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-apiserver.yaml
@@ -258,7 +258,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-apiserver.yaml
@@ -258,7 +258,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-controller-manager.yaml
@@ -84,7 +84,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-apiserver.yaml
@@ -242,7 +242,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-apiserver.yaml
@@ -242,7 +242,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-apiserver.yaml
@@ -242,7 +242,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-apiserver.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-apiserver.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-apiserver.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver-externalCloudProvider.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver-externalCloudProvider.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver-externalCloudProvider.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver-externalCloudProvider.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.20.0
+        image: registry.k8s.io/kube-apiserver:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.20.0
+        image: registry.k8s.io/kube-controller-manager:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.7.0
+        image: registry.k8s.io/coredns/coredns:v1.7.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.20.0
+        image: registry.k8s.io/kube-scheduler:v1.20.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver-externalCloudProvider.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.21.0
+        image: registry.k8s.io/kube-apiserver:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.21.0
+        image: registry.k8s.io/kube-controller-manager:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.0
+        image: registry.k8s.io/coredns/coredns:v1.8.0
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.21.0
+        image: registry.k8s.io/kube-scheduler:v1.21.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver-externalCloudProvider.yaml
@@ -244,7 +244,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-apiserver.yaml
@@ -248,7 +248,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-apiserver:v1.22.1
+        image: registry.k8s.io/kube-apiserver:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager-externalCloudProvider.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-controller-manager.yaml
@@ -74,7 +74,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: no_proxy
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
-        image: k8s.gcr.io/kube-controller-manager:v1.22.1
+        image: registry.k8s.io/kube-controller-manager:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-dns-resolver.yaml
@@ -45,7 +45,7 @@ spec:
       - args:
         - -conf
         - /etc/coredns/Corefile
-        image: k8s.gcr.io/coredns/coredns:v1.8.4
+        image: registry.k8s.io/coredns/coredns:v1.8.4
         name: dns-resolver
         readinessProbe:
           failureThreshold: 3

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-kube-state-metrics.yaml
@@ -36,7 +36,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.3
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.2.3
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-metrics-server.yaml
@@ -53,7 +53,7 @@ spec:
         - '{"command":"/metrics-server","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authentication-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--authorization-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--kubelet-insecure-tls","--kubelet-use-node-status-port","--metric-resolution","15s","--kubelet-preferred-address-types","ExternalIP,InternalIP","--v","1","--tls-cert-file","/etc/serving-cert/serving.crt","--tls-private-key-file","/etc/serving-cert/serving.key"]}'
         command:
         - /http-prober-bin/http-prober
-        image: k8s.gcr.io/metrics-server/metrics-server:v0.5.0
+        image: registry.k8s.io/metrics-server/metrics-server:v0.5.0
         name: metrics-server
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-scheduler.yaml
@@ -60,7 +60,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubernetes/pki/ca-bundle/ca-bundle.pem
-        image: k8s.gcr.io/kube-scheduler:v1.22.1
+        image: registry.k8s.io/kube-scheduler:v1.22.1
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/test/e2e/nodeport-proxy/images.go
+++ b/pkg/test/e2e/nodeport-proxy/images.go
@@ -18,5 +18,5 @@ package nodeportproxy
 
 // TODO make registries configurable
 const (
-	AgnhostImage = "k8s.gcr.io/e2e-test-images/agnhost:2.21"
+	AgnhostImage = "registry.k8s.io/e2e-test-images/agnhost:2.21"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes upstream introduced a new registry URL called registry.k8s.io, which acts as a kind of proxy (well, technically it only redirects) for upstream images. This can speed up the image pull process if a local mirror is available that you're forwarded to (mainly on AWS, as far as I understand from upstream documentation) and is the suggested source of images now. Let's switch to it.

This is a manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/11079.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards #9987

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ACTION REQUIRED: Use `registry.k8s.io` instead of `k8s.gcr.io` for Kubernetes upstream images. It might be necessary to update firewall rules or mirror registries accordingly
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
