### PR TITLE
Observe configured addons tag suffix when extracting images from addons

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -92,7 +92,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 
 	cmd.PersistentFlags().StringVar(&opt.Config, "config", "", "Path to the KubermaticConfiguration YAML file")
 	cmd.PersistentFlags().StringVar(&opt.VersionFilter, "version-filter", "", "Version constraint which can be used to filter for specific versions")
-	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of found images")
+	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")
 
 	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image")
 	cmd.PersistentFlags().StringVar(&opt.AddonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")
@@ -167,7 +167,14 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 		if options.AddonsPath == "" {
 			addonsImage := options.AddonsImage
 			if addonsImage == "" {
-				addonsImage = kubermaticConfig.Spec.UserCluster.Addons.DockerRepository + ":" + versions.Kubermatic
+				suffix := kubermaticConfig.Spec.UserCluster.Addons.DockerTagSuffix
+
+				tag := versions.Kubermatic
+				if suffix != "" {
+					tag = fmt.Sprintf("%s-%s", versions.Kubermatic, suffix)
+				}
+
+				addonsImage = kubermaticConfig.Spec.UserCluster.Addons.DockerRepository + ":" + tag
 			}
 
 			if addonsImage != "" {


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubermatic-installer mirror-images` uses the `addons` image configured in the `KubermaticConfiguration` object to extract information about images it needs to mirror. As reported in #11700, it ignored the image suffix configuration we introduced for addon images. This PR fixes that.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards #11700

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Observe configured addons tag suffix when extracting addon images in `kubermatic-installer mirror-images` command
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
