### PR TITLE
[release/v2.21] Pin MLA version for CI to v0.2.5

### DIFF
--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -29,7 +29,7 @@ source hack/lib.sh
 URL="https://github.com/kubermatic/mla.git"
 
 # KKP master should follow kubermatic/mla master, please freeze when branching out a release!
-REF="main"
+REF="v0.2.5"
 
 # Ensure Github's host key is available and disable IP checking.
 # ensure_github_host_pubkey


### PR DESCRIPTION
**What this PR does / why we need it**:
We didn't properly pin the MLA version. We've now released MLA v0.2.5, so this is a good time as any to properly pin the version.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
