### PR TITLE
Allow apiserver to osm-webhook communication in seed

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -613,8 +613,9 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			apiserver.DenyAllPolicyReconciler(),
 			apiserver.DNSAllowReconciler(c, data),
 			apiserver.EctdAllowReconciler(c),
-			apiserver.MachineControllerWebhookReconciler(c),
-			apiserver.UserClusterWebhookReconciler(c),
+			apiserver.MachineControllerWebhookAllowReconciler(c),
+			apiserver.UserClusterWebhookAllowReconciler(c),
+			apiserver.OSMWebhookAllowReconciler(c),
 		}
 
 		// one shared limited context for all hostname resolutions

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -160,7 +160,7 @@ func OpenVPNServerAllowReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetw
 	}
 }
 
-func MachineControllerWebhookReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyReconcilerFactory {
+func MachineControllerWebhookAllowReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		return resources.NetworkPolicyMachineControllerWebhookAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -192,7 +192,7 @@ func MachineControllerWebhookReconciler(c *kubermaticv1.Cluster) reconciling.Nam
 	}
 }
 
-func UserClusterWebhookReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyReconcilerFactory {
+func UserClusterWebhookAllowReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		return resources.NetworkPolicyUserClusterWebhookAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
@@ -211,6 +211,38 @@ func UserClusterWebhookReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetw
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
 										resources.AppLabelKey: resources.UserClusterWebhookDeploymentName,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}
+
+func OSMWebhookAllowReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetworkPolicyReconcilerFactory {
+	return func() (string, reconciling.NetworkPolicyReconciler) {
+		return resources.NetworkPolicyOperatingSystemManagerWebhookAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: resources.OperatingSystemManagerWebhookDeploymentName,
 									},
 								},
 							},

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -988,15 +988,16 @@ const (
 )
 
 const (
-	NetworkPolicyDefaultDenyAllEgress          = "default-deny-all-egress"
-	NetworkPolicyEtcdAllow                     = "etcd-allow"
-	NetworkPolicyDNSAllow                      = "dns-allow"
-	NetworkPolicyOpenVPNServerAllow            = "openvpn-server-allow"
-	NetworkPolicyMachineControllerWebhookAllow = "machine-controller-webhook-allow"
-	NetworkPolicyUserClusterWebhookAllow       = "usercluster-webhook-allow"
-	NetworkPolicyMetricsServerAllow            = "metrics-server-allow"
-	NetworkPolicyClusterExternalAddrAllow      = "cluster-external-addr-allow"
-	NetworkPolicyOIDCIssuerAllow               = "oidc-issuer-allow"
+	NetworkPolicyDefaultDenyAllEgress               = "default-deny-all-egress"
+	NetworkPolicyEtcdAllow                          = "etcd-allow"
+	NetworkPolicyDNSAllow                           = "dns-allow"
+	NetworkPolicyOpenVPNServerAllow                 = "openvpn-server-allow"
+	NetworkPolicyMachineControllerWebhookAllow      = "machine-controller-webhook-allow"
+	NetworkPolicyUserClusterWebhookAllow            = "usercluster-webhook-allow"
+	NetworkPolicyOperatingSystemManagerWebhookAllow = "operating-system-manager-webhook-allow"
+	NetworkPolicyMetricsServerAllow                 = "metrics-server-allow"
+	NetworkPolicyClusterExternalAddrAllow           = "cluster-external-addr-allow"
+	NetworkPolicyOIDCIssuerAllow                    = "oidc-issuer-allow"
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
It seems that by introducing the OSM webhook (https://github.com/kubermatic/kubermatic/pull/11325) we forgot to add the network policy to allow apiserver->osm-webhook communication. This PR fixes it by adding such network policy.

The missing policy manifests itself with the following error:
```
failed to create initial MachineDeployment: Internal error occurred: failed calling webhook "operating-system-manager.kubermatic.io-machinedeployments": failed to call webhook: Post "https://operating-system-manager-webhook.cluster-jh5zdkzd8n.svc.cluster.local/./mutate-v1alpha1-machinedeployment?timeout=10s": context deadline exceeded
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
