### PR TITLE
Fix for prioritising front LB service IPs

### DIFF
--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -109,18 +109,7 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 		if err := m.client.Get(ctx, nn, frontProxyLoadBalancerService); err != nil {
 			return nil, fmt.Errorf("failed to get the front-loadbalancer service: %w", err)
 		}
-		frontProxyLBServiceIP = frontProxyLoadBalancerService.Spec.LoadBalancerIP // default in case the implementation doesn't populate the status
-		for _, ingress := range frontProxyLoadBalancerService.Status.LoadBalancer.Ingress {
-			if ingress.IP != "" {
-				frontProxyLBServiceIP = ingress.IP
-			}
-			if ingress.Hostname != "" {
-				frontProxyLBServiceHostname = ingress.Hostname
-			}
-		}
-		if len(frontProxyLoadBalancerService.Status.LoadBalancer.Ingress) > 1 {
-			m.log.Debugw("Multiple ingress values in LB status, the following values will be used", "ip", frontProxyLBServiceIP, "hostname", frontProxyLBServiceHostname)
-		}
+		frontProxyLBServiceIP, frontProxyLBServiceHostname = m.getFrontProxyLBServiceData(frontProxyLoadBalancerService)
 	}
 
 	// External Name
@@ -220,6 +209,39 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 	}
 
 	return modifiers, nil
+}
+
+func (m *ModifiersBuilder) getFrontProxyLBServiceData(frontProxyLoadBalancerService *corev1.Service) (string, string) {
+	//  frontProxyLBServiceIP is set according to below priority
+	// 1. First public IP from the status list
+	// 2. First private IP from the status list
+	// 3. Default IP as per configured spec if status is not populated
+	serviceIP := ""
+	serviceHostname := ""
+	if len(frontProxyLoadBalancerService.Status.LoadBalancer.Ingress) > 0 {
+		var tmpIP string
+		for _, ingress := range frontProxyLoadBalancerService.Status.LoadBalancer.Ingress {
+			if ingress.IP != "" && !net.ParseIP(ingress.IP).IsPrivate() && tmpIP == "" {
+				tmpIP = ingress.IP
+			}
+			if ingress.Hostname != "" {
+				serviceHostname = ingress.Hostname
+			}
+		}
+
+		if tmpIP != "" {
+			serviceIP = tmpIP
+		} else {
+			serviceIP = frontProxyLoadBalancerService.Status.LoadBalancer.Ingress[0].IP
+		}
+		m.log.Debugw("Multiple ingress values in LB status, the following values will be used", "ip", serviceIP, "hostname", serviceHostname)
+	}
+	// default in case the implementation doesn't populate the status
+	if len(frontProxyLoadBalancerService.Status.LoadBalancer.Ingress) == 0 {
+		serviceIP = frontProxyLoadBalancerService.Spec.LoadBalancerIP
+	}
+
+	return serviceIP, serviceHostname
 }
 
 func (m *ModifiersBuilder) getExternalIPv4(hostname string) (string, error) {

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -147,6 +147,89 @@ func TestSyncClusterAddress(t *testing.T) {
 			expectedURL:          fmt.Sprintf("https://%s", net.JoinHostPort(loadbBalancerHostName, "443")),
 		},
 		{
+			name: "Verify properties for service type LoadBalancer with private IP only",
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{NodePort: int32(443)}},
+				},
+			},
+			frontproxyService: corev1.Service{
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "10.10.10.2"}},
+					},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyLoadBalancer,
+			expectedExternalName: "10.10.10.2",
+			expectedIP:           "10.10.10.2",
+			expectedPort:         int32(443),
+			expectedURL:          "https://10.10.10.2:443",
+		},
+		{
+			name: "Verify properties for service type LoadBalancer with private and public IP",
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{NodePort: int32(443)}},
+				},
+			},
+			frontproxyService: corev1.Service{
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "10.10.10.2"}, {IP: "10.10.10.3"}, {IP: "3.67.176.129"}},
+					},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyLoadBalancer,
+			expectedExternalName: "3.67.176.129",
+			expectedIP:           "3.67.176.129",
+			expectedPort:         int32(443),
+			expectedURL:          "https://3.67.176.129:443",
+		},
+		{
+			name: "Verify properties for service type LoadBalancer with IPv6 in the list",
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{NodePort: int32(443)}},
+				},
+			},
+			frontproxyService: corev1.Service{
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: "2a01::1"}, {IP: "10.10.10.3"}, {IP: "3.67.176.129"}},
+					},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyLoadBalancer,
+			expectedExternalName: "3.67.176.129",
+			expectedIP:           "3.67.176.129",
+			expectedPort:         int32(443),
+			expectedURL:          "https://3.67.176.129:443",
+		},
+		{
+			name: "Verify properties for service type LoadBalancer in default case with no IP in status",
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{NodePort: int32(443)}},
+				},
+			},
+			frontproxyService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					LoadBalancerIP: "10.10.10.2",
+				},
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{},
+					},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyLoadBalancer,
+			expectedExternalName: "10.10.10.2",
+			expectedIP:           "10.10.10.2",
+			expectedPort:         int32(443),
+			expectedURL:          "https://10.10.10.2:443",
+		},
+		{
 			name: "Verify properties for service type NodePort",
 			apiserverService: corev1.Service{
 				Spec: corev1.ServiceSpec{


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
This PR prioritise setting front LoadBalancer service IP to public IP over private IP when both are returned from the cloud providers. 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #  [#11499](https://github.com/kubermatic/kubermatic/issues/11499)

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
The `Build` method is refactored and created new method to fix gocyclo lint error.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prioritise public IP over private IP in front LoadBalancer service
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
