### PR TITLE
[release/v2.21] Use seed config proxy for seed-cm (#11561)

### DIFF
--- a/pkg/controller/operator/common/util.go
+++ b/pkg/controller/operator/common/util.go
@@ -212,25 +212,23 @@ func CleanupClusterResource(ctx context.Context, client ctrlruntimeclient.Client
 	return nil
 }
 
-func ProxyEnvironmentVars(cfg *kubermaticv1.KubermaticConfiguration) []corev1.EnvVar {
-	result := []corev1.EnvVar{}
-	settings := cfg.Spec.Proxy
-
-	if settings.HTTP == "" && settings.HTTPS == "" {
-		return result
+// KubermaticProxyEnvironmentVars returns ProxySettings from Kubermatic configuration as env vars.
+func KubermaticProxyEnvironmentVars(p *kubermaticv1.KubermaticProxyConfiguration) (result []corev1.EnvVar) {
+	if p == nil || (p.HTTP == "" && p.HTTPS == "") {
+		return
 	}
 
-	if settings.HTTP != "" {
+	if p.HTTP != "" {
 		result = append(result, corev1.EnvVar{
 			Name:  "HTTP_PROXY",
-			Value: settings.HTTP,
+			Value: p.HTTP,
 		})
 	}
 
-	if settings.HTTPS != "" {
+	if p.HTTPS != "" {
 		result = append(result, corev1.EnvVar{
 			Name:  "HTTPS_PROXY",
-			Value: settings.HTTPS,
+			Value: p.HTTPS,
 		})
 	}
 
@@ -238,8 +236,8 @@ func ProxyEnvironmentVars(cfg *kubermaticv1.KubermaticConfiguration) []corev1.En
 		defaults.DefaultNoProxy,
 	}
 
-	if settings.NoProxy != "" {
-		noProxy = append(noProxy, settings.NoProxy)
+	if p.NoProxy != "" {
+		noProxy = append(noProxy, p.NoProxy)
 	}
 
 	result = append(result, corev1.EnvVar{
@@ -247,7 +245,39 @@ func ProxyEnvironmentVars(cfg *kubermaticv1.KubermaticConfiguration) []corev1.En
 		Value: strings.Join(noProxy, ","),
 	})
 
-	return result
+	return
+}
+
+// SeedProxyEnvironmentVars returns ProxySettings from Seed as env vars.
+func SeedProxyEnvironmentVars(p *kubermaticv1.ProxySettings) (result []corev1.EnvVar) {
+	if p == nil || p.Empty() {
+		return
+	}
+
+	result = append(result, corev1.EnvVar{
+		Name:  "HTTP_PROXY",
+		Value: p.HTTPProxy.String(),
+	})
+
+	result = append(result, corev1.EnvVar{
+		Name:  "HTTPS_PROXY",
+		Value: p.HTTPProxy.String(),
+	})
+
+	noProxy := []string{
+		defaulting.DefaultNoProxy,
+	}
+
+	if p.NoProxy.String() != "" {
+		noProxy = append(noProxy, p.NoProxy.String())
+	}
+
+	result = append(result, corev1.EnvVar{
+		Name:  "NO_PROXY",
+		Value: strings.Join(noProxy, ","),
+	})
+
+	return
 }
 
 func DeleteObject(ctx context.Context, client ctrlruntimeclient.Client, name, namespace string, obj ctrlruntimeclient.Object) error {

--- a/pkg/controller/operator/common/util.go
+++ b/pkg/controller/operator/common/util.go
@@ -265,7 +265,7 @@ func SeedProxyEnvironmentVars(p *kubermaticv1.ProxySettings) (result []corev1.En
 	})
 
 	noProxy := []string{
-		defaulting.DefaultNoProxy,
+		defaults.DefaultNoProxy,
 	}
 
 	if p.NoProxy.String() != "" {

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -197,7 +197,7 @@ func WebhookDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, version
 			// ensure that the 2 controllers will not overwrite each other (master-operator
 			// removing the -seed-name flag, seed-operator adding it again). Instead
 			// of fiddling with CLI flags, we just use an env variable to store the seed.
-			envVars := ProxyEnvironmentVars(cfg)
+			envVars := KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy)
 
 			if !removeSeed {
 				seedName := ""

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -249,7 +249,7 @@ func APIDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, workerName 
 					Image:   cfg.Spec.API.DockerRepository + ":" + versions.Kubermatic,
 					Command: []string{"kubermatic-api"},
 					Args:    args,
-					Env:     common.ProxyEnvironmentVars(cfg),
+					Env:     common.KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "metrics",

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -85,7 +85,7 @@ func MasterControllerManagerDeploymentCreator(cfg *kubermaticv1.KubermaticConfig
 					Image:   cfg.Spec.MasterController.DockerRepository + ":" + versions.Kubermatic,
 					Command: []string{"master-controller-manager"},
 					Args:    args,
-					Env:     common.ProxyEnvironmentVars(cfg),
+					Env:     common.KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "metrics",

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -60,7 +60,7 @@ func UIDeploymentCreator(cfg *kubermaticv1.KubermaticConfiguration, versions kub
 				{
 					Name:  "webserver",
 					Image: cfg.Spec.UI.DockerRepository + ":" + tag,
-					Env:   common.ProxyEnvironmentVars(cfg),
+					Env:   common.KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -164,7 +164,7 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions kubermat
 					Image:   cfg.Spec.SeedController.DockerRepository + ":" + versions.Kubermatic,
 					Command: []string{"seed-controller-manager"},
 					Args:    args,
-					Env:     common.ProxyEnvironmentVars(cfg),
+					Env:     common.SeedProxyEnvironmentVars(seed.Spec.ProxySettings),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "metrics",


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of:
https://github.com/kubermatic/kubermatic/pull/11561

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11509

**What type of PR is this?**

/kind bug


```release-note
Use seed proxy configuration for seed-controler-manager
```

```documentation
NONE
```
