### PR TITLE
fix user-ssh-keys-agent Docker imagefor arm64 containing the amd64 binary

### DIFF
--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -26,10 +26,10 @@ ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
 
 WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
-RUN CMD="user-ssh-keys-agent" make build
+RUN make -C ./cmd/user-ssh-keys-agent build
 
 FROM docker.io/alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-COPY --from=builder /go/src/k8c.io/kubermatic/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
+COPY --from=builder /go/src/k8c.io/kubermatic/cmd/user-ssh-keys-agent/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]


### PR DESCRIPTION
**What this PR does / why we need it**:
The old Dockerfile got confused because before we build any Docker image, we run `make build` in the KKP repo. This will build all binaries, including the user-ssh-keys-agent. Then afterwards the Dockerfile would get the `_build` directory copied into it and then `CMD="...." make build` would do nothing:

```
[2022-12-12T09:13:22+00:00] Building user-ssh-keys-agent image for amd64...
STEP 1: FROM docker.io/golang:1.18.9 AS builder
Getting image source signatures
Copying blob sha256:3a06c91201dd22ae0ea7eef5937fffadda06ced8d46c724c3a956db8a2f3e72d
Copying blob sha256:aa3a609d15798d35c1484072876b7d22a316e98de6a097de33b9dade6a689cd1
Copying blob sha256:5c8cfbf51e6e6869f1af2a1e7067b07fd6733036a333c9d29f743b0285e26037
Copying blob sha256:094e7d9bb04ebf214ea8dc5a488995449684104ae8ad9603bf061cac0d18eb54
Copying blob sha256:3eb5927575302d6dc81a3152fd20e63445540caaefa79af119bef50051351487
Copying blob sha256:f2f58072e9ed1aa1b0143341c5ee83815c00ce47548309fa240155067ab0e698
Copying blob sha256:8419c568f921e324ce8c9d399c64311b937ebf1448230610782e2e083c1950ba
Copying config sha256:39c8a0f6c6b33bf9c2723cfb5dc6b3e0c490f8bcde5e0c96c1c874a19bcb8189
Writing manifest to image destination
Storing signatures
STEP 2: ARG GOPROXY=
STEP 3: ARG GOCACHE=
STEP 4: ARG KUBERMATIC_EDITION=ce
STEP 5: ENV GOPROXY=$GOPROXY
STEP 6: ENV GOCACHE=$GOCACHE
STEP 7: ENV KUBERMATIC_EDITION=$KUBERMATIC_EDITION
STEP 8: WORKDIR /go/src/k8c.io/kubermatic
STEP 9: COPY . .
STEP 10: RUN CMD="user-ssh-keys-agent" make build
make: Nothing to be done for 'build'. <------------
STEP 11: FROM docker.io/alpine:3.13
Getting image source signatures
....
```

Compare this to the kubeletdnat-controller, which uses a slightly different method (`make -C ./cmd/.... build`), which will put the resulting binary in a different spot, thereby not copying it into the container. This ensures that everytime we build the controller image, we actually compile the binary.

This PR makes the user-ssh-keys-agent work identically to the kubeletdnat-controller. This however undoes the effects from #9387, so .... not sure what is the right solution.

From what I can see, this affects all 2.21.0+ releases, but 2.20.x seems fine.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix user-ssh-keys-agent Docker imagefor arm64 containing the amd64 binary
```

**Documentation**:
```documentation
NONE
```
