### PR TITLE
Use gsed when available to run update-codegen.sh on macOS

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -21,13 +21,16 @@ source hack/lib.sh
 
 CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.19-node-18-2 containerize ./hack/update-codegen.sh
 
+sed="sed"
+[ "$(command -v gsed)" ] && sed="gsed"
+
 echodate "Generating reconciling helpers"
 
 reconcileHelpers=pkg/resources/reconciling/zz_generated_reconcile.go
 go run k8c.io/reconciler/cmd/reconciler-gen --config hack/reconciling.yaml > $reconcileHelpers
 
 currentYear=$(date +%Y)
-sed -i "s/Copyright YEAR/Copyright $currentYear/g" $reconcileHelpers
+$sed -i "s/Copyright YEAR/Copyright $currentYear/g" $reconcileHelpers
 
 CRD_DIR=pkg/crd/k8c.io
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`gsed` is GNU sed on macOS (when GNU coreutils are installed). We do this in `hack/update-docs.sh` already but recently added a call to `sed` in `hack/update-codegen.sh`. This PR makes the script executable under macOS.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
