### PR TITLE
KubeVirt switch CI to DC.. cleanup phase

### DIFF
--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -17,7 +17,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-kubevirt-dc: "true"
+      preset-kubevirt: "true"
       preset-vault: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
@@ -60,7 +60,7 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-kubevirt-dc: "true"
+      preset-kubevirt: "true"
       preset-vault: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Now that all repos have been tested and everything is OK for the switch of KubeVirt CI to our DC, here is the cleanup phase.

- I have updated the existing `preset-kubevirt` with the DC credentials.
- I can now switch back to `preset-kubevirt` that targets Kv cluster in our DC in all repos.
- I will then delete `preset-kubevirt-dc` from the infra repo.

In the vault:
- e2e-kubevirt now contains the DC credentials
- e2e-kubevirt-legacy contains the Equinix credentials.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
