### PR TITLE
[release/v2.20] KubeVirt fix CI for DC

### DIFF
--- a/cmd/conformance-tests/scenarios_kubevirt.go
+++ b/cmd/conformance-tests/scenarios_kubevirt.go
@@ -102,9 +102,9 @@ func (s *kubevirtScenario) NodeDeployments(_ context.Context, num int, _ secrets
 					Cloud: &apimodels.NodeCloudSpec{
 						Kubevirt: &apimodels.KubevirtNodeSpec{
 							Memory:           utilpointer.StringPtr("4Gi"),
-							Namespace:        utilpointer.StringPtr("kube-system"),
+							Namespace:        utilpointer.StringPtr("default"),
 							SourceURL:        utilpointer.StringPtr(sourceURL),
-							StorageClassName: utilpointer.StringPtr("longhorn"),
+							StorageClassName: utilpointer.StringPtr("px-csi-db"),
 							PVCSize:          utilpointer.StringPtr("25Gi"),
 							CPUs:             utilpointer.StringPtr("2"),
 						},

--- a/pkg/apis/kubermatic/v1/helper/helper.go
+++ b/pkg/apis/kubermatic/v1/helper/helper.go
@@ -61,10 +61,10 @@ func UpdateClusterStatus(ctx context.Context, client ctrlruntimeclient.Client, c
 
 // ClusterReconcileWrapper is a wrapper that should be used around
 // any cluster reconciliaton. It:
-// * Checks if the cluster is paused
-// * Checks if the worker-name matches
-// * Sets the ReconcileSuccess condition for the controller by fetching
-//   the current Cluster object and patching its status.
+//   - Checks if the cluster is paused
+//   - Checks if the worker-name matches
+//   - Sets the ReconcileSuccess condition for the controller by fetching
+//     the current Cluster object and patching its status.
 func ClusterReconcileWrapper(
 	ctx context.Context,
 	client ctrlruntimeclient.Client,


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Fixes the CI for KubeVirt e2e tests with the new KubeVirt DC infra cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt switch infra cluster to DC for e2e tests.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
