### PR TITLE
[release/v2.20] Update MC to v1.45.6 and OSM to v0.4.6

### DIFF
--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -52,7 +52,7 @@ var (
 
 const (
 	Name = "machine-controller"
-	Tag  = "v1.45.5"
+	Tag  = "v1.45.6"
 )
 
 type machinecontrollerData interface {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -52,7 +52,7 @@ var (
 
 const (
 	Name = "operating-system-manager"
-	Tag  = "v0.4.5"
+	Tag  = "v0.4.6"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.20.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.21.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.20.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.21.0-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
@@ -61,7 +61,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
@@ -64,7 +64,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller-webhook.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.20.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller-webhook.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.21.0-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
@@ -53,7 +53,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
@@ -56,7 +56,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller-webhook.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.20.0-machine-controller.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller-webhook.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.21.0-machine-controller.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
@@ -55,7 +55,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
@@ -58,7 +58,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.20.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.21.0-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
@@ -66,7 +66,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
@@ -69,7 +69,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-externalCloudProvider.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.20.0-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-externalCloudProvider.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.21.0-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
@@ -59,7 +59,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
@@ -62,7 +62,7 @@ spec:
           value: apiserver-external.cluster-de-test-01.svc.cluster.local.
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: docker.io/kubermatic/machine-controller:v1.45.5
+        image: docker.io/kubermatic/machine-controller:v1.45.6
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates machine-controller to v1.45.6 and operating-system-manager to v0.4.6 on the `release/v2.20` branch. This is needed to fix the issue with the new worker nodes not joining the cluster because of missing containerd and Docker packages.

**Which issue(s) this PR fixes**:
xref #11793

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update machine-controller to v1.45.6 and operating-system-manager (OSM) to v0.4.6. containerd is updated to v1.6 (from 1.4) and Docker is updated to 20.10 (from 19.03).
```

**Documentation**:
```documentation
NONE
```