### PR TITLE
Add conformance-tester tests for k8s.gcr.io images

### DIFF
--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -565,6 +565,15 @@ func (r *TestRunner) testCluster(
 		log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
 	}
 
+	// Check for Pods with k8s.gcr.io images on user cluster
+	if err := util.JUnitWrapper("[KKP] Test container images not containing k8s.gcr.io on user cluster", report, func() error {
+		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
+			return tests.TestUserClusterNoK8sGcrImages(ctx, log, r.opts, cluster, userClusterClient)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify that no user cluster containers has k8s.gcr.io image: %v", err)
+	}
+
 	// Check security context (seccomp profiles) for control plane pods running on seed cluster
 	if err := util.JUnitWrapper("[KKP] Test pod security context on seed cluster", report, func() error {
 		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
@@ -572,6 +581,15 @@ func (r *TestRunner) testCluster(
 		})
 	}); err != nil {
 		log.Errorf("failed to verify security context for control plane pods: %v", err)
+	}
+
+	// Check for Pods with k8s.gcr.io images on user cluster
+	if err := util.JUnitWrapper("[KKP] Test container images not containing k8s.gcr.io on seed cluster", report, func() error {
+		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
+			return tests.TestNoK8sGcrImages(ctx, log, r.opts, cluster)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify that no seed cluster containers has k8s.gcr.io image: %v", err)
 	}
 
 	// Check telemetry is working

--- a/cmd/conformance-tester/pkg/tests/images.go
+++ b/cmd/conformance-tester/pkg/tests/images.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster) error {
+	if !opts.Tests.Has(ctypes.K8sGcrImageTests) {
+		log.Info("Tests for k8s.gcr.io disabled, skipping.")
+		return nil
+	}
+
+	log.Infof("Testing ...")
+
+	pods := &corev1.PodList{}
+
+	if err := opts.SeedClusterClient.List(ctx, pods, &ctrlruntimeclient.ListOptions{Namespace: cluster.Status.NamespaceName}); err != nil {
+		return fmt.Errorf("failed to list control plane pods: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no control plane pods found")
+	}
+
+	errors := []string{}
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+
+		for _, initContainer := range pod.Spec.InitContainers {
+			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(strings.Join(errors, "\n"))
+}

--- a/cmd/conformance-tester/pkg/tests/images.go
+++ b/cmd/conformance-tester/pkg/tests/images.go
@@ -37,7 +37,7 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 		return nil
 	}
 
-	log.Infof("Testing ...")
+	log.Infof("Testing that no k8s.gcr.io images exist in control plane ...")
 
 	pods := &corev1.PodList{}
 

--- a/cmd/conformance-tester/pkg/tests/images.go
+++ b/cmd/conformance-tester/pkg/tests/images.go
@@ -53,7 +53,7 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
-			if !strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
 				errors = append(
 					errors,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
@@ -62,7 +62,7 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 		}
 
 		for _, initContainer := range pod.Spec.InitContainers {
-			if !strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
 				errors = append(
 					errors,
 					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),

--- a/cmd/conformance-tester/pkg/tests/images.go
+++ b/cmd/conformance-tester/pkg/tests/images.go
@@ -53,7 +53,7 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 
 	for _, pod := range pods.Items {
 		for _, container := range pod.Spec.Containers {
-			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+			if !strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
 				errors = append(
 					errors,
 					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
@@ -62,7 +62,7 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 		}
 
 		for _, initContainer := range pod.Spec.InitContainers {
-			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+			if !strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
 				errors = append(
 					errors,
 					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),

--- a/cmd/conformance-tester/pkg/tests/usercluster_controller.go
+++ b/cmd/conformance-tester/pkg/tests/usercluster_controller.go
@@ -205,7 +205,6 @@ func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, 
 	}
 
 	return fmt.Errorf(strings.Join(errors, "\n"))
-
 }
 
 func rbacResourceNames() []string {

--- a/cmd/conformance-tester/pkg/tests/usercluster_controller.go
+++ b/cmd/conformance-tester/pkg/tests/usercluster_controller.go
@@ -165,6 +165,49 @@ func TestUserClusterSeccompProfiles(ctx context.Context, log *zap.SugaredLogger,
 	return fmt.Errorf(strings.Join(errors, "\n"))
 }
 
+func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client) error {
+	if !opts.Tests.Has(ctypes.UserClusterSeccompTests) {
+		log.Info("User cluster Seccomp tests disabled, skipping.")
+		return nil
+	}
+
+	pods := &corev1.PodList{}
+
+	errors := []string{}
+
+	// get all Pods running on the cluster
+	if err := userClusterClient.List(ctx, pods, &ctrlruntimeclient.ListOptions{Namespace: ""}); err != nil {
+		return fmt.Errorf("failed to list Pods in user cluster: %w", err)
+	}
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+
+		for _, initContainer := range pod.Spec.InitContainers {
+			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(strings.Join(errors, "\n"))
+
+}
+
 func rbacResourceNames() []string {
 	return []string{rbacusercluster.ResourceOwnerName, rbacusercluster.ResourceEditorName, rbacusercluster.ResourceViewerName}
 }

--- a/cmd/conformance-tester/pkg/types/tests.go
+++ b/cmd/conformance-tester/pkg/types/tests.go
@@ -19,14 +19,16 @@ package types
 import "k8s.io/apimachinery/pkg/util/sets"
 
 const (
-	ConformanceTests        = "conformance"
-	LoadbalancerTests       = "loadbalancer"
-	StorageTests            = "storage"
-	MetricsTests            = "metrics"
-	SecurityContextTests    = "securitycontext"
-	TelemetryTests          = "telemetry"
-	UserClusterRBACTests    = "usercluster-rbac"
-	UserClusterSeccompTests = "usercluster-seccomp"
+	ConformanceTests            = "conformance"
+	LoadbalancerTests           = "loadbalancer"
+	StorageTests                = "storage"
+	MetricsTests                = "metrics"
+	SecurityContextTests        = "securitycontext"
+	TelemetryTests              = "telemetry"
+	K8sGcrImageTests            = "gcr-images"
+	UserClusterRBACTests        = "usercluster-rbac"
+	UserClusterSeccompTests     = "usercluster-seccomp"
+	UserClusterK8sGcrImageTests = "usercluster-gcr-images"
 )
 
 var AllTests = sets.NewString(
@@ -36,6 +38,8 @@ var AllTests = sets.NewString(
 	MetricsTests,
 	SecurityContextTests,
 	TelemetryTests,
+	K8sGcrImageTests,
 	UserClusterRBACTests,
 	UserClusterSeccompTests,
+	UserClusterK8sGcrImageTests,
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
We removed `k8s.gcr.io` images, however we tend to forget about this kind of stuff over time, so I would like to add this test in our e2e to make sure we don't re-add `k8s.gcr.io` images in the future.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
