### PR TITLE
KubeVirt add imageCloningEnabled field to cluster

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -118,7 +118,7 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 	kubevirtHTTPSource := kubermaticv1.HTTPSource{
 		OperatingSystems: map[providerconfig.OperatingSystem]kubermaticv1.OSVersions{},
 		ImageCloning: kubermaticv1.ImageCloning{
-			Enable:       false,
+			Enabled:      false,
 			StorageClass: "",
 		},
 	}

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -142,10 +142,12 @@ spec:
             http:
               # Optional: ImageCloning represents options for kubevirt disk-image cloning.
               imageCloning:
-                # Enable allows you to enable/disable cloning of standard images. When this option is enabled,
+                # DataVolumeSize is the size of the DataVolume used for caching the image. Default value is 11Gi.
+                dataVolumeSize: ""
+                # Enabled allows you to enable/disable cloning of standard images. When this option is enabled,
                 # downloading images from the http source destination will happen only once. Later,
                 # Machine Controller will clone the disks using DataVolumes with the cloning source.
-                enable: false
+                enabled: false
                 # StorageClass represents storage-class for DataVolumes of standard images.
                 storageClass: ""
               # OperatingSystems represents list of supported operating-systems with their URLs.

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -142,10 +142,12 @@ spec:
             http:
               # Optional: ImageCloning represents options for kubevirt disk-image cloning.
               imageCloning:
-                # Enable allows you to enable/disable cloning of standard images. When this option is enabled,
+                # DataVolumeSize is the size of the DataVolume used for caching the image. Default value is 11Gi.
+                dataVolumeSize: ""
+                # Enabled allows you to enable/disable cloning of standard images. When this option is enabled,
                 # downloading images from the http source destination will happen only once. Later,
                 # Machine Controller will clone the disks using DataVolumes with the cloning source.
-                enable: false
+                enabled: false
                 # StorageClass represents storage-class for DataVolumes of standard images.
                 storageClass: ""
               # OperatingSystems represents list of supported operating-systems with their URLs.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1201,6 +1201,8 @@ type KubevirtCloudSpec struct {
 	// InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
 	InfraStorageClasses []string `json:"infraStorageClasses,omitempty"`
+	// ImageCloningEnabled flag enable/disable cloning for a cluster.
+	ImageCloningEnabled bool `json:"imageCloningEnabled,omitempty"`
 }
 
 type PreAllocatedDataVolume struct {

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -731,12 +731,14 @@ type HTTPSource struct {
 
 // ImageCloning represents options for kubevirt disk-image cloning.
 type ImageCloning struct {
-	// Enable allows you to enable/disable cloning of standard images. When this option is enabled,
+	// Enabled allows you to enable/disable cloning of standard images. When this option is enabled,
 	// downloading images from the http source destination will happen only once. Later,
 	// Machine Controller will clone the disks using DataVolumes with the cloning source.
-	Enable bool `json:"enable"`
+	Enabled bool `json:"enabled"`
 	// StorageClass represents storage-class for DataVolumes of standard images.
 	StorageClass string `json:"storageClass"`
+	// DataVolumeSize is the size of the DataVolume used for caching the image. Default value is 11Gi.
+	DataVolumeSize string `json:"dataVolumeSize,omitempty"`
 }
 
 // DatacenterSpecNutanix describes a Nutanix datacenter.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -558,6 +558,9 @@ spec:
                           x-kubernetes-map-type: atomic
                         csiKubeconfig:
                           type: string
+                        imageCloningEnabled:
+                          description: ImageCloningEnabled flag enable/disable cloning for a cluster.
+                          type: boolean
                         infraStorageClasses:
                           description: InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
                           items:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -553,6 +553,9 @@ spec:
                           x-kubernetes-map-type: atomic
                         csiKubeconfig:
                           type: string
+                        imageCloningEnabled:
+                          description: ImageCloningEnabled flag enable/disable cloning for a cluster.
+                          type: boolean
                         infraStorageClasses:
                           description: InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
                           items:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -254,14 +254,17 @@ spec:
                                       imageCloning:
                                         description: 'Optional: ImageCloning represents options for kubevirt disk-image cloning.'
                                         properties:
-                                          enable:
-                                            description: Enable allows you to enable/disable cloning of standard images. When this option is enabled, downloading images from the http source destination will happen only once. Later, Machine Controller will clone the disks using DataVolumes with the cloning source.
+                                          dataVolumeSize:
+                                            description: DataVolumeSize is the size of the DataVolume used for caching the image. Default value is 11Gi.
+                                            type: string
+                                          enabled:
+                                            description: Enabled allows you to enable/disable cloning of standard images. When this option is enabled, downloading images from the http source destination will happen only once. Later, Machine Controller will clone the disks using DataVolumes with the cloning source.
                                             type: boolean
                                           storageClass:
                                             description: StorageClass represents storage-class for DataVolumes of standard images.
                                             type: string
                                         required:
-                                          - enable
+                                          - enabled
                                           - storageClass
                                         type: object
                                       operatingSystems:

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -151,7 +151,7 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 		return cluster, err
 	}
 
-	enableImageCloning := k.dc.Images.HTTP != nil && k.dc.Images.HTTP.ImageCloning.Enable
+	enableImageCloning := k.dc.Images.HTTP != nil && k.dc.Images.HTTP.ImageCloning.Enabled
 	if enableImageCloning || k.dc.Images.EnableCustomImages {
 		err = reconcileKubeVirtImagesNamespace(ctx, KubeVirtImagesNamespace, client)
 		if err != nil {

--- a/pkg/webhook/seed/validation_ce.go
+++ b/pkg/webhook/seed/validation_ce.go
@@ -90,7 +90,7 @@ func (v *fixedNameValidator) validate(ctx context.Context, obj runtime.Object, i
 
 func validateKubeVirtDataCenterSpec(subject *kubermaticv1.Seed) error {
 	for _, dc := range subject.Spec.Datacenters {
-		if dc.Spec.Kubevirt != nil && (dc.Spec.Kubevirt.Images.EnableCustomImages) || (dc.Spec.Kubevirt.Images.HTTP != nil && dc.Spec.Kubevirt.Images.HTTP.ImageCloning.Enable) {
+		if dc.Spec.Kubevirt != nil && (dc.Spec.Kubevirt.Images.EnableCustomImages) || (dc.Spec.Kubevirt.Images.HTTP != nil && dc.Spec.Kubevirt.Images.HTTP.ImageCloning.Enabled) {
 			return errors.New("this option is disabled for the Community Edition")
 		}
 	}


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
This PR prepares for the  #11234 by adding new needs fields in cluster and seed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature 
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt add DataVolumeSize field to seed and ImageCloningEnabled to cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
