### PR TITLE
Make defaultDestination an optional field in the Seed

### DIFF
--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -312,7 +312,7 @@ type EtcdBackupRestore struct {
 	// DefaultDestination marks the default destination that will be used for the default etcd backup config which is
 	// created for every user cluster. Has to correspond to a destination in Destinations.
 	// If removed, it removes the related default etcd backup configs.
-	DefaultDestination string `json:"defaultDestination"`
+	DefaultDestination string `json:"defaultDestination,omitempty"`
 }
 
 // BackupDestination defines the bucket name and endpoint as a backup destination, and holds reference to the credentials secret.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -876,8 +876,6 @@ spec:
                         type: object
                       description: Destinations stores all the possible destinations where the backups for the Seed can be stored. If not empty, it enables automatic backup and restore for the seed.
                       type: object
-                  required:
-                    - defaultDestination
                   type: object
                 exposeStrategy:
                   description: 'Optional: ExposeStrategy explicitly sets the expose strategy for this seed cluster, if not set, the default provided by the master is used.'

--- a/pkg/webhook/seed/validation.go
+++ b/pkg/webhook/seed/validation.go
@@ -235,12 +235,10 @@ func validateEtcdBackupConfiguration(ctx context.Context, seedClient ctrlruntime
 			return errors.New("invalid etcd backup configuration: must define at least one backup destination")
 		}
 
-		if subject.Spec.EtcdBackupRestore.DefaultDestination == "" {
-			return errors.New("invalid etcd backup configuration: no default destination specified")
-		}
-
-		if _, exists := subject.Spec.EtcdBackupRestore.Destinations[subject.Spec.EtcdBackupRestore.DefaultDestination]; !exists {
-			return fmt.Errorf("invalid etcd backup configuration: default destination %q does not exist", subject.Spec.EtcdBackupRestore.DefaultDestination)
+		if subject.Spec.EtcdBackupRestore.DefaultDestination != "" {
+			if _, exists := subject.Spec.EtcdBackupRestore.Destinations[subject.Spec.EtcdBackupRestore.DefaultDestination]; !exists {
+				return fmt.Errorf("invalid etcd backup configuration: default destination %q does not exist", subject.Spec.EtcdBackupRestore.DefaultDestination)
+			}
 		}
 
 		for name, dest := range subject.Spec.EtcdBackupRestore.Destinations {


### PR DESCRIPTION
**What this PR does / why we need it**:
We have code in place that assumes `defaultDestination` can be empty, however the restrictive regex on the field prevents `defaultDestination: ""` and the field is a required field. The code in question: https://github.com/kubermatic/kubermatic/blob/5656b4e932c2a1aca334b62058d8dff5291bc8b8/pkg/apis/kubermatic/v1/datacenter.go#L880-L887

This PR unlocks the ability to omit the field and as such, empty strings will be produced as a result, triggering the condition above and disabling default etcd backups.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11590

**What type of PR is this?**
/kind bug
/kind api-change

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Seed spec no longer requires `defaultDestination` for `etcdBackupRestore`; Omitting it allows to disable default etcd backups
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
