### PR TITLE
Allow k8s version upgrade for non-amd64 nodes with Canal and IPVS for all k8s versions

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -533,21 +533,13 @@ spec:
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version
-        condition: nonAMD64WithCanalAndIPVS
+        condition: externalCloudProvider
         # Operation is the operation triggering the compatibility check (CREATE or UPDATE)
-        operation: UPGRADE
+        operation: SUPPORT
         # Provider to which to apply the compatibility check.
         # Empty string matches all providers
-        provider: ""
-        # Version is the Kubernetes version that must be checked. Wildcards are allowed, e.g. "1.25.*".
-        version: 1.23.*
-      - condition: nonAMD64WithCanalAndIPVS
-        operation: UPGRADE
-        provider: ""
-        version: 1.24.*
-      - condition: externalCloudProvider
-        operation: SUPPORT
         provider: aws
+        # Version is the Kubernetes version that must be checked. Wildcards are allowed, e.g. "1.25.*".
         version: < 1.24.0
       - condition: externalCloudProvider
         operation: CREATE

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -533,21 +533,13 @@ spec:
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version
-        condition: nonAMD64WithCanalAndIPVS
+        condition: externalCloudProvider
         # Operation is the operation triggering the compatibility check (CREATE or UPDATE)
-        operation: UPGRADE
+        operation: SUPPORT
         # Provider to which to apply the compatibility check.
         # Empty string matches all providers
-        provider: ""
-        # Version is the Kubernetes version that must be checked. Wildcards are allowed, e.g. "1.25.*".
-        version: 1.23.*
-      - condition: nonAMD64WithCanalAndIPVS
-        operation: UPGRADE
-        provider: ""
-        version: 1.24.*
-      - condition: externalCloudProvider
-        operation: SUPPORT
         provider: aws
+        # Version is the Kubernetes version that must be checked. Wildcards are allowed, e.g. "1.25.*".
         version: < 1.24.0
       - condition: externalCloudProvider
         operation: CREATE

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=always;externalCloudProvider;nonAMD64WithCanalAndIPVS
+// +kubebuilder:validation:Enum=always;externalCloudProvider
 
 // ConditionType is the type defining the cluster or datacenter condition that must be met to block a specific version.
 type ConditionType string
@@ -33,9 +33,6 @@ const (
 	AlwaysCondition ConditionType = "always"
 	// ExternalCloudProviderCondition is an incompatibility condition that represents the usage of the external Cloud Provider.
 	ExternalCloudProviderCondition ConditionType = ClusterFeatureExternalCloudProvider
-	// NonAMD64WithCanalAndIPVSClusterCondition is an incompatibility condition that represents the usage of non-amd64 nodes in the cluster
-	// running Canal and kube-proxy in the IPVS mode.
-	NonAMD64WithCanalAndIPVSClusterCondition ConditionType = "nonAMD64WithCanalAndIPVS"
 )
 
 // +kubebuilder:validation:Enum=CREATE;UPGRADE;SUPPORT

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -520,7 +520,6 @@ spec:
                             enum:
                               - always
                               - externalCloudProvider
-                              - nonAMD64WithCanalAndIPVS
                             type: string
                           operation:
                             description: Operation is the operation triggering the compatibility check (CREATE or UPDATE)

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -319,21 +319,6 @@ var (
 			},
 		},
 		ProviderIncompatibilities: []kubermaticv1.Incompatibility{
-			{
-				// Applies to all providers.
-				Provider:  "",
-				Version:   "1.23.*",
-				Condition: kubermaticv1.NonAMD64WithCanalAndIPVSClusterCondition,
-				Operation: kubermaticv1.UpdateOperation,
-			},
-			{
-				// Applies to all providers.
-				Provider:  "",
-				Version:   "1.24.*",
-				Condition: kubermaticv1.NonAMD64WithCanalAndIPVSClusterCondition,
-				Operation: kubermaticv1.UpdateOperation,
-			},
-
 			// External CCM on AWS requires Kubernetes 1.24+
 			{
 				Provider:  kubermaticv1.AWSCloudProvider,


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
As the Canal CNI issue with ARM platform has been fixed in recent Canal CNI versions, we should allow k8s version upgrade for non-amd64 nodes with Canal and IPVS for all k8s versions.

Also removes the `NonAMD64WithCanalAndIPVSClusterCondition` incompatibility condition as it is not needed anymore.

<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow k8s version upgrade for clusters with non-amd64 nodes & Canal CNI and IPVS for all k8s versions
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1318
```
