### PR TITLE
KubeVirt add custom Network Policies to KubeVirt DC

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/util/edition"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/test-infra/pkg/genyaml"
@@ -199,6 +200,19 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 							DNSPolicy: "",
 							DNSConfig: &corev1.PodDNSConfig{},
 							Images:    kubermaticv1.ImageSources{HTTP: &kubevirtHTTPSource},
+							CustomNetworkPolicies: []*networkingv1.NetworkPolicy{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "deny-ingress",
+									},
+									Spec: networkingv1.NetworkPolicySpec{
+										PodSelector: metav1.LabelSelector{},
+										PolicyTypes: []networkingv1.PolicyType{
+											networkingv1.PolicyTypeIngress,
+										},
+									},
+								},
+							},
 						},
 						Alibaba: &kubermaticv1.DatacenterSpecAlibaba{},
 						Anexia:  &kubermaticv1.DatacenterSpecAnexia{},

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -114,6 +114,9 @@ spec:
           network: ""
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
+          # AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed
+          # in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
+          additionalNetPols: null
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
           dnsConfig:

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -114,9 +114,15 @@ spec:
           network: ""
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
-          # AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed
-          # in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
-          additionalNetPols: null
+          # CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed
+          # in the dedicated infra KubeVirt cluster. They are added to the defaults.
+          customNetworkPolicies:
+            - metadata:
+                name: deny-ingress
+              spec:
+                podSelector: {}
+                policyTypes:
+                  - Ingress
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
           dnsConfig:

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -114,6 +114,9 @@ spec:
           network: ""
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
+          # AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed
+          # in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
+          additionalNetPols: null
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
           dnsConfig:

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -114,9 +114,15 @@ spec:
           network: ""
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
-          # AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed
-          # in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
-          additionalNetPols: null
+          # CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed
+          # in the dedicated infra KubeVirt cluster. They are added to the defaults.
+          customNetworkPolicies:
+            - metadata:
+                name: deny-ingress
+              spec:
+                podSelector: {}
+                policyTypes:
+                  - Ingress
           # DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
           # configuration based on DNSPolicy.
           dnsConfig:

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -23,6 +23,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -695,6 +696,10 @@ type DatacenterSpecKubevirt struct {
 	// DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS
 	// configuration based on DNSPolicy.
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
+
+	// AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed
+	// in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
+	AdditionalNetPols []*networkingv1.NetworkPolicy `json:"additionalNetPols,omitempty"`
 
 	// Images represents standard VM Image sources.
 	Images ImageSources `json:"images,omitempty"`

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -697,9 +697,9 @@ type DatacenterSpecKubevirt struct {
 	// configuration based on DNSPolicy.
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
 
-	// AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed
-	// in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
-	AdditionalNetPols []*networkingv1.NetworkPolicy `json:"additionalNetPols,omitempty"`
+	// CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed
+	// in the dedicated infra KubeVirt cluster. They are added to the defaults.
+	CustomNetworkPolicies []*networkingv1.NetworkPolicy `json:"customNetworkPolicies,omitempty"`
 
 	// Images represents standard VM Image sources.
 	Images ImageSources `json:"images,omitempty"`

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -27,6 +27,7 @@ import (
 	templatesv1 "github.com/open-policy-agent/frameworks/constraint/pkg/apis/templates/v1"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -2142,6 +2143,17 @@ func (in *DatacenterSpecKubevirt) DeepCopyInto(out *DatacenterSpecKubevirt) {
 		in, out := &in.DNSConfig, &out.DNSConfig
 		*out = new(corev1.PodDNSConfig)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.AdditionalNetPols != nil {
+		in, out := &in.AdditionalNetPols, &out.AdditionalNetPols
+		*out = make([]*networkingv1.NetworkPolicy, len(*in))
+		for i := range *in {
+			if (*in)[i] != nil {
+				in, out := &(*in)[i], &(*out)[i]
+				*out = new(networkingv1.NetworkPolicy)
+				(*in).DeepCopyInto(*out)
+			}
+		}
 	}
 	in.Images.DeepCopyInto(&out.Images)
 }

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -2144,8 +2144,8 @@ func (in *DatacenterSpecKubevirt) DeepCopyInto(out *DatacenterSpecKubevirt) {
 		*out = new(corev1.PodDNSConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.AdditionalNetPols != nil {
-		in, out := &in.AdditionalNetPols, &out.AdditionalNetPols
+	if in.CustomNetworkPolicies != nil {
+		in, out := &in.CustomNetworkPolicies, &out.CustomNetworkPolicies
 		*out = make([]*networkingv1.NetworkPolicy, len(*in))
 		for i := range *in {
 			if (*in)[i] != nil {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -207,6 +207,338 @@ spec:
                           kubevirt:
                             description: Kubevirt configures a KubeVirt datacenter.
                             properties:
+                              additionalNetPols:
+                                description: AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
+                                items:
+                                  description: NetworkPolicy describes what network traffic is allowed for a set of Pods
+                                  properties:
+                                    apiVersion:
+                                      description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                                      type: string
+                                    kind:
+                                      description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    metadata:
+                                      description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                                      type: object
+                                    spec:
+                                      description: Specification of the desired behavior for this NetworkPolicy.
+                                      properties:
+                                        egress:
+                                          description: List of egress rules to be applied to the selected pods. Outgoing traffic is allowed if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic matches at least one egress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy limits all outgoing traffic (and serves solely to ensure that the pods it selects are isolated by default). This field is beta-level in 1.8
+                                          items:
+                                            description: NetworkPolicyEgressRule describes a particular set of traffic that is allowed out of pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and to. This type is beta-level in 1.8
+                                            properties:
+                                              ports:
+                                                description: List of destination ports for outgoing traffic. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                                                items:
+                                                  description: NetworkPolicyPort describes a port to allow traffic on
+                                                  properties:
+                                                    endPort:
+                                                      description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
+                                                      format: int32
+                                                      type: integer
+                                                    port:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                                      x-kubernetes-int-or-string: true
+                                                    protocol:
+                                                      default: TCP
+                                                      description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                              to:
+                                                description: List of destinations for outgoing traffic of pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all destinations (traffic not restricted by destination). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the to list.
+                                                items:
+                                                  description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                                  properties:
+                                                    ipBlock:
+                                                      description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                                      properties:
+                                                        cidr:
+                                                          description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                                          type: string
+                                                        except:
+                                                          description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                        - cidr
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                          items:
+                                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is the label key that the selector applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                              - key
+                                                              - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    podSelector:
+                                                      description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                          items:
+                                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is the label key that the selector applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                              - key
+                                                              - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                        ingress:
+                                          description: List of ingress rules to be applied to the selected pods. Traffic is allowed to a pod if there are no NetworkPolicies selecting the pod (and cluster policy otherwise allows the traffic), OR if the traffic source is the pod's local node, OR if the traffic matches at least one ingress rule across all of the NetworkPolicy objects whose podSelector matches the pod. If this field is empty then this NetworkPolicy does not allow any traffic (and serves solely to ensure that the pods it selects are isolated by default)
+                                          items:
+                                            description: NetworkPolicyIngressRule describes a particular set of traffic that is allowed to the pods matched by a NetworkPolicySpec's podSelector. The traffic must match both ports and from.
+                                            properties:
+                                              from:
+                                                description: List of sources which should be able to access the pods selected for this rule. Items in this list are combined using a logical OR operation. If this field is empty or missing, this rule matches all sources (traffic not restricted by source). If this field is present and contains at least one item, this rule allows traffic only if the traffic matches at least one item in the from list.
+                                                items:
+                                                  description: NetworkPolicyPeer describes a peer to allow traffic to/from. Only certain combinations of fields are allowed
+                                                  properties:
+                                                    ipBlock:
+                                                      description: IPBlock defines policy on a particular IPBlock. If this field is set then neither of the other fields can be.
+                                                      properties:
+                                                        cidr:
+                                                          description: CIDR is a string representing the IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64"
+                                                          type: string
+                                                        except:
+                                                          description: Except is a slice of CIDRs that should not be included within an IP Block Valid examples are "192.168.1.1/24" or "2001:db9::/64" Except values will be rejected if they are outside the CIDR range
+                                                          items:
+                                                            type: string
+                                                          type: array
+                                                      required:
+                                                        - cidr
+                                                      type: object
+                                                    namespaceSelector:
+                                                      description: "Selects Namespaces using cluster-scoped labels. This field follows standard label selector semantics; if present but empty, it selects all namespaces. \n If PodSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects all Pods in the Namespaces selected by NamespaceSelector."
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                          items:
+                                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is the label key that the selector applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                              - key
+                                                              - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                    podSelector:
+                                                      description: "This is a label selector which selects Pods. This field follows standard label selector semantics; if present but empty, it selects all pods. \n If NamespaceSelector is also set, then the NetworkPolicyPeer as a whole selects the Pods matching PodSelector in the Namespaces selected by NamespaceSelector. Otherwise it selects the Pods matching PodSelector in the policy's own Namespace."
+                                                      properties:
+                                                        matchExpressions:
+                                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                                          items:
+                                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                            properties:
+                                                              key:
+                                                                description: key is the label key that the selector applies to.
+                                                                type: string
+                                                              operator:
+                                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                                type: string
+                                                              values:
+                                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                                items:
+                                                                  type: string
+                                                                type: array
+                                                            required:
+                                                              - key
+                                                              - operator
+                                                            type: object
+                                                          type: array
+                                                        matchLabels:
+                                                          additionalProperties:
+                                                            type: string
+                                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                                          type: object
+                                                      type: object
+                                                      x-kubernetes-map-type: atomic
+                                                  type: object
+                                                type: array
+                                              ports:
+                                                description: List of ports which should be made accessible on the pods selected for this rule. Each item in this list is combined using a logical OR. If this field is empty or missing, this rule matches all ports (traffic not restricted by port). If this field is present and contains at least one item, then this rule allows traffic only if the traffic matches at least one port in the list.
+                                                items:
+                                                  description: NetworkPolicyPort describes a port to allow traffic on
+                                                  properties:
+                                                    endPort:
+                                                      description: If set, indicates that the range of ports from port to endPort, inclusive, should be allowed by the policy. This field cannot be defined if the port field is not defined or if the port field is defined as a named (string) port. The endPort must be equal or greater than port.
+                                                      format: int32
+                                                      type: integer
+                                                    port:
+                                                      anyOf:
+                                                        - type: integer
+                                                        - type: string
+                                                      description: The port on the given protocol. This can either be a numerical or named port on a pod. If this field is not provided, this matches all port names and numbers. If present, only traffic on the specified protocol AND port will be matched.
+                                                      x-kubernetes-int-or-string: true
+                                                    protocol:
+                                                      default: TCP
+                                                      description: The protocol (TCP, UDP, or SCTP) which traffic must match. If not specified, this field defaults to TCP.
+                                                      type: string
+                                                  type: object
+                                                type: array
+                                            type: object
+                                          type: array
+                                        podSelector:
+                                          description: Selects the pods to which this NetworkPolicy object applies. The array of ingress rules is applied to any pods selected by this field. Multiple network policies can select the same set of pods. In this case, the ingress rules for each are combined additively. This field is NOT optional and follows standard label selector semantics. An empty podSelector matches all pods in this namespace.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                  - key
+                                                  - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        policyTypes:
+                                          description: List of rule types that the NetworkPolicy relates to. Valid options are ["Ingress"], ["Egress"], or ["Ingress", "Egress"]. If this field is not specified, it will default based on the existence of Ingress or Egress rules; policies that contain an Egress section are assumed to affect Egress, and all policies (whether or not they contain an Ingress section) are assumed to affect Ingress. If you want to write an egress-only policy, you must explicitly specify policyTypes [ "Egress" ]. Likewise, if you want to write a policy that specifies that no egress is allowed, you must specify a policyTypes value that include "Egress" (since such a policy would not include an Egress section and would otherwise default to just [ "Ingress" ]). This field is beta-level in 1.8
+                                          items:
+                                            description: PolicyType string describes the NetworkPolicy type This type is beta-level in 1.8
+                                            type: string
+                                          type: array
+                                      required:
+                                        - podSelector
+                                      type: object
+                                    status:
+                                      description: 'Status is the current state of the NetworkPolicy. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+                                      properties:
+                                        conditions:
+                                          description: Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state
+                                          items:
+                                            description: "Condition contains details for one aspect of the current state of this API Resource. --- This struct is intended for direct use as an array at the field path .status.conditions.  For example, \n type FooStatus struct{ // Represents the observations of a foo's current state. // Known .status.conditions.type are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge // +listType=map // +listMapKey=type Conditions []metav1.Condition `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields }"
+                                            properties:
+                                              lastTransitionTime:
+                                                description: lastTransitionTime is the last time the condition transitioned from one status to another. This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                                                format: date-time
+                                                type: string
+                                              message:
+                                                description: message is a human readable message indicating details about the transition. This may be an empty string.
+                                                maxLength: 32768
+                                                type: string
+                                              observedGeneration:
+                                                description: observedGeneration represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date with respect to the current state of the instance.
+                                                format: int64
+                                                minimum: 0
+                                                type: integer
+                                              reason:
+                                                description: reason contains a programmatic identifier indicating the reason for the condition's last transition. Producers of specific condition types may define expected values and meanings for this field, and whether the values are considered a guaranteed API. The value should be a CamelCase string. This field may not be empty.
+                                                maxLength: 1024
+                                                minLength: 1
+                                                pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                                                type: string
+                                              status:
+                                                description: status of the condition, one of True, False, Unknown.
+                                                enum:
+                                                  - "True"
+                                                  - "False"
+                                                  - Unknown
+                                                type: string
+                                              type:
+                                                description: type of condition in CamelCase or in foo.example.com/CamelCase. --- Many .condition.type values are consistent across resources like Available, but because arbitrary conditions can be useful (see .node.status.conditions), the ability to deconflict is important. The regex it matches is (dns1123SubdomainFmt/)?(qualifiedNameFmt)
+                                                maxLength: 316
+                                                pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                                                type: string
+                                            required:
+                                              - lastTransitionTime
+                                              - message
+                                              - reason
+                                              - status
+                                              - type
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-map-keys:
+                                            - type
+                                          x-kubernetes-list-type: map
+                                      type: object
+                                  type: object
+                                type: array
                               dnsConfig:
                                 description: DNSConfig represents the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                                 properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -207,8 +207,8 @@ spec:
                           kubevirt:
                             description: Kubevirt configures a KubeVirt datacenter.
                             properties:
-                              additionalNetPols:
-                                description: AdditionalNetPols (optional) allows to add some extra custom NetworkPolicies, that are deployed in the dedicated infra KubeVirt cluster. They are added to the default `cluster-isolation` one.
+                              customNetworkPolicies:
+                                description: CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed in the dedicated infra KubeVirt cluster. They are added to the defaults.
                                 items:
                                   description: NetworkPolicy describes what network traffic is allowed for a set of Pods
                                   properties:


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Adding to the KubeVirt DC a new field to allow to deploy some custom Network Policies.
We allow to deploy any network policy, it's the admin responsibility to control what policies are deployed.
Those policies will be deployed, along with the `cluster-isolation` in the cluster-xyz dedicated namespace in the KubeVirt infra cluster (next PR).
This PR only prepares this feature, adding the field to the seed object, next PR will implement the reconciliation.
Will fix https://github.com/kubermatic-customer/a3s-rki/issues/93

**Manual backport to 2.21 is needed** , but not this PR, the next ones.
After testing, we will change a bit the Seed CRD in the next PR.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt update KubeVirt DC: add additional network policies configuration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://docs.kubermatic.com/kubermatic/main/architecture/supported-providers/kubevirt/kubevirt/
```
