### PR TITLE
Applications: add validating and mutating webhook for deployOptions

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -34,6 +34,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	addonmutation "k8c.io/kubermatic/v2/pkg/webhook/addon/mutation"
+	applicationdefinitionmutation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationdefinition/mutation"
 	applicationdefinitionvalidation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationdefinition/validation"
 	clustermutation "k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation"
 	clustervalidation "k8c.io/kubermatic/v2/pkg/webhook/cluster/validation"
@@ -221,6 +222,12 @@ func main() {
 
 	// Setup the validation admission handler for OperatingSystemProfile CRDs
 	ospvalidation.NewAdmissionHandler().SetupWebhookWithManager(mgr)
+
+	// /////////////////////////////////////////
+	// setup ApplicationDefinition webhooh
+
+	// Setup the mutation admission handler for ApplicationDefinition CRDs
+	applicationdefinitionmutation.NewAdmissionHandler().SetupWebhookWithManager(mgr)
 
 	// Setup the validation admission handler for ApplicationDefinition CRDs
 	applicationdefinitionvalidation.NewAdmissionHandler().SetupWebhookWithManager(mgr)

--- a/cmd/user-cluster-webhook/main.go
+++ b/cmd/user-cluster-webhook/main.go
@@ -31,6 +31,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/util/cli"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+	applicationinstallationmutation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationinstallation/mutation"
 	applicationinstallationvalidation "k8c.io/kubermatic/v2/pkg/webhook/application/applicationinstallation/validation"
 	machinevalidation "k8c.io/kubermatic/v2/pkg/webhook/machine/validation"
 
@@ -121,6 +122,9 @@ func main() {
 
 	// /////////////////////////////////////////
 	// setup webhooks
+
+	// Setup the mutation admission handler for ApplicationInstallation CRDs in seed manager.
+	applicationinstallationmutation.NewAdmissionHandler().SetupWebhookWithManager(seedMgr)
 
 	// Setup the validation admission handler for ApplicationInstallation CRDs in seed manager.
 	applicationinstallationvalidation.NewAdmissionHandler(seedMgr.GetClient()).SetupWebhookWithManager(seedMgr)

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -448,6 +448,7 @@ func (r *Reconciler) reconcileMutatingWebhooks(ctx context.Context, config *kube
 	reconcilers := []reconciling.NamedMutatingWebhookConfigurationReconcilerFactory{
 		kubermatic.UserSSHKeyMutatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		kubermatic.ExternalClusterMutatingWebhookConfigurationReconciler(ctx, config, r.Client),
+		common.ApplicationDefinitionMutatingWebhookConfigurationReconciler(ctx, config, r.Client),
 	}
 
 	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, reconcilers, "", r.Client); err != nil {

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -670,6 +670,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 		kubermaticseed.ClusterMutatingWebhookConfigurationReconciler(ctx, cfg, client),
 		kubermaticseed.AddonMutatingWebhookConfigurationReconciler(ctx, cfg, client),
 		kubermaticseed.MLAAdminSettingMutatingWebhookConfigurationReconciler(ctx, cfg, client),
+		common.ApplicationDefinitionMutatingWebhookConfigurationReconciler(ctx, cfg, client),
 	}
 
 	if err := reconciling.ReconcileMutatingWebhookConfigurations(ctx, mutatingWebhookReconcilers, "", client); err != nil {

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -672,6 +672,7 @@ func (r *reconciler) reconcileCRDs(ctx context.Context) error {
 func (r *reconciler) reconcileMutatingWebhookConfigurations(ctx context.Context, data reconcileData) error {
 	creators := []reconciling.NamedMutatingWebhookConfigurationReconcilerFactory{
 		machinecontroller.MutatingwebhookConfigurationReconciler(data.caCert.Cert, r.namespace),
+		applications.ApplicationInstallationMutatingWebhookConfigurationReconciler(data.caCert.Cert, r.namespace),
 	}
 	if r.opaIntegration && r.opaEnableMutation {
 		creators = append(creators, gatekeeper.MutatingWebhookConfigurationReconciler(r.opaWebhookTimeout))

--- a/pkg/defaulting/application_definition.go
+++ b/pkg/defaulting/application_definition.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting
+
+import appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+func DefaultApplicationDefinition(appInstall *appskubermaticv1.ApplicationDefinition) error {
+	DefaultDeployOpts(appInstall.Spec.DefaultDeployOptions)
+	return nil
+}

--- a/pkg/defaulting/application_definition_test.go
+++ b/pkg/defaulting/application_definition_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting_test
+
+import (
+	"testing"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/test/diff"
+	"k8c.io/kubermatic/v2/pkg/validation"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDefaultApplicationDefinition(t *testing.T) {
+	tests := []struct {
+		name           string
+		appDef         *appskubermaticv1.ApplicationDefinition
+		expectedAppDef *appskubermaticv1.ApplicationDefinition
+		wantErr        bool
+	}{
+		{
+			name:           "test no mutation - DefaultDeployOps is nil",
+			appDef:         getApplicationDefinition(nil),
+			expectedAppDef: getApplicationDefinition(nil),
+			wantErr:        false,
+		},
+		{
+			name:           "test no mutation - DefaultDeployOps.Helm is nil",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{}),
+			wantErr:        false,
+		},
+		{
+			name:           "test no mutation - DefaultDeployOps.Helm is all filled",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			wantErr:        false,
+		},
+		{
+			name:           "test no mutation - DefaultDeployOps.Helm is all filled (atomic=false)",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			wantErr:        false,
+		},
+		{
+			name:           "test no mutation - DefaultDeployOps.Helm is all filled (atomic=false, wait= false, timeout = 0)",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}),
+			wantErr:        false,
+		},
+		{
+			name:           "test mutation - DefaultDeployOps.Helm atomic =true --> wait and timeout should be defaulted",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true}}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			wantErr:        false,
+		},
+		{
+			name:           "test mutation - DefaultDeployOps.Helm atomic =true  and wait= true -->  timeout should be defaulted",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true}}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			wantErr:        false,
+		},
+		{
+			name:           "test mutation - DefaultDeployOps.Helm atomic =false  and wait= true -->  timeout should be defaulted",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true}}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			wantErr:        false,
+		},
+		{
+			name:           "test mutation - DefaultDeployOps.Helm atomic =true and timeout=10  --> wait should be defaulted",
+			appDef:         getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Timeout: metav1.Duration{Duration: 10}}}),
+			expectedAppDef: getApplicationDefinition(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 10}}}),
+			wantErr:        false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := defaulting.DefaultApplicationDefinition(tc.appDef)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("defaultApplicationDefinition() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if !diff.SemanticallyEqual(tc.appDef, tc.expectedAppDef) {
+				t.Fatalf("mutate applicationDefinition differs from expected:\n%s", diff.ObjectDiff(tc.expectedAppDef, tc.appDef))
+			}
+
+			// test that mutate object is valid
+			if errs := validation.ValidateApplicationDefinitionSpec(*tc.appDef); len(errs) > 0 {
+				t.Fatalf("mutated applicationDefinition does not pass validation: %v", errs)
+			}
+		})
+	}
+}
+
+func getApplicationDefinition(defaultDeployOps *appskubermaticv1.DeployOptions) *appskubermaticv1.ApplicationDefinition {
+	return &appskubermaticv1.ApplicationDefinition{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ApplicationDefinition",
+			APIVersion: appskubermaticv1.GroupName + "/" + appskubermaticv1.GroupVersion,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-1",
+			Namespace: "kube-system",
+		},
+		Spec: appskubermaticv1.ApplicationDefinitionSpec{
+			Description: "an app",
+			Method:      appskubermaticv1.HelmTemplateMethod,
+			Versions: []appskubermaticv1.ApplicationVersion{
+				{
+					Version: "v1.0.0",
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
+								URL:          "https://localhost/some-repo",
+								ChartName:    "chartName",
+								ChartVersion: "1.0.0",
+							},
+						},
+					},
+				},
+			},
+			DefaultDeployOptions: defaultDeployOps,
+		},
+	}
+}

--- a/pkg/defaulting/application_installation.go
+++ b/pkg/defaulting/application_installation.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting
+
+import (
+	"time"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+)
+
+// DefaultHelmTimeout is the default time to wait for any individual Kubernetes operation.
+const DefaultHelmTimeout = 5 * time.Minute
+
+func DefaultApplicationInstallation(appInstall *appskubermaticv1.ApplicationInstallation) error {
+	DefaultDeployOpts(appInstall.Spec.DeployOptions)
+	return nil
+}
+
+func DefaultDeployOpts(deployOpts *appskubermaticv1.DeployOptions) {
+	if deployOpts != nil && deployOpts.Helm != nil {
+		// atomic implies wait = true
+		if deployOpts.Helm.Atomic {
+			deployOpts.Helm.Wait = true
+		}
+		// wait implies timeout > 0
+		if deployOpts.Helm.Wait && deployOpts.Helm.Timeout.Duration == 0 {
+			deployOpts.Helm.Timeout.Duration = DefaultHelmTimeout
+		}
+	}
+}

--- a/pkg/defaulting/application_installation_test.go
+++ b/pkg/defaulting/application_installation_test.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaulting_test
+
+import (
+	"context"
+	"testing"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/test/diff"
+	"k8c.io/kubermatic/v2/pkg/validation"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = appskubermaticv1.AddToScheme(testScheme)
+}
+
+func TestDefaultApplicationInstallation(t *testing.T) {
+	appDef := &appskubermaticv1.ApplicationDefinition{ObjectMeta: metav1.ObjectMeta{Name: "appDef-1"}, Spec: appskubermaticv1.ApplicationDefinitionSpec{Description: "Description", Versions: []appskubermaticv1.ApplicationVersion{{Version: "v1.0.0"}}}}
+	fakeClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(appDef).
+		Build()
+
+	tests := []struct {
+		name        string
+		appInstall  *appskubermaticv1.ApplicationInstallation
+		expectedApp *appskubermaticv1.ApplicationInstallation
+		wantErr     bool
+	}{
+		{
+			name:        "test no mutation - deployOpts is nil",
+			appInstall:  getApplicationInstallation(nil),
+			expectedApp: getApplicationInstallation(nil),
+			wantErr:     false,
+		},
+		{
+			name:        "test no mutation - deployOpts.Helm is nil",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{}),
+			wantErr:     false,
+		},
+		{
+			name:        "test no mutation - deployOpts.Helm is all filled",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			wantErr:     false,
+		},
+		{
+			name:        "test no mutation - deployOpts.Helm is all filled (atomic=false)",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			wantErr:     false,
+		},
+		{
+			name:        "test no mutation - deployOpts.Helm is all filled (atomic=false, wait= false, timeout = 0)",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}),
+			wantErr:     false,
+		},
+		{
+			name:        "test mutation - deployOpts.Helm atomic =true --> wait and timeout should be defaulted",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true}}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			wantErr:     false,
+		},
+		{
+			name:        "test mutation - deployOpts.Helm atomic =true  and wait= true -->  timeout should be defaulted",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true}}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			wantErr:     false,
+		},
+		{
+			name:        "test mutation - deployOpts.Helm atomic =false  and wait= true -->  timeout should be defaulted",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true}}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			wantErr:     false,
+		},
+		{
+			name:        "test mutation - deployOpts.Helm atomic =true and timeout=10  --> wait should be defaulted",
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Timeout: metav1.Duration{Duration: 10}}}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 10}}}),
+			wantErr:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := defaulting.DefaultApplicationInstallation(tc.appInstall)
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("DefaultApplicationInstallation() error = %v, wantErr %v", err, tc.wantErr)
+			}
+
+			if !diff.SemanticallyEqual(tc.appInstall, tc.expectedApp) {
+				t.Fatalf("mutate applicationInstllation differs from expected:\n%s", diff.ObjectDiff(tc.expectedApp, tc.appInstall))
+			}
+
+			// test that mutate object is valid
+			if errs := validation.ValidateApplicationInstallationSpec(context.Background(), fakeClient, tc.appInstall.Spec); len(errs) > 0 {
+				t.Fatalf("mutated applicationInstllation does not pass validation: %v", errs)
+			}
+		})
+	}
+}
+
+func getApplicationInstallation(deployOpts *appskubermaticv1.DeployOptions) *appskubermaticv1.ApplicationInstallation {
+	return &appskubermaticv1.ApplicationInstallation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-1",
+			Namespace: "kube-system",
+		},
+		Spec: appskubermaticv1.ApplicationInstallationSpec{
+			Namespace: appskubermaticv1.AppNamespaceSpec{
+				Name: "default",
+			},
+			ApplicationRef: appskubermaticv1.ApplicationRef{
+				Name:    "appDef-1",
+				Version: "v1.0.0",
+			},
+			DeployOptions: deployOpts,
+		},
+	}
+}

--- a/pkg/validation/application_definition.go
+++ b/pkg/validation/application_definition.go
@@ -32,9 +32,8 @@ func ValidateApplicationDefinitionSpec(ad appskubermaticv1.ApplicationDefinition
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateApplicationDefinitionWithOpenAPI(ad, parentFieldPath)...)
-
 	allErrs = append(allErrs, ValidateApplicationVersions(ad.Spec.Versions, parentFieldPath.Child("spec"))...)
-
+	allErrs = append(allErrs, ValidateDeployOpts(ad.Spec.DefaultDeployOptions, parentFieldPath.Child("spec.defaultDeployOptions"))...)
 	return allErrs
 }
 

--- a/pkg/validation/application_definition_test.go
+++ b/pkg/validation/application_definition_test.go
@@ -108,7 +108,7 @@ func TestValidateApplicationDefinitionSpec(t *testing.T) {
 					s := spec.DeepCopy()
 					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
 						Wait:    true,
-						Timeout: metav1.Duration{5},
+						Timeout: metav1.Duration{Duration: 5},
 						Atomic:  false,
 					}}
 					return *s
@@ -122,7 +122,7 @@ func TestValidateApplicationDefinitionSpec(t *testing.T) {
 					s := spec.DeepCopy()
 					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
 						Wait:    false,
-						Timeout: metav1.Duration{0},
+						Timeout: metav1.Duration{Duration: 0},
 						Atomic:  true,
 					}}
 					return *s
@@ -136,7 +136,7 @@ func TestValidateApplicationDefinitionSpec(t *testing.T) {
 					s := spec.DeepCopy()
 					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
 						Wait:    true,
-						Timeout: metav1.Duration{0},
+						Timeout: metav1.Duration{Duration: 0},
 						Atomic:  false,
 					}}
 					return *s
@@ -150,7 +150,7 @@ func TestValidateApplicationDefinitionSpec(t *testing.T) {
 					s := spec.DeepCopy()
 					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
 						Wait:    false,
-						Timeout: metav1.Duration{5},
+						Timeout: metav1.Duration{Duration: 5},
 						Atomic:  false,
 					}}
 					return *s

--- a/pkg/validation/application_definition_test.go
+++ b/pkg/validation/application_definition_test.go
@@ -78,6 +78,86 @@ func TestValidateApplicationDefinitionSpec(t *testing.T) {
 			},
 			0,
 		},
+		"valid DeployOpts helm is nil": {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					s := spec.DeepCopy()
+					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{}
+					return *s
+				}(),
+			},
+			0,
+		},
+		"valid DeployOpts helm={wait: true, timeout: 5, atomic: true}": {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					s := spec.DeepCopy()
+					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    true,
+						Timeout: metav1.Duration{Duration: 5},
+						Atomic:  true,
+					}}
+					return *s
+				}(),
+			},
+			0,
+		},
+		"valid DeployOpts helm ={wait: true, timeout: 5, atomic: false}": {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					s := spec.DeepCopy()
+					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    true,
+						Timeout: metav1.Duration{5},
+						Atomic:  false,
+					}}
+					return *s
+				}(),
+			},
+			0,
+		},
+		"invalid DeployOpts helm (atomic=true but wait=false)": {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					s := spec.DeepCopy()
+					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    false,
+						Timeout: metav1.Duration{0},
+						Atomic:  true,
+					}}
+					return *s
+				}(),
+			},
+			1,
+		},
+		"invalid DeployOpts helm (wait=true but timeout=0)": {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					s := spec.DeepCopy()
+					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    true,
+						Timeout: metav1.Duration{0},
+						Atomic:  false,
+					}}
+					return *s
+				}(),
+			},
+			1,
+		},
+		"invalid DeployOpts helm (wait false but timeout defined)": {
+			appskubermaticv1.ApplicationDefinition{
+				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
+					s := spec.DeepCopy()
+					s.DefaultDeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    false,
+						Timeout: metav1.Duration{5},
+						Atomic:  false,
+					}}
+					return *s
+				}(),
+			},
+			1,
+		},
 		"invalid method": {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {

--- a/pkg/validation/application_installation_test.go
+++ b/pkg/validation/application_installation_test.go
@@ -66,6 +66,86 @@ func TestValidateApplicationInstallationSpec(t *testing.T) {
 			expectedError: "[]",
 		},
 		{
+			name: "Create ApplicationInstallation Success - DeployOpts helm is nil",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.DeployOptions = &appskubermaticv1.DeployOptions{}
+					return *spec
+				}(),
+			}, expectedError: "[]",
+		},
+		{
+			name: "Create ApplicationInstallation Success - DeployOpts helm={wait: true, timeout: 5, atomic: true}",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.DeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    true,
+						Timeout: metav1.Duration{Duration: 5},
+						Atomic:  true,
+					}}
+					return *spec
+				}(),
+			}, expectedError: "[]",
+		},
+		{
+			name: "Create ApplicationInstallation Success - DeployOpts helm ={wait: true, timeout: 5, atomic: false}",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.DeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    true,
+						Timeout: metav1.Duration{Duration: 5},
+						Atomic:  false,
+					}}
+					return *spec
+				}(),
+			}, expectedError: "[]",
+		},
+		{
+			name: "Create ApplicationInstallation Failure - DeployOpts helm (atomic=true but wait=false)",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.DeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    false,
+						Timeout: metav1.Duration{Duration: 0},
+						Atomic:  true,
+					}}
+					return *spec
+				}(),
+			}, expectedError: "[spec.deployOptions.helm: Forbidden: if atomic=true then wait must also be true]",
+		},
+		{
+			name: "Create ApplicationInstallation Failure - DeployOpts helm (wait=true but timeout=0)",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.DeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    true,
+						Timeout: metav1.Duration{Duration: 0},
+						Atomic:  true,
+					}}
+					return *spec
+				}(),
+			}, expectedError: "[spec.deployOptions.helm: Forbidden: if wait = true then timeout must be greater than 0]",
+		},
+		{
+			name: "Create ApplicationInstallation Failure - DeployOpts helm (wait false but timeout defined)",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.DeployOptions = &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
+						Wait:    false,
+						Timeout: metav1.Duration{Duration: 5},
+						Atomic:  false,
+					}}
+					return *spec
+				}(),
+			}, expectedError: "[spec.deployOptions.helm: Forbidden: if timeout is defined then wait must be true]",
+		},
+		{
 			name: "Create ApplicationInstallation Failure - ApplicationDefinitation doesn't exist",
 			ai: &appskubermaticv1.ApplicationInstallation{
 				Spec: func() appskubermaticv1.ApplicationInstallationSpec {

--- a/pkg/webhook/application/applicationdefinition/mutation/mutation.go
+++ b/pkg/webhook/application/applicationdefinition/mutation/mutation.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for mutating Kubermatic ApplicationDefinition CRD.
+type AdmissionHandler struct {
+	log     logr.Logger
+	decoder *admission.Decoder
+}
+
+// NewAdmissionHandler returns a new ApplicationDefinition AdmissionHandler.
+func NewAdmissionHandler() *AdmissionHandler {
+	return &AdmissionHandler{}
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-application-definition", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) InjectLogger(l logr.Logger) error {
+	h.log = l.WithName("application-Definition-mutation-handler")
+	return nil
+}
+
+func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	appDef := &appskubermaticv1.ApplicationDefinition{}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		if err := h.decoder.Decode(req, appDef); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if err := defaulting.DefaultApplicationDefinition(appDef); err != nil {
+			h.log.Error(err, "ApplicationDefinition mutation failed")
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("ApplicationDefinition mutation request %s failed: %w", req.UID, err))
+		}
+
+	case admissionv1.Update:
+		if err := h.decoder.Decode(req, appDef); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if err := defaulting.DefaultApplicationDefinition(appDef); err != nil {
+			h.log.Error(err, "ApplicationDefinition mutation failed")
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("ApplicationDefinition mutation request %s failed: %w", req.UID, err))
+		}
+
+	case admissionv1.Delete:
+		return webhook.Allowed(fmt.Sprintf("no mutation done for request %s", req.UID))
+
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on ApplicationDefinition resources", req.Operation))
+	}
+
+	mutatedAppInstall, err := json.Marshal(appDef)
+	if err != nil {
+		return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling ApplicationDefinition object failed: %w", err))
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, mutatedAppInstall)
+}

--- a/pkg/webhook/application/applicationdefinition/mutation/mutation_test.go
+++ b/pkg/webhook/application/applicationdefinition/mutation/mutation_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-test/deep"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = appskubermaticv1.AddToScheme(testScheme)
+}
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         webhook.AdmissionRequest
+		wantPatches []jsonpatch.JsonPatchOperation
+	}{
+		{
+			name: "Create ApplicationDefinition with DefaultDeployOps.Helm.Atomic=true --> DefaultDeployOps.Helm.Wait and DefaultDeployOps.Helm.timeout should be defaulted",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
+						Kind:    "ApplicationDefinition",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawAppDeflGen{
+							DefaultDeployOps: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true}},
+						}.Do(),
+					},
+				},
+			},
+			wantPatches: []jsonpatch.Operation{
+				jsonpatch.NewOperation("add", "/spec/defaultDeployOptions/helm/wait", true),
+				jsonpatch.NewOperation("replace", "/spec/defaultDeployOptions/helm/timeout", "5m0s"),
+			},
+		},
+		{
+			name: "Update applicationDefinition with DefaultDeployOps.Helm.Wait=true-->  DefaultDeployOps.Helm.timeout should be defaulted",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
+						Kind:    "ApplicationDefinition",
+					},
+					Name: "foo",
+					OldObject: runtime.RawExtension{
+						Raw: rawAppDeflGen{
+							DefaultDeployOps: &appskubermaticv1.DeployOptions{},
+						}.Do(),
+					},
+					Object: runtime.RawExtension{
+						Raw: rawAppDeflGen{
+							DefaultDeployOps: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true}},
+						}.Do(),
+					},
+				},
+			},
+			wantPatches: []jsonpatch.Operation{
+				jsonpatch.NewOperation("replace", "/spec/defaultDeployOptions/helm/timeout", "5m0s"),
+			},
+		},
+		{
+			name: "Delete applicationDefinition should not generate path",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
+						Kind:    "ApplicationDefinition",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawAppDeflGen{
+							DefaultDeployOps: &appskubermaticv1.DeployOptions{},
+						}.Do(),
+					},
+				},
+			},
+			wantPatches: []jsonpatch.Operation{},
+		},
+	}
+
+	for _, tt := range tests {
+		d, err := admission.NewDecoder(testScheme)
+		if err != nil {
+			t.Fatalf("error occurred while creating decoder: %v", err)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			handler := AdmissionHandler{
+				log:     logr.Discard(),
+				decoder: d,
+			}
+			res := handler.Handle(context.Background(), tt.req)
+			if res.AdmissionResponse.Result != nil && (res.AdmissionResponse.Result.Code == http.StatusInternalServerError || res.AdmissionResponse.Result.Code == http.StatusBadRequest) {
+				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+			}
+
+			a := map[string]jsonpatch.JsonPatchOperation{}
+			for _, p := range res.Patches {
+				a[p.Path] = p
+			}
+			w := map[string]jsonpatch.JsonPatchOperation{}
+			for _, p := range tt.wantPatches {
+				w[p.Path] = p
+			}
+			if diff := deep.Equal(a, w); len(diff) > 0 {
+				t.Errorf("Diff found between wanted and actual patches: %+v", diff)
+			}
+		})
+	}
+}
+
+type rawAppDeflGen struct {
+	DefaultDeployOps *appskubermaticv1.DeployOptions
+}
+
+func (r rawAppDeflGen) Do() []byte {
+	key := appskubermaticv1.ApplicationDefinition{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appskubermaticv1.GroupName + "/" + appskubermaticv1.GroupVersion,
+			Kind:       "ApplicationDefinition",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "app-def-1",
+		},
+		Spec: appskubermaticv1.ApplicationDefinitionSpec{
+			Description: "an app",
+			Method:      appskubermaticv1.HelmTemplateMethod,
+			Versions: []appskubermaticv1.ApplicationVersion{
+				{
+					Version: "v1.0.0",
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
+								URL:          "https://localhost/some-repo",
+								ChartName:    "chartName",
+								ChartVersion: "1.0.0",
+							},
+						},
+					},
+				},
+			},
+			DefaultDeployOptions: r.DefaultDeployOps,
+		},
+	}
+
+	s := json.NewSerializerWithOptions(json.DefaultMetaFactory, testScheme, testScheme, json.SerializerOptions{Pretty: true})
+	buff := bytes.NewBuffer([]byte{})
+	_ = s.Encode(&key, buff)
+
+	return buff.Bytes()
+}

--- a/pkg/webhook/application/applicationinstallation/mutation/mutation.go
+++ b/pkg/webhook/application/applicationinstallation/mutation/mutation.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// AdmissionHandler for mutating Kubermatic ApplicationInstallation CRD.
+type AdmissionHandler struct {
+	log     logr.Logger
+	decoder *admission.Decoder
+}
+
+// NewAdmissionHandler returns a new ApplicationInstallation AdmissionHandler.
+func NewAdmissionHandler() *AdmissionHandler {
+	return &AdmissionHandler{}
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-application-installation", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) InjectLogger(l logr.Logger) error {
+	h.log = l.WithName("application-installation-mutation-handler")
+	return nil
+}
+
+func (h *AdmissionHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	appInstall := &appskubermaticv1.ApplicationInstallation{}
+
+	switch req.Operation {
+	case admissionv1.Create:
+		if err := h.decoder.Decode(req, appInstall); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if err := defaulting.DefaultApplicationInstallation(appInstall); err != nil {
+			h.log.Error(err, "ApplicationInstallation mutation failed")
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("ApplicationInstallation mutation request %s failed: %w", req.UID, err))
+		}
+
+	case admissionv1.Update:
+		if err := h.decoder.Decode(req, appInstall); err != nil {
+			return admission.Errored(http.StatusBadRequest, err)
+		}
+
+		if err := defaulting.DefaultApplicationInstallation(appInstall); err != nil {
+			h.log.Error(err, "ApplicationInstallation mutation failed")
+			return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("ApplicationInstallation mutation request %s failed: %w", req.UID, err))
+		}
+
+	case admissionv1.Delete:
+		return webhook.Allowed(fmt.Sprintf("no mutation done for request %s", req.UID))
+
+	default:
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported on ApplicationInstallation resources", req.Operation))
+	}
+
+	mutatedAppInstall, err := json.Marshal(appInstall)
+	if err != nil {
+		return webhook.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling ApplicationInstallation object failed: %w", err))
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, mutatedAppInstall)
+}

--- a/pkg/webhook/application/applicationinstallation/mutation/mutation_test.go
+++ b/pkg/webhook/application/applicationinstallation/mutation/mutation_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutation
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-test/deep"
+	jsonpatch "gomodules.xyz/jsonpatch/v2"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var (
+	testScheme = runtime.NewScheme()
+)
+
+func init() {
+	_ = appskubermaticv1.AddToScheme(testScheme)
+}
+
+func TestHandle(t *testing.T) {
+	tests := []struct {
+		name        string
+		req         webhook.AdmissionRequest
+		wantPatches []jsonpatch.JsonPatchOperation
+	}{
+		{
+			name: "Create applicationInstallation with DeployOps.Helm.Atomic=true --> DeployOps.Helm.Wait and DeployOps.Helm.timeout should be defaulted",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
+						Kind:    "ApplicationInstallation",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawAppInstallGen{
+							DeployOps: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true}},
+						}.Do(),
+					},
+				},
+			},
+			wantPatches: []jsonpatch.Operation{
+				jsonpatch.NewOperation("add", "/spec/deployOptions/helm/wait", true),
+				jsonpatch.NewOperation("replace", "/spec/deployOptions/helm/timeout", "5m0s"),
+			},
+		},
+		{
+			name: "Update applicationInstallation with DeployOps.Helm.Wait=true-->  DeployOps.Helm.timeout should be defaulted",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
+						Kind:    "ApplicationInstallation",
+					},
+					Name: "foo",
+					OldObject: runtime.RawExtension{
+						Raw: rawAppInstallGen{
+							DeployOps: &appskubermaticv1.DeployOptions{},
+						}.Do(),
+					},
+					Object: runtime.RawExtension{
+						Raw: rawAppInstallGen{
+							DeployOps: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true}},
+						}.Do(),
+					},
+				},
+			},
+			wantPatches: []jsonpatch.Operation{
+				jsonpatch.NewOperation("replace", "/spec/deployOptions/helm/timeout", "5m0s"),
+			},
+		},
+		{
+			name: "Delete applicationInstallation should not generate path",
+			req: webhook.AdmissionRequest{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+					RequestKind: &metav1.GroupVersionKind{
+						Group:   appskubermaticv1.GroupName,
+						Version: appskubermaticv1.GroupVersion,
+						Kind:    "ApplicationInstallation",
+					},
+					Name: "foo",
+					Object: runtime.RawExtension{
+						Raw: rawAppInstallGen{
+							DeployOps: &appskubermaticv1.DeployOptions{},
+						}.Do(),
+					},
+				},
+			},
+			wantPatches: []jsonpatch.Operation{},
+		},
+	}
+
+	for _, tt := range tests {
+		d, err := admission.NewDecoder(testScheme)
+		if err != nil {
+			t.Fatalf("error occurred while creating decoder: %v", err)
+		}
+
+		t.Run(tt.name, func(t *testing.T) {
+			handler := AdmissionHandler{
+				log:     logr.Discard(),
+				decoder: d,
+			}
+			res := handler.Handle(context.Background(), tt.req)
+			if res.AdmissionResponse.Result != nil && (res.AdmissionResponse.Result.Code == http.StatusInternalServerError || res.AdmissionResponse.Result.Code == http.StatusBadRequest) {
+				t.Fatalf("Request failed: %v", res.AdmissionResponse.Result.Message)
+			}
+
+			a := map[string]jsonpatch.JsonPatchOperation{}
+			for _, p := range res.Patches {
+				a[p.Path] = p
+			}
+			w := map[string]jsonpatch.JsonPatchOperation{}
+			for _, p := range tt.wantPatches {
+				w[p.Path] = p
+			}
+			if diff := deep.Equal(a, w); len(diff) > 0 {
+				t.Errorf("Diff found between wanted and actual patches: %+v", diff)
+			}
+		})
+	}
+}
+
+type rawAppInstallGen struct {
+	DeployOps *appskubermaticv1.DeployOptions
+}
+
+func (r rawAppInstallGen) Do() []byte {
+	key := appskubermaticv1.ApplicationInstallation{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: appskubermaticv1.GroupName + "/" + appskubermaticv1.GroupVersion,
+			Kind:       "ApplicationInstallation",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "app-1",
+			Namespace: "default",
+		},
+		Spec: appskubermaticv1.ApplicationInstallationSpec{
+			Namespace: appskubermaticv1.AppNamespaceSpec{
+				Name: "default",
+			},
+			ApplicationRef: appskubermaticv1.ApplicationRef{
+				Name:    "app-def-1",
+				Version: "v1.0.0",
+			},
+			DeployOptions: r.DeployOps,
+		},
+	}
+
+	s := json.NewSerializerWithOptions(json.DefaultMetaFactory, testScheme, testScheme, json.SerializerOptions{Pretty: true})
+	buff := bytes.NewBuffer([]byte{})
+	_ = s.Encode(&key, buff)
+
+	return buff.Bytes()
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

 add validating and mutating webhook for `ApplicationInstinstallation.spec.deployOptions` and `ApplicationDefinition.spec.defaultDeployOptions`.

Logic for validation and defaulting is describe in #11610

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11610

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
each webhook is implemented in a separate commit.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
applications: add validating and defaulting webhook for deployOptions.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
