### PR TITLE
[release/v2.19] Use seed config proxy for seed-cm

### DIFF
--- a/pkg/controller/operator/common/util.go
+++ b/pkg/controller/operator/common/util.go
@@ -206,7 +206,7 @@ func CleanupClusterResource(client ctrlruntimeclient.Client, obj ctrlruntimeclie
 	return nil
 }
 
-func ProxyEnvironmentVars(cfg *operatorv1alpha1.KubermaticConfiguration) []corev1.EnvVar {
+func KubermaticProxyEnvironmentVars(cfg *operatorv1alpha1.KubermaticConfiguration) []corev1.EnvVar {
 	result := []corev1.EnvVar{}
 	settings := cfg.Spec.Proxy
 
@@ -242,4 +242,36 @@ func ProxyEnvironmentVars(cfg *operatorv1alpha1.KubermaticConfiguration) []corev
 	})
 
 	return result
+}
+
+// SeedProxyEnvironmentVars returns ProxySettings from Seed as env vars.
+func SeedProxyEnvironmentVars(p *kubermaticv1.ProxySettings) (result []corev1.EnvVar) {
+	if p == nil || p.Empty() {
+		return
+	}
+
+	result = append(result, corev1.EnvVar{
+		Name:  "HTTP_PROXY",
+		Value: p.HTTPProxy.String(),
+	})
+
+	result = append(result, corev1.EnvVar{
+		Name:  "HTTPS_PROXY",
+		Value: p.HTTPProxy.String(),
+	})
+
+	noProxy := []string{
+		defaults.DefaultNoProxy,
+	}
+
+	if p.NoProxy.String() != "" {
+		noProxy = append(noProxy, p.NoProxy.String())
+	}
+
+	result = append(result, corev1.EnvVar{
+		Name:  "NO_PROXY",
+		Value: strings.Join(noProxy, ","),
+	})
+
+	return
 }

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -137,7 +137,7 @@ func APIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, workerN
 					Image:   cfg.Spec.API.DockerRepository + ":" + versions.Kubermatic,
 					Command: []string{"kubermatic-api"},
 					Args:    args,
-					Env:     common.ProxyEnvironmentVars(cfg),
+					Env:     common.KubermaticProxyEnvironmentVars(cfg),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "metrics",

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -94,7 +94,7 @@ func MasterControllerManagerDeploymentCreator(cfg *operatorv1alpha1.KubermaticCo
 					Image:   cfg.Spec.MasterController.DockerRepository + ":" + versions.Kubermatic,
 					Command: []string{"master-controller-manager"},
 					Args:    args,
-					Env:     common.ProxyEnvironmentVars(cfg),
+					Env:     common.KubermaticProxyEnvironmentVars(cfg),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "metrics",

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -60,7 +60,7 @@ func UIDeploymentCreator(cfg *operatorv1alpha1.KubermaticConfiguration, versions
 				{
 					Name:  "webserver",
 					Image: cfg.Spec.UI.DockerRepository + ":" + tag,
-					Env:   common.ProxyEnvironmentVars(cfg),
+					Env:   common.KubermaticProxyEnvironmentVars(cfg),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "http",

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -208,7 +208,7 @@ func SeedControllerManagerDeploymentCreator(workerName string, versions kubermat
 					Image:   cfg.Spec.SeedController.DockerRepository + ":" + versions.Kubermatic,
 					Command: []string{"seed-controller-manager"},
 					Args:    args,
-					Env:     common.ProxyEnvironmentVars(cfg),
+					Env:     common.SeedProxyEnvironmentVars(seed.Spec.ProxySettings),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "metrics",


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of:
https://github.com/kubermatic/kubermatic/pull/11561

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11509

**What type of PR is this?**

/kind bug


```release-note
Use seed proxy configuration for seed-controler-manager
```

```documentation
NONE
```
