### PR TITLE
[release/v2.21] Add option to set cluster autoscaler annotation on MD through API 

### DIFF
--- a/cmd/kubermatic-api/swagger.json
+++ b/cmd/kubermatic-api/swagger.json
@@ -29575,6 +29575,16 @@
           "type": "boolean",
           "x-go-name": "DynamicConfig"
         },
+        "maxReplicas": {
+          "type": "integer",
+          "format": "uint32",
+          "x-go-name": "MaxReplicas"
+        },
+        "minReplicas": {
+          "type": "integer",
+          "format": "uint32",
+          "x-go-name": "MinReplicas"
+        },
         "paused": {
           "type": "boolean",
           "x-go-name": "Paused"

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -2477,6 +2477,10 @@ type NodeDeploymentSpec struct {
 	// Only supported for nodes with Kubernetes 1.23 or less.
 	// required: false
 	DynamicConfig *bool `json:"dynamicConfig,omitempty"`
+	// required: false
+	MinReplicas *uint32 `json:"minReplicas,omitempty"`
+	// required: false
+	MaxReplicas *uint32 `json:"maxReplicas,omitempty"`
 }
 
 // Event is a report of an event somewhere in the cluster.

--- a/pkg/resources/machine/machinedeployment.go
+++ b/pkg/resources/machine/machinedeployment.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 
 	semverlib "github.com/Masterminds/semver/v3"
@@ -39,6 +40,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+const (
+	AutoscalerMinSizeAnnotation = "cluster.k8s.io/cluster-api-autoscaler-node-group-min-size"
+	AutoscalerMaxSizeAnnotation = "cluster.k8s.io/cluster-api-autoscaler-node-group-max-size"
 )
 
 // Deployment returns a Machine Deployment object for the given Node Deployment spec.
@@ -86,6 +92,24 @@ func Deployment(c *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kubermati
 	// Create a copy to avoid changing the ND when changing the MD
 	replicas := nd.Spec.Replicas
 	md.Spec.Replicas = &replicas
+
+	// Set autoscaler min and max replicas if present
+	if md.Annotations == nil {
+		md.Annotations = map[string]string{}
+	}
+	max := nd.Spec.MaxReplicas
+	if max != nil {
+		md.Annotations[AutoscalerMaxSizeAnnotation] = strconv.Itoa(int(*max))
+	} else {
+		delete(md.Annotations, AutoscalerMaxSizeAnnotation)
+	}
+
+	min := nd.Spec.MinReplicas
+	if min != nil {
+		md.Annotations[AutoscalerMinSizeAnnotation] = strconv.Itoa(int(*min))
+	} else {
+		delete(md.Annotations, AutoscalerMinSizeAnnotation)
+	}
 
 	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet
 

--- a/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
+++ b/pkg/test/e2e/utils/apiclient/models/node_deployment_spec.go
@@ -22,6 +22,12 @@ type NodeDeploymentSpec struct {
 	// Only supported for nodes with Kubernetes 1.23 or less.
 	DynamicConfig bool `json:"dynamicConfig,omitempty"`
 
+	// max replicas
+	MaxReplicas uint32 `json:"maxReplicas,omitempty"`
+
+	// min replicas
+	MinReplicas uint32 `json:"minReplicas,omitempty"`
+
 	// paused
 	Paused bool `json:"paused,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:
this is a cherrypick from https://github.com/kubermatic/dashboard/pull/5361

**What type of PR is this?**
/kind feature
/kind api-change
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added the option to set autoscaler min and max replicas for a machine deployment through the KKP API. They are only relevant if the autoscaler addon is installed.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
