### PR TITLE
Fix: AWS security group propagation for initial machines

### DIFF
--- a/pkg/machine/provider/aws.go
+++ b/pkg/machine/provider/aws.go
@@ -181,7 +181,16 @@ func CompleteAWSProviderSpec(config *aws.RawConfig, cluster *kubermaticv1.Cluste
 			config.InstanceProfile.Value = cluster.Spec.Cloud.AWS.InstanceProfileName
 		}
 
-		if len(config.SecurityGroupIDs) == 0 {
+		securityGroupIDExists := false
+		// Check if a valid SecurityGroupID exists.
+		for _, sec := range config.SecurityGroupIDs {
+			if !IsConfigVarStringEmpty(sec) {
+				securityGroupIDExists = true
+				break
+			}
+		}
+
+		if !securityGroupIDExists {
 			config.SecurityGroupIDs = []providerconfig.ConfigVarString{{
 				Value: cluster.Spec.Cloud.AWS.SecurityGroupID,
 			}}

--- a/pkg/machine/provider/helpers.go
+++ b/pkg/machine/provider/helpers.go
@@ -58,3 +58,23 @@ func mergeTags(existing []providerconfig.ConfigVarString, newTags []string) []pr
 
 	return existing
 }
+
+func IsConfigVarStringEmpty(val providerconfig.ConfigVarString) bool {
+	// Check if SecretKeyRef is empty.
+	if val.SecretKeyRef.ObjectReference.Namespace != "" ||
+		val.SecretKeyRef.ObjectReference.Name != "" ||
+		val.SecretKeyRef.Key != "" {
+		return false
+	}
+	// Check if ConfigMapKeyRef is empty.
+	if val.ConfigMapKeyRef.ObjectReference.Namespace != "" ||
+		val.ConfigMapKeyRef.ObjectReference.Name != "" ||
+		val.ConfigMapKeyRef.Key != "" {
+		return false
+	}
+	// Check if Value is empty.
+	if val.Value != "" {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
This fixes an issue where security groups were not being properly configured/assigned for the inital machine deployments. The problem was that a slice of [ConfigVarString](https://github.com/kubermatic/machine-controller/blob/main/pkg/providerconfig/types/types.go#L164) was being initialized with an empty string instead of `nil`. With these changes, we do a deep check to properly check if a ConfigVarString is empty or not.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
