### PR TITLE
Revert "Do not use spot instances (during Black Friday week) (#11395)"

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -106,7 +106,7 @@ func (s *awsScenario) MachineDeployments(ctx context.Context, num int, secrets t
 			WithDiskType(awsVolumeType).
 			WithAvailabilityZone(*subnet.AvailabilityZone).
 			WithSubnetID(*subnet.SubnetId).
-			// WithSpotInstanceMaxPrice("0.5").
+			WithSpotInstanceMaxPrice("0.5").
 			Build()
 
 		md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts commit 2630426a765d89b174f1962e1c500174429a5f4b. Black Friday / Cyber Monday is over, we should move back to spot instances for CI cost optimisation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
