### PR TITLE
Rename kubeone secrets

### DIFF
--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -30,6 +30,16 @@ const (
 
 	// ExternalClusterKind represents "Kind" defined in Kubernetes.
 	ExternalClusterKind = "ExternalCluster"
+
+	// ExternalCluster Kubeconfig secret prefix.
+	ExternalClusterKubeconfigPrefix = "kubeconfig-external-cluster"
+
+	// don't change this as these prefixes are used for rbac generation.
+	// KubeOne ssh secret prefixes.
+	KubeOneSSHSecretPrefix = "ssh-kubeone-external-cluster"
+
+	// KubeOne manifest secret prefixes.
+	KubeOneManifestSecretPrefix = "manifest-kubeone-external-cluster"
 )
 
 // +kubebuilder:validation:Enum=aks;bringyourown;eks;gke;kubeone
@@ -274,7 +284,7 @@ type ExternalClusterAKSCloudSpec struct {
 }
 
 func (i *ExternalCluster) GetKubeconfigSecretName() string {
-	return fmt.Sprintf("kubeconfig-external-cluster-%s", i.Name)
+	return fmt.Sprintf("%s-%s", ExternalClusterKubeconfigPrefix, i.Name)
 }
 
 func (i *ExternalCluster) GetCredentialsSecretName() string {
@@ -302,4 +312,17 @@ func (i *ExternalCluster) GetCredentialsSecretName() string {
 		cluster.Spec.Cloud.Azure = &AzureCloudSpec{}
 	}
 	return cluster.GetSecretName()
+}
+
+func (i *ExternalCluster) GetKubeOneCredentialsSecretName() string {
+	providerName := i.Spec.CloudSpec.KubeOne.ProviderName
+	return fmt.Sprintf("%s-%s-%s", CredentialPrefix, providerName, i.Name)
+}
+
+func (i *ExternalCluster) GetKubeOneSSHSecretName() string {
+	return fmt.Sprintf("%s-%s", KubeOneSSHSecretPrefix, i.Name)
+}
+
+func (i *ExternalCluster) GetKubeOneManifestSecretName() string {
+	return fmt.Sprintf("%s-%s", KubeOneManifestSecretPrefix, i.Name)
 }

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -157,7 +157,7 @@ func enqueueExternalCluster(client ctrlruntimeclient.Client, log *zap.SugaredLog
 
 func ByNameAndNamespace() predicate.Funcs {
 	return kubermaticpred.Factory(func(o ctrlruntimeclient.Object) bool {
-		return o.GetName() == resources.KubeOneManifestSecretName && strings.HasPrefix(o.GetNamespace(), resources.KubeOneNamespacePrefix)
+		return strings.HasPrefix(o.GetName(), resources.KubeOneManifestSecretPrefix) && strings.HasPrefix(o.GetNamespace(), resources.KubeOneNamespacePrefix)
 	})
 }
 
@@ -657,7 +657,7 @@ func (r *reconciler) CreateOrUpdateKubeconfigSecretForCluster(ctx context.Contex
 
 	return &providerconfig.GlobalSecretKeySelector{
 		ObjectReference: corev1.ObjectReference{
-			Name:      resources.KubeOneKubeconfigSecretName,
+			Name:      resources.ExternalClusterKubeconfigPrefix,
 			Namespace: namespace,
 		},
 	}, nil
@@ -665,7 +665,7 @@ func (r *reconciler) CreateOrUpdateKubeconfigSecretForCluster(ctx context.Contex
 
 func kubeconfigSecretReconcilerFactory(cluster *kubermaticv1.ExternalCluster, secretData map[string][]byte) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return resources.KubeOneKubeconfigSecretName, func(existing *corev1.Secret) (*corev1.Secret, error) {
+		return resources.ExternalClusterKubeconfigPrefix, func(existing *corev1.Secret) (*corev1.Secret, error) {
 			if existing.Labels == nil {
 				existing.Labels = map[string]string{}
 			}

--- a/pkg/provider/kubernetes/external_cluster.go
+++ b/pkg/provider/kubernetes/external_cluster.go
@@ -473,7 +473,7 @@ func (p *ExternalClusterProvider) GetMasterClient() ctrlruntimeclient.Client {
 }
 
 func (p *ExternalClusterProvider) CreateOrUpdateKubeOneManifestSecret(ctx context.Context, encodedManifest string, externalCluster *kubermaticv1.ExternalCluster) error {
-	secretName := resources.KubeOneManifestSecretName
+	secretName := resources.KubeOneManifestSecretPrefix
 	manifest, err := base64.StdEncoding.DecodeString(encodedManifest)
 	if err != nil {
 		return fmt.Errorf("failed to decode kubeone manifest: %w", err)
@@ -494,7 +494,7 @@ func (p *ExternalClusterProvider) CreateOrUpdateKubeOneManifestSecret(ctx contex
 }
 
 func (p *ExternalClusterProvider) CreateOrUpdateKubeOneSSHSecret(ctx context.Context, sshKey apiv2.KubeOneSSHKey, externalCluster *kubermaticv1.ExternalCluster) error {
-	secretName := resources.KubeOneSSHSecretName
+	secretName := resources.KubeOneSSHSecretPrefix
 	privateKey, err := base64.StdEncoding.DecodeString(sshKey.PrivateKey)
 	if err != nil {
 		return fmt.Errorf("failed to decode kubeone ssh key: %w", err)

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -612,12 +612,13 @@ const (
 )
 
 const (
+	ExternalClusterKubeconfigPrefix = "kubeconfig-external-cluster"
 	// KubeOneNamespacePrefix is the kubeone namespace prefix.
-	KubeOneNamespacePrefix = "kubeone-"
-	// KubeOne secret names.
-	KubeOneSSHSecretName        = "ssh"
-	KubeOneManifestSecretName   = "manifest"
-	KubeOneKubeconfigSecretName = "kubeconfig"
+	KubeOneNamespacePrefix = "kubeone"
+	// KubeOne secret prefixes.
+	// don't change this as these prefixes are used for rbac generation.
+	KubeOneSSHSecretPrefix      = "ssh-kubeone-external-cluster"
+	KubeOneManifestSecretPrefix = "manifest-kubeone-external-cluster"
 	// KubOne ConfigMap name.
 	KubeOneScriptConfigMapName = "kubeone"
 	// KubeOne secret keys.


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: Rename kubeone secrets to make them more general and add secret name methods

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
