### PR TITLE
Avoid using OSM APIs in KKP for OSM migration

### DIFF
--- a/cmd/kubermatic-operator/main.go
+++ b/cmd/kubermatic-operator/main.go
@@ -33,7 +33,6 @@ import (
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
-	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/klog/v2"
@@ -110,10 +109,6 @@ func main() {
 
 	if err := apiextensionsv1.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Fatalw("Failed to register scheme", zap.Stringer("api", apiextensionsv1.SchemeGroupVersion), zap.Error(err))
-	}
-
-	if err := osmv1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatalw("Failed to register scheme", zap.Stringer("api", osmv1alpha1.SchemeGroupVersion), zap.Error(err))
 	}
 
 	configGetter, err := kubernetesprovider.DynamicKubermaticConfigurationGetterFactory(mgr.GetClient(), opt.namespace)

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -40,7 +40,6 @@ import (
 	crdutil "k8c.io/kubermatic/v2/pkg/util/crd"
 	osmmigration "k8c.io/kubermatic/v2/pkg/util/migration"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
-	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -49,6 +48,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -714,7 +714,10 @@ func (r *Reconciler) migrationForOSM(ctx context.Context, client ctrlruntimeclie
 
 	// Check if there are any OSP resources in the cluster. If nothing is found then the OSP CRD can be safely deleted.
 	if ospCRDExists {
-		ospList := &osmv1alpha1.OperatingSystemProfileList{}
+		ospList := &unstructured.UnstructuredList{}
+		ospList.SetAPIVersion(osmmigration.OperatingSystemManagerAPIVersion)
+		ospList.SetKind(fmt.Sprintf("%sList", osmmigration.OperatingSystemProfileKind))
+
 		err = client.List(ctx, ospList)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to list operatingSystemProfiles: %w", err))

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
@@ -57,9 +57,9 @@ const (
 	cleanupFinalizer = "kubermatic.k8c.io/cleanup-kubermatic-operating-system-profiles"
 	ospNamespace     = metav1.NamespaceSystem
 
-	customOperatingSystemProfileAPIVersion = "operatingsystemmanager.k8c.io/v1alpha1"
-	customOperatingSystemProfileKind       = "CustomOperatingSystemProfile"
-	operatingSystemProfileKind             = "OperatingSystemProfile"
+	operatingSystemManagerAPIVersion = "operatingsystemmanager.k8c.io/v1alpha1"
+	customOperatingSystemProfileKind = "CustomOperatingSystemProfile"
+	operatingSystemProfileKind       = "OperatingSystemProfile"
 )
 
 // UserClusterClientProvider provides functionality to get a user cluster client.
@@ -108,7 +108,7 @@ func Add(
 
 	// Watch changes for Custom Operating System Profiles.
 	customOSP := &unstructured.Unstructured{}
-	customOSP.SetAPIVersion(customOperatingSystemProfileAPIVersion)
+	customOSP.SetAPIVersion(operatingSystemManagerAPIVersion)
 	customOSP.SetKind(customOperatingSystemProfileKind)
 
 	if err := c.Watch(
@@ -136,7 +136,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Reconciling")
 
 	osp := &unstructured.Unstructured{}
-	osp.SetAPIVersion(customOperatingSystemProfileAPIVersion)
+	osp.SetAPIVersion(operatingSystemManagerAPIVersion)
 	osp.SetKind(customOperatingSystemProfileKind)
 
 	if err := r.seedClient.Get(ctx, request.NamespacedName, osp); err != nil {
@@ -278,7 +278,7 @@ func enqueueOperatingSystemProfiles(client ctrlruntimeclient.Client, log *zap.Su
 		var requests []reconcile.Request
 
 		ospList := &unstructured.UnstructuredList{}
-		ospList.SetAPIVersion(customOperatingSystemProfileAPIVersion)
+		ospList.SetAPIVersion(operatingSystemManagerAPIVersion)
 		ospList.SetKind(fmt.Sprintf("%sList", customOperatingSystemProfileKind))
 
 		if err := client.List(context.Background(), ospList, &ctrlruntimeclient.ListOptions{Namespace: namespace}); err != nil {

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
@@ -312,9 +312,10 @@ func ospReconciler(osp *osmv1alpha1.OperatingSystemProfile) reconciling.NamedOpe
 
 func customOSPToOSP(u *unstructured.Unstructured) (*osmv1alpha1.OperatingSystemProfile, error) {
 	osp := &osmv1alpha1.OperatingSystemProfile{}
-	// Required for converting CustomOperatingSystemProfile to OperatingSystemProfile
-	u.SetKind(operatingSystemProfileKind)
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, osp); err != nil {
+	// Required for converting CustomOperatingSystemProfile to OperatingSystemProfile.
+	obj := u.DeepCopy()
+	obj.SetKind(operatingSystemProfileKind)
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, osp); err != nil {
 		return osp, fmt.Errorf("failed to decode CustomOperatingSystemProfile: %w", err)
 	}
 	return osp, nil

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -63,13 +63,13 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	osmmigration "k8c.io/kubermatic/v2/pkg/util/migration"
-	osmv1alpha1 "k8c.io/operating-system-manager/pkg/crd/osm/v1alpha1"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -1505,7 +1505,11 @@ func (r *reconciler) migrationForOSM(ctx context.Context) error {
 	// Delete all OSC from user cluster namespace. They will be recreated by OSM automatically in the user-cluster.
 	if oscCRDExists {
 		listOpts := ctrlruntimeclient.InNamespace(r.namespace)
-		if err = r.seedClient.DeleteAllOf(ctx, &osmv1alpha1.OperatingSystemProfile{}, listOpts); err != nil {
+		osc := &unstructured.Unstructured{}
+		osc.SetAPIVersion(osmmigration.OperatingSystemManagerAPIVersion)
+		osc.SetKind(osmmigration.OperatingSystemConfigKind)
+
+		if err = r.seedClient.DeleteAllOf(ctx, osc, listOpts); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete OperatingSystemConfigs: %w", err))
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of using OSM APIs, rely on unstructured objects to avoid caching issues. This gives us a way to not register the scheme for OSM with the controller manager.

```
E0125 13:43:51.485290       1 reflector.go:140] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:169: Failed to watch *v1alpha1.OperatingSystemProfile: failed to list *v1alpha1.OperatingSystemProfile: the server could not find the requested resource (get operatingsystemprofiles.operatingsystemmanager.k8c.io)
W0125 13:43:53.039394       1 reflector.go:424] k8s.io/client-go@v12.0.0+incompatible/tools/cache/reflector.go:169: failed to list *v1alpha1.OperatingSystemProfile: the server could not find the requested resource (get operatingsystemprofiles.operatingsystemmanager.k8c.io)
```
OSP and OSC CRD are not deployed on seed/master cluster anymore. Although the migration logic depends on them; it will migrate all OSP, OSC CRs and eventually remove the CRDs from the seed cluster. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
