### PR TITLE
Add support for kube-dns configmap for nodelocaldns

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -105,6 +105,10 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 							Name:      "config-volume",
 							MountPath: "/etc/coredns",
 						},
+						{
+							Name:      "kube-dns-config",
+							MountPath: "/etc/kube-dns",
+						},
 					},
 
 					Ports: []corev1.ContainerPort{
@@ -173,6 +177,17 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 									Path: "Corefile.base",
 								},
 							},
+						},
+					},
+				},
+				{
+					Name: "kube-dns-config",
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "kube-dns",
+							},
+							Optional: pointer.Bool(true),
 						},
 					},
 				},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -93,7 +93,7 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 						"-localip",
 						kubesystem.NodeLocalDNSCacheAddress,
 						"-conf",
-						"/etc/coredns/Corefile",
+						"/etc/Corefile",
 					},
 
 					VolumeMounts: []corev1.VolumeMount{
@@ -170,7 +170,7 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 							Items: []corev1.KeyToPath{
 								{
 									Key:  "Corefile",
-									Path: "Corefile",
+									Path: "Corefile.base",
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

If NodeLocal DNSCache is enabled for a user cluster, it is not possible to do any customization for the dns settings. 
The configuration cannot be adjusted as it is reconciled back. For exactly this use case NodeLocal DNSCache has support for an optional config map called kube-dns, that allows injection of dns stub and upstream servers without interfering the reconciliation. This PR adds support for the kube-dns config map to our NodeLocal DNSCache deployment.

Fixes a bug with a wrong mounted Corefile:
`[ERROR] Failed to write config file /etc/coredns/Corefile - err open /etc/coredns/Corefile: read-only file system`

/kind feature
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for kube-dns configmap for NodeLocal DNSCache to allow customization of dns.
Fixes an issue with a wrong mounted Corefile in NodeLocal DNSCache.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/#stubdomains-and-upstream-server-configuration
```
