### PR TITLE
KubeVirt switch StorageClass config to DC

### DIFF
--- a/addons/csi/kubevirt/csi-driver-operator.yaml
+++ b/addons/csi/kubevirt/csi-driver-operator.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: tenants.csiprovisioner.kubevirt.io
 spec:
@@ -30,95 +30,95 @@ spec:
     singular: tenant
   scope: Cluster
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: Tenant is the Schema for the tenants API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Tenant is the Schema for the tenants API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: TenantSpec defines the desired state of Tenant.
-              properties:
-                imageRepository:
-                  description: Image repository address
-                  type: string
-                imageTag:
-                  description: Image tag that should be used for all csi driver components
-                  type: string
-                storageClasses:
-                  description: StorageClasses represents storage classes that the tenant
-                    operator should create.
-                  items:
-                    description: StorageClass represents a storage class that should
-                      reference a KubeVirt storage class on infra cluster.
-                    properties:
-                      bus:
-                        description: The VM bus type, defaults to scsi.
-                        type: string
-                      infraStorageClassName:
-                        description: Name of the storage class to use on the infrastructure
-                          cluster.
-                        type: string
-                    required:
-                      - infraStorageClassName
-                    type: object
-                  type: array
-              type: object
-            status:
-              description: TenantStatus defines the observed state of Tenant.
-              properties:
-                resourceConditions:
-                  description: Conditions represents resource conditions that operator
-                    reconciles.
-                  items:
-                    description: ResourceStatusCondition contains details for the current
-                      condition.
-                    properties:
-                      lastTransitionTime:
-                        description: Last time the condition transitioned from one status
-                          to another.
-                        format: date-time
-                        type: string
-                      operationResult:
-                        description: OperationResult is the action result of a CreateOrUpdate
-                          call.
-                        type: string
-                      reason:
-                        description: Unique, one-word, CamelCase reason for the condition's
-                          last transition.
-                        type: string
-                      resource:
-                        description: Resource represents a k8s resource that has been
-                          created/updated by the operator.
-                        type: string
-                    required:
-                      - operationResult
-                      - resource
-                    type: object
-                  type: array
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: TenantSpec defines the desired state of Tenant.
+            properties:
+              imageRepository:
+                description: Image repository address
+                type: string
+              imageTag:
+                description: Image tag that should be used for all csi driver components
+                type: string
+              storageClasses:
+                description: StorageClasses represents storage classes that the tenant
+                  operator should create.
+                items:
+                  description: StorageClass represents a storage class that should
+                    reference a KubeVirt storage class on infra cluster.
+                  properties:
+                    bus:
+                      description: The VM bus type, defaults to scsi.
+                      type: string
+                    infraStorageClassName:
+                      description: Name of the storage class to use on the infrastructure
+                        cluster.
+                      type: string
+                    isDefaultClass:
+                      description: 'Optional: IsDefaultClass if true, the created
+                        StorageClass will be annotated with: storageclass.kubernetes.io/is-default-class
+                        : true If missing or false, annotation will be: storageclass.kubernetes.io/is-default-class
+                        : false'
+                      type: boolean
+                  required:
+                  - infraStorageClassName
+                  type: object
+                type: array
+            type: object
+          status:
+            description: TenantStatus defines the observed state of Tenant.
+            properties:
+              resourceConditions:
+                description: Conditions represents resource conditions that operator
+                  reconciles.
+                items:
+                  description: ResourceStatusCondition contains details for the current
+                    condition.
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transitioned from one status
+                        to another.
+                      format: date-time
+                      type: string
+                    operationResult:
+                      description: OperationResult is the action result of a CreateOrUpdate
+                        call.
+                      type: string
+                    reason:
+                      description: Unique, one-word, CamelCase reason for the condition's
+                        last transition.
+                      type: string
+                    resource:
+                      description: Resource represents a k8s resource that has been
+                        created/updated by the operator.
+                      type: string
+                  required:
+                  - operationResult
+                  - resource
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 ---
 apiVersion: v1
 kind: Namespace
@@ -334,7 +334,7 @@ spec:
             - /manager
           args:
             - --leader-elect
-          image: quay.io/kubermatic/kubevirt-csi-driver-operator:v0.2.0
+          image: quay.io/kubermatic/kubevirt-csi-driver-operator:v0.3.0
           imagePullPolicy: Always
           name: manager
           securityContext:
@@ -368,7 +368,8 @@ metadata:
 spec:
   storageClasses:
 {{- range  .Cluster.KubeVirtInfraStorageClasses }}
-   - infraStorageClassName: {{ . }}
+   - infraStorageClassName: {{ .Name }}
+     isDefaultClass: {{ .IsDefaultClass }}
      bus: scsi
 {{- end }}
 {{end}}

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -25,6 +25,8 @@ import (
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -32,7 +34,7 @@ const (
 	kubevirtCPUs               = 2
 	kubevirtMemory             = "4Gi"
 	kubevirtDiskSize           = "25Gi"
-	kubevirtDiskClassName      = "px-csi-db"
+	kubevirtStorageClassName   = "px-csi-db"
 )
 
 type kubevirtScenario struct {
@@ -46,6 +48,11 @@ func (s *kubevirtScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterS
 			DatacenterName: secrets.Kubevirt.KKPDatacenter,
 			Kubevirt: &kubermaticv1.KubevirtCloudSpec{
 				Kubeconfig: secrets.Kubevirt.Kubeconfig,
+				StorageClasses: []kubermaticv1.KubeVirtInfraStorageClass{{
+					Name:           kubevirtStorageClassName,
+					IsDefaultClass: pointer.Bool(true),
+				},
+				},
 			},
 		},
 		Version: s.version,
@@ -63,7 +70,7 @@ func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secret
 		WithMemory(kubevirtMemory).
 		WithPrimaryDiskOSImage(image).
 		WithPrimaryDiskSize(kubevirtDiskSize).
-		WithPrimaryDiskStorageClassName(kubevirtDiskClassName).
+		WithPrimaryDiskStorageClassName(kubevirtStorageClassName).
 		Build()
 
 	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -60,7 +60,7 @@ type ClusterData struct {
 	CSIMigration bool
 	// KubeVirtInfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
-	KubeVirtInfraStorageClasses []string
+	KubeVirtInfraStorageClasses []kubermaticv1.KubeVirtInfraStorageClass
 }
 
 // ClusterAddress stores access and address information of a cluster.

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -181,7 +181,7 @@ spec:
               # storageclass.kubernetes.io/is-default-class : true
               # If missing or false, annotation will be:
               # storageclass.kubernetes.io/is-default-class : false
-              isDefautClass: true
+              isDefaultClass: true
               name: px-csi-db
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -181,7 +181,7 @@ spec:
               # storageclass.kubernetes.io/is-default-class : true
               # If missing or false, annotation will be:
               # storageclass.kubernetes.io/is-default-class : false
-              isDefautClass: true
+              isDefaultClass: true
               name: px-csi-db
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -158,6 +158,9 @@ spec:
                 podSelector: {}
                 policyTypes:
                 - Ingress
+          infraStorageClasses:
+            - isDefaultClass: true
+              name: px-csi-db
     syseleven-dbl1:
       country: DE
       location: Syseleven - dbl1

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -110,9 +110,9 @@ func NewTemplateData(
 		ipvs = *cluster.Spec.ClusterNetwork.IPVS
 	}
 
-	var kubeVirtStorageClasses []string
+	var kubeVirtStorageClasses []kubermaticv1.KubeVirtInfraStorageClass
 	if cluster.Spec.Cloud.Kubevirt != nil {
-		kubeVirtStorageClasses = cluster.Spec.Cloud.Kubevirt.InfraStorageClasses
+		kubeVirtStorageClasses = cluster.Spec.Cloud.Kubevirt.StorageClasses
 	}
 
 	var ipamAllocationsData map[string]IPAMAllocation
@@ -230,7 +230,7 @@ type ClusterData struct {
 	CSIMigration bool
 	// KubeVirtInfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
-	KubeVirtInfraStorageClasses []string
+	KubeVirtInfraStorageClasses []kubermaticv1.KubeVirtInfraStorageClass
 }
 
 type ClusterNetwork struct {

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1198,6 +1198,7 @@ type KubevirtCloudSpec struct {
 	// PreAllocatedDataVolumes represents a list of DataVolumes that are tied to cluster lifecycle and can be referenced by machines.
 	// Custom Images are a good example of this use case.
 	PreAllocatedDataVolumes []PreAllocatedDataVolume `json:"preAllocatedDataVolumes,omitempty"`
+	// Deprecated: in favor of InfraStorageClasses.
 	// InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
 	InfraStorageClasses []string `json:"infraStorageClasses,omitempty"`

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -719,7 +719,7 @@ type KubeVirtInfraStorageClass struct {
 	// storageclass.kubernetes.io/is-default-class : true
 	// If missing or false, annotation will be:
 	// storageclass.kubernetes.io/is-default-class : false
-	IsDefaultClass *bool `json:"isDefautClass"`
+	IsDefaultClass *bool `json:"isDefaultClass,omitempty"`
 }
 
 // CustomNetworkPolicy contains a name and the Spec of a NetworkPolicy.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -562,7 +562,7 @@ spec:
                           description: ImageCloningEnabled flag enable/disable cloning for a cluster.
                           type: boolean
                         infraStorageClasses:
-                          description: InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
+                          description: 'Deprecated: in favor of InfraStorageClasses. InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)'
                           items:
                             type: string
                           type: array
@@ -596,13 +596,12 @@ spec:
                           description: StorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks. It contains also some flag specifying which one is the default one.
                           items:
                             properties:
-                              isDefautClass:
+                              isDefaultClass:
                                 description: 'Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with: storageclass.kubernetes.io/is-default-class : true If missing or false, annotation will be: storageclass.kubernetes.io/is-default-class : false'
                                 type: boolean
                               name:
                                 type: string
                             required:
-                              - isDefautClass
                               - name
                             type: object
                           type: array

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -557,7 +557,7 @@ spec:
                           description: ImageCloningEnabled flag enable/disable cloning for a cluster.
                           type: boolean
                         infraStorageClasses:
-                          description: InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
+                          description: 'Deprecated: in favor of InfraStorageClasses. InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)'
                           items:
                             type: string
                           type: array
@@ -591,13 +591,12 @@ spec:
                           description: StorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks. It contains also some flag specifying which one is the default one.
                           items:
                             properties:
-                              isDefautClass:
+                              isDefaultClass:
                                 description: 'Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with: storageclass.kubernetes.io/is-default-class : true If missing or false, annotation will be: storageclass.kubernetes.io/is-default-class : false'
                                 type: boolean
                               name:
                                 type: string
                             required:
-                              - isDefautClass
                               - name
                             type: object
                           type: array

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -563,13 +563,12 @@ spec:
                                 description: 'InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names that will be used to initialise StorageClasses in the tenant cluster. In the tenant cluster, the created StorageClass name will have as name: kubevirt-<infra-storageClass-name>'
                                 items:
                                   properties:
-                                    isDefautClass:
+                                    isDefaultClass:
                                       description: 'Optional: IsDefaultClass. If true, the created StorageClass in the tenant cluster will be annotated with: storageclass.kubernetes.io/is-default-class : true If missing or false, annotation will be: storageclass.kubernetes.io/is-default-class : false'
                                       type: boolean
                                     name:
                                       type: string
                                   required:
-                                    - isDefautClass
                                     - name
                                   type: object
                                 type: array

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -72,7 +72,7 @@ func (k *kubevirt) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.Clus
 		return err
 	}
 
-	return updateInfraStorageClassesInfo(ctx, client, &spec.Cloud)
+	return updateInfraStorageClassesInfo(ctx, client, spec.Cloud.Kubevirt, k.dc)
 }
 
 func (k *kubevirt) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.CloudSpec) error {


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
This PR:
- deprecated the cluster InfraStorageClasses in favour of StorageClasses
- switch the configuration from infra KubeVirt cluster StorageClass annotation to proper configuration in Seed

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11689 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
This PR fixes 2 mistakes on the definition of StorageClasses:
- typo: `isDefautClass` -> `isDefaultClass`
-  really makes `isDefaultClass` optional

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt switch StorageClasses init configuration from annotation to DC
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1311
```
