### PR TITLE
mark optional fields in Openstack spec as omitempty

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -177,6 +177,10 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 							TrustDevicePath:      pointer.Bool(false),
 							EnabledFlavors:       []string{},
 							IPv6Enabled:          pointer.Bool(false),
+							NodeSizeRequirements: &kubermaticv1.OpenstackNodeSizeRequirements{
+								MinimumVCPUs:  0,
+								MinimumMemory: 0,
+							},
 						},
 						Packet: &kubermaticv1.DatacenterSpecPacket{
 							Facilities: []string{},

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -208,6 +208,9 @@ spec:
           # Optional: Gets mapped to the "manage-security-groups" setting in the cloud config.
           # This setting defaults to true.
           manageSecurityGroups: true
+          # Optional: Restrict the allowed VM configurations that can be chosen in
+          # the KKP dashboard. This setting does not affect the validation webhook for
+          # MachineDeployments.
           nodeSizeRequirements:
             # MinimumMemory is the minimum required amount of memory, measured in MB
             minimumMemory: 0

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -208,6 +208,9 @@ spec:
           # Optional: Gets mapped to the "manage-security-groups" setting in the cloud config.
           # This setting defaults to true.
           manageSecurityGroups: true
+          # Optional: Restrict the allowed VM configurations that can be chosen in
+          # the KKP dashboard. This setting does not affect the validation webhook for
+          # MachineDeployments.
           nodeSizeRequirements:
             # MinimumMemory is the minimum required amount of memory, measured in MB
             minimumMemory: 0

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -529,14 +529,14 @@ type DatacenterSpecDigitalocean struct {
 // DatacenterSpecOpenstack describes an OpenStack datacenter.
 type DatacenterSpecOpenstack struct {
 	AuthURL          string `json:"authURL"`
-	AvailabilityZone string `json:"availabilityZone"`
+	AvailabilityZone string `json:"availabilityZone,omitempty"`
 	Region           string `json:"region"`
 	// Optional
 	IgnoreVolumeAZ bool `json:"ignoreVolumeAZ,omitempty"` //nolint:tagliatelle
 	// Optional
 	EnforceFloatingIP bool `json:"enforceFloatingIP,omitempty"`
 	// Used for automatic network creation
-	DNSServers []string `json:"dnsServers"`
+	DNSServers []string `json:"dnsServers,omitempty"`
 	// Images to use for each supported operating system.
 	Images ImageList `json:"images"`
 	// Optional: Gets mapped to the "manage-security-groups" setting in the cloud config.
@@ -548,8 +548,11 @@ type DatacenterSpecOpenstack struct {
 	UseOctavia *bool `json:"useOctavia,omitempty"`
 	// Optional: Gets mapped to the "trust-device-path" setting in the cloud config.
 	// This setting defaults to false.
-	TrustDevicePath      *bool                         `json:"trustDevicePath,omitempty"`
-	NodeSizeRequirements OpenstackNodeSizeRequirements `json:"nodeSizeRequirements"`
+	TrustDevicePath *bool `json:"trustDevicePath,omitempty"`
+	// Optional: Restrict the allowed VM configurations that can be chosen in
+	// the KKP dashboard. This setting does not affect the validation webhook for
+	// MachineDeployments.
+	NodeSizeRequirements *OpenstackNodeSizeRequirements `json:"nodeSizeRequirements,omitempty"`
 	// Optional: List of enabled flavors for the given datacenter
 	EnabledFlavors []string `json:"enabledFlavors,omitempty"`
 	// Optional: defines if the IPv6 is enabled for the datacenter
@@ -558,9 +561,9 @@ type DatacenterSpecOpenstack struct {
 
 type OpenstackNodeSizeRequirements struct {
 	// VCPUs is the minimum required amount of (virtual) CPUs
-	MinimumVCPUs int `json:"minimumVCPUs"` //nolint:tagliatelle
+	MinimumVCPUs int `json:"minimumVCPUs,omitempty"` //nolint:tagliatelle
 	// MinimumMemory is the minimum required amount of memory, measured in MB
-	MinimumMemory int `json:"minimumMemory"`
+	MinimumMemory int `json:"minimumMemory,omitempty"`
 }
 
 // DatacenterSpecAzure describes an Azure cloud datacenter.

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -2213,7 +2213,11 @@ func (in *DatacenterSpecOpenstack) DeepCopyInto(out *DatacenterSpecOpenstack) {
 		*out = new(bool)
 		**out = **in
 	}
-	out.NodeSizeRequirements = in.NodeSizeRequirements
+	if in.NodeSizeRequirements != nil {
+		in, out := &in.NodeSizeRequirements, &out.NodeSizeRequirements
+		*out = new(OpenstackNodeSizeRequirements)
+		**out = **in
+	}
 	if in.EnabledFlavors != nil {
 		in, out := &in.EnabledFlavors, &out.EnabledFlavors
 		*out = make([]string, len(*in))

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -369,6 +369,7 @@ spec:
                                 description: 'Optional: Gets mapped to the "manage-security-groups" setting in the cloud config. This setting defaults to true.'
                                 type: boolean
                               nodeSizeRequirements:
+                                description: 'Optional: Restrict the allowed VM configurations that can be chosen in the KKP dashboard. This setting does not affect the validation webhook for MachineDeployments.'
                                 properties:
                                   minimumMemory:
                                     description: MinimumMemory is the minimum required amount of memory, measured in MB
@@ -376,9 +377,6 @@ spec:
                                   minimumVCPUs:
                                     description: VCPUs is the minimum required amount of (virtual) CPUs
                                     type: integer
-                                required:
-                                  - minimumMemory
-                                  - minimumVCPUs
                                 type: object
                               region:
                                 type: string
@@ -390,10 +388,7 @@ spec:
                                 type: boolean
                             required:
                               - authURL
-                              - availabilityZone
-                              - dnsServers
                               - images
-                              - nodeSizeRequirements
                               - region
                             type: object
                           operatingSystemProfiles:


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes some optional fields for the openstack config truly optional.

**Which issue(s) this PR fixes**:
Fixes #11593

**What type of PR is this?**
/kind bug
/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
`availabilityZone`, `dnsServers` and `nodeSizeRequirements` are now optional in the Openstack datacenter spec.
```

**Documentation**:
```documentation
NONE
```
