### PR TITLE
fixed cluster templates getting deleted when failing to create a cluster

### DIFF
--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -155,16 +155,16 @@ func (r *reconciler) createClusters(ctx context.Context, instance *kubermaticv1.
 
 		for i := 0; i < int(instance.Spec.Replicas); i++ {
 			if err := r.createCluster(ctx, log, template, instance); err != nil {
-				created := int64(i + 1)
+				created := int64(i)
 				totalReplicas := instance.Spec.Replicas
 
-				if err := r.patchInstance(ctx, instance, func(i *kubermaticv1.ClusterTemplateInstance) {
+				if patchErr := r.patchInstance(ctx, instance, func(i *kubermaticv1.ClusterTemplateInstance) {
 					i.Spec.Replicas = totalReplicas - created
-				}); err != nil {
-					return err
+				}); patchErr != nil {
+					return fmt.Errorf("error patching cluster template instance (%v), after cluster creation fail: %w", patchErr, err)
 				}
 
-				return fmt.Errorf("failed to create desired number of clusters. Created %d of %d", created, totalReplicas)
+				return fmt.Errorf("failed to create desired number of clusters. Created %d of %d: %w", created, totalReplicas, err)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes an issue when creating a cluster through ClusterTemplates fails misteriously and without a trace.

The flow to create Clusters through ClusterTemplates is like this:

- create a ClusterTemplateInstance which has the desired replica count and info about which clustertemplate to use
- the ClusterTemplateInstance controller ranges over the replicas count and creates clusters
  - if it succeds, it deletes the ClusterTemplateInstance
  - if it fails, it removes from the replica count the amount of clusters it already created, then fails

The issue was that the replica count removal had an issue in the logic of counting the amount of clusters it already created (it always thought it created 1 more then it did). So if a ClusterTemplateInsance with replica 1 was created, and the cluster creation failed, the ClusterTemplateInsance will be updated with replicas = replicas -1 , so 0. And then the next reconcile iteration would conclude that ll is done and it can delete the CTI.

This doesnt fix the fact that UI still wont see that the ClusterTemplateInstance is failing. It just fixes it not to fail silenty and without a trace as the ClusterTemplateInstance will not be deleted plus the logs were improved so to see what is wrong.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11386 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed an issue where creating Clusters through ClusterTemplates failed without leaving a trace (the ClusterTemplateInstance got deleted as if all was good).
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
