### PR TITLE
fix constraint-syncer: EnforcementAction is not removed

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -194,6 +194,8 @@ func constraintReconcilerFactory(constraint *kubermaticv1.Constraint) reconcilin
 				if err := unstructured.SetNestedField(u.Object, constraint.Spec.EnforcementAction, spec, enforcementAction); err != nil {
 					return nil, fmt.Errorf("error setting constraint nested EnforcementAction: %w", err)
 				}
+			} else {
+				unstructured.RemoveNestedField(u.Object, spec, enforcementAction)
 			}
 
 			return u, nil

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -228,6 +228,37 @@ func TestReconcile(t *testing.T) {
 				WithScheme(scheme.Scheme).
 				Build(),
 		},
+		{
+			name: "scenario 8: update constraint to user cluster with enforcement Action removed",
+			namespacedName: types.NamespacedName{
+				Namespace: "namespace",
+				Name:      constraintName,
+			},
+			expectedConstraint: func() apiv2.Constraint {
+				constraint := generator.GenDefaultAPIConstraint(constraintName, kind)
+				return constraint
+			}(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(
+					func() *kubermaticv1.Constraint {
+						constraint := generator.GenConstraint(constraintName, "namespace", kind)
+						return constraint
+					}(),
+				).
+				Build(),
+			userClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(&test.RequiredLabel{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: constraintName,
+					},
+					Spec: test.ConstraintSpec{EnforcementAction: "warn"},
+				}).
+				Build(),
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:
When we remove spec.EnforcementAction from k8c constraint, it should also be remove from the gatekeeper constraint in user cluster

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
