### PR TITLE
Bump Konnectivity version to v0.0.35

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -52,7 +52,7 @@ func DeploymentReconciler(kServerHost string, kServerPort int, imageRewriter reg
 	return func() (string, reconciling.DeploymentReconciler) {
 		const (
 			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
-			version = "v0.0.33"
+			version = "v0.0.35"
 		)
 
 		return resources.KonnectivityDeploymentName, func(ds *appsv1.Deployment) (*appsv1.Deployment, error) {

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -44,7 +44,7 @@ var (
 func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Container, error) {
 	const (
 		name    = "k8s-artifacts-prod/kas-network-proxy/proxy-server"
-		version = "v0.0.33"
+		version = "v0.0.35"
 	)
 
 	return &corev1.Container{


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Bumps Konnectivity version to v0.0.35 to fix some minor issues.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump Konnectivity version to v0.0.35
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
