### PR TITLE
Improve CRD description of DatacenterSpec fields

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -44,13 +44,16 @@ spec:
       # Spec describes the cloud provider settings used to manage resources
       # in this datacenter. Exactly one cloud provider must be defined.
       spec:
+        # Alibaba configures an Alibaba Cloud datacenter.
         alibaba:
           # Region to use, for a full list of regions see
           # https://www.alibabacloud.com/help/doc-detail/40654.htm
           region: ""
+        # Anexia configures an Anexia datacenter.
         anexia:
           # LocationID the location of the region
           locationID: ""
+        # AWS configures an Amazon Web Services (AWS) datacenter.
         aws:
           # List of AMIs to use for a given operating system.
           # This gets defaulted by querying for the latest AMI for the given distribution
@@ -67,6 +70,7 @@ spec:
           # The AWS region to use, e.g. "us-east-1". For a list of available regions, see
           # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
           region: ""
+        # Azure configures an Azure datacenter.
         azure:
           # Region to use, for example "westeurope". A list of available regions can be
           # found at https://azure.microsoft.com/en-us/global-infrastructure/locations/
@@ -78,12 +82,13 @@ spec:
           # Datacenter location, e.g. "ams3". A list of existing datacenters can be found
           # at https://www.digitalocean.com/docs/platform/availability-matrix/
           region: ""
-        # EnforceAuditLogging enforces audit logging on every cluster within the DC,
+        # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
-        # EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
-        # ignoring cluster-specific settings
+        # Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
+        # ignoring cluster-specific settings.
         enforcePodSecurityPolicy: false
+        # GCP configures a Google Cloud Platform (GCP) datacenter.
         gcp:
           # Region to use, for example "europe-west3", for a full list of regions see
           # https://cloud.google.com/compute/docs/regions-zones/
@@ -95,6 +100,7 @@ spec:
           # List of enabled zones, for example [a, c]. See the link above for the available
           # zones in your chosen region.
           zoneSuffixes: []
+        # Hetzner configures a Hetzner datacenter.
         hetzner:
           # Datacenter location, e.g. "nbg1-dc3". A list of existing datacenters can be found
           # at https://docs.hetzner.com/general/others/data-centers-and-connection/
@@ -106,6 +112,7 @@ spec:
           # While machines can be in multiple networks, a single one must be chosen for the
           # HCloud CCM to work.
           network: ""
+        # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
@@ -153,7 +160,7 @@ spec:
                   <<version>>: <<url>>
                 ubuntu:
                   <<version>>: <<url>>
-        # MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
+        # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:
           # Include VMs with GPU
           enableGPU: false
@@ -165,7 +172,7 @@ spec:
           minCPU: 0
           # Minimum RAM size in GB
           minRAM: 0
-        # Nutanix is experimental and unsupported
+        # Nutanix configures a Nutanix HCI datacenter.
         nutanix:
           # Optional: AllowInsecure allows to disable the TLS certificate check against the endpoint (defaults to false)
           allowInsecure: false
@@ -183,6 +190,7 @@ spec:
             ubuntu: ""
           # Optional: Port to use when connecting to the Nutanix Prism Central endpoint (defaults to 9440)
           port: 9440
+        # Openstack configures an Openstack datacenter.
         openstack:
           authURL: ""
           availabilityZone: ""
@@ -224,7 +232,7 @@ spec:
           # use-octavia is enabled by default in CCM since v1.17.0, and disabled by
           # default with the in-tree cloud provider.
           useOctavia: true
-        # DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.
+        # Optional: DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.
         operatingSystemProfiles:
           amzn2: ""
           centos: ""
@@ -233,6 +241,7 @@ spec:
           rockylinux: ""
           sles: ""
           ubuntu: ""
+        # Packet configures an Equinix Metal datacenter.
         packet:
           # The list of enabled facilities, for example "ams1", for a full list of available
           # facilities see https://metal.equinix.com/developers/docs/locations/facilities/
@@ -240,7 +249,7 @@ spec:
           # Metros are facilities that are grouped together geographically and share capacity
           # and networking features, see https://metal.equinix.com/developers/docs/locations/metros/
           metro: ""
-        # ProviderReconciliationInterval is the time that must have passed since a
+        # Optional: ProviderReconciliationInterval is the time that must have passed since a
         # Cluster's status.lastProviderReconciliation to make the cliuster controller
         # perform an in-depth provider reconciliation, where for example missing security
         # groups will be reconciled.
@@ -253,6 +262,7 @@ spec:
         # domains, e.g. "example.com", one of which must match the email domain
         # exactly (i.e. "example.com" will not match "user@test.example.com").
         requiredEmails: []
+        # VMwareCloudDirector configures a VMware Cloud Director datacenter.
         vmwareclouddirector:
           # If set to true, disables the TLS certificate check against the endpoint.
           allowInsecure: false
@@ -272,6 +282,7 @@ spec:
             ubuntu: ""
           # Endpoint URL to use, including protocol, for example "https://vclouddirector.example.com".
           url: ""
+        # VSphere configures a VMware vSphere datacenter.
         vsphere:
           # If set to true, disables the TLS certificate check against the endpoint.
           allowInsecure: false

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -44,13 +44,16 @@ spec:
       # Spec describes the cloud provider settings used to manage resources
       # in this datacenter. Exactly one cloud provider must be defined.
       spec:
+        # Alibaba configures an Alibaba Cloud datacenter.
         alibaba:
           # Region to use, for a full list of regions see
           # https://www.alibabacloud.com/help/doc-detail/40654.htm
           region: ""
+        # Anexia configures an Anexia datacenter.
         anexia:
           # LocationID the location of the region
           locationID: ""
+        # AWS configures an Amazon Web Services (AWS) datacenter.
         aws:
           # List of AMIs to use for a given operating system.
           # This gets defaulted by querying for the latest AMI for the given distribution
@@ -67,6 +70,7 @@ spec:
           # The AWS region to use, e.g. "us-east-1". For a list of available regions, see
           # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html
           region: ""
+        # Azure configures an Azure datacenter.
         azure:
           # Region to use, for example "westeurope". A list of available regions can be
           # found at https://azure.microsoft.com/en-us/global-infrastructure/locations/
@@ -78,12 +82,13 @@ spec:
           # Datacenter location, e.g. "ams3". A list of existing datacenters can be found
           # at https://www.digitalocean.com/docs/platform/availability-matrix/
           region: ""
-        # EnforceAuditLogging enforces audit logging on every cluster within the DC,
+        # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false
-        # EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
-        # ignoring cluster-specific settings
+        # Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
+        # ignoring cluster-specific settings.
         enforcePodSecurityPolicy: false
+        # GCP configures a Google Cloud Platform (GCP) datacenter.
         gcp:
           # Region to use, for example "europe-west3", for a full list of regions see
           # https://cloud.google.com/compute/docs/regions-zones/
@@ -95,6 +100,7 @@ spec:
           # List of enabled zones, for example [a, c]. See the link above for the available
           # zones in your chosen region.
           zoneSuffixes: []
+        # Hetzner configures a Hetzner datacenter.
         hetzner:
           # Datacenter location, e.g. "nbg1-dc3". A list of existing datacenters can be found
           # at https://docs.hetzner.com/general/others/data-centers-and-connection/
@@ -106,6 +112,7 @@ spec:
           # While machines can be in multiple networks, a single one must be chosen for the
           # HCloud CCM to work.
           network: ""
+        # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
@@ -153,7 +160,7 @@ spec:
                   <<version>>: <<url>>
                 ubuntu:
                   <<version>>: <<url>>
-        # MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
+        # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:
           # Include VMs with GPU
           enableGPU: false
@@ -165,7 +172,7 @@ spec:
           minCPU: 0
           # Minimum RAM size in GB
           minRAM: 0
-        # Nutanix is experimental and unsupported
+        # Nutanix configures a Nutanix HCI datacenter.
         nutanix:
           # Optional: AllowInsecure allows to disable the TLS certificate check against the endpoint (defaults to false)
           allowInsecure: false
@@ -183,6 +190,7 @@ spec:
             ubuntu: ""
           # Optional: Port to use when connecting to the Nutanix Prism Central endpoint (defaults to 9440)
           port: 9440
+        # Openstack configures an Openstack datacenter.
         openstack:
           authURL: ""
           availabilityZone: ""
@@ -224,7 +232,7 @@ spec:
           # use-octavia is enabled by default in CCM since v1.17.0, and disabled by
           # default with the in-tree cloud provider.
           useOctavia: true
-        # DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.
+        # Optional: DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.
         operatingSystemProfiles:
           amzn2: ""
           centos: ""
@@ -233,6 +241,7 @@ spec:
           rockylinux: ""
           sles: ""
           ubuntu: ""
+        # Packet configures an Equinix Metal datacenter.
         packet:
           # The list of enabled facilities, for example "ams1", for a full list of available
           # facilities see https://metal.equinix.com/developers/docs/locations/facilities/
@@ -240,7 +249,7 @@ spec:
           # Metros are facilities that are grouped together geographically and share capacity
           # and networking features, see https://metal.equinix.com/developers/docs/locations/metros/
           metro: ""
-        # ProviderReconciliationInterval is the time that must have passed since a
+        # Optional: ProviderReconciliationInterval is the time that must have passed since a
         # Cluster's status.lastProviderReconciliation to make the cliuster controller
         # perform an in-depth provider reconciliation, where for example missing security
         # groups will be reconciled.
@@ -253,6 +262,7 @@ spec:
         # domains, e.g. "example.com", one of which must match the email domain
         # exactly (i.e. "example.com" will not match "user@test.example.com").
         requiredEmails: []
+        # VMwareCloudDirector configures a VMware Cloud Director datacenter.
         vmwareclouddirector:
           # If set to true, disables the TLS certificate check against the endpoint.
           allowInsecure: false
@@ -272,6 +282,7 @@ spec:
             ubuntu: ""
           # Endpoint URL to use, including protocol, for example "https://vclouddirector.example.com".
           url: ""
+        # VSphere configures a VMware vSphere datacenter.
         vsphere:
           # If set to true, disables the TLS certificate check against the endpoint.
           allowInsecure: false

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -380,24 +380,36 @@ type Datacenter struct {
 	Spec DatacenterSpec `json:"spec"`
 }
 
-// DatacenterSpec mutually points to provider datacenter spec.
+// DatacenterSpec configures a KKP datacenter. Provider configuration is mutually exclusive,
+// and as such only a single provider can be configured per datacenter.
 type DatacenterSpec struct {
 	Digitalocean *DatacenterSpecDigitalocean `json:"digitalocean,omitempty"`
 	// BringYourOwn contains settings for clusters using manually created
 	// nodes via kubeadm.
-	BringYourOwn        *DatacenterSpecBringYourOwn        `json:"bringyourown,omitempty"`
-	AWS                 *DatacenterSpecAWS                 `json:"aws,omitempty"`
-	Azure               *DatacenterSpecAzure               `json:"azure,omitempty"`
-	Openstack           *DatacenterSpecOpenstack           `json:"openstack,omitempty"`
-	Packet              *DatacenterSpecPacket              `json:"packet,omitempty"`
-	Hetzner             *DatacenterSpecHetzner             `json:"hetzner,omitempty"`
-	VSphere             *DatacenterSpecVSphere             `json:"vsphere,omitempty"`
+	BringYourOwn *DatacenterSpecBringYourOwn `json:"bringyourown,omitempty"`
+	// AWS configures an Amazon Web Services (AWS) datacenter.
+	AWS *DatacenterSpecAWS `json:"aws,omitempty"`
+	// Azure configures an Azure datacenter.
+	Azure *DatacenterSpecAzure `json:"azure,omitempty"`
+	// Openstack configures an Openstack datacenter.
+	Openstack *DatacenterSpecOpenstack `json:"openstack,omitempty"`
+	// Packet configures an Equinix Metal datacenter.
+	Packet *DatacenterSpecPacket `json:"packet,omitempty"`
+	// Hetzner configures a Hetzner datacenter.
+	Hetzner *DatacenterSpecHetzner `json:"hetzner,omitempty"`
+	// VSphere configures a VMware vSphere datacenter.
+	VSphere *DatacenterSpecVSphere `json:"vsphere,omitempty"`
+	// VMwareCloudDirector configures a VMware Cloud Director datacenter.
 	VMwareCloudDirector *DatacenterSpecVMwareCloudDirector `json:"vmwareclouddirector,omitempty"`
-	GCP                 *DatacenterSpecGCP                 `json:"gcp,omitempty"`
-	Kubevirt            *DatacenterSpecKubevirt            `json:"kubevirt,omitempty"`
-	Alibaba             *DatacenterSpecAlibaba             `json:"alibaba,omitempty"`
-	Anexia              *DatacenterSpecAnexia              `json:"anexia,omitempty"`
-	// Nutanix is experimental and unsupported
+	// GCP configures a Google Cloud Platform (GCP) datacenter.
+	GCP *DatacenterSpecGCP `json:"gcp,omitempty"`
+	// Kubevirt configures a KubeVirt datacenter.
+	Kubevirt *DatacenterSpecKubevirt `json:"kubevirt,omitempty"`
+	// Alibaba configures an Alibaba Cloud datacenter.
+	Alibaba *DatacenterSpecAlibaba `json:"alibaba,omitempty"`
+	// Anexia configures an Anexia datacenter.
+	Anexia *DatacenterSpecAnexia `json:"anexia,omitempty"`
+	// Nutanix configures a Nutanix HCI datacenter.
 	Nutanix *DatacenterSpecNutanix `json:"nutanix,omitempty"`
 
 	//nolint:staticcheck
@@ -410,15 +422,15 @@ type DatacenterSpec struct {
 	// exactly (i.e. "example.com" will not match "user@test.example.com").
 	RequiredEmails []string `json:"requiredEmails,omitempty"`
 
-	// EnforceAuditLogging enforces audit logging on every cluster within the DC,
+	// Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
 	// ignoring cluster-specific settings.
 	EnforceAuditLogging bool `json:"enforceAuditLogging,omitempty"`
 
-	// EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
-	// ignoring cluster-specific settings
+	// Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC,
+	// ignoring cluster-specific settings.
 	EnforcePodSecurityPolicy bool `json:"enforcePodSecurityPolicy,omitempty"`
 
-	// ProviderReconciliationInterval is the time that must have passed since a
+	// Optional: ProviderReconciliationInterval is the time that must have passed since a
 	// Cluster's status.lastProviderReconciliation to make the cliuster controller
 	// perform an in-depth provider reconciliation, where for example missing security
 	// groups will be reconciled.
@@ -427,10 +439,10 @@ type DatacenterSpec struct {
 	// of KKP, it will take this long to fix it.
 	ProviderReconciliationInterval *metav1.Duration `json:"providerReconciliationInterval,omitempty"`
 
-	// DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.
+	// Optional: DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.
 	DefaultOperatingSystemProfiles OperatingSystemProfileList `json:"operatingSystemProfiles,omitempty"`
 
-	// MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
+	// Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
 	MachineFlavorFilter *MachineFlavorFilter `json:"machineFlavorFilter,omitempty"`
 }
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -106,7 +106,7 @@ spec:
                         description: Spec describes the cloud provider settings used to manage resources in this datacenter. Exactly one cloud provider must be defined.
                         properties:
                           alibaba:
-                            description: DatacenterSpecAlibaba describes a alibaba datacenter.
+                            description: Alibaba configures an Alibaba Cloud datacenter.
                             properties:
                               region:
                                 description: Region to use, for a full list of regions see https://www.alibabacloud.com/help/doc-detail/40654.htm
@@ -115,7 +115,7 @@ spec:
                               - region
                             type: object
                           anexia:
-                            description: DatacenterSpecAnexia describes a anexia datacenter.
+                            description: Anexia configures an Anexia datacenter.
                             properties:
                               locationID:
                                 description: LocationID the location of the region
@@ -124,7 +124,7 @@ spec:
                               - locationID
                             type: object
                           aws:
-                            description: DatacenterSpecAWS describes an AWS datacenter.
+                            description: AWS configures an Amazon Web Services (AWS) datacenter.
                             properties:
                               images:
                                 additionalProperties:
@@ -138,7 +138,7 @@ spec:
                               - region
                             type: object
                           azure:
-                            description: DatacenterSpecAzure describes an Azure cloud datacenter.
+                            description: Azure configures an Azure datacenter.
                             properties:
                               location:
                                 description: Region to use, for example "westeurope". A list of available regions can be found at https://azure.microsoft.com/en-us/global-infrastructure/locations/
@@ -159,10 +159,10 @@ spec:
                               - region
                             type: object
                           enforceAuditLogging:
-                            description: EnforceAuditLogging enforces audit logging on every cluster within the DC, ignoring cluster-specific settings.
+                            description: 'Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC, ignoring cluster-specific settings.'
                             type: boolean
                           enforcePodSecurityPolicy:
-                            description: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC, ignoring cluster-specific settings
+                            description: 'Optional: EnforcePodSecurityPolicy enforces pod security policy plugin on every clusters within the DC, ignoring cluster-specific settings.'
                             type: boolean
                           fake:
                             description: DatacenterSpecFake describes a fake datacenter.
@@ -171,7 +171,7 @@ spec:
                                 type: string
                             type: object
                           gcp:
-                            description: DatacenterSpecGCP describes a GCP datacenter.
+                            description: GCP configures a Google Cloud Platform (GCP) datacenter.
                             properties:
                               region:
                                 description: Region to use, for example "europe-west3", for a full list of regions see https://cloud.google.com/compute/docs/regions-zones/
@@ -189,7 +189,7 @@ spec:
                               - zoneSuffixes
                             type: object
                           hetzner:
-                            description: DatacenterSpecHetzner describes a Hetzner cloud datacenter.
+                            description: Hetzner configures a Hetzner datacenter.
                             properties:
                               datacenter:
                                 description: Datacenter location, e.g. "nbg1-dc3". A list of existing datacenters can be found at https://docs.hetzner.com/general/others/data-centers-and-connection/
@@ -205,7 +205,7 @@ spec:
                               - network
                             type: object
                           kubevirt:
-                            description: DatacenterSpecKubevirt describes a kubevirt datacenter.
+                            description: Kubevirt configures a KubeVirt datacenter.
                             properties:
                               dnsConfig:
                                 description: DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
@@ -280,7 +280,7 @@ spec:
                                 type: object
                             type: object
                           machineFlavorFilter:
-                            description: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
+                            description: 'Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.'
                             properties:
                               enableGPU:
                                 description: Include VMs with GPU
@@ -313,7 +313,7 @@ spec:
                               - minRAM
                             type: object
                           nutanix:
-                            description: Nutanix is experimental and unsupported
+                            description: Nutanix configures a Nutanix HCI datacenter.
                             properties:
                               allowInsecure:
                                 description: 'Optional: AllowInsecure allows to disable the TLS certificate check against the endpoint (defaults to false)'
@@ -335,7 +335,7 @@ spec:
                               - images
                             type: object
                           openstack:
-                            description: DatacenterSpecOpenstack describes an OpenStack datacenter.
+                            description: Openstack configures an Openstack datacenter.
                             properties:
                               authURL:
                                 type: string
@@ -394,10 +394,10 @@ spec:
                           operatingSystemProfiles:
                             additionalProperties:
                               type: string
-                            description: DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.
+                            description: 'Optional: DefaultOperatingSystemProfiles specifies the OperatingSystemProfiles to use for each supported operating system.'
                             type: object
                           packet:
-                            description: DatacenterSpecPacket describes a Packet datacenter.
+                            description: Packet configures an Equinix Metal datacenter.
                             properties:
                               facilities:
                                 description: The list of enabled facilities, for example "ams1", for a full list of available facilities see https://metal.equinix.com/developers/docs/locations/facilities/
@@ -409,7 +409,7 @@ spec:
                                 type: string
                             type: object
                           providerReconciliationInterval:
-                            description: ProviderReconciliationInterval is the time that must have passed since a Cluster's status.lastProviderReconciliation to make the cliuster controller perform an in-depth provider reconciliation, where for example missing security groups will be reconciled. Setting this too low can cause rate limits by the cloud provider, setting this too high means that *if* a resource at a cloud provider is removed/changed outside of KKP, it will take this long to fix it.
+                            description: 'Optional: ProviderReconciliationInterval is the time that must have passed since a Cluster''s status.lastProviderReconciliation to make the cliuster controller perform an in-depth provider reconciliation, where for example missing security groups will be reconciled. Setting this too low can cause rate limits by the cloud provider, setting this too high means that *if* a resource at a cloud provider is removed/changed outside of KKP, it will take this long to fix it.'
                             type: string
                           requiredEmails:
                             description: 'Optional: When defined, only users with an e-mail address on the given domains can make use of this datacenter. You can define multiple domains, e.g. "example.com", one of which must match the email domain exactly (i.e. "example.com" will not match "user@test.example.com").'
@@ -417,6 +417,7 @@ spec:
                               type: string
                             type: array
                           vmwareclouddirector:
+                            description: VMwareCloudDirector configures a VMware Cloud Director datacenter.
                             properties:
                               allowInsecure:
                                 description: If set to true, disables the TLS certificate check against the endpoint.
@@ -440,7 +441,7 @@ spec:
                               - url
                             type: object
                           vsphere:
-                            description: DatacenterSpecVSphere describes a vSphere datacenter.
+                            description: VSphere configures a VMware vSphere datacenter.
                             properties:
                               allowInsecure:
                                 description: If set to true, disables the TLS certificate check against the endpoint.


### PR DESCRIPTION
**What this PR does / why we need it**:
I was browsing our installation docs and we now link (rightfully) to the `DatacenterSpec` CRD documentation to explain how to configure your own datacenters. I thought it would be nice to improve the descriptions on some fields. Some of them are obvious (like "BlaBla configures a BlaBla datacenter.") but make the generated CRD documentation look nicer.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
