### PR TITLE
applications installation: reset Status.failures to 0 if the app'spec has changed

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -212,6 +212,12 @@ type ApplicationInstallationCondition struct {
 	Reason string `json:"reason,omitempty"`
 	// Human readable message indicating details about last transition.
 	Message string `json:"message,omitempty"`
+
+	// observedGeneration represents the .metadata.generation that the condition was set based upon.
+	// For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the instance.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=ManifestsRetrieved;Ready
@@ -246,6 +252,7 @@ func (appInstallation *ApplicationInstallation) SetCondition(conditionType Appli
 	condition.LastHeartbeatTime = now
 	condition.Reason = reason
 	condition.Message = message
+	condition.ObservedGeneration = appInstallation.Generation
 
 	if appInstallation.Status.Conditions == nil {
 		appInstallation.Status.Conditions = map[ApplicationInstallationConditionType]ApplicationInstallationCondition{}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -319,7 +319,7 @@ func createApplicationDef(t *testing.T, ctx context.Context, client ctrlruntimec
 
 func createApplicationInstallation(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, appInstallName string, appDefName string, version string) appskubermaticv1.ApplicationInstallation {
 	// Create applicationInstallation.
-	if err := client.Create(ctx, genApplicationInstallation(appInstallName, appDefName, version, 0)); err != nil {
+	if err := client.Create(ctx, genApplicationInstallation(appInstallName, appDefName, version, 0, 1, 0)); err != nil {
 		t.Fatalf("failed to create applicationInstallation: %s", err)
 	}
 

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -372,6 +372,10 @@ spec:
                       message:
                         description: Human readable message indicating details about last transition.
                         type: string
+                      observedGeneration:
+                        description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                        format: int64
+                        type: integer
                       reason:
                         description: (brief) reason for the condition's last transition.
                         type: string


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a follow-up of #11608, which introduced a max number of retires to avoid an infinite loop in case of application is deployed with `helm` method and deployOption` atomic=true`

If the application installation has reached the max number of retries due to a wrong configuration (e.g. invalid values), and the application's spec changes (e.g by fixing values), then we have to reset ` Status.failures` to 0, otherwise, there is no way to fix the application installation.
To do that, we use the `ObservedGeneration` pattern to detect that spec has changed and reset the failure counter to 0.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
