### PR TITLE
Improve validation for versioning configuration

### DIFF
--- a/pkg/defaulting/configuration_test.go
+++ b/pkg/defaulting/configuration_test.go
@@ -14,49 +14,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package defaulting
+package defaulting_test
 
 import (
 	"testing"
 
-	"k8c.io/kubermatic/v2/pkg/semver"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/validation"
 )
 
-func TestAutomaticUpdateRulesMatchVersions(t *testing.T) {
-	for i, update := range DefaultKubernetesVersioning.Updates {
-		// only test automatic rules
-		if update.Automatic == nil || !*update.Automatic {
-			continue
-		}
-
-		toVersion, err := semver.NewSemver(update.To)
-		if err != nil {
-			t.Errorf("Version %q in update rule %d is not a valid version: %v", update.To, i, err)
-			continue
-		}
-
-		found := false
-		for _, v := range DefaultKubernetesVersioning.Versions {
-			if v.Equal(toVersion) {
-				found = true
-			}
-		}
-
-		if !found {
-			t.Errorf("Version %s in update rule %d is not configured as a supported version.", update.To, i)
-		}
-	}
-}
-
-func TestDefaultVersionIsSupported(t *testing.T) {
-	found := false
-	for _, v := range DefaultKubernetesVersioning.Versions {
-		if v.Equal(DefaultKubernetesVersioning.Default) {
-			found = true
-		}
-	}
-
-	if !found {
-		t.Errorf("Default version %s is not configured as a supported version.", DefaultKubernetesVersioning.Default)
+func TestDefaultConfigurationIsValid(t *testing.T) {
+	errs := validation.ValidateKubermaticVersioningConfiguration(defaulting.DefaultKubernetesVersioning, nil)
+	for _, err := range errs {
+		t.Error(err)
 	}
 }

--- a/pkg/validation/kubermaticconfiguration.go
+++ b/pkg/validation/kubermaticconfiguration.go
@@ -24,7 +24,6 @@ import (
 
 	semverlib "github.com/Masterminds/semver/v3"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/version"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -116,7 +115,7 @@ func validateAutomaticUpdateRulesOnlyPointToValidVersions(config kubermaticv1.Ku
 		return allErrs
 	}
 
-	for i, update := range defaulting.DefaultKubernetesVersioning.Updates {
+	for i, update := range config.Updates {
 		is := strconv.Itoa(i)
 
 		// only test automatic rules

--- a/pkg/validation/kubermaticconfiguration.go
+++ b/pkg/validation/kubermaticconfiguration.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	semverlib "github.com/Masterminds/semver/v3"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/version"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The KKP webhook is using the version manager to validate a cluster's version. The manager only considers versions for which no update rules exist to be valid.

However if we as humans have configured update rules accidentally like

1. `1.22.* => 1.22.5` and
2. `1.22.5 => 1.22.7`

Then 1.22.5 is **not** considered to be a valid version.

To make this easier and prevent us (or admins!) from configuring wrong update rules, this PR moves the unit tests for the default configuration into the validation package, i.e. why only validate our default config, why not simply validate _all_ configs at build and at runtime later? So now the unit tests for the default config simply use the existing validation logic.

**Which issue(s) this PR fixes**:
Fixes #11721 once it's backported to 2.21.x

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Improve validation for versioning/update configuration in KubermaticConfigurations
```

**Documentation**:
```documentation
NONE
```
