### PR TITLE
Add rbac for kubeone secrets in kubermatic namespace

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
@@ -112,7 +112,7 @@ func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManager
 			},
 			namespace: "kubermatic",
 			predicate: func(o ctrlruntimeclient.Object) bool {
-				// do not reconcile secrets without "sa-token", "credential" and "kubeconfig-external-cluster", "kubeone-manifest", "kubeone-ssh" prefix
+				// do not reconcile secrets without "sa-token", "credential" and "kubeconfig-external-cluster", "manifest-kubeone", "ssh-kubeone" prefix
 				return shouldEnqueueSecret(o.GetName())
 			},
 		},
@@ -183,7 +183,7 @@ func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManager
 }
 
 func shouldEnqueueSecret(name string) bool {
-	supportedPrefixes := []string{"sa-token", "credential", "kubeconfig-external-cluster", "kubeone-manifest", "kubeone-ssh"}
+	supportedPrefixes := []string{"sa-token", "credential", "kubeconfig-external-cluster", "manifest-kubeone", "ssh-kubeone"}
 	for _, prefix := range supportedPrefixes {
 		if strings.HasPrefix(name, prefix) {
 			return true

--- a/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
+++ b/pkg/controller/master-controller-manager/rbac/rbac_controller_aggregator.go
@@ -112,7 +112,7 @@ func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManager
 			},
 			namespace: "kubermatic",
 			predicate: func(o ctrlruntimeclient.Object) bool {
-				// do not reconcile secrets without "sa-token", "credential" and "kubeconfig-external-cluster" prefix
+				// do not reconcile secrets without "sa-token", "credential" and "kubeconfig-external-cluster", "kubeone-manifest", "kubeone-ssh" prefix
 				return shouldEnqueueSecret(o.GetName())
 			},
 		},
@@ -183,7 +183,7 @@ func New(ctx context.Context, metrics *Metrics, mgr manager.Manager, seedManager
 }
 
 func shouldEnqueueSecret(name string) bool {
-	supportedPrefixes := []string{"sa-token", "credential", "kubeconfig-external-cluster"}
+	supportedPrefixes := []string{"sa-token", "credential", "kubeconfig-external-cluster", "kubeone-manifest", "kubeone-ssh"}
 	for _, prefix := range supportedPrefixes {
 		if strings.HasPrefix(name, prefix) {
 			return true


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: Add rbac for kubeone secrets in kubermatic namespace
kubeone in rbac controller
- manifest secret: add secret prefix
- ssh secret: add secret prefix
- kubeconfig secret: already managed in rbac controller
- credential secret: already managed in rbac controller

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11534

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
