### PR TITLE
Stop overriding upstream chart tolerations for logging/promtail

### DIFF
--- a/charts/logging/promtail/test/default.yaml.out
+++ b/charts/logging/promtail/test/default.yaml.out
@@ -464,6 +464,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
       volumes:
         - name: config
           secret:

--- a/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ce.yaml.out
@@ -464,6 +464,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
       volumes:
         - name: config
           secret:

--- a/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
+++ b/charts/logging/promtail/test/kubermatic.example.ee.yaml.out
@@ -464,6 +464,9 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/master
           operator: Exists
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Exists
       volumes:
         - name: config
           secret:

--- a/charts/logging/promtail/values.yaml
+++ b/charts/logging/promtail/values.yaml
@@ -48,11 +48,6 @@ promtail:
       mountPath: /var/log/journal
       readOnly: true
 
-  tolerations:
-  - key: node-role.kubernetes.io/master
-    operator: Exists
-    effect: NoSchedule
-
   config:
     clients:
       - url: http://loki:3100/loki/api/v1/push


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't need to override the tolerations by default, the upstream defaults are fairly good and, more importantly, include `node-role.kubernetes.io/control-plane` by default. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11589

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Stop overriding upstream chart tolerations for logging/promtail by default, adding `node-role.kubernetes.io/control-plane` toleration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
