### PR TITLE
Switch KubeVirt CI to DC

### DIFF
--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -17,7 +17,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-kubevirt: "true"
+      preset-kubevirt-dc: "true"
       preset-vault: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
@@ -60,7 +60,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-kubevirt: "true"
+      preset-kubevirt-dc: "true"
       preset-vault: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -32,7 +32,7 @@ const (
 	kubevirtCPUs               = 2
 	kubevirtMemory             = "4Gi"
 	kubevirtDiskSize           = "25Gi"
-	kubevirtDiskClassName      = "longhorn"
+	kubevirtDiskClassName      = "csi-rbd"
 )
 
 type kubevirtScenario struct {

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	kubevirtStorageClassName = "kubevirt-longhorn"
+	kubevirtStorageClassName = "kubevirt-csi-rbd"
 )
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {

--- a/pkg/resources/csi/kubevirt/secret.go
+++ b/pkg/resources/csi/kubevirt/secret.go
@@ -61,8 +61,16 @@ func InfraAccessSecretReconciler(ctx context.Context, data *resources.TemplateDa
 				return nil, err
 			}
 
+			// k8s 1.24 by default disabled automatic token creation for service accounts
+			// if created < 1.24, tokenName is retrieved from the SA
+			// if not, it's created by KKP with a fixed name
+			tokenName := resources.KubeVirtCSIServiceAccountName
+			if len(csiSA.Secrets) > 0 {
+				tokenName = csiSA.Secrets[0].Name
+			}
+
 			csiInfraTokenSecret := corev1.Secret{}
-			err = infraClient.Get(ctx, types.NamespacedName{Name: csiSA.Secrets[0].Name, Namespace: data.Cluster().Status.NamespaceName}, &csiInfraTokenSecret)
+			err = infraClient.Get(ctx, types.NamespacedName{Name: tokenName, Namespace: data.Cluster().Status.NamespaceName}, &csiInfraTokenSecret)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
**Switch KubeVirt CI to our DC.**
Note that the switch will be done in several steps:
1- Use `preset-kubevirt-dc` that contains the new credentials in all repos
2- When OK for all repos, I will update the existing `preset-kubevirt` with the new credentials
3- Cleanup up PRs to re-use `preset-kubevirt` 
4- `infra` PR to remove `preset-kubevirt-dc`

**It also contains a fix for infra Kv cluster with k8s version >= 1.24**
The CSI driver deployment split recently done, did introduce a regression. 
This PR also fixes this, and running on the DC where k8s is 1.24.7 shows that the issue is fixed.
With the Equinix infra cluster (k8s 1.22.7), issue was not present.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
