### PR TITLE
Fix Cilium version upgrade + add registry override support

### DIFF
--- a/addons/cilium/cilium_v1.12.yaml
+++ b/addons/cilium/cilium_v1.12.yaml
@@ -25,7 +25,9 @@
 #   - templates/hubble, templates/hubble-relay and templates/hubble-ui components moved to a separate addon "hubble"
 
 {{ if eq .Cluster.CNIPlugin.Type "cilium" }}
-{{ if eq .Cluster.CNIPlugin.Version "v1.12" }}
+{{ if or (eq .Cluster.CNIPlugin.Version "v1.12") (hasPrefix "1.13" .Cluster.CNIPlugin.Version) }}
+# NOTE: 1.13 above allows proper uninstallation by the addon-controller by migration to Applications infra for Cilium CNI as of 1.13
+# We rely on KKP webhooks to make sure the migration is allowed only by upgrade from 1.12 to 1.13
 
 {{ $apiServerURL := urlParse .Cluster.Address.URL }}
 {{ $hostParts := split ":" $apiServerURL.host }}

--- a/pkg/cni/cilium.go
+++ b/pkg/cni/cilium.go
@@ -70,7 +70,7 @@ func CiliumApplicationDefinitionReconciler() reconciling.NamedApplicationDefinit
 			if app.Spec.DefaultValues == nil {
 				defaultValues := map[string]any{
 					"operator": map[string]any{
-						"replicas": "1",
+						"replicas": 1,
 					},
 					"hubble": map[string]any{
 						"relay": map[string]any{
@@ -120,7 +120,7 @@ func GetCiliumAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteR
 	if cluster.Spec.ClusterNetwork.ProxyMode == resources.EBPFProxyMode {
 		values["kubeProxyReplacement"] = "strict"
 		values["k8sServiceHost"] = cluster.Status.Address.ExternalName
-		values["k8sServicePort"] = fmt.Sprintf("%d", cluster.Status.Address.Port)
+		values["k8sServicePort"] = cluster.Status.Address.Port
 	} else {
 		values["kubeProxyReplacement"] = "disabled"
 	}

--- a/pkg/cni/cilium_test.go
+++ b/pkg/cni/cilium_test.go
@@ -61,13 +61,13 @@ func TestGetCiliumAppInstallOverrideValues(t *testing.T) {
 			name:              "default values",
 			cluster:           testCluster,
 			overwriteRegistry: "",
-			expectedValues:    `{"cni":{"exclusive":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":"6443","kubeProxyReplacement":"strict","operator":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
+			expectedValues:    `{"cni":{"exclusive":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","operator":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
 		},
 		{
 			name:              "default values with overwrite registry",
 			cluster:           testCluster,
 			overwriteRegistry: "myregistry.io",
-			expectedValues:    `{"certgen":{"image":{"repository":"myregistry.io/cilium/certgen","useDigest":false}},"cni":{"exclusive":false},"hubble":{"relay":{"image":{"repository":"myregistry.io/cilium/hubble-relay","useDigest":false}},"ui":{"backend":{"image":{"repository":"myregistry.io/cilium/hubble-ui-backend","useDigest":false}},"frontend":{"image":{"repository":"myregistry.io/cilium/hubble-ui","useDigest":false}}}},"image":{"repository":"myregistry.io/cilium/cilium","useDigest":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":"6443","kubeProxyReplacement":"strict","operator":{"image":{"repository":"myregistry.io/cilium/operator","useDigest":false},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
+			expectedValues:    `{"certgen":{"image":{"repository":"myregistry.io/cilium/certgen","useDigest":false}},"cni":{"exclusive":false},"hubble":{"relay":{"image":{"repository":"myregistry.io/cilium/hubble-relay","useDigest":false}},"ui":{"backend":{"image":{"repository":"myregistry.io/cilium/hubble-ui-backend","useDigest":false}},"frontend":{"image":{"repository":"myregistry.io/cilium/hubble-ui","useDigest":false}}}},"image":{"repository":"myregistry.io/cilium/cilium","useDigest":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","operator":{"image":{"repository":"myregistry.io/cilium/operator","useDigest":false},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
 		},
 	}
 	for _, testCase := range testCases {

--- a/pkg/cni/cilium_test.go
+++ b/pkg/cni/cilium_test.go
@@ -36,9 +36,9 @@ var testCluster = &kubermaticv1.Cluster{
 		},
 		ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
 			Pods: kubermaticv1.NetworkRanges{
-				CIDRBlocks: []string{"192.168.0.0"},
+				CIDRBlocks: []string{"192.168.0.0/24"},
 			},
-			NodeCIDRMaskSizeIPv4: pointer.Int32(24),
+			NodeCIDRMaskSizeIPv4: pointer.Int32(16),
 			ProxyMode:            resources.EBPFProxyMode,
 		},
 	},
@@ -48,6 +48,37 @@ var testCluster = &kubermaticv1.Cluster{
 			Port:         6443,
 		},
 	},
+}
+
+func TestGetCiliumAppInstallOverrideValues(t *testing.T) {
+	testCases := []struct {
+		name              string
+		cluster           *kubermaticv1.Cluster
+		overwriteRegistry string
+		expectedValues    string
+	}{
+		{
+			name:              "default values",
+			cluster:           testCluster,
+			overwriteRegistry: "",
+			expectedValues:    `{"cni":{"exclusive":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":"6443","kubeProxyReplacement":"strict","operator":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
+		},
+		{
+			name:              "default values with overwrite registry",
+			cluster:           testCluster,
+			overwriteRegistry: "myregistry.io",
+			expectedValues:    `{"certgen":{"image":{"repository":"myregistry.io/cilium/certgen","useDigest":false}},"cni":{"exclusive":false},"hubble":{"relay":{"image":{"repository":"myregistry.io/cilium/hubble-relay","useDigest":false}},"ui":{"backend":{"image":{"repository":"myregistry.io/cilium/hubble-ui-backend","useDigest":false}},"frontend":{"image":{"repository":"myregistry.io/cilium/hubble-ui","useDigest":false}}}},"image":{"repository":"myregistry.io/cilium/cilium","useDigest":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":"6443","kubeProxyReplacement":"strict","operator":{"image":{"repository":"myregistry.io/cilium/operator","useDigest":false},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			values := GetCiliumAppInstallOverrideValues(testCluster, testCase.overwriteRegistry)
+			rawValues, _ := json.Marshal(values)
+			if string(rawValues) != testCase.expectedValues {
+				t.Fatalf("values '%s' do not match expected values '%s'", rawValues, testCase.expectedValues)
+			}
+		})
+	}
 }
 
 func TestValidateCiliumValuesUpdate(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes Cilium version upgrade from 1.12 to 1.13 + adds registry override support for Cilium 1.13

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11567 

**What type of PR is this?**
/kind feature
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
