### PR TITLE
Fix health status for user cluster components

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/health.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/health.go
@@ -89,7 +89,7 @@ func (r *Reconciler) clusterHealth(ctx context.Context, cluster *kubermaticv1.Cl
 			return nil, fmt.Errorf("failed to get machine controller health: %w", err)
 		}
 	}
-	extendedHealth.MachineController = mcHealthStatus
+	extendedHealth.MachineController = kubermaticv1helper.GetHealthStatus(mcHealthStatus, cluster, r.versions)
 
 	applicationControllerHealthStatus := kubermaticv1.HealthStatusDown
 	if extendedHealth.Apiserver == kubermaticv1.HealthStatusUp {
@@ -98,7 +98,7 @@ func (r *Reconciler) clusterHealth(ctx context.Context, cluster *kubermaticv1.Cl
 			return nil, fmt.Errorf("failed to evaluate application controller health: %w", err)
 		}
 	}
-	extendedHealth.ApplicationController = applicationControllerHealthStatus
+	extendedHealth.ApplicationController = kubermaticv1helper.GetHealthStatus(applicationControllerHealthStatus, cluster, r.versions)
 
 	if cluster.Spec.IsOperatingSystemManagerEnabled() {
 		status, err := r.operatingSystemManagerHealthCheck(ctx, cluster, ns)
@@ -203,6 +203,7 @@ func (r *Reconciler) operatingSystemManagerHealthCheck(ctx context.Context, clus
 	if err != nil {
 		return kubermaticv1.HealthStatusDown, fmt.Errorf("failed to determine deployment's health %q: %w", resources.OperatingSystemManagerDeploymentName, err)
 	}
+	status = kubermaticv1helper.GetHealthStatus(status, cluster, r.versions)
 	return status, nil
 }
 
@@ -213,6 +214,7 @@ func (r *Reconciler) kubernetesDashboardHealthCheck(ctx context.Context, cluster
 	if err != nil {
 		return kubermaticv1.HealthStatusDown, fmt.Errorf("failed to determine deployment's health %q: %w", resources.KubernetesDashboardDeploymentName, err)
 	}
+	status = kubermaticv1helper.GetHealthStatus(status, cluster, r.versions)
 	return status, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the health status for user cluster KKP components.

As they needed the user cluster API server to be ready before they can even be checked, we used to set them as DOWN. But in reality they should be considered in PROVISIONING state as long as the API server is in the PROVISIONING state as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11654 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
