### PR TITLE
Removed e2e-test mention from 2.20 changelog

### DIFF
--- a/docs/changelogs/CHANGELOG-2.20.md
+++ b/docs/changelogs/CHANGELOG-2.20.md
@@ -21,7 +21,6 @@
 - Fix an issue where creating Clusters through ClusterTemplates failed without leaving a trace (the ClusterTemplateInstance got deleted as if all was good) ([#11601](https://github.com/kubermatic/kubermatic/pull/11601))
 - Fix yet another API error in extended disk configuration for provider Anexia ([#11603](https://github.com/kubermatic/kubermatic/pull/11603))
 - Use seed proxy configuration for seed-controller-manager ([#11631](https://github.com/kubermatic/kubermatic/pull/11631))
-- KubeVirt switch infra cluster to DC for e2e tests ([#11675](https://github.com/kubermatic/kubermatic/pull/11675))
 - Add support for kube-dns configmap for NodeLocal DNSCache to allow customization of dns. Fixes an issue with a wrong mounted Corefile in NodeLocal DNSCache ([#11664](https://github.com/kubermatic/kubermatic/pull/11664))
 
 ### Misc


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't need to inform users about test updates in change logs.

**Which issue(s) this PR fixes**:


**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
