### PR TITLE
Automate docs sync for KKP components page

### DIFF
--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -82,8 +82,8 @@ EOT
 
 # iterate over all charts to extract version information
 for filepath in $(find charts -name Chart.yaml | sort); do
-  # extract chart_name by removing a "../charts/" prefix and a "Chart.yaml" suffix from the full file path
-  chart_name=$(echo ${filepath} | sed -e 's/^\.\.\/charts\///g' -e 's/\/Chart\.yaml$//g')
+  # extract chart name by removing a "../charts/" prefix from the directory path
+  chart_name=$(dirname ${filepath} | sed -e 's/^\.\.\/charts\///g')
   # read appVersion from Chart.yaml and normalize version format by removing a "v" prefix
   app_version=$(yq '.appVersion' ${filepath} | sed -e 's/^v//g/')
   # append information to components markdown file

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -80,7 +80,15 @@ of provided software and therefore releases updates regularly that also include 
 | ----------------------------- | ---------------------------- |
 EOT
 
-for filepath in $(find charts -name Chart.yaml | sort); do echo "| $(echo ${filepath} | sed -e 's/^\.\.\/charts\///g' -e 's/\/Chart\.yaml$//g') | $(yq '.appVersion' ${filepath} | sed -e 's/^v//g') |" >> ${components_file}; done
+# iterate over all charts to extract version information
+for filepath in $(find charts -name Chart.yaml | sort); do
+  # extract chart_name by removing a "../charts/" prefix and a "Chart.yaml" suffix from the full file path
+  chart_name=$(echo ${filepath} | sed -e 's/^\.\.\/charts\///g' -e 's/\/Chart\.yaml$//g')
+  # read appVersion from Chart.yaml and normalize version format by removing a "v" prefix
+  app_version=$(yq '.appVersion' ${filepath} | sed -e 's/^v//g/')
+  # append information to components markdown file
+  echo "| ${chart_name} | ${app_version} |" >> ${components_file}
+done
 
 # update repo
 git add .

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -63,7 +63,7 @@ hack/render-crds.sh
 
 # update components page
 components_file=content/kubermatic/main/architecture/compatibility/KKP-components-versioning/_index.en.md
-echo > ${components_file} <<EOT
+cat > ${components_file} <<EOT
 +++
 title = "KKP Components"
 date = 2021-04-13T20:07:15+02:00
@@ -79,7 +79,7 @@ The following list is only eligible for the version that is currently available.
 | ----------------------------- | ---------------------------- |
 EOT
 
-for filepath in $(find charts -name Chart.yaml | sort); do echo "| $(echo ${filepath} | sed -e 's/^charts\///g' -e 's/\/Chart\.yaml$//g') | $(yq '.appVersion' ${filepath} | sed -e 's/^v//g') |" >> ${components_file}; done
+for filepath in $(find charts -name Chart.yaml | sort); do echo "| $(echo ${filepath} | sed -e 's/^\.\.\/charts\///g' -e 's/\/Chart\.yaml$//g') | $(yq '.appVersion' ${filepath} | sed -e 's/^v//g') |" >> ${components_file}; done
 
 # update repo
 git add .

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -63,7 +63,7 @@ hack/render-crds.sh
 
 # update components page
 components_file=content/kubermatic/main/architecture/compatibility/KKP-components-versioning/_index.en.md
-cat > ${components_file} <<EOT
+cat > ${components_file} << EOT
 +++
 title = "KKP Components"
 date = 2021-04-13T20:07:15+02:00

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -73,7 +73,8 @@ weight = 2
 
 ## Kubermatic Kubernetes Platform Components
 
-The following list is only eligible for the version that is currently available. Kubermatic has a strong emphasis on the security and reliability of the provided software and releases updates regularly that also update components.
+The following list is only applicable for the KKP version that is currently available. Kubermatic has a strong emphasis on security and reliability
+of provided software and therefore releases updates regularly that also include component updates.
 
 | KKP Components                | Version                      |
 | ----------------------------- | ---------------------------- |

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -61,6 +61,26 @@ make runbook
 # update CRDs reference
 hack/render-crds.sh
 
+# update components page
+components_file=content/kubermatic/main/architecture/compatibility/KKP-components-versioning/_index.en.md
+echo > ${components_file} <<EOT
++++
+title = "KKP Components"
+date = 2021-04-13T20:07:15+02:00
+weight = 2
+
++++
+
+## Kubermatic Kubernetes Platform Components
+
+The following list is only eligible for the version that is currently available. Kubermatic has a strong emphasis on the security and reliability of the provided software and releases updates regularly that also update components.
+
+| KKP Components                | Version                      |
+| ----------------------------- | ---------------------------- |
+EOT
+
+for filepath in $(find charts -name Chart.yaml | sort); do echo "| $(echo ${filepath} | sed -e 's/^charts\///g' -e 's/\/Chart\.yaml$//g') | $(yq '.appVersion' ${filepath} | sed -e 's/^v//g') |" >> ${components_file}; done
+
 # update repo
 git add .
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The components page in our docs is outdated quite a bit. This adds the page to be synced from our docs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
