### PR TITLE
Reconcile CNI ApplicationInstallation periodically

### DIFF
--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -325,6 +325,7 @@ func createCNIApplicationInstallationController(ctrlCtx *controllerContext) erro
 		ctrlCtx.mgr,
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
+		ctrlCtx.runOptions.systemAppEnforceInterval,
 		ctrlCtx.clientProvider,
 		ctrlCtx.log,
 		ctrlCtx.versions,

--- a/cmd/seed-controller-manager/options.go
+++ b/cmd/seed-controller-manager/options.go
@@ -66,6 +66,7 @@ type controllerRunOptions struct {
 	namespace                string
 	concurrentClusterUpdate  int
 	addonEnforceInterval     int
+	systemAppEnforceInterval int
 	caBundle                 *certificates.CABundle
 
 	// for development purposes, a local configuration file
@@ -134,6 +135,7 @@ func newControllerRunOptions() (controllerRunOptions, error) {
 	flag.StringVar(&c.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for Seed resources")
 	flag.IntVar(&c.concurrentClusterUpdate, "max-parallel-reconcile", 10, "The default number of resources updates per cluster")
 	flag.IntVar(&c.addonEnforceInterval, "addon-enforce-interval", 5, "Check and ensure default usercluster addons are deployed every interval in minutes. Set to 0 to disable.")
+	flag.IntVar(&c.systemAppEnforceInterval, "system-app-enforce-interval", 5, "Check and ensure system ApplicationInstallations in user cluster every interval in minutes. Set to 0 to disable.")
 	flag.StringVar(&caBundleFile, "ca-bundle", "", "File containing the PEM-encoded CA bundle for all userclusters")
 	flag.Var(&c.tunnelingAgentIP, "tunneling-agent-ip", "The address used by the tunneling agents.")
 	flag.BoolVar(&c.enableUserClusterMLA, "enable-user-cluster-mla", false, "Enables user cluster MLA (Monitoring, Logging & Alerting) stack in the seed.")

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -71,13 +71,15 @@ type Reconciler struct {
 	userClusterConnectionProvider UserClusterClientProvider
 	log                           *zap.SugaredLogger
 	versions                      kubermatic.Versions
+	systemAppEnforceInterval      int
 	overwriteRegistry             string
 }
 
-func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName string, userClusterConnectionProvider UserClusterClientProvider, log *zap.SugaredLogger, versions kubermatic.Versions, overwriteRegistry string) error {
+func Add(ctx context.Context, mgr manager.Manager, numWorkers int, workerName string, systemAppEnforceInterval int, userClusterConnectionProvider UserClusterClientProvider, log *zap.SugaredLogger, versions kubermatic.Versions, overwriteRegistry string) error {
 	reconciler := &Reconciler{
 		Client:                        mgr.GetClient(),
 		workerName:                    workerName,
+		systemAppEnforceInterval:      systemAppEnforceInterval,
 		recorder:                      mgr.GetEventRecorderFor(ControllerName),
 		userClusterConnectionProvider: userClusterConnectionProvider,
 		log:                           log.Named(ControllerName),
@@ -168,12 +170,23 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	if result == nil {
 		result = &reconcile.Result{}
+
+		if r.systemAppEnforceInterval != 0 {
+			// Reconciliation was successful, but requeue in systemAppEnforceInterval minutes if set.
+			// We do this to make sure that ApplicationInstallation in the user cluster is not modified in a wrong way / deleted accidentally.
+			// Even though it is protected by a webhook, not all unwanted modifications can be easily prevented there.
+			result.RequeueAfter = time.Duration(r.systemAppEnforceInterval) * time.Minute
+		}
 	}
 	return *result, err
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, logger *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
 	log := logger.With("CNIType", cluster.Spec.CNIPlugin.Type, "CNIVersion", cluster.Spec.CNIPlugin.Version)
+
+	if !cni.IsManagedByAppInfra(cluster.Spec.CNIPlugin.Type, cluster.Spec.CNIPlugin.Version) {
+		return &reconcile.Result{}, nil // in case that CNI changed since last requeue, skip if it is not managed by this controller
+	}
 
 	// Make sure that cluster is in a state when creating ApplicationInstallation is permissible
 	if !cluster.Status.ExtendedHealth.ApplicationControllerHealthy() {

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -170,13 +170,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	if result == nil {
 		result = &reconcile.Result{}
-
-		if r.systemAppEnforceInterval != 0 {
-			// Reconciliation was successful, but requeue in systemAppEnforceInterval minutes if set.
-			// We do this to make sure that ApplicationInstallation in the user cluster is not modified in a wrong way / deleted accidentally.
-			// Even though it is protected by a webhook, not all unwanted modifications can be easily prevented there.
-			result.RequeueAfter = time.Duration(r.systemAppEnforceInterval) * time.Minute
-		}
 	}
 	return *result, err
 }
@@ -231,7 +224,15 @@ func (r *Reconciler) reconcile(ctx context.Context, logger *zap.SugaredLogger, c
 		}
 	}
 
-	return nil, nil
+	result := &reconcile.Result{}
+	if r.systemAppEnforceInterval != 0 {
+		// Reconciliation was successful, but requeue in systemAppEnforceInterval minutes if set.
+		// We do this to make sure that ApplicationInstallation in the user cluster is not modified in a wrong way / deleted accidentally.
+		// Even though it is protected by a webhook, not all unwanted modifications can be easily prevented there.
+		result.RequeueAfter = time.Duration(r.systemAppEnforceInterval) * time.Minute
+	}
+
+	return result, nil
 }
 
 func (r *Reconciler) ensureLegacyCNIAddonIsRemoved(ctx context.Context, cluster *kubermaticv1.Cluster) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensures we reconcile system (CNI) `ApplicationInstallation` periodically, as cluster can be put into a broken state if the CNI ApplicationInstallation is accidentally deleted / modified in a wrong way by the cluster user.
Even though it is protected by a webhook, not all unwanted modifications can be easily prevented there.

Similar approach is already in place for Addons.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
