### PR TITLE
KubeVirt switch back to Equinix for tests

### DIFF
--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -32,7 +32,7 @@ const (
 	kubevirtCPUs               = 2
 	kubevirtMemory             = "4Gi"
 	kubevirtDiskSize           = "25Gi"
-	kubevirtDiskClassName      = "csi-rbd"
+	kubevirtDiskClassName      = "longhorn"
 )
 
 type kubevirtScenario struct {

--- a/cmd/conformance-tester/pkg/tests/loadbalancer.go
+++ b/cmd/conformance-tester/pkg/tests/loadbalancer.go
@@ -43,8 +43,7 @@ func supportsLoadBalancer(cluster *kubermaticv1.Cluster) bool {
 	return cluster.Spec.Cloud.Azure != nil ||
 		cluster.Spec.Cloud.AWS != nil ||
 		cluster.Spec.Cloud.GCP != nil ||
-		cluster.Spec.Cloud.Hetzner != nil ||
-		cluster.Spec.Cloud.Kubevirt != nil
+		cluster.Spec.Cloud.Hetzner != nil
 }
 
 func TestLoadBalancer(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client, attempt int) error {

--- a/cmd/conformance-tester/pkg/tests/storage.go
+++ b/cmd/conformance-tester/pkg/tests/storage.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	kubevirtStorageClassName = "kubevirt-csi-rbd"
+	kubevirtStorageClassName = "kubevirt-longhorn"
 )
 
 func supportsStorage(cluster *kubermaticv1.Cluster) bool {


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Until the DC KubeVirt infra cluster is ready, switching back to Equinix Metal.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
