### PR TITLE
Add validation for installer to fail if a docker cluster still exists

### DIFF
--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -171,6 +171,12 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 			if !clusterVersionIsConfigured(clusterVersion, defaulted, upgradeConstraints) {
 				errs = append(errs, fmt.Errorf("cluster %s (version %s) on Seed %s would not be supported anymore", cluster.Name, clusterVersion, seedName))
 			}
+
+			// we effectivel ydon't support docker in KKP 2.22; Kubernetes 1.23 clusters that are
+			// still running it need to be upgraded before proceeding with the KKP upgrade.
+			if cluster.Spec.ContainerRuntime == "docker" {
+				errs = append(errs, fmt.Errorf("cluster %s on Seed %s is running 'docker' as container runtime; please upgrade it to 'containerd' before proceeding", cluster.Name, seedName))
+			}
 		}
 	}
 

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -172,7 +172,7 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 				errs = append(errs, fmt.Errorf("cluster %s (version %s) on Seed %s would not be supported anymore", cluster.Name, clusterVersion, seedName))
 			}
 
-			// we effectivel ydon't support docker in KKP 2.22; Kubernetes 1.23 clusters that are
+			// we effectively don't support docker in KKP 2.22; Kubernetes 1.23 clusters that are
 			// still running it need to be upgraded before proceeding with the KKP upgrade.
 			if cluster.Spec.ContainerRuntime == "docker" {
 				errs = append(errs, fmt.Errorf("cluster %s on Seed %s is running 'docker' as container runtime; please upgrade it to 'containerd' before proceeding", cluster.Name, seedName))


### PR DESCRIPTION
**What this PR does / why we need it**:
We don't want to allow upgrading KKP if clusters with `docker` as container runtime since KKP 2.22 will only support Kubernetes 1.24+. As such, we want users to upgrade their container runtime before making the jump to KKP 2.22.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrading KKP requires to change container runtime for all user clusters to containerd beforehand
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
