### PR TITLE
Dualstack e2e: split AWS per CNI, use t3.medium for AWS

### DIFF
--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -90,9 +90,7 @@ presubmits:
               memory: 4Gi
               cpu: 2
 
-  - name: pre-kubermatic-dualstack-e2e-aws
-    # TODO: Mark them as required, remove optional flag, when the test are functional again.
-    optional: true
+  - name: pre-kubermatic-dualstack-e2e-aws-cilium
     run_if_changed: ".*(cilium|canal|dualstack|addon|cni|provider|machine|webhook|.prow|go.mod|proxy|network).*"
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -111,7 +109,43 @@ presubmits:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
             - name: CNI
-              value: canal,cilium
+              value: cilium
+            - name: PROVIDER
+              value: aws
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+
+  - name: pre-kubermatic-dualstack-e2e-aws-canal
+    run_if_changed: ".*(cilium|canal|dualstack|addon|cni|provider|machine|webhook|.prow|go.mod|proxy|network).*"
+    decorate: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-kubeconfig-ci: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-kind-volume-mounts: "true"
+      preset-vault: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
+          imagePullPolicy: Always
+          command:
+            - "./hack/ci/run-dualstack-e2e-test.sh"
+          env:
+            - name: CNI
+              value: canal
             - name: PROVIDER
               value: aws
             - name: KUBERMATIC_EDITION

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -20,6 +20,7 @@ package dualstack
 
 import (
 	"context"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"strings"

--- a/pkg/test/dualstack/dualstack_test.go
+++ b/pkg/test/dualstack/dualstack_test.go
@@ -110,6 +110,22 @@ func TestExistingCluster(t *testing.T) {
 func testUserCluster(t *testing.T, ctx context.Context, log *zap.SugaredLogger, userclusterClient ctrlruntimeclient.Client, ipFamily util.IPFamily, skipNodes, skipHostNetworkPods, skipEgressConnectivity bool) {
 	log.Infow("Testing cluster", "ipfamily", ipFamily)
 
+	// get events from user-cluster for debugging
+	// aws+canal e2e flakes
+	// TODO: check again in 1m; remove if the test looks good
+	defer func() {
+		events := new(corev1.EventList)
+		err := userclusterClient.List(ctx, events)
+		if err != nil {
+			t.Logf("Failed to get events from usercluster: %+v", err)
+		}
+		t.Logf("Events for debugging logged below.")
+		for _, event := range events.Items {
+			e, _ := json.Marshal(event)
+			t.Logf(string(e))
+		}
+	}()
+
 	// validate nodes
 	if skipNodes {
 		log.Info("Skipping validation for nodes")

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -143,7 +143,7 @@ func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, cred
 			},
 		})
 
-	awsConfig := provider.NewAWSConfig().WithInstanceType("t3.small")
+	awsConfig := provider.NewAWSConfig().WithInstanceType("t3.medium")
 	if spotMaxPriceUSD != nil {
 		awsConfig.WithSpotInstanceMaxPrice(*spotMaxPriceUSD)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Use VM with more memory. Canal test reportedly fails due to not enough memory.  

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11519

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
