### PR TITLE
Actually validate container runtime during cluster validation

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -85,6 +85,11 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 		spec.ExposeStrategy = seed.Spec.ExposeStrategy
 	}
 
+	// set container runtime to containerd if unset; this is in line with our CRD comments.
+	if spec.ContainerRuntime == "" {
+		spec.ContainerRuntime = "containerd"
+	}
+
 	// Though the caller probably had already determined the datacenter
 	// to construct the cloud provider instance, we do not take the DC
 	// as a parameter, to keep this function's signature at least somewhat

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -85,11 +85,6 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 		spec.ExposeStrategy = seed.Spec.ExposeStrategy
 	}
 
-	// set container runtime to containerd if unset; this is in line with our CRD comments.
-	if spec.ContainerRuntime == "" {
-		spec.ContainerRuntime = "containerd"
-	}
-
 	// Though the caller probably had already determined the datacenter
 	// to construct the cloud provider instance, we do not take the DC
 	// as a parameter, to keep this function's signature at least somewhat

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -109,6 +109,11 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 		}
 	}
 
+	// Validate if container runtime is valid for this cluster (in particular this checks for docker support).
+	if err := ValidateContainerRuntime(spec); err != nil {
+		allErrs = append(allErrs, field.Invalid(parentFieldPath.Child("containerRuntime"), spec.ContainerRuntime, fmt.Sprintf("failed to validate container runtime: %s", err)))
+	}
+
 	if !kubermaticv1.AllExposeStrategies.Has(spec.ExposeStrategy) {
 		allErrs = append(allErrs, field.NotSupported(parentFieldPath.Child("exposeStrategy"), spec.ExposeStrategy, kubermaticv1.AllExposeStrategies.Items()))
 	}

--- a/pkg/webhook/cluster/validation/validation_test.go
+++ b/pkg/webhook/cluster/validation/validation_test.go
@@ -1780,6 +1780,7 @@ func (r rawClusterGen) Build() kubermaticv1.Cluster {
 		Spec: kubermaticv1.ClusterSpec{
 			HumanReadableName: "a test cluster",
 			Version:           *version,
+			ContainerRuntime:  "containerd",
 			Cloud: kubermaticv1.CloudSpec{
 				DatacenterName: datacenterName,
 				ProviderName:   string(kubermaticv1.HetznerCloudProvider),

--- a/pkg/webhook/clustertemplate/validation/validation_test.go
+++ b/pkg/webhook/clustertemplate/validation/validation_test.go
@@ -731,6 +731,7 @@ func (r rawTemplateGen) Build() kubermaticv1.ClusterTemplate {
 		Spec: kubermaticv1.ClusterSpec{
 			HumanReadableName: "a-test-cluster",
 			Version:           *version,
+			ContainerRuntime:  "containerd",
 			Cloud: kubermaticv1.CloudSpec{
 				DatacenterName: datacenterName,
 				ProviderName:   string(kubermaticv1.HetznerCloudProvider),


### PR DESCRIPTION
**What this PR does / why we need it**:
We have code for validating the container runtime settings, but we were only calling it during cluster creation in our API handler code. We want to validate every cluster passing through our webhook.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11782

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Container runtime configuration is properly validated while creating or upgrading clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
