### PR TITLE
Tunneling expose strategy: report proper ext. address in cluster's status.address.ip

### DIFF
--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -159,14 +159,14 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 			}
 		}
 	case kubermaticv1.ExposeStrategyNodePort:
+		fallthrough
+	case kubermaticv1.ExposeStrategyTunneling:
 		var err error
 		// Always lookup IP address, in case it changes (IP's on AWS LB's change)
 		ip, err = m.getExternalIPv4(externalName)
 		if err != nil {
 			return nil, err
 		}
-	case kubermaticv1.ExposeStrategyTunneling:
-		ip = m.tunnelingAgentIP
 	}
 	if m.cluster.Status.Address.IP != ip {
 		modifiers = append(modifiers, func(c *kubermaticv1.Cluster) {

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -269,6 +269,25 @@ func TestSyncClusterAddress(t *testing.T) {
 			expectedURL:          fmt.Sprintf("https://%s.alias-europe-west3-c.%s:32000", fakeClusterName, fakeExternalURL),
 		},
 		{
+			name: "Verify properties for Tunneling expose strategy",
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							Port:       int32(6443),
+							TargetPort: intstr.FromInt(6443),
+							NodePort:   32000,
+						}},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyTunneling,
+			expectedExternalName: fmt.Sprintf("%s.%s.%s", fakeClusterName, fakeDCName, fakeExternalURL),
+			expectedIP:           externalIP,
+			expectedPort:         int32(6443),
+			expectedURL:          fmt.Sprintf("https://%s.%s.%s:6443", fakeClusterName, fakeDCName, fakeExternalURL),
+		},
+		{
 			name: "Verify error when service has less than one ports",
 			apiserverService: corev1.Service{
 				Spec: corev1.ServiceSpec{
@@ -318,6 +337,7 @@ func TestSyncClusterAddress(t *testing.T) {
 				Seed(seed).
 				ExternalURL(fakeExternalURL).
 				lookupFunc(testLookupFunction).
+				TunnelingAgentIP(resources.DefaultTunnelingAgentIP).
 				Build(context.Background())
 			if err != nil {
 				if tc.errExpected {


### PR DESCRIPTION
**What this PR does / why we need it**:
For tunneling expose strategy we exported the "special" (private) tunneling agent IP in cluster's `status.address.ip`. That is incorrect as it should be the "external IP under which the apiserver is available". That can cause problems if some tooling is relying on it, as it is e.g. the web terminal.

As this address is used in the user-cluster-controller-manager to reconcile the `kubernetes` service endpoints, a bit of refactoring and passing of proper address for the tunneling case was needed there as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11682 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix external cluster address in cluster's status.address.ip for the Tunneling expose strategy.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
