### PR TITLE
[release/v2.21] Anexia: fix panic when configuring Node Pool with new Disks attribute

### DIFF
--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -620,7 +620,6 @@ func GetAnexiaProviderConfig(_ *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, d
 		TemplateID: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Anexia.TemplateID},
 		CPUs:       nodeSpec.Cloud.Anexia.CPUs,
 		Memory:     int(nodeSpec.Cloud.Anexia.Memory),
-		DiskSize:   int(*nodeSpec.Cloud.Anexia.DiskSize),
 		LocationID: providerconfig.ConfigVarString{Value: dc.Spec.Anexia.LocationID},
 	}
 
@@ -640,7 +639,7 @@ func GetAnexiaProviderConfig(_ *kubermaticv1.Cluster, nodeSpec apiv1.NodeSpec, d
 		}
 	}
 
-	if config.DiskSize >= 0 && len(config.Disks) > 0 {
+	if config.DiskSize > 0 && len(config.Disks) > 0 {
 		return nil, anexiaProvider.ErrConfigDiskSizeAndDisks
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

There is another mistake in our new disk config handling code that slipped through in #10816 and #11050 - this fixes that.

When having a `MachineDeployment` in a user cluster with only the new `disks` attribute set, API panics due to a nil-pointer dereference.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
I'm aware of the API being moved into the dashboard code and will provide a PR there as well.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix yet another API error in extended disk configuration for provider Anexia
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
