### PR TITLE
helm client: make uninstall idempotent

### DIFF
--- a/pkg/applications/helmclient/client_integration_test.go
+++ b/pkg/applications/helmclient/client_integration_test.go
@@ -213,10 +213,10 @@ func TestHelmClient(t *testing.T) {
 			},
 		},
 		{
-			name: "uninstall should be failed when chart is not already installed",
+			name: "uninstall should be successful when chart has already been installed (idempotent)",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				uninstallShloulFailedIfnotAlreadyInstalledTest(t, ctx, ns)
+				uninstallTest(t, ctx, client, ns)
 			},
 		},
 		{
@@ -406,27 +406,6 @@ func uninstallTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.C
 		return err != nil && apierrors.IsNotFound(err)
 	}) {
 		t.Fatal("configMap has not been removed by helm unsintall")
-	}
-}
-
-func uninstallShloulFailedIfnotAlreadyInstalledTest(t *testing.T, ctx context.Context, ns *corev1.Namespace) {
-	tempDir := t.TempDir()
-	settings := NewSettings(tempDir)
-
-	restClientGetter := &genericclioptions.ConfigFlags{
-		KubeConfig: pointer.String(kubeconfigPath),
-		Namespace:  &ns.Name,
-	}
-
-	helmClient, err := NewClient(ctx, restClientGetter, settings, ns.Name, kubermaticlog.Logger)
-	if err != nil {
-		t.Fatalf("failed to create helm client: %s", err)
-	}
-
-	_, err = helmClient.Uninstall(releaseName)
-
-	if err == nil {
-		t.Fatal("helm uninstall should failed if release it not already installed, but not error was raised")
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In ApplicationInstallation crontroller when an applicationInstallation is deleted, we uninstall the app and remove finalizer on the CR. if it failed the event is re-queue and then the uninstall failed (as helm release is already unsintall) to avoid that, we make uninstall idempotent


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Applications: make uninstall idempotent
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
