### PR TITLE
WIP: Add kubevirt vmi eviction controller

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -103,6 +103,7 @@ type controllerRunOptions struct {
 	konnectivityServerHost            string
 	konnectivityServerPort            int
 	applicationCache                  string
+	kubevirtInfraKubeconfigPath       string
 }
 
 func main() {
@@ -149,6 +150,7 @@ func main() {
 	flag.StringVar(&runOp.konnectivityServerHost, "konnectivity-server-host", "", "Konnectivity Server host.")
 	flag.IntVar(&runOp.konnectivityServerPort, "konnectivity-server-port", 6443, "Konnectivity Server port.")
 	flag.StringVar(&runOp.applicationCache, "application-cache", "", "Path to Application cache directory.")
+	flag.StringVar(&runOp.kubevirtInfraKubeconfigPath, "kubevirt-infra-kubeconfig", "", "Path to kubevirt infra kubeconfig.")
 	flag.Parse()
 
 	rawLog := kubermaticlog.New(logOpts.Debug, logOpts.Format)
@@ -406,7 +408,7 @@ func main() {
 	}
 	log.Info("Registered Resource Usage controller")
 
-	if err := kubevirtvmievictioncontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, runOp.clusterName); err != nil {
+	if err := kubevirtvmievictioncontroller.Add(rootCtx, log, mgr, runOp.kubevirtInfraKubeconfigPath, runOp.clusterName, isPausedChecker); err != nil {
 		log.Fatalw("Failed to add Kubevirt VMI eviction controller to mgr", zap.Error(err))
 	}
 

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -37,6 +37,7 @@ import (
 	constraintsyncer "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/constraint-syncer"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/flatcar"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/ipam"
+	kubevirtvmievictioncontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller"
 	nodelabeler "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler"
 	nodeversioncontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-version-controller"
 	ownerbindingcreator "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/owner-binding-creator"
@@ -404,6 +405,10 @@ func main() {
 		log.Fatalw("Failed to add user Resource Usage controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered Resource Usage controller")
+
+	if err := kubevirtvmievictioncontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, runOp.clusterName); err != nil {
+		log.Fatalw("Failed to add Kubevirt VMI eviction controller to mgr", zap.Error(err))
+	}
 
 	if err := mgr.Start(rootCtx); err != nil {
 		log.Fatalw("Failed running manager", zap.Error(err))

--- a/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/OWNERS
+++ b/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+  - sig-virtualization
+
+reviewers:
+  - sig-virtualization
+
+labels:
+  - sig/virtualization
+
+options:
+  no_parent_owners: true

--- a/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/controller.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubevirtvmievictioncontroller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	"go.uber.org/zap"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	userclustercontrollermanager "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager"
+	"k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	"k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	controllerName   = "kubevirt-vmi-eviction-controller"
+	machineNamespace = "kube-system"
+)
+
+type reconciler struct {
+	log             *zap.SugaredLogger
+	infraClient     ctrlruntimeclient.Client
+	userClient      ctrlruntimeclient.Client
+	clusterIsPaused userclustercontrollermanager.IsPausedChecker
+}
+
+func Add(ctx context.Context, log *zap.SugaredLogger, seedMgr, userMgr manager.Manager, clusterIsPaused userclustercontrollermanager.IsPausedChecker, clusterName string) error {
+
+	seedClient := seedMgr.GetClient()
+	cluster := &kubermaticv1.Cluster{}
+	if err := seedClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to get cluster %q: %w", clusterName, err)
+	}
+
+	data := resources.NewTemplateDataBuilder().WithCluster(cluster).Build()
+
+	credentials, err := resources.GetCredentials(data)
+	if err != nil {
+		return fmt.Errorf("failed getting credentials: %w", err)
+	}
+	infraKubeconfig := credentials.Kubevirt.KubeConfig
+	infraClient, err := kubevirt.NewClient(infraKubeconfig, kubevirt.ClientOptions{})
+	if err != nil {
+		return fmt.Errorf("failed creating kubevirt infra client: %w", err)
+	}
+
+	r := &reconciler{
+		log:             log.Named(controllerName),
+		infraClient:     infraClient,
+		userClient:      userMgr.GetClient(),
+		clusterIsPaused: clusterIsPaused,
+	}
+
+	c, err := controller.New(controllerName, userMgr, controller.Options{Reconciler: r})
+
+	namespacePredicate := predicate.ByNamespace(cluster.Status.NamespaceName)
+
+	if err = c.Watch(&source.Kind{Type: &kubevirtv1.VirtualMachineInstance{}}, &handler.EnqueueRequestForObject{}, namespacePredicate); err != nil {
+		return fmt.Errorf("failed creating watch for kubevirt VirtualMachineInstance: %w", err)
+	}
+
+	return nil
+}
+
+func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := r.log.With("kubevirt-vmi-eviction", request)
+	log.Debug("Processing")
+
+	paused, err := r.clusterIsPaused(ctx)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
+	}
+	if paused {
+		return reconcile.Result{}, nil
+	}
+
+	vmi := &kubevirtv1.VirtualMachineInstance{}
+	if err = r.infraClient.Get(ctx, request.NamespacedName, vmi); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debug("VirtualMachineInstance not found, returning")
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("failed getting VirtualMachineInstance: %w", err)
+	}
+
+	err = r.reconcile(ctx, log, vmi)
+	if err != nil {
+		log.Errorw("ReconcilingError", zap.Error(err))
+	}
+
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, vmi *kubevirtv1.VirtualMachineInstance) error {
+
+	// If `status.evacuationNodeName` is set, trigger graceful delete of the Machine linked to this VMI
+	if vmi.Status.EvacuationNodeName != "" {
+		namepacedMachineName := types.NamespacedName{Name: vmi.Name, Namespace: machineNamespace}
+		machine := &v1alpha1.Machine{}
+		if err := r.userClient.Get(ctx, namepacedMachineName, machine); err != nil {
+			return fmt.Errorf("failed getting Machine %q: %w", vmi.Name, err)
+		}
+
+		if err := r.userClient.Delete(ctx, machine); err != nil {
+			return fmt.Errorf("failed deleting Machine %q: %w", vmi.Name, err)
+		}
+
+	}
+
+	return nil
+}

--- a/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/controller.go
@@ -121,7 +121,12 @@ func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, vmi 
 		namepacedMachineName := types.NamespacedName{Name: vmi.Name, Namespace: machineNamespace}
 		machine := &v1alpha1.Machine{}
 		if err := r.userClient.Get(ctx, namepacedMachineName, machine); err != nil {
-			return fmt.Errorf("failed getting Machine %q: %w", vmi.Name, err)
+			if apierrors.IsNotFound(err) {
+				log.Debugf("Machine %q already gone. Nothing to do here.")
+				return nil
+			} else {
+				return fmt.Errorf("failed getting Machine %q: %w", vmi.Name, err)
+			}
 		}
 
 		if err := r.userClient.Delete(ctx, machine); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/controller_test.go
@@ -1,0 +1,91 @@
+package kubevirtvmievictioncontroller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	kubevirtv1 "kubevirt.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func genVirtualMachineInstance(vmiName, evacuationNodeName string) *kubevirtv1.VirtualMachineInstance {
+	return &kubevirtv1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vmiName,
+			Namespace: fmt.Sprintf("cluster-%s", vmiName),
+		},
+		Spec: kubevirtv1.VirtualMachineInstanceSpec{},
+		Status: kubevirtv1.VirtualMachineInstanceStatus{
+			EvacuationNodeName: evacuationNodeName,
+		},
+	}
+}
+func genMachine(clusterName string) *v1alpha1.Machine {
+	return &v1alpha1.Machine{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: machineNamespace,
+		},
+	}
+}
+
+func TestReconcile(t *testing.T) {
+
+	scheme := runtime.NewScheme()
+	_ = kubevirtv1.AddToScheme(scheme)
+	_ = clusterv1alpha1.AddToScheme(scheme)
+
+	testCases := map[string]struct {
+		vmiName            string
+		evacuationNodeName string
+		expecDeleted       bool
+	}{
+		"No EvacuationNodeName: No Machine deletion": {
+			vmiName:      "test-vmi",
+			expecDeleted: false,
+		},
+		"EvacuationNodeName set: Machine deletion": {
+			vmiName:            "test-vmi",
+			evacuationNodeName: "nodeA",
+			expecDeleted:       true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+
+			r := reconciler{
+				log:         kubermaticlog.NewDefault().Sugar(),
+				infraClient: fake.NewClientBuilder().WithScheme(scheme).WithObjects(genVirtualMachineInstance(tc.vmiName, tc.evacuationNodeName)).Build(),
+				userClient:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(genMachine(tc.vmiName)).Build(),
+				clusterIsPaused: func(context.Context) (bool, error) {
+					return false, nil
+				},
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: fmt.Sprintf("cluster-%s", tc.vmiName), Name: tc.vmiName}}
+			_, err := r.Reconcile(context.Background(), request)
+			if err != nil {
+				t.Fatalf("Got err %q from Reconcile(), expected no error", err)
+			}
+
+			namepacedMachineName := types.NamespacedName{Name: tc.vmiName, Namespace: machineNamespace}
+			machine := &v1alpha1.Machine{}
+			err = r.userClient.Get(context.Background(), namepacedMachineName, machine)
+			if tc.expecDeleted && !errors.IsNotFound(err) {
+				t.Errorf("Got err %q, expected MC to be deleted", err)
+			}
+
+		})
+
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/doc.go
+++ b/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction-controller/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package kubevirtvmievictioncontroller contains a controller that implements an external eviction strategy for Kubevirt VirtualMachineInstances.
+*/
+package kubevirtvmievictioncontroller

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"path"
 	"strings"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -269,13 +270,13 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 				},
 			}
 			if kubermaticv1.ProviderType(providerName) == kubermaticv1.KubevirtCloudProvider {
-				mountPath := "/etc/kubernetes/kubevirt-infra-kubeconfig"
+				mountPath := "/etc/kubernetes/kubevirt"
 				volumeMounts = append(volumeMounts, corev1.VolumeMount{
 					Name:      resources.KubeVirtInfraSecretName,
 					MountPath: mountPath,
 					ReadOnly:  true,
 				})
-				args = append(args, "-kubevirt-infra-kubeconfig", mountPath)
+				args = append(args, "-kubevirt-infra-kubeconfig", path.Join(mountPath, resources.KubeVirtInfraSecretKey))
 			}
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:
This RP implements the external node eviction strategy for KubeVirt nodes, that we need after https://github.com/kubermatic/machine-controller/pull/1504.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11563 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
This PR is not integration tested and probably still needs some work.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt: Adding a VMI eviction controller that implements an external eviction strategy for KubeVirt nodes
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
