### PR TITLE
Set default value for nodePortsAllowedIPRanges in cloud spec

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -75,7 +75,7 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 
 	// Give cloud providers a chance to default their spec.
 	if cloudProvider != nil {
-		if err := cloudProvider.DefaultCloudSpec(ctx, &spec.Cloud); err != nil {
+		if err := cloudProvider.DefaultCloudSpec(ctx, spec); err != nil {
 			return fmt.Errorf("failed to default cloud spec: %w", err)
 		}
 	}

--- a/pkg/provider/cloud/alibaba/provider.go
+++ b/pkg/provider/cloud/alibaba/provider.go
@@ -45,7 +45,7 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 	}, nil
 }
 
-func (a *Alibaba) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (a *Alibaba) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/anexia/provider.go
+++ b/pkg/provider/cloud/anexia/provider.go
@@ -45,7 +45,7 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 	}, nil
 }
 
-func (a *Anexia) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (a *Anexia) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/bringyourown/provider.go
+++ b/pkg/provider/cloud/bringyourown/provider.go
@@ -32,7 +32,7 @@ func NewCloudProvider() provider.CloudProvider {
 
 var _ provider.ReconcilingCloudProvider = &bringyourown{}
 
-func (b *bringyourown) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (b *bringyourown) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/digitalocean/provider.go
+++ b/pkg/provider/cloud/digitalocean/provider.go
@@ -42,7 +42,7 @@ func NewCloudProvider(secretKeyGetter provider.SecretKeySelectorValueFunc) provi
 
 var _ provider.CloudProvider = &digitalocean{}
 
-func (do *digitalocean) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.CloudSpec) error {
+func (do *digitalocean) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/fake/provider.go
+++ b/pkg/provider/cloud/fake/provider.go
@@ -32,7 +32,7 @@ func NewCloudProvider() provider.CloudProvider {
 
 var _ provider.CloudProvider = &fakeCloudProvider{}
 
-func (p *fakeCloudProvider) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (p *fakeCloudProvider) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/gcp/provider.go
+++ b/pkg/provider/cloud/gcp/provider.go
@@ -114,7 +114,20 @@ func (g *gcp) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluste
 }
 
 // DefaultCloudSpec adds defaults to the cloud spec.
-func (g *gcp) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.CloudSpec) error {
+func (g *gcp) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec) error {
+	if spec.Cloud.GCP == nil {
+		return errors.New("no GCP cloud spec found")
+	}
+	switch spec.ClusterNetwork.IPFamily {
+	case kubermaticv1.IPFamilyIPv4:
+		spec.Cloud.GCP.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
+		}
+	case kubermaticv1.IPFamilyDualStack:
+		spec.Cloud.GCP.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+		}
+	}
 	return nil
 }
 

--- a/pkg/provider/cloud/hetzner/provider.go
+++ b/pkg/provider/cloud/hetzner/provider.go
@@ -43,7 +43,7 @@ func NewCloudProvider(secretKeyGetter provider.SecretKeySelectorValueFunc) provi
 var _ provider.CloudProvider = &hetzner{}
 
 // DefaultCloudSpec.
-func (h *hetzner) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (h *hetzner) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -62,17 +62,17 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 
 var _ provider.ReconcilingCloudProvider = &kubevirt{}
 
-func (k *kubevirt) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.CloudSpec) error {
-	if spec.Kubevirt == nil {
+func (k *kubevirt) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec) error {
+	if spec.Cloud.Kubevirt == nil {
 		return errors.New("KubeVirt cloud provider spec is empty")
 	}
 
-	client, err := k.GetClientForCluster(*spec)
+	client, err := k.GetClientForCluster(spec.Cloud)
 	if err != nil {
 		return err
 	}
 
-	return updateInfraStorageClassesInfo(ctx, client, spec)
+	return updateInfraStorageClassesInfo(ctx, client, &spec.Cloud)
 }
 
 func (k *kubevirt) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.CloudSpec) error {

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -94,11 +94,11 @@ func (n *Nutanix) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv
 	})
 }
 
-func (n *Nutanix) DefaultCloudSpec(_ context.Context, spec *kubermaticv1.CloudSpec) error {
+func (n *Nutanix) DefaultCloudSpec(_ context.Context, spec *kubermaticv1.ClusterSpec) error {
 	// default csi
-	if spec.Nutanix.CSI != nil {
-		if spec.Nutanix.CSI.Port == nil {
-			spec.Nutanix.CSI.Port = pointer.Int32(9440)
+	if spec.Cloud.Nutanix.CSI != nil {
+		if spec.Cloud.Nutanix.CSI.Port == nil {
+			spec.Cloud.Nutanix.CSI.Port = pointer.Int32(9440)
 		}
 	}
 

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -95,7 +95,20 @@ func NewCloudProvider(
 var _ provider.CloudProvider = &Provider{}
 
 // DefaultCloudSpec adds defaults to the cloud spec.
-func (os *Provider) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.CloudSpec) error {
+func (os *Provider) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec) error {
+	if spec.Cloud.Openstack == nil {
+		return errors.New("no Openstack cloud spec found")
+	}
+	switch spec.ClusterNetwork.IPFamily {
+	case kubermaticv1.IPFamilyIPv4:
+		spec.Cloud.Openstack.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
+		}
+	case kubermaticv1.IPFamilyDualStack:
+		spec.Cloud.Openstack.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+		}
+	}
 	return nil
 }
 

--- a/pkg/provider/cloud/packet/provider.go
+++ b/pkg/provider/cloud/packet/provider.go
@@ -51,7 +51,7 @@ func NewCloudProvider(secretKeyGetter provider.SecretKeySelectorValueFunc) provi
 var _ provider.CloudProvider = &packet{}
 
 // DefaultCloudSpec adds defaults to the CloudSpec.
-func (p *packet) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (p *packet) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/vmwareclouddirector/provider.go
+++ b/pkg/provider/cloud/vmwareclouddirector/provider.go
@@ -53,7 +53,7 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 
 var _ provider.ReconcilingCloudProvider = &Provider{}
 
-func (p *Provider) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.CloudSpec) error {
+func (p *Provider) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) error {
 	return nil
 }
 

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -247,9 +247,9 @@ func GetVMFolders(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere, u
 }
 
 // DefaultCloudSpec adds defaults to the cloud spec.
-func (v *Provider) DefaultCloudSpec(_ context.Context, spec *kubermaticv1.CloudSpec) error {
-	if spec.VSphere.TagCategoryID == "" {
-		spec.VSphere.TagCategoryID = v.dc.DefaultTagCategoryID
+func (v *Provider) DefaultCloudSpec(_ context.Context, spec *kubermaticv1.ClusterSpec) error {
+	if spec.Cloud.VSphere.TagCategoryID == "" {
+		spec.Cloud.VSphere.TagCategoryID = v.dc.DefaultTagCategoryID
 	}
 
 	return nil

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -72,7 +72,7 @@ type SeedClientGetter = func(seed *kubermaticv1.Seed) (ctrlruntimeclient.Client,
 type CloudProvider interface {
 	InitializeCloudProvider(context.Context, *kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
 	CleanUpCloudProvider(context.Context, *kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
-	DefaultCloudSpec(context.Context, *kubermaticv1.CloudSpec) error
+	DefaultCloudSpec(context.Context, *kubermaticv1.ClusterSpec) error
 	ValidateCloudSpec(context.Context, kubermaticv1.CloudSpec) error
 	ValidateCloudSpecUpdate(ctx context.Context, oldSpec kubermaticv1.CloudSpec, newSpec kubermaticv1.CloudSpec) error
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -1744,19 +1744,12 @@ func GetClusterNodeCIDRMaskSizeIPv6(cluster *kubermaticv1.Cluster) int32 {
 // GetNodePortsAllowedIPRanges returns effective CIDR range to be used for NodePort services for the given cluster
 // and provided allowed IP ranges coming from provider-specific API.
 func GetNodePortsAllowedIPRanges(cluster *kubermaticv1.Cluster, allowedIPRanges *kubermaticv1.NetworkRanges, allowedIPRange string) (res kubermaticv1.NetworkRanges) {
-	var ipRangesMap []string
 	if allowedIPRanges != nil {
-		ipRangesMap = allowedIPRanges.CIDRBlocks
+		res.CIDRBlocks = allowedIPRanges.CIDRBlocks
 	}
-
-	if allowedIPRange != "" {
-		for _, cidr := range allowedIPRanges.CIDRBlocks {
-			if cidr != allowedIPRange {
-				ipRangesMap = append(ipRangesMap, allowedIPRange)
-			}
-		}
+	if allowedIPRange != "" && !containsString(allowedIPRanges.CIDRBlocks, allowedIPRange) {
+		res.CIDRBlocks = append(res.CIDRBlocks, allowedIPRange)
 	}
-	res.CIDRBlocks = append(res.CIDRBlocks, ipRangesMap...)
 
 	if len(res.CIDRBlocks) == 0 {
 		if cluster.IsIPv4Only() || cluster.IsDualStack() {
@@ -1818,4 +1811,13 @@ func GetKubeletPreferredAddressTypes(cluster *kubermaticv1.Cluster, isKonnectivi
 		return "InternalIP,ExternalIP"
 	}
 	return "ExternalIP,InternalIP"
+}
+
+func containsString(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -1744,12 +1744,20 @@ func GetClusterNodeCIDRMaskSizeIPv6(cluster *kubermaticv1.Cluster) int32 {
 // GetNodePortsAllowedIPRanges returns effective CIDR range to be used for NodePort services for the given cluster
 // and provided allowed IP ranges coming from provider-specific API.
 func GetNodePortsAllowedIPRanges(cluster *kubermaticv1.Cluster, allowedIPRanges *kubermaticv1.NetworkRanges, allowedIPRange string) (res kubermaticv1.NetworkRanges) {
+	var ipRangesMap []string
 	if allowedIPRanges != nil {
-		res.CIDRBlocks = append(res.CIDRBlocks, allowedIPRanges.CIDRBlocks...)
+		ipRangesMap = allowedIPRanges.CIDRBlocks
 	}
+
 	if allowedIPRange != "" {
-		res.CIDRBlocks = append(res.CIDRBlocks, allowedIPRange)
+		for _, cidr := range allowedIPRanges.CIDRBlocks {
+			if cidr != allowedIPRange {
+				ipRangesMap = append(ipRangesMap, allowedIPRange)
+			}
+		}
 	}
+	res.CIDRBlocks = append(res.CIDRBlocks, ipRangesMap...)
+
 	if len(res.CIDRBlocks) == 0 {
 		if cluster.IsIPv4Only() || cluster.IsDualStack() {
 			res.CIDRBlocks = append(res.CIDRBlocks, IPv4MatchAnyCIDR)

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -76,7 +76,6 @@ func newAlibabaTestJig(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogg
 func newAWSTestJig(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *jig.TestJig {
 	jig := jig.NewAWSCluster(seedClient, log, awsCredentials, 1, nil)
 	jig.ClusterJig.WithPatch(func(c *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
-		c.Cloud.AWS.NodePortsAllowedIPRange = "0.0.0.0/0"
 		return c
 	})
 	jig.MachineJig.WithCloudProviderSpecPatch(func(providerSpec interface{}) interface{} {
@@ -118,7 +117,6 @@ func newHetznerTestJig(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogg
 func newOpenstackTestJig(seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) *jig.TestJig {
 	jig := jig.NewOpenstackCluster(seedClient, log, openstackCredentials, 1)
 	jig.ClusterJig.WithPatch(func(c *kubermaticv1.ClusterSpec) *kubermaticv1.ClusterSpec {
-		c.Cloud.Openstack.NodePortsAllowedIPRange = "0.0.0.0/0"
 		c.Cloud.Openstack.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
 			CIDRBlocks: []string{"0.0.0.0/0", "::/0"},
 		}


### PR DESCRIPTION
Signed-off-by: Sachin Tiptur <sachin@kubermatic.com>

**What this PR does / why we need it**:
This PR sets the `nodePortsAllowedIPRanges` default value in cluster cloud spec. This is supported only in AWS,Azure,GCP and Openstack cloud providers. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #[5376](https://github.com/kubermatic/dashboard/issues/5376)

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
