### PR TITLE
Refactor vSphere integration tests

### DIFF
--- a/pkg/provider/cloud/vsphere/folder_test.go
+++ b/pkg/provider/cloud/vsphere/folder_test.go
@@ -30,79 +30,59 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func TestCreateVMFolder(t *testing.T) {
-	dc := getTestDC()
-	dc.RootPath = path.Join("/", vSphereDatacenter, "vm")
-
-	ctx := context.Background()
-	session, err := newSession(ctx, dc, vSphereUsername, vSpherePassword, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Use a unique ID to prevent side effects when running this test concurrently
-	id := "kubermatic-e2e-" + rand.String(8)
-	folder := path.Join(dc.RootPath, id)
-
-	// Cheap way to test idempotency
-	for i := 0; i < 2; i++ {
-		if err := createVMFolder(ctx, session, folder); err != nil {
-			t.Fatal(err)
-		}
-	}
-	for i := 0; i < 2; i++ {
-		if err := deleteVMFolder(ctx, session, folder); err != nil {
-			t.Fatal(err)
-		}
-	}
-}
-
 func TestProvider_GetVMFolders(t *testing.T) {
 	tests := []struct {
-		name            string
-		dc              *kubermaticv1.DatacenterSpecVSphere
-		expectedFolders sets.String
+		name           string
+		dc             *kubermaticv1.DatacenterSpecVSphere
+		expectedFolder string
 	}{
 		{
-			name: "successfully-list-default-folders",
-			dc:   getTestDC(),
-			expectedFolders: sets.NewString(
-				path.Join("/", vSphereDatacenter, "vm"),
-				path.Join("/", vSphereDatacenter, "vm", "sig-infra"),
-				path.Join("/", vSphereDatacenter, "vm", "Kubermatic-dev"),
-			),
-		},
-		{
-			name: "successfully-list-folders-below-custom-root",
+			name: "successfully-create-and-list-folders-below-custom-root",
 			dc: &kubermaticv1.DatacenterSpecVSphere{
 				Datacenter:    vSphereDatacenter,
 				Endpoint:      vSphereEndpoint,
 				AllowInsecure: true,
-				RootPath:      path.Join("/", vSphereDatacenter, "vm"),
+				RootPath:      path.Join("/", vSphereDatacenter, vSphereVMRootFolder),
 			},
-			expectedFolders: sets.NewString(
-				path.Join("/", vSphereDatacenter, "vm", "sig-infra"),
-				path.Join("/", vSphereDatacenter, "vm", "Kubermatic-dev"),
-			),
+			expectedFolder: path.Join("/", vSphereDatacenter, vSphereVMRootFolder, generateTestFolder()),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			session, err := newSession(context.Background(), test.dc, vSphereUsername, vSpherePassword, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := createVMFolder(context.Background(), session, test.expectedFolder); err != nil {
+				t.Fatal(err)
+			}
+
 			folders, err := GetVMFolders(context.Background(), test.dc, vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
+			folderFound := false
 			gotFolders := sets.NewString()
 			for _, folder := range folders {
-				gotFolders.Insert(folder.Path)
-			}
-			t.Logf("Got folders: %v", gotFolders.List())
+				if folder.Path == test.expectedFolder {
+					folderFound = true
 
-			if test.expectedFolders.Difference(gotFolders).Len() > 0 {
-				t.Fatalf("Response is missing expected folders:\n%v", diff.SetDiff[string](test.expectedFolders, gotFolders))
+					if err := deleteVMFolder(context.Background(), session, test.expectedFolder); err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			if !folderFound {
+				t.Fatalf("Response is missing expected folders:\n%v", diff.SetDiff[string](sets.NewString(test.expectedFolder), gotFolders))
 			}
 		})
 	}
+}
+
+func generateTestFolder() string {
+	return "kubermatic-e2e-" + rand.String(8)
 }

--- a/pkg/provider/cloud/vsphere/integration_test.go
+++ b/pkg/provider/cloud/vsphere/integration_test.go
@@ -29,6 +29,8 @@ var (
 	vSphereEndpoint   = os.Getenv("VSPHERE_E2E_ADDRESS")
 	vSphereUsername   = os.Getenv("VSPHERE_E2E_USERNAME")
 	vSpherePassword   = os.Getenv("VSPHERE_E2E_PASSWORD")
+
+	vSphereVMRootFolder = "vm/Kubermatic-ci"
 )
 
 func getTestDC() *kubermaticv1.DatacenterSpecVSphere {


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems that the current vSphere integration tests are kinda inaccurate by assuming that, KKP needs specific folders in order for it to run correctly. This PR refactors the integration tests to adjust to what we have in our infra.  

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind failing-test
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
