### PR TITLE
Fix passing of proper tunneling agent IP to the usercluster-controller-mgr

### DIFF
--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -186,8 +186,8 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 			}
 
 			if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
-				args = append(args, "-tunneling-agent-ip", address.IP)
-				args = append(args, "-kas-secure-port", fmt.Sprint(address.Port))
+				args = append(args, "-tunneling-agent-ip", data.Cluster().Spec.ClusterNetwork.TunnelingAgentIP)
+				args = append(args, "-kas-secure-port", fmt.Sprint(resources.APIServerSecurePort))
 			}
 
 			providerName, err := data.GetCloudProviderName()


### PR DESCRIPTION
**What this PR does / why we need it**:
This has been forgotten in https://github.com/kubermatic/kubermatic/pull/11687 and still relies on the cluster's `status.address.ip`

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
