### PR TITLE
Fix unit test build error in network-interface-manager

### DIFF
--- a/cmd/network-interface-manager/README.md
+++ b/cmd/network-interface-manager/README.md
@@ -1,0 +1,18 @@
+# Kubermatic Network Interface Manager
+A linux based tool which can be used to create and manage dummy network interface.
+
+## Overview
+The network-interface-manager is used as an init and side car container by envoy-agent. It creates and manages the dummy interface required for envoy-agent for `Tunnelling` expose strategy.
+
+## Usage
+Create interface:
+
+`network-interface-manager -mode init -if envoy -addr 10.10.10.3`
+
+Monitor interface:
+
+`network-interface-manager -mode probe -if envoy -addr 10.10.10.3`
+
+
+## Release
+The network-interface-manager gets automatically built in CI and it is built only for linux targets.

--- a/cmd/network-interface-manager/main.go
+++ b/cmd/network-interface-manager/main.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 /*
 Copyright 2022 The Kubermatic Kubernetes Platform contributors.
 


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
Fixes unit test build errors for macOS users. As network-interface-manager is linux only, it fails to build on Mac causing unit tests to fail.
Also added a README file.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
