### PR TITLE
applications: support wait, timeout, and atomic on helm client 

### DIFF
--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -466,6 +467,89 @@ func TestBuildDependencies(t *testing.T) {
 					}
 				}
 			}()
+		})
+	}
+}
+
+func TestNewDeploySettings(t *testing.T) {
+	tests := []struct {
+		name    string
+		wait    bool
+		timeout time.Duration
+		atomic  bool
+		want    *DeployOpts
+		wantErr bool
+	}{
+		{
+			name:    "test valid: no wait, timeout and atomic",
+			wait:    false,
+			timeout: 0,
+			atomic:  false,
+			want: &DeployOpts{
+				wait:    false,
+				timeout: 0,
+				atomic:  false,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "test valid: wait=true timeout=10s and no atomic",
+			wait:    true,
+			timeout: 10 * time.Second,
+			atomic:  false,
+			want: &DeployOpts{
+				wait:    true,
+				timeout: 10 * time.Second,
+				atomic:  false,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "test valid: wait=true timeout=10s atomic=true",
+			wait:    true,
+			timeout: 10 * time.Second,
+			atomic:  true,
+			want: &DeployOpts{
+				wait:    true,
+				timeout: 10 * time.Second,
+				atomic:  true,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "test invalid: wait=true without timeout",
+			wait:    true,
+			timeout: 0,
+			atomic:  false,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "test invalid: atomic=true without wait",
+			wait:    false,
+			timeout: 10 * time.Second,
+			atomic:  true,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewDeployOpts(tt.wait, tt.timeout, tt.atomic)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewDeployOpts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				if tt.want.wait != got.wait {
+					t.Errorf("want DeployOpts.wait=%v, got %v", tt.want.wait, got.wait)
+				}
+				if tt.want.timeout != got.timeout {
+					t.Errorf("want DeployOpts.timeout=%v, got %v", tt.want.timeout, got.timeout)
+				}
+				if tt.want.atomic != got.atomic {
+					t.Errorf("want DeployOpts.atomic=%v, got %v", tt.want.atomic, got.atomic)
+				}
+			}
 		})
 	}
 }

--- a/pkg/applications/helmclient/testdata/examplechart-v2/Chart.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart-v2/Chart.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: |
+  This chart is the version 2 of testdata/examplechart. the difference with the version 1 are the following:
+     * the default values of the configmap (data and label) are different
+     * a service a type LoadBalanacer may be deployed (default false). This service allows us to test wait and atomic options.
 name: examplechart
 version: 0.2.0

--- a/pkg/applications/helmclient/testdata/examplechart-v2/templates/service.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart-v2/templates/service.yaml
@@ -11,15 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# Default values for examplechart.
-# This is a YAML-formatted file.
-# Declare name/value pairs to be passed into your templates.
-# name: value
-
-cmData:
-  foo-version-2: bar-version-2
-
-versionLabel: "2.0"
-
-deployService: false
+{{ if .Values.deployService }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-1
+spec:
+  ports:
+    - name: "80"
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+  selector:
+    app: svc-1
+  sessionAffinity: None
+  type: LoadBalancer
+{{ end }}

--- a/pkg/applications/helmclient/testdata/examplechart/Chart.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart/Chart.yaml
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: This chart just deployed a configmap. The values allow to setup configmap's data and label.
 name: examplechart
 version: 0.1.0

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -94,7 +94,8 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, applicationInstallation 
 		}
 	}
 
-	helmRelease, err := helmClient.InstallOrUpgrade(chartLoc, getReleaseName(applicationInstallation), values, auth)
+	// todo vgramer: build helmclient.DeployOpts{} from application. will be done in another pr
+	helmRelease, err := helmClient.InstallOrUpgrade(chartLoc, getReleaseName(applicationInstallation), values, helmclient.DeployOpts{}, auth)
 	statusUpdater := util.NoStatusUpdate
 
 	// In some case, even if an error occurred, the helmRelease is updated.

--- a/pkg/applications/test/helm.go
+++ b/pkg/applications/test/helm.go
@@ -59,6 +59,12 @@ const (
 
 	// DefaultVerionLabelV2 is the default value of the version label the configmap deployed by pkg/applications/helmclient/testdata/examplechart-v2 chart.
 	DefaultVerionLabelV2 = "2.0"
+
+	// SvcName is the name of the service deploy by chart chart-with-lb.
+	SvcName = "svc-1"
+
+	// DeploySvcKey is the key values.yaml of examplechart-v2 to enable / disabled the deployment of the service.
+	DeploySvcKey = "deployService"
 )
 
 var (

--- a/pkg/applications/test/helm.go
+++ b/pkg/applications/test/helm.go
@@ -60,7 +60,7 @@ const (
 	// DefaultVerionLabelV2 is the default value of the version label the configmap deployed by pkg/applications/helmclient/testdata/examplechart-v2 chart.
 	DefaultVerionLabelV2 = "2.0"
 
-	// SvcName is the name of the service deploy by chart chart-with-lb.
+	// SvcName is the name of the service deployed by chart chart-with-lb.
 	SvcName = "svc-1"
 
 	// DeploySvcKey is the key values.yaml of examplechart-v2 to enable / disabled the deployment of the service.


### PR DESCRIPTION
**What this PR does / why we need it**:

this PR add options wait, timeout and atomic to helm client. In order to be able to test this feature, the `pkg/applications/helmclient/testdata/examplechart-v2` has been updated to optionally deploy a service of type LoadBalancer. Helm marks the release as successful only the LB service has a public IP, which can not happen in our testing environment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11448 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
