### PR TITLE
Fix web socket connections timeout

### DIFF
--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -97,7 +97,12 @@ func IngressReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Na
 			if i.Annotations == nil {
 				i.Annotations = make(map[string]string)
 			}
-			i.Annotations["kubernetes.io/ingress.class"] = cfg.Spec.Ingress.ClassName
+			i.Annotations["kubernetes.io/ingress.class"] = cfg.Spec.Ingress.ClassNam
+
+			// NGINX ingress annotations to avoid timeout of websocket connections after 1 minute.
+			// Needed for Web Terminal feature, for example.
+			i.Annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"] = "3600" // 1 hour
+			i.Annotations["nginx.ingress.kubernetes.io/proxy-send-timeout"] = "3600" // 1 hour
 
 			// If a Certificate is being issued, configure cert-manager by
 			// setting up the required annotations.

--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -97,7 +97,7 @@ func IngressReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.Na
 			if i.Annotations == nil {
 				i.Annotations = make(map[string]string)
 			}
-			i.Annotations["kubernetes.io/ingress.class"] = cfg.Spec.Ingress.ClassNam
+			i.Annotations["kubernetes.io/ingress.class"] = cfg.Spec.Ingress.ClassName
 
 			// NGINX ingress annotations to avoid timeout of websocket connections after 1 minute.
 			// Needed for Web Terminal feature, for example.


### PR DESCRIPTION
**What this PR does / why we need it**:
NGINX ingress limits all API requests to a 1 minute timeout, which makes web socket connections (like for Web Terminal) be disconnected after 1 minute.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11755

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set nginx ingress `proxy-read-timeout` and `proxy-send-timeout` to 1 hour to support long-lasting connections (e.g. websocket)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1336
```
