### PR TITLE
Fix changelog headers for new releases

### DIFF
--- a/docs/changelogs/CHANGELOG-2.19.md
+++ b/docs/changelogs/CHANGELOG-2.19.md
@@ -16,7 +16,7 @@
 - [v2.19.13](#v21913)
 - [v2.19.14](#v21914)
 
-## [2.19.14](https://github.com/kubermatic/kubermatic/releases/tag/2.19.14)
+## [v2.19.14](https://github.com/kubermatic/kubermatic/releases/tag/v2.19.14)
 
 ### Bugfixes
 

--- a/docs/changelogs/CHANGELOG-2.20.md
+++ b/docs/changelogs/CHANGELOG-2.20.md
@@ -14,7 +14,7 @@
 - [v2.20.11](#v22011)
 - [v2.20.12](#v22012)
 
-## [2.20.12](https://github.com/kubermatic/kubermatic/releases/tag/2.20.12)
+## [v2.20.12](https://github.com/kubermatic/kubermatic/releases/tag/v2.20.12)
 
 ### Bugfixes
 

--- a/docs/changelogs/CHANGELOG-2.21.md
+++ b/docs/changelogs/CHANGELOG-2.21.md
@@ -7,7 +7,7 @@
 - [v2.21.4](#v2214)
 - [v2.21.5](#v2215)
 
-## [2.21.5](https://github.com/kubermatic/kubermatic/releases/tag/2.21.5)
+## [v2.21.5](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.5)
 
 ### API Changes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
I overlooked this during review, but the headers for the new releases were missing the `v` prefix, breaking anchors and links.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
