### PR TITLE
Fix missing SSH keys in e2e tests

### DIFF
--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -24,10 +24,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -63,10 +63,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -101,10 +101,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -137,10 +137,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-4
-          imagePullPolicy: Always
+        - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -173,10 +173,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -209,10 +209,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -245,10 +245,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -281,10 +281,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -317,10 +317,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -353,10 +353,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -389,10 +389,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -425,10 +425,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -461,10 +461,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -499,10 +499,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -537,10 +537,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -575,10 +575,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -613,10 +613,10 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
-          imagePullPolicy: Always
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -26,6 +26,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
@@ -60,6 +61,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
@@ -95,6 +97,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
@@ -130,6 +133,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
@@ -162,6 +166,7 @@ presubmits:
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
@@ -189,6 +194,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
@@ -221,6 +227,7 @@ presubmits:
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5
@@ -251,6 +258,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
       preset-vault: "true"
       preset-goproxy: "true"
+      preset-e2e-ssh: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.19-node-18-kind-0.17-5

--- a/cmd/conformance-tester/pkg/scenarios/alibaba.go
+++ b/cmd/conformance-tester/pkg/scenarios/alibaba.go
@@ -43,7 +43,7 @@ func (s *alibabaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 	}
 }
 
-func (s *alibabaScenario) MachineDeployments(_ context.Context, replicas int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *alibabaScenario) MachineDeployments(_ context.Context, replicas int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewAlibabaConfig().
 		WithInstanceType("ecs.c6.xsmall").
 		WithDiskSize(40).
@@ -51,7 +51,7 @@ func (s *alibabaScenario) MachineDeployments(_ context.Context, replicas int, se
 		WithVSwitchID("vsw-gw8g8mn4ohmj483hsylmn").
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, replicas, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, replicas, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/anexia.go
+++ b/cmd/conformance-tester/pkg/scenarios/anexia.go
@@ -64,7 +64,7 @@ func (s *anexiaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 	}
 }
 
-func (s *anexiaScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *anexiaScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewAnexiaConfig().
 		WithCPUs(nodeCpu).
 		WithMemory(nodeMemory).
@@ -73,7 +73,7 @@ func (s *anexiaScenario) MachineDeployments(_ context.Context, num int, secrets 
 		WithVlanID(secrets.Anexia.VlanID).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -57,7 +57,7 @@ func (s *awsScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	}
 }
 
-func (s *awsScenario) MachineDeployments(ctx context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *awsScenario) MachineDeployments(ctx context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	vpcs, err := awsprovider.GetVPCS(ctx, secrets.AWS.AccessKeyID, secrets.AWS.SecretAccessKey, "", "", s.datacenter.Spec.AWS.Region)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ func (s *awsScenario) MachineDeployments(ctx context.Context, num int, secrets t
 			WithSpotInstanceMaxPrice("0.5").
 			Build()
 
-		md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+		md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/conformance-tester/pkg/scenarios/azure.go
+++ b/cmd/conformance-tester/pkg/scenarios/azure.go
@@ -50,12 +50,12 @@ func (s *azureScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec
 	}
 }
 
-func (s *azureScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *azureScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewAzureConfig().
 		WithVMSize(azureVMSize).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/base.go
+++ b/cmd/conformance-tester/pkg/scenarios/base.go
@@ -50,7 +50,7 @@ type Scenario interface {
 	IsValid(opts *types.Options, log *zap.SugaredLogger) bool
 
 	Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec
-	MachineDeployments(ctx context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error)
+	MachineDeployments(ctx context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error)
 
 	SetDualstackEnabled(bool)
 }
@@ -113,7 +113,7 @@ func (s *baseScenario) IsValid(opts *types.Options, log *zap.SugaredLogger) bool
 	return true
 }
 
-func (s *baseScenario) createMachineDeployment(cluster *kubermaticv1.Cluster, replicas int, cloudProviderSpec interface{}) (clusterv1alpha1.MachineDeployment, error) {
+func (s *baseScenario) createMachineDeployment(cluster *kubermaticv1.Cluster, replicas int, cloudProviderSpec interface{}, sshPubKeys []string) (clusterv1alpha1.MachineDeployment, error) {
 	replicas32 := int32(replicas)
 
 	osSpec, err := operatingsystem.DefaultSpec(s.operatingSystem, s.cloudProvider)
@@ -132,6 +132,7 @@ func (s *baseScenario) createMachineDeployment(cluster *kubermaticv1.Cluster, re
 		WithOperatingSystemSpec(osSpec).
 		WithCloudProviderSpec(cloudProviderSpec).
 		WithNetworkConfig(networkConfig).
+		AddSSHPublicKey(sshPubKeys...).
 		BuildProviderSpec()
 	if err != nil {
 		return clusterv1alpha1.MachineDeployment{}, err

--- a/cmd/conformance-tester/pkg/scenarios/digitalocean.go
+++ b/cmd/conformance-tester/pkg/scenarios/digitalocean.go
@@ -46,12 +46,12 @@ func (s *digitaloceanScenario) Cluster(secrets types.Secrets) *kubermaticv1.Clus
 	}
 }
 
-func (s *digitaloceanScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *digitaloceanScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewDigitaloceanConfig().
 		WithSize(dropletSize).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/google.go
+++ b/cmd/conformance-tester/pkg/scenarios/google.go
@@ -61,7 +61,7 @@ func (s *googleScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 	}
 }
 
-func (s *googleScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *googleScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewGCPConfig().
 		WithMachineType("n1-standard-2").
 		WithDiskType("pd-standard").
@@ -69,7 +69,7 @@ func (s *googleScenario) MachineDeployments(_ context.Context, num int, secrets 
 		WithPreemptible(false).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/hetzner.go
+++ b/cmd/conformance-tester/pkg/scenarios/hetzner.go
@@ -46,12 +46,12 @@ func (s *hetznerScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 	}
 }
 
-func (s *hetznerScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *hetznerScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewHetznerConfig().
 		WithServerType(hetznerServerType).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -52,7 +52,7 @@ func (s *kubevirtScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterS
 	}
 }
 
-func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	image, err := s.getOSImage()
 	if err != nil {
 		return nil, err
@@ -66,7 +66,7 @@ func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secret
 		WithPrimaryDiskStorageClassName(kubevirtDiskClassName).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/nutanix.go
+++ b/cmd/conformance-tester/pkg/scenarios/nutanix.go
@@ -57,7 +57,7 @@ func (s *nutanixScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 	}
 }
 
-func (s *nutanixScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *nutanixScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewNutanixConfig().
 		WithSubnetName(secrets.Nutanix.SubnetName).
 		WithCPUs(nutanixCPUs).
@@ -65,7 +65,7 @@ func (s *nutanixScenario) MachineDeployments(_ context.Context, num int, secrets
 		WithDiskSize(nutanixDiskSize).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/openstack.go
+++ b/cmd/conformance-tester/pkg/scenarios/openstack.go
@@ -55,14 +55,14 @@ func (s *openStackScenario) Cluster(secrets types.Secrets) *kubermaticv1.Cluster
 	}
 }
 
-func (s *openStackScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *openStackScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewOpenstackConfig().
 		WithFlavor(openStackFlavor).
 		WithInstanceReadyCheckPeriod(openStackInstanceReadyCheckPeriod).
 		WithInstanceReadyCheckTimeout(openStackInstanceReadyCheckTimeout).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/packet.go
+++ b/cmd/conformance-tester/pkg/scenarios/packet.go
@@ -47,12 +47,12 @@ func (s *packetScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 	}
 }
 
-func (s *packetScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *packetScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewEquinixMetalConfig().
 		WithInstanceType(packetInstanceType).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -61,7 +61,7 @@ func (s *vmwareCloudDirectorScenario) Cluster(secrets types.Secrets) *kubermatic
 	return spec
 }
 
-func (s *vmwareCloudDirectorScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *vmwareCloudDirectorScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewVMwareCloudDirectorConfig().
 		WithCatalog(vmwareCloudDirectorCatalog).
 		WithCPUs(vmwareCloudDirectorCPUs).
@@ -71,7 +71,7 @@ func (s *vmwareCloudDirectorScenario) MachineDeployments(_ context.Context, num 
 		WithIPAllocationMode(vmwareCloudDirectorIPAllocationMode).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/vsphere.go
+++ b/cmd/conformance-tester/pkg/scenarios/vsphere.go
@@ -59,14 +59,14 @@ func (s *vSphereScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 	return spec
 }
 
-func (s *vSphereScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster) ([]clusterv1alpha1.MachineDeployment, error) {
+func (s *vSphereScenario) MachineDeployments(_ context.Context, num int, secrets types.Secrets, cluster *kubermaticv1.Cluster, sshPubKeys []string) ([]clusterv1alpha1.MachineDeployment, error) {
 	cloudProviderSpec := provider.NewVSphereConfig().
 		WithCPUs(2).
 		WithMemoryMB(4096).
 		WithDiskSizeGB(10).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/hack/ci/run-ipam-e2e-tests.sh
+++ b/hack/ci/run-ipam-e2e-tests.sh
@@ -29,12 +29,26 @@ beforeGocache=$(nowms)
 make download-gocache
 pushElapsed gocache_download_duration_milliseconds $beforeGocache
 
+if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
+  echodate "Getting default SSH pubkey for machines from Vault"
+  retry 5 vault_ci_login
+  E2E_SSH_PUBKEY="$(mktemp)"
+  vault kv get -field=pubkey dev/e2e-machine-controller-ssh-key > "${E2E_SSH_PUBKEY}"
+else
+  E2E_SSH_PUBKEY_CONTENT="${E2E_SSH_PUBKEY}"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  echo "${E2E_SSH_PUBKEY_CONTENT}" > "${E2E_SSH_PUBKEY}"
+fi
+
+echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 ${E2E_SSH_PUBKEY})"
+
 export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
 export KUBERMATIC_YAML=hack/ci/testdata/kubermatic.yaml
 
 source hack/ci/setup-kind-cluster.sh
 
-# gather the logs of all things in the Kubermatic namespace
+# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 
 source hack/ci/setup-kubermatic-in-kind.sh
@@ -43,6 +57,7 @@ echodate "Running IPAM tests..."
 
 go_test ipam_e2e -timeout 45m -tags ipam -v ./pkg/test/e2e/ipam \
   -kubeconfig "$KUBECONFIG" \
-  -hetzner-kkp-datacenter hetzner-nbg1
+  -hetzner-kkp-datacenter hetzner-nbg1 \
+  -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -33,7 +33,8 @@ export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
 export KUBERMATIC_YAML=hack/ci/testdata/kubermatic_konnectivity.yaml
 source hack/ci/setup-kind-cluster.sh
 
-# gather the logs of all things in the Kubermatic namespace
+# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 
 source hack/ci/setup-kubermatic-in-kind.sh
@@ -43,6 +44,18 @@ export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 echodate "Getting secrets from Vault"
 retry 5 vault_ci_login
 
+if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
+  echodate "Getting default SSH pubkey for machines from Vault"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  vault kv get -field=pubkey dev/e2e-machine-controller-ssh-key > "${E2E_SSH_PUBKEY}"
+else
+  E2E_SSH_PUBKEY_CONTENT="${E2E_SSH_PUBKEY}"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  echo "${E2E_SSH_PUBKEY_CONTENT}" > "${E2E_SSH_PUBKEY}"
+fi
+
+echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 ${E2E_SSH_PUBKEY})"
+
 export AWS_E2E_TESTS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws-kkp)
 export AWS_E2E_TESTS_SECRET=$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)
 
@@ -51,6 +64,7 @@ echodate "Successfully got secrets for dev from Vault"
 echodate "Running Konnectivity tests..."
 
 go_test konnectivity_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity \
-  -aws-kkp-datacenter aws-eu-central-1a
+  -aws-kkp-datacenter aws-eu-central-1a \
+  -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Konnectivity tests done."

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -29,11 +29,25 @@ beforeGocache=$(nowms)
 make download-gocache
 pushElapsed gocache_download_duration_milliseconds $beforeGocache
 
+if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
+  echodate "Getting default SSH pubkey for machines from Vault"
+  retry 5 vault_ci_login
+  E2E_SSH_PUBKEY="$(mktemp)"
+  vault kv get -field=pubkey dev/e2e-machine-controller-ssh-key > "${E2E_SSH_PUBKEY}"
+else
+  E2E_SSH_PUBKEY_CONTENT="${E2E_SSH_PUBKEY}"
+  E2E_SSH_PUBKEY="$(mktemp)"
+  echo "${E2E_SSH_PUBKEY_CONTENT}" > "${E2E_SSH_PUBKEY}"
+fi
+
+echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 ${E2E_SSH_PUBKEY})"
+
 export KIND_CLUSTER_NAME="${SEED_NAME:-kubermatic}"
 export KUBERMATIC_YAML=hack/ci/testdata/kubermatic.yaml
 source hack/ci/setup-kind-cluster.sh
 
-# gather the logs of all things in the Kubermatic namespace
+# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 
 source hack/ci/setup-kubermatic-in-kind.sh
@@ -41,6 +55,7 @@ source hack/ci/setup-kubermatic-in-kind.sh
 echodate "Running OPA tests..."
 
 go_test opa_e2e -timeout 30m -tags e2e,ee -v ./pkg/test/e2e/opa \
-  -hetzner-kkp-datacenter hetzner-nbg1
+  -hetzner-kkp-datacenter hetzner-nbg1 \
+  -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Tests completed successfully!"

--- a/pkg/test/e2e/jig/flags.go
+++ b/pkg/test/e2e/jig/flags.go
@@ -41,6 +41,7 @@ var (
 	buildID      string
 	project      string
 	version      string
+	sshPubKey    string
 
 	// once is for goroutine-safe defaulting of the build ID.
 	once = &sync.Once{}
@@ -51,6 +52,11 @@ func AddFlags(fs *flag.FlagSet) {
 	flag.StringVar(&kkpNamespace, "namespace", kkpNamespace, "namespace where KKP is installed into")
 	flag.StringVar(&project, "project", project, "KKP project to use (if not given, a new project might be created)")
 	flag.StringVar(&version, "cluster-version", version, "Kubernetes version of the new user cluster (defaults to $VERSION_TO_TEST or the default version compiled into KKP)")
+	flag.StringVar(&sshPubKey, "ssh-pub-key", sshPubKey, "Optional SSH public key to assign to the Machine objects (requires user-ssh-key-agent to be disabled)")
+}
+
+func SSHPublicKey() string {
+	return sshPubKey
 }
 
 func BuildID() string {

--- a/pkg/test/e2e/jig/presets.go
+++ b/pkg/test/e2e/jig/presets.go
@@ -119,6 +119,7 @@ func NewAlibabaCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, 
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewAlibabaConfig().WithInstanceType("ecs.ic5.large").WithDiskSize(40).Build())
 
 	return &TestJig{
@@ -151,6 +152,7 @@ func NewAWSCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, cred
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(awsConfig.Build())
 
 	return &TestJig{
@@ -180,6 +182,7 @@ func NewAzureCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, cr
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewAzureConfig().
 			WithVMSize("Standard_B1ms").
 			// From Azure VM there is no IPv6-only route to the internet
@@ -212,6 +215,7 @@ func NewHetznerCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, 
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewHetznerConfig().WithServerType("cx21").Build())
 
 	return &TestJig{
@@ -243,6 +247,7 @@ func NewOpenstackCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewOpenstackConfig().WithFlavor("m1.small").Build())
 
 	return &TestJig{
@@ -270,6 +275,7 @@ func NewVSphereCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, 
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewVSphereConfig().WithCPUs(2).WithMemoryMB(4096).WithDiskSizeGB(10).Build())
 
 	return &TestJig{
@@ -296,6 +302,7 @@ func NewDigitaloceanCluster(client ctrlruntimeclient.Client, log *zap.SugaredLog
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewDigitaloceanConfig().WithSize("c-2").WithBackups(false).WithMonitoring(false).Build())
 
 	return &TestJig{
@@ -322,6 +329,7 @@ func NewGCPCluster(client ctrlruntimeclient.Client, log *zap.SugaredLogger, cred
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewGCPConfig().WithMachineType("e2-small").WithDiskSize(25).WithDiskType("pd-standard").WithPreemptible(false).Build())
 
 	return &TestJig{
@@ -349,6 +357,7 @@ func NewEquinixMetalCluster(client ctrlruntimeclient.Client, log *zap.SugaredLog
 	machineJig := NewMachineJig(client, log, nil).
 		WithClusterJig(clusterJig).
 		WithReplicas(replicas).
+		AddSSHPublicKey(SSHPublicKey()).
 		WithCloudProviderSpec(provider.NewEquinixMetalConfig().WithInstanceType("c3.small.x86").Build())
 
 	return &TestJig{


### PR DESCRIPTION
**What this PR does / why we need it**:
Not all of our tests correctly injected SSH keys to help debugging. Even the conformance tests relied on the user-ssh-key-agent, which is disabled in e2e tests, so there were no keys on any e2e nodes.

Additionally, this also adds more `protokol` usages to capture cluster control plane logs (I don't remember why we didn't do this earlier).

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
