### PR TITLE
Periodically reconcile CNI app & use atomic deployment option

### DIFF
--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -305,6 +305,18 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 			app.Spec.Namespace = appskubermaticv1.AppNamespaceSpec{
 				Name: cniPluginNamespace,
 			}
+			app.Spec.DeployOptions = &appskubermaticv1.DeployOptions{
+				Helm: &appskubermaticv1.HelmDeployOptions{
+					Atomic: true,
+					Wait:   true,
+					Timeout: metav1.Duration{
+						Duration: 10 * time.Minute, // use longer timeout, as it may take some time for the CNI to be fully up
+					},
+				},
+			}
+			app.Spec.ReconciliationInterval = metav1.Duration{
+				Duration: 60 * time.Minute, // reconcile the app periodically
+			}
 
 			// Unmarshall existing values
 			values := make(map[string]any)


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Makes CNI ApplicationInstallation periodically reconciled & uses atomic Helm deployment option for it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
