### PR TITLE
fix CCM migration test flags

### DIFF
--- a/pkg/test/e2e/ccm-migration/ccm_migration_test.go
+++ b/pkg/test/e2e/ccm-migration/ccm_migration_test.go
@@ -75,13 +75,15 @@ var (
 func init() {
 	flag.BoolVar(&options.skipCleanup, "skip-cleanup", false, "Skip clean-up of resources")
 	flag.StringVar(&options.provider, "provider", "", "Cloud provider to test")
-	flag.StringVar(&options.kubernetesRelease, "cluster-version", "", "Kubernetes version or release for the usercluster")
+	flag.StringVar(&options.kubernetesRelease, "kubernetes-release", "", "Kubernetes version or release for the usercluster")
 
 	options.awsCredentials.AddFlags(flag.CommandLine)
 	options.azureCredentials.AddFlags(flag.CommandLine)
 	options.osCredentials.AddFlags(flag.CommandLine)
 	options.vsphereCredentials.AddFlags(flag.CommandLine)
 	options.logOptions.AddFlags(flag.CommandLine)
+
+	jig.AddFlags(flag.CommandLine)
 }
 
 func TestCCMMigration(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
I made an oversight in #11639 and for some reason we didn't run the ccm-migration tests in that PR.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
