### PR TITLE
add new fields to externalcluster crd

### DIFF
--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"k8c.io/kubermatic/v2/pkg/semver"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -96,7 +97,11 @@ type ExternalClusterKubeOneCloudSpec struct {
 	// ProviderName is the name of the cloud provider used, one of
 	// "aws", "azure", "digitalocean", "gcp",
 	// "hetzner", "nutanix", "openstack", "packet", "vsphere" KubeOne natively-supported providers
-	ProviderName         string                                  `json:"providerName"`
+	ProviderName string `json:"providerName"`
+
+	// Region is the kubernetes control plane region.
+	Region string `json:"region,omitempty"`
+
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`
 	SSHReference         *providerconfig.GlobalSecretKeySelector `json:"sshReference,omitempty"`
 	ManifestReference    *providerconfig.GlobalSecretKeySelector `json:"manifestReference,omitempty"`
@@ -120,6 +125,9 @@ type ExternalClusterSpec struct {
 
 	// KubeconfigReference is reference to cluster Kubeconfig
 	KubeconfigReference *providerconfig.GlobalSecretKeySelector `json:"kubeconfigReference,omitempty"`
+
+	// Version defines the wanted version of the control plane.
+	Version semver.Semver `json:"version"`
 
 	// CloudSpec contains provider specific fields
 	CloudSpec ExternalClusterCloudSpec `json:"cloudSpec"`

--- a/pkg/apis/kubermatic/v1/external_cluster.go
+++ b/pkg/apis/kubermatic/v1/external_cluster.go
@@ -99,7 +99,8 @@ type ExternalClusterKubeOneCloudSpec struct {
 	// "hetzner", "nutanix", "openstack", "packet", "vsphere" KubeOne natively-supported providers
 	ProviderName string `json:"providerName"`
 
-	// Region is the kubernetes control plane region.
+	// Region is the cloud provider region in which the cluster resides.
+	// This field is used only to display information.
 	Region string `json:"region,omitempty"`
 
 	CredentialsReference *providerconfig.GlobalSecretKeySelector `json:"credentialsReference,omitempty"`

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -3184,6 +3184,7 @@ func (in *ExternalClusterSpec) DeepCopyInto(out *ExternalClusterSpec) {
 		*out = new(types.GlobalSecretKeySelector)
 		**out = **in
 	}
+	out.Version = in.Version.DeepCopy()
 	in.CloudSpec.DeepCopyInto(&out.CloudSpec)
 	in.ClusterNetwork.DeepCopyInto(&out.ClusterNetwork)
 }

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -280,6 +280,9 @@ spec:
                         providerName:
                           description: ProviderName is the name of the cloud provider used, one of "aws", "azure", "digitalocean", "gcp", "hetzner", "nutanix", "openstack", "packet", "vsphere" KubeOne natively-supported providers
                           type: string
+                        region:
+                          description: Region is the kubernetes control plane region.
+                          type: string
                         sshReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
                           properties:
@@ -383,10 +386,14 @@ spec:
                 pauseReason:
                   description: PauseReason is the reason why the cluster is not being managed. This field is for informational purpose only and can be set by a user or a controller to communicate the reason for pausing the cluster.
                   type: string
+                version:
+                  description: Version defines the wanted version of the control plane.
+                  type: string
               required:
                 - cloudSpec
                 - humanReadableName
                 - pause
+                - version
               type: object
             status:
               description: Status contains reconciliation information for the cluster.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_externalclusters.yaml
@@ -281,7 +281,7 @@ spec:
                           description: ProviderName is the name of the cloud provider used, one of "aws", "azure", "digitalocean", "gcp", "hetzner", "nutanix", "openstack", "packet", "vsphere" KubeOne natively-supported providers
                           type: string
                         region:
-                          description: Region is the kubernetes control plane region.
+                          description: Region is the cloud provider region in which the cluster resides. This field is used only to display information.
                           type: string
                         sshReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.


### PR DESCRIPTION
Signed-off-by: Harshita sharma <harshita.sharma6174@gmail.com>

**What this PR does / why we need it**: add new fields to externalcluster crd :
- KubeOne Control Plane Region: This field will store and display KubeOne cluster region information.
- Control Plane Version: This field is used in order to process desired version KubeOne Clusters using the KubeOne controller.
Similar changes for AKS/EKS/GKE will be done in future PRs

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds `spec.version` and `spec.cloudSpec.kubeone.region` fields in External cluster CRD.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
``` documentation
NONE
```
