### PR TITLE
Add `--registry-prefix` flag to `mirror-images` installer command

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -39,12 +39,12 @@ import (
 type MirrorImagesOptions struct {
 	Options
 
-	Registry string
-
+	Registry                  string
 	Config                    string
 	VersionFilter             string
-	DryRun                    bool
+	RegistryPrefix            string
 	IgnoreRepositoryOverrides bool
+	DryRun                    bool
 
 	AddonsPath  string
 	AddonsImage string
@@ -93,6 +93,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 
 	cmd.PersistentFlags().StringVar(&opt.Config, "config", "", "Path to the KubermaticConfiguration YAML file")
 	cmd.PersistentFlags().StringVar(&opt.VersionFilter, "version-filter", "", "Version constraint which can be used to filter for specific versions")
+	cmd.PersistentFlags().StringVar(&opt.RegistryPrefix, "registry-prefix", "", "Check source registries against this prefix and only include images that match it")
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")
 	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides in the referenced KubermaticConfiguration to re-use a configuration that already specifies overrides (note that custom tags will still be observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
 
@@ -238,6 +239,7 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 						options.AddonsPath,
 						versions,
 						caBundle,
+						options.RegistryPrefix,
 					)
 					if err != nil {
 						return fmt.Errorf("failed to get images: %w", err)
@@ -254,6 +256,7 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 						options.AddonsPath,
 						versions,
 						caBundle,
+						options.RegistryPrefix,
 					)
 					if err != nil {
 						return fmt.Errorf("failed to get images: %w", err)
@@ -267,7 +270,7 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 			chartsLogger := logger.WithField("charts-directory", options.ChartsDirectory)
 			chartsLogger.Info("🚀 Rendering Helm charts…")
 
-			images, err := images.GetImagesForHelmCharts(ctx, chartsLogger, kubermaticConfig, helmClient, options.ChartsDirectory, options.HelmValuesFile)
+			images, err := images.GetImagesForHelmCharts(ctx, chartsLogger, kubermaticConfig, helmClient, options.ChartsDirectory, options.HelmValuesFile, options.RegistryPrefix)
 			if err != nil {
 				return fmt.Errorf("failed to get images: %w", err)
 			}

--- a/pkg/install/images/helm.go
+++ b/pkg/install/images/helm.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
@@ -34,7 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 )
 
-func GetImagesForHelmCharts(ctx context.Context, log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, helmClient helm.Client, chartsPath string, valuesFile string) ([]string, error) {
+func GetImagesForHelmCharts(ctx context.Context, log logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, helmClient helm.Client, chartsPath string, valuesFile string, registryPrefix string) ([]string, error) {
 	if info, err := os.Stat(chartsPath); err != nil || !info.IsDir() {
 		return nil, fmt.Errorf("%s is not a valid directory", chartsPath)
 	}
@@ -87,6 +88,17 @@ func GetImagesForHelmCharts(ctx context.Context, log logrus.FieldLogger, config 
 
 			images = append(images, manifestImages...)
 		}
+	}
+
+	if registryPrefix != "" {
+		var filteredImages []string
+		for _, image := range images {
+			if strings.HasPrefix(image, registryPrefix) {
+				filteredImages = append(filteredImages, image)
+			}
+		}
+
+		images = filteredImages
 	}
 
 	return images, nil

--- a/pkg/install/images/images_test.go
+++ b/pkg/install/images/images_test.go
@@ -58,7 +58,7 @@ func TestRetagImageForAllVersions(t *testing.T) {
 	for _, clusterVersion := range clusterVersions {
 		for _, cloudSpec := range GetCloudSpecs() {
 			for _, cniPlugin := range GetCNIPlugins() {
-				images, err := GetImagesForVersion(log, clusterVersion, cloudSpec, cniPlugin, false, config, addonPath, kubermaticVersions, caBundle)
+				images, err := GetImagesForVersion(log, clusterVersion, cloudSpec, cniPlugin, false, config, addonPath, kubermaticVersions, caBundle, "")
 				if err != nil {
 					t.Errorf("Error calling getImagesForVersion: %v", err)
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes you might only want to mirror a subset of images. We're adding a `--registry-prefix` flag to `kubermatic-installer mirror-images` to filter by a prefix string, e.g.`--registry-prefix docker.io` to only mirror DockerHub images to a target location.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards #11699

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `--registry-prefix` flag to `kubermatic-installer mirror-images` command
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1307
```
