### PR TITLE
[release/v2.20] Add support for Kubernetes v1.22.17 and v1.23.15

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -321,7 +321,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.22.16"
+          value: "v1.22.17"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -363,7 +363,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -406,7 +406,7 @@ presubmits:
         - name: ONLY_TEST_CREATION
           value: "true"
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: SERVICE_ACCOUNT_KEY
@@ -451,7 +451,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: DISTRIBUTIONS
           value: ubuntu
         - name: PROVIDER
@@ -497,7 +497,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -540,7 +540,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "gcp"
         - name: DISTRIBUTIONS
@@ -588,7 +588,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: DISTRIBUTIONS
           value: centos
         - name: PROVIDER
@@ -631,7 +631,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "packet"
         - name: DISTRIBUTIONS
@@ -674,7 +674,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "kubevirt"
         - name: DISTRIBUTIONS
@@ -717,7 +717,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "hetzner"
         - name: DISTRIBUTIONS
@@ -762,7 +762,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "openstack"
         - name: DISTRIBUTIONS
@@ -807,7 +807,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "openstack"
         - name: DEFAULT_TIMEOUT_MINUTES
@@ -852,7 +852,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -896,7 +896,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -942,7 +942,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "vsphere"
         - name: DISTRIBUTIONS
@@ -988,7 +988,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "nutanix"
         - name: DISTRIBUTIONS
@@ -1032,7 +1032,7 @@ presubmits:
         - name: KUBERMATIC_EDITION
           value: ee
         - name: VERSIONS_TO_TEST
-          value: "v1.23.14"
+          value: "v1.23.15"
         - name: PROVIDER
           value: "nutanix"
         - name: DISTRIBUTIONS
@@ -1081,7 +1081,7 @@ presubmits:
         - "./hack/ci/run-api-e2e.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.23.14
+          value: v1.23.15
         - name: KUBERMATIC_EDITION
           value: ee
         - name: SERVICE_ACCOUNT_KEY
@@ -1121,7 +1121,7 @@ presubmits:
         - "./hack/ci/run-etcd-launcher-tests.sh"
         env:
         - name: VERSION_TO_TEST
-          value: v1.23.14
+          value: v1.23.15
         - name: KUBERMATIC_EDITION
           value: ee
         - name: SERVICE_ACCOUNT_KEY
@@ -1189,7 +1189,7 @@ presubmits:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.23.14
+              value: v1.23.15
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY
@@ -1318,7 +1318,7 @@ presubmits:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
             - name: VERSION_TO_TEST
-              value: v1.23.14
+              value: v1.23.15
             - name: KUBERMATIC_EDITION
               value: ee
             - name: SERVICE_ACCOUNT_KEY

--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -514,9 +514,11 @@ spec:
       - v1.22.9
       - v1.22.15
       - v1.22.16
+      - v1.22.17
       - v1.23.6
       - v1.23.12
       - v1.23.14
+      - v1.23.15
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -219,10 +219,12 @@ var (
 			newSemver("v1.22.9"),
 			newSemver("v1.22.15"),
 			newSemver("v1.22.16"),
+			newSemver("v1.22.17"),
 			// Kubernetes 1.23
 			newSemver("v1.23.6"),
 			newSemver("v1.23.12"),
 			newSemver("v1.23.14"),
+			newSemver("v1.23.15"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.19 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for Kubernetes patch releases from December 8. Manual cherry-pick of #11553.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Kubernetes v1.22.17 and v1.23.15
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
