### PR TITLE
[release/v2.19] Update MLA to v0.1.5

### DIFF
--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -36,7 +36,7 @@ echodate "Cloning MLA repo"
 tempdir="$(mktemp -d)"
 trap "rm -rf '$tempdir'" EXIT
 # We intentionally force an existing release here
-git clone --depth 1 --branch v0.1.4 "$URL" "$tempdir"
+git clone --depth 1 --branch release/v0.1 "$URL" "$tempdir"
 (
   cd "$tempdir"
 

--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -36,11 +36,9 @@ echodate "Cloning MLA repo"
 tempdir="$(mktemp -d)"
 trap "rm -rf '$tempdir'" EXIT
 # We intentionally force an existing release here
-git clone --depth 1 --branch release/v0.1 "$URL" "$tempdir"
+git clone --depth 1 --branch v0.1.5 "$URL" "$tempdir"
 (
   cd "$tempdir"
-
-  chmod +x hack/fetch-chart-dependencies.sh
 
   # due to the anti affinities, getting more than 1 replica can take forever in kind,
   # so we reduce the replica count for all those components

--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -36,7 +36,7 @@ echodate "Cloning MLA repo"
 tempdir="$(mktemp -d)"
 trap "rm -rf '$tempdir'" EXIT
 # We intentionally force an existing release here
-git clone --depth 1 --branch v0.1.3 "$URL" "$tempdir"
+git clone --depth 1 --branch v0.1.4 "$URL" "$tempdir"
 (
   cd "$tempdir"
 

--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -40,6 +40,8 @@ git clone --depth 1 --branch release/v0.1 "$URL" "$tempdir"
 (
   cd "$tempdir"
 
+  chmod +x hack/fetch-chart-dependencies.sh
+
   # due to the anti affinities, getting more than 1 replica can take forever in kind,
   # so we reduce the replica count for all those components
   yq write --inplace config/cortex/values.yaml cortex.ingester.replicas 1


### PR DESCRIPTION
**What this PR does / why we need it**:
MLA v0.1.3 has a problem with a memcached chart being removed from upstream. This uses the new MLA version that includes that missing chart.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
