### PR TITLE
Include system Applications in kubermatic-installer mirror-images

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -281,6 +281,13 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 			imageSet.Insert(images...)
 		}
 
+		logger.Info("🚀 Rendering system Applications Helm charts…")
+		appImages, err := images.GetImagesFromSystemApplicationDefinitions(logger, kubermaticConfig, helmClient, options.HelmTimeout, options.RegistryPrefix)
+		if err != nil {
+			return fmt.Errorf("failed to get images for system Applications: %w", err)
+		}
+		imageSet.Insert(appImages...)
+
 		userAgent := fmt.Sprintf("kubermatic-installer/%s", versions.Kubermatic)
 
 		copiedCount, fullCount, err := images.ProcessImages(ctx, logger, options.DryRun, imageSet.List(), options.Registry, userAgent)

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package images
 
 import (

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -1,0 +1,105 @@
+package images
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/applications/providers"
+	"k8c.io/kubermatic/v2/pkg/cni/cilium"
+	"k8c.io/kubermatic/v2/pkg/install/helm"
+	"k8c.io/kubermatic/v2/pkg/log"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
+)
+
+func GetImagesFromSystemApplicationDefinitions(logger logrus.FieldLogger, config *kubermaticv1.KubermaticConfiguration, helmClient helm.Client, helmTimeout time.Duration, registryPrefix string) ([]string, error) {
+	var images []string
+
+	var appDefReconcilers []reconciling.NamedApplicationDefinitionReconcilerFactory
+	appDefReconcilers = append(appDefReconcilers,
+		cilium.ApplicationDefinitionReconciler(config),
+	)
+
+	for _, createFunc := range appDefReconcilers {
+		appName, creator := createFunc()
+		appDef, err := creator(&appskubermaticv1.ApplicationDefinition{})
+		if err != nil {
+			return nil, err
+		}
+		appLog := logger.WithFields(logrus.Fields{"application-name": appName})
+		appDefImages, err := getImagesFromApplicationDefinition(appLog, helmClient, appDef, helmTimeout, registryPrefix)
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, appDefImages...)
+	}
+
+	return images, nil
+}
+
+func getImagesFromApplicationDefinition(logger logrus.FieldLogger, helmClient helm.Client, appDef *appskubermaticv1.ApplicationDefinition, helmTimeout time.Duration, registryPrefix string) ([]string, error) {
+	if appDef.Spec.Method != appskubermaticv1.HelmTemplateMethod {
+		// Only Helm ApplicationDefinitions are supported at the moment
+		logger.Debugf("Skipping the ApplicationDefinition as the method '%s' is not supported yet", appDef.Spec.Method)
+		return nil, nil
+	}
+	logger.Info("Retrieving images…")
+
+	tmpDir, err := os.MkdirTemp("", "helm-charts")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			logger.Fatalf("Failed to remove temp dir: %v", err)
+		}
+	}()
+
+	// if DefaultValues is provided, use it as values file
+	valuesFile := ""
+	if appDef.Spec.DefaultValues != nil {
+		valuesFile = tmpDir + "values.yaml"
+		err = os.WriteFile(valuesFile, appDef.Spec.DefaultValues.Raw, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create values file: %w", err)
+		}
+	}
+
+	var images []string
+	for _, appVer := range appDef.Spec.Versions {
+		appVerLog := logger.WithField("application-version", appVer.Version)
+		appVerLog.Debug("Downloading Helm chart…")
+		// pull the chart
+		chartPath, err := downloadAppSourceChart(&appVer.Template.Source, tmpDir, helmTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("failed to pull app chart: %w", err)
+		}
+		// get images
+		chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, valuesFile, registryPrefix)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get images for chart: %w", err)
+		}
+		images = append(images, chartImages...)
+	}
+
+	return images, nil
+}
+
+func downloadAppSourceChart(appSource *appskubermaticv1.ApplicationSource, directory string, timeout time.Duration) (chartPath string, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	sp, err := providers.NewSourceProvider(ctx, log.NewDefault().Sugar(), nil, "", directory, appSource, "")
+	if err != nil {
+		return "", fmt.Errorf("failed to create app source provider: %w", err)
+	}
+	chartPath, err = sp.DownloadSource(directory)
+	if err != nil {
+		return "", fmt.Errorf("failed to download app source: %w", err)
+	}
+	return
+}

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -79,7 +80,7 @@ func getImagesFromApplicationDefinition(logger logrus.FieldLogger, helmClient he
 	// if DefaultValues is provided, use it as values file
 	valuesFile := ""
 	if appDef.Spec.DefaultValues != nil {
-		valuesFile = tmpDir + "values.yaml"
+		valuesFile = path.Join(tmpDir, "values.yaml")
 		err = os.WriteFile(valuesFile, appDef.Spec.DefaultValues.Raw, 0644)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create values file: %w", err)
@@ -109,6 +110,7 @@ func getImagesFromApplicationDefinition(logger logrus.FieldLogger, helmClient he
 func downloadAppSourceChart(appSource *appskubermaticv1.ApplicationSource, directory string, timeout time.Duration) (chartPath string, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
 	sp, err := providers.NewSourceProvider(ctx, log.NewDefault().Sugar(), nil, "", directory, appSource, "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create app source provider: %w", err)
@@ -117,5 +119,5 @@ func downloadAppSourceChart(appSource *appskubermaticv1.ApplicationSource, direc
 	if err != nil {
 		return "", fmt.Errorf("failed to download app source: %w", err)
 	}
-	return
+	return chartPath, nil
 }

--- a/pkg/install/images/images_test.go
+++ b/pkg/install/images/images_test.go
@@ -106,7 +106,7 @@ func TestProcessImagesFromHelmChartsAndSystemApps(t *testing.T) {
 	}
 	images = append(images, appImages...)
 
-	if err := ProcessImages(context.Background(), log, "docker", true, images, "test-registry:5000"); err != nil {
+	if _, _, err := ProcessImages(context.Background(), log, true, images, "test-registry:5000", "kubermatic-installer/test"); err != nil {
 		t.Errorf("Error calling processImages: %v", err)
 	}
 }

--- a/pkg/install/images/images_test.go
+++ b/pkg/install/images/images_test.go
@@ -18,13 +18,16 @@ package images
 
 import (
 	"context"
+	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/install/helm"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
@@ -68,6 +71,42 @@ func TestRetagImageForAllVersions(t *testing.T) {
 	}
 
 	if _, _, err := ProcessImages(context.Background(), log, true, imageSet.List(), "test-registry:5000", "kubermatic-installer/test"); err != nil {
+		t.Errorf("Error calling processImages: %v", err)
+	}
+}
+
+func TestProcessImagesFromHelmChartsAndSystemApps(t *testing.T) {
+	log := logrus.New()
+
+	helmBinary, err := exec.LookPath("helm")
+	if err != nil {
+		t.Skip("Skipping test due to missing helm binary")
+	}
+
+	helmClient, err := helm.NewCLI(helmBinary, "", "", 5*time.Minute, log)
+	if err != nil {
+		t.Errorf("failed to create Helm client: %v", err)
+	}
+
+	config, err := defaulting.DefaultConfiguration(&kubermaticv1.KubermaticConfiguration{}, zap.NewNop().Sugar())
+	if err != nil {
+		t.Errorf("failed to determine versions: %v", err)
+	}
+
+	var images []string
+	chartImages, err := GetImagesForHelmCharts(context.Background(), log, config, helmClient, "../../../charts/monitoring", "", "")
+	if err != nil {
+		t.Errorf("error calling GetImagesForHelmCharts: %v", err)
+	}
+	images = append(images, chartImages...)
+
+	appImages, err := GetImagesFromSystemApplicationDefinitions(log, config, helmClient, 5*time.Minute, "")
+	if err != nil {
+		t.Errorf("Error calling GetImagesFromSystemApplicationDefinitions: %v", err)
+	}
+	images = append(images, appImages...)
+
+	if err := ProcessImages(context.Background(), log, "docker", true, images, "test-registry:5000"); err != nil {
 		t.Errorf("Error calling processImages: %v", err)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Adds `kubermatic-installer mirror-images` support for system Applications (only Cilium CNI at the moment).

Also includes the previously existing `GetImagesForHelmCharts` in the unit test, as it was not exercised by any unit test before.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11691 

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
