### PR TITLE
fix push-images not using docker mirror

### DIFF
--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -37,7 +37,7 @@ apt install time -y
 
 if [ -z "${NO_DOCKER_IMAGES:-}" ]; then
   echodate "Logging into Quay"
-  docker ps > /dev/null 2>&1 || start-docker.sh
+  start_docker_daemon_ci
   retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
   retry 5 buildah login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
   echodate "Successfully logged into Quay"


### PR DESCRIPTION
**What this PR does / why we need it**:
Calling `start-docker.sh` will circumvent the important env renaming, where the Prow-provided `DOCKER_REGISTRY_MIRROR_ADDR` env is renamed to `DOCKER_REGISTRY_MIRROR`, which is what the `start-docker.sh` expects. It's a bit unintuitive, but so widespread in our CI system that changing it is not quickly doable.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
