### PR TITLE
Add support for Kubernetes v1.23.15, v1.24.9 and v1.25.5

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.24.8
+    default: v1.24.9
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -562,11 +562,14 @@ spec:
       - v1.23.9
       - v1.23.12
       - v1.23.14
+      - v1.23.15
       - v1.24.3
       - v1.24.6
       - v1.24.8
+      - v1.24.9
       - v1.25.2
       - v1.25.4
+      - v1.25.5
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -464,7 +464,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.24.8
+    default: v1.24.9
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -562,11 +562,14 @@ spec:
       - v1.23.9
       - v1.23.12
       - v1.23.14
+      - v1.23.15
       - v1.24.3
       - v1.24.6
       - v1.24.8
+      - v1.24.9
       - v1.25.2
       - v1.25.4
+      - v1.25.5
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.24.8"),
+		Default: semver.NewSemverOrDie("v1.24.9"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -230,13 +230,16 @@ var (
 			newSemver("v1.23.9"),
 			newSemver("v1.23.12"),
 			newSemver("v1.23.14"),
+			newSemver("v1.23.15"),
 			// Kubernetes 1.24
 			newSemver("v1.24.3"),
 			newSemver("v1.24.6"),
 			newSemver("v1.24.8"),
+			newSemver("v1.24.9"),
 			// Kubernetes 1.25
 			newSemver("v1.25.2"),
 			newSemver("v1.25.4"),
+			newSemver("v1.25.5"),
 		},
 		Updates: []kubermaticv1.Update{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds Kubernetes versions released yesterday.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Kubernetes v1.23.15, v1.24.9 and v1.25.5
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
