### PR TITLE
Default container runtime to 'containerd' if not set

### DIFF
--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -85,6 +85,11 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 		spec.ExposeStrategy = seed.Spec.ExposeStrategy
 	}
 
+	// containerd is the default runtime; our CRD documentation says we default to it.
+	if spec.ContainerRuntime == "" {
+		spec.ContainerRuntime = "containerd"
+	}
+
 	// Though the caller probably had already determined the datacenter
 	// to construct the cloud provider instance, we do not take the DC
 	// as a parameter, to keep this function's signature at least somewhat

--- a/pkg/webhook/cluster/mutation/mutator_test.go
+++ b/pkg/webhook/cluster/mutation/mutator_test.go
@@ -1006,10 +1006,11 @@ func (r rawClusterGen) Do() *kubermaticv1.Cluster {
 			Name: r.Name,
 		},
 		Spec: kubermaticv1.ClusterSpec{
-			Version:        r.Version,
-			Cloud:          r.CloudSpec,
-			ClusterNetwork: r.NetworkConfig,
-			CNIPlugin:      r.CNIPluginSpec,
+			ContainerRuntime: "containerd",
+			Version:          r.Version,
+			Cloud:            r.CloudSpec,
+			ClusterNetwork:   r.NetworkConfig,
+			CNIPlugin:        r.CNIPluginSpec,
 		},
 		Status: kubermaticv1.ClusterStatus{
 			Versions: kubermaticv1.ClusterVersionsStatus{


### PR DESCRIPTION
**What this PR does / why we need it**:
We only support containerd as container runtime right now. Let's default the field in our CR, especially given that we documented it that way in our CRD docs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Container runtime for user clusters defaults to `containerd` at the custom resource level
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
