### PR TITLE
Add autoscaler support for Kubernetes 1.26

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -25,6 +25,9 @@
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
 {{ $version = "v1.25.0"}}
 {{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.26" }}
+{{ $version = "v1.26.1"}}
+{{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
I think we missed(?) adding support for cluster-autoscaler in Kubernetes 1.26. This adds it. I checked https://github.com/kubernetes/autoscaler/compare/cluster-autoscaler-1.25.0...cluster-autoscaler-1.26.1 and couldn't see big changes in the Helm charts, so bumping the version should suffice.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
