### PR TITLE
[release/v2.21] Increase timeout on e2e azure sizes API call

### DIFF
--- a/pkg/test/e2e/utils/client.go
+++ b/pkg/test/e2e/utils/client.go
@@ -1715,10 +1715,10 @@ func (r *TestClient) ListDOSizes(credential string) (*models.DigitaloceanSizeLis
 
 // ListAzureSizes returns list Azure sizes.
 func (r *TestClient) ListAzureSizes(credential, location string) (models.AzureSizeList, error) {
-	params := &azure.ListAzureSizesParams{
-		Credential: &credential,
-		Location:   &location,
-	}
+	params := azure.NewListAzureSizesParamsWithTimeout(time.Second * 30)
+	params.Credential = &credential
+	params.Location = &location
+
 	SetupRetryParams(r.test, params, Backoff{
 		Duration: 1 * time.Second,
 		Steps:    4,


### PR DESCRIPTION
**What this PR does / why we need it**:
Increases timeout on this API call during e2e testing because it frequently times out. Manual cherry-pick of https://github.com/kubermatic/dashboard/pull/5404.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind flake

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
