### PR TITLE
Disable cloud route config in aws-ccm

### DIFF
--- a/pkg/resources/cloudcontroller/aws.go
+++ b/pkg/resources/cloudcontroller/aws.go
@@ -81,7 +81,7 @@ func awsDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDepl
 				"/bin/aws-cloud-controller-manager",
 				"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 				"--cloud-config=/etc/kubernetes/cloud/config",
-				"--cloud-provider=aws",
+				"--cloud-provider=aws", "--configure-cloud-routes=false",
 				fmt.Sprintf("--cluster-cidr=%s", data.Cluster().Spec.ClusterNetwork.Pods.GetIPv4CIDR()),
 			}
 

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/bin/aws-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=aws","--cluster-cidr=172.25.0.0/16"]}'
+        - '{"command":"/bin/aws-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=aws","--configure-cloud-routes=false","--cluster-cidr=172.25.0.0/16"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/bin/aws-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=aws","--cluster-cidr=172.25.0.0/16"]}'
+        - '{"command":"/bin/aws-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=aws","--configure-cloud-routes=false","--cluster-cidr=172.25.0.0/16"]}'
         command:
         - /http-prober-bin/http-prober
         env:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -32,7 +32,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/bin/aws-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=aws","--cluster-cidr=172.25.0.0/16"]}'
+        - '{"command":"/bin/aws-cloud-controller-manager","args":["--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig","--cloud-config=/etc/kubernetes/cloud/config","--cloud-provider=aws","--configure-cloud-routes=false","--cluster-cidr=172.25.0.0/16"]}'
         command:
         - /http-prober-bin/http-prober
         env:


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
Disables the route reconciliation in aws-ccm.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11522 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Disables route reconciliation in AWS CCM
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
