### PR TITLE
Cleanup k8s dashboard resources in usercluster if the dashboard is disabled

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -280,6 +280,12 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
+	if !data.kubernetesDashboardEnabled {
+		if err := r.ensureKubernetesDashboardResourcesAreRemoved(ctx); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -1364,6 +1370,16 @@ func (r *reconciler) ensureOSMResourcesAreRemoved(ctx context.Context) error {
 		err := r.Client.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure OSM resources are removed/not present: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Context) error {
+	for _, resource := range kubernetesdashboard.ResourcesForDeletion() {
+		err := r.Client.Delete(ctx, resource)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to ensure Kubernetes Dashboard resources are removed/not present: %w", err)
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Cleans up k8s dashboard resources in the user cluster if the k8s dashboard is disabled.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11573 

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Properly clean up k8s dashboard resources in the user cluster if the k8s dashboard is disabled.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
