### PR TITLE
OPA integration: allow to define enforcementAction in constraints.kubermatic.k8c.io/v1

### DIFF
--- a/pkg/apis/kubermatic/v1/constraint.go
+++ b/pkg/apis/kubermatic/v1/constraint.go
@@ -70,6 +70,10 @@ type ConstraintSpec struct {
 	Parameters Parameters `json:"parameters,omitempty"`
 	// Selector specifies the cluster selection filters
 	Selector ConstraintSelector `json:"selector,omitempty"`
+
+	// EnforcementAction defines the action to take in response to a constraint being violated.
+	// By default, EnforcementAction is set to deny as the default behavior is to deny admission requests with any violation.
+	EnforcementAction string `json:"enforcementAction,omitempty"`
 }
 
 type Parameters map[string]json.RawMessage

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -48,6 +48,7 @@ const (
 	parametersField      = "parameters"
 	matchField           = "match"
 	rawJsonField         = "rawJSON"
+	enforcementAction    = "enforcementAction"
 )
 
 type reconciler struct {
@@ -186,6 +187,13 @@ func constraintReconcilerFactory(constraint *kubermaticv1.Constraint) reconcilin
 			err = unstructured.SetNestedField(u.Object, matchMap, spec, matchField)
 			if err != nil {
 				return nil, fmt.Errorf("error setting constraint nested spec: %w", err)
+			}
+
+			// set EnforcementAction
+			if len(constraint.Spec.EnforcementAction) > 0 {
+				if err := unstructured.SetNestedField(u.Object, constraint.Spec.EnforcementAction, spec, enforcementAction); err != nil {
+					return nil, fmt.Errorf("error setting constraint nested EnforcementAction: %w", err)
+				}
 			}
 
 			return u, nil

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_constraints.yaml
@@ -42,6 +42,9 @@ spec:
                 disabled:
                   description: Disabled  is the flag for disabling OPA constraints
                   type: boolean
+                enforcementAction:
+                  description: EnforcementAction defines the action to take in response to a constraint being violated. By default, EnforcementAction is set to deny as the default behavior is to deny admission requests with any violation.
+                  type: string
                 match:
                   description: Match contains the constraint to resource matching data
                   properties:

--- a/pkg/test/constraints.go
+++ b/pkg/test/constraints.go
@@ -82,8 +82,9 @@ type UniqueLabelList struct {
 }
 
 type ConstraintSpec struct {
-	Match      kubermaticv1.Match     `json:"match,omitempty"`
-	Parameters map[string]interface{} `json:"parameters,omitempty"`
+	Match             kubermaticv1.Match     `json:"match,omitempty"`
+	Parameters        map[string]interface{} `json:"parameters,omitempty"`
+	EnforcementAction string                 `json:"enforcementAction,omitempty"`
 }
 
 type ConstraintStatus struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
As an Admin, I would like to deprecate an Application version. To do so, I would like to create` Default Constraints` that warn users that this version is deprecated.

Example:
```
k edit -n default applicationInstallation my-apache
Warning: [warn-deprecate-app-example-v1] application `apache` in version `9.2.9` is deprecated. Please upgrade to next version
applicationinstallation.apps.kubermatic.k8c.io/my-apache edited
```

This can be done by setting [enforcementAction: warn](https://open-policy-agent.github.io/gatekeeper/website/docs/violations/#warn-enforcement-action) in `constraints.gatekeeper.sh/v1beta1`

This PR adds `enforcementAction` to  k8c  constraint 's spec and replicates it value when creating the gatekeeper 's constraint.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
OPA integration:  allow to define enforcementAction in kubermatic 's constraint.
EnforcementAction defines the action to take in response to a constraint being violated.
By default, EnforcementAction is set to deny as the default behavior is to deny admission requests with any violation.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1308
```
