### PR TITLE
Default `KubermaticConfiguration` to enable etcd-launcher by default

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -66,7 +66,8 @@ spec:
   # if this is set to LoadBalancerStrategy.
   exposeStrategy: NodePort
   # FeatureGates are used to optionally enable certain features.
-  featureGates: {}
+  featureGates:
+    etcdLauncher: true
   # ImagePullSecret is used to authenticate against Docker registries.
   imagePullSecret: ""
   # Ingress contains settings for making the API and UI accessible remotely.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -66,7 +66,8 @@ spec:
   # if this is set to LoadBalancerStrategy.
   exposeStrategy: NodePort
   # FeatureGates are used to optionally enable certain features.
-  featureGates: {}
+  featureGates:
+    etcdLauncher: true
   # ImagePullSecret is used to authenticate against Docker registries.
   imagePullSecret: ""
   # Ingress contains settings for making the API and UI accessible remotely.

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -522,6 +522,15 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 
 	configCopy.Spec.Auth = auth
 
+	// default etcdLauncher feature flag if it is not set
+	if _, etcdLauncherFeatureGateSet := configCopy.Spec.FeatureGates[kubermaticv1.ClusterFeatureEtcdLauncher]; !etcdLauncherFeatureGateSet {
+		if configCopy.Spec.FeatureGates == nil {
+			configCopy.Spec.FeatureGates = make(map[string]bool)
+		}
+
+		configCopy.Spec.FeatureGates[kubermaticv1.ClusterFeatureEtcdLauncher] = true
+	}
+
 	if err := defaultDockerRepo(&configCopy.Spec.API.DockerRepository, DefaultDashboardImage, "api.dockerRepository", logger); err != nil {
 		return configCopy, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
We want to enable `etcd-launcher` by default in KKP 2.22, so this PR adds defaulting to set the feature flag if it's not set. This gives users the ability to disable it, but will enable it by default.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11107

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Feature flag `EtcdLauncher` is enabled by default for `KubermaticConfiguration`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1316
```
