### PR TITLE
[release/v2.20] Anexia: fix panic when configuring Node Pool with new Disks attribute

### DIFF
--- a/pkg/resources/machine/common.go
+++ b/pkg/resources/machine/common.go
@@ -459,7 +459,6 @@ func getAnexiaProviderSpec(nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter)
 		TemplateID: providerconfig.ConfigVarString{Value: nodeSpec.Cloud.Anexia.TemplateID},
 		CPUs:       nodeSpec.Cloud.Anexia.CPUs,
 		Memory:     int(nodeSpec.Cloud.Anexia.Memory),
-		DiskSize:   int(*nodeSpec.Cloud.Anexia.DiskSize),
 		LocationID: providerconfig.ConfigVarString{Value: dc.Spec.Anexia.LocationID},
 	}
 
@@ -479,7 +478,7 @@ func getAnexiaProviderSpec(nodeSpec apiv1.NodeSpec, dc *kubermaticv1.Datacenter)
 		}
 	}
 
-	if config.DiskSize >= 0 && len(config.Disks) > 0 {
+	if config.DiskSize > 0 && len(config.Disks) > 0 {
 		return nil, anexiaProvider.ErrConfigDiskSizeAndDisks
 	}
 

--- a/pkg/resources/machine/common_test.go
+++ b/pkg/resources/machine/common_test.go
@@ -21,6 +21,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	anexia "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia"
+	anexiatypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/anexia/types"
 	vsphere "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
 	providerconfigtypes "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	apiv1 "k8c.io/kubermatic/v2/pkg/api/v1"
@@ -135,6 +139,146 @@ func TestGetVSphereProviderSpec(t *testing.T) {
 			}
 			if !reflect.DeepEqual(gotRawConf, tt.wantRawConf) {
 				t.Errorf("getVSphereProviderSpec() = %+v, want %+v", gotRawConf, tt.wantRawConf)
+			}
+		})
+	}
+}
+
+func TestGetAnexiaProviderSpec(t *testing.T) {
+	const (
+		vlanID     = "vlan-identifier"
+		templateID = "template-identifier"
+		locationID = "location-identifier"
+	)
+
+	tests := []struct {
+		name           string
+		anexiaNodeSpec apiv1.AnexiaNodeSpec
+		wantRawConf    *anexiatypes.RawConfig
+		wantErr        error
+	}{
+		{
+			name: "Anexia node spec with DiskSize attribute",
+			anexiaNodeSpec: apiv1.AnexiaNodeSpec{
+				VlanID:     vlanID,
+				TemplateID: templateID,
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   pointer.Int64(80),
+			},
+			wantRawConf: &anexiatypes.RawConfig{
+				VlanID:     providerconfigtypes.ConfigVarString{Value: vlanID},
+				TemplateID: providerconfigtypes.ConfigVarString{Value: templateID},
+				LocationID: providerconfigtypes.ConfigVarString{Value: locationID},
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   80,
+				Disks:      nil,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Anexia node spec with Disks attribute",
+			anexiaNodeSpec: apiv1.AnexiaNodeSpec{
+				VlanID:     vlanID,
+				TemplateID: templateID,
+				CPUs:       4,
+				Memory:     4096,
+				Disks: []apiv1.AnexiaDiskConfig{
+					{
+						Size:            80,
+						PerformanceType: pointer.String("ENT2"),
+					},
+				},
+			},
+			wantRawConf: &anexiatypes.RawConfig{
+				VlanID:     providerconfigtypes.ConfigVarString{Value: vlanID},
+				TemplateID: providerconfigtypes.ConfigVarString{Value: templateID},
+				LocationID: providerconfigtypes.ConfigVarString{Value: locationID},
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   0,
+				Disks: []anexiatypes.RawDisk{
+					{
+						Size:            80,
+						PerformanceType: providerconfigtypes.ConfigVarString{Value: "ENT2"},
+					},
+				},
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Anexia node spec with both DiskSize and Disks attributes",
+			anexiaNodeSpec: apiv1.AnexiaNodeSpec{
+				VlanID:     vlanID,
+				TemplateID: templateID,
+				CPUs:       4,
+				Memory:     4096,
+				DiskSize:   pointer.Int64(80),
+				Disks: []apiv1.AnexiaDiskConfig{
+					{
+						Size:            80,
+						PerformanceType: pointer.String("ENT2"),
+					},
+				},
+			},
+			wantRawConf: nil,
+			wantErr:     anexia.ErrConfigDiskSizeAndDisks,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			dc := kubermaticv1.Datacenter{
+				Spec: kubermaticv1.DatacenterSpec{
+					Anexia: &kubermaticv1.DatacenterSpecAnexia{
+						LocationID: locationID,
+					},
+				},
+			}
+
+			nodeSpec := apiv1.NodeSpec{
+				Cloud: apiv1.NodeCloudSpec{
+					Anexia: &test.anexiaNodeSpec,
+				},
+			}
+
+			result, err := getAnexiaProviderSpec(nodeSpec, &dc)
+
+			if test.wantErr != nil {
+				assert.Nil(t, result, "expected an error, not a result")
+				assert.ErrorIs(t, err, test.wantErr, "expected an error, not a result")
+			} else {
+				assert.NotNil(t, result)
+
+				resultRawConfig := anexiatypes.RawConfig{}
+				err := json.Unmarshal(result.Raw, &resultRawConfig)
+				assert.Nil(t, err)
+
+				assert.Equal(t, resultRawConfig.VlanID.Value, vlanID, "VLAN should be set correctly")
+				assert.Equal(t, resultRawConfig.TemplateID.Value, templateID, "Template should be set correctly")
+				assert.Equal(t, resultRawConfig.LocationID.Value, locationID, "Location should be set correctly")
+
+				assert.EqualValues(t, resultRawConfig.CPUs, test.anexiaNodeSpec.CPUs, "CPUs should be set correctly")
+				assert.EqualValues(t, resultRawConfig.Memory, test.anexiaNodeSpec.Memory, "Memory should be set correctly")
+
+				if test.anexiaNodeSpec.DiskSize != nil {
+					assert.EqualValues(t, resultRawConfig.DiskSize, *test.anexiaNodeSpec.DiskSize, "DiskSize should be set correctly")
+					assert.Nil(t, resultRawConfig.Disks, "Disks attribute should be nil")
+				} else {
+					assert.EqualValues(t, resultRawConfig.DiskSize, 0, "DiskSize should be set to 0")
+					assert.Len(t, resultRawConfig.Disks, len(test.anexiaNodeSpec.Disks), "Disks attribute should have correct length")
+
+					for i, dc := range test.anexiaNodeSpec.Disks {
+						assert.EqualValues(t, resultRawConfig.Disks[i].Size, dc.Size, "Disk entry should have correct size")
+
+						if dc.PerformanceType != nil {
+							assert.EqualValues(t, resultRawConfig.Disks[i].PerformanceType.Value, *dc.PerformanceType, "Disk entry should have correct performance type")
+						} else {
+							assert.Empty(t, resultRawConfig.Disks[i].PerformanceType.Value, "Disk entry should have no performance type")
+						}
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

There is another mistake in our new disk config handling code that slipped through in #10816 and #11050 - this fixes that.

When having a `MachineDeployment` in a user cluster with only the new `disks` attribute set, API panics due to a nil-pointer dereference.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
This is the same as #11602, but for 2.20, from which we sadly still didn't upgrade..

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix yet another API error in extended disk configuration for provider Anexia
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
