### PR TITLE
Changed arguments in the machine resource calculation util

### DIFF
--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -127,7 +127,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluster, machines *clusterv1alpha1.MachineList) error {
 	resourceUsage := kubermaticv1.NewResourceDetails(resource.Quantity{}, resource.Quantity{}, resource.Quantity{})
 	for _, machine := range machines.Items {
-		resourceDetails, err := machinevalidation.GetMachineResourceUsage(ctx, r.userClient, &machine, r.caBundle)
+		resourceDetails, err := machinevalidation.GetMachineResourceUsage(ctx, r.userClient, &machine, r.caBundle.CertPool())
 		if err != nil {
 			return fmt.Errorf("error getting machine resource usage for machine %q: %w", machine.Name, err)
 		}

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -57,7 +57,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/openstack"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/packet"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/ee/validation/machine/resourcequota.go
+++ b/pkg/ee/validation/machine/resourcequota.go
@@ -26,6 +26,7 @@ package machine
 
 import (
 	"context"
+	"crypto/x509"
 	"errors"
 	"fmt"
 
@@ -34,7 +35,6 @@ import (
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -45,10 +45,10 @@ func ValidateQuota(ctx context.Context,
 	log *zap.SugaredLogger,
 	userClient ctrlruntimeclient.Client,
 	machine *clusterv1alpha1.Machine,
-	caBundle *certificates.CABundle,
+	certPool *x509.CertPool,
 	resourceQuota *kubermaticv1.ResourceQuota,
 ) error {
-	machineResourceUsage, err := GetMachineResourceUsage(ctx, userClient, machine, caBundle)
+	machineResourceUsage, err := GetMachineResourceUsage(ctx, userClient, machine, certPool)
 	if err != nil {
 		return fmt.Errorf("error getting machine resource request: %w", err)
 	}

--- a/pkg/webhook/machine/validation/validation.go
+++ b/pkg/webhook/machine/validation/validation.go
@@ -81,7 +81,7 @@ func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) erro
 		return err
 	}
 	if quota != nil {
-		return validateQuota(ctx, log, v.userClient, machine, v.caBundle, quota)
+		return validateQuota(ctx, log, v.userClient, machine, v.caBundle.CertPool(), quota)
 	}
 	return nil
 }

--- a/pkg/webhook/machine/validation/wrappers_ce.go
+++ b/pkg/webhook/machine/validation/wrappers_ce.go
@@ -20,19 +20,19 @@ package validation
 
 import (
 	"context"
+	"crypto/x509"
 
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	"k8s.io/apimachinery/pkg/labels"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func validateQuota(_ context.Context, _ *zap.SugaredLogger, _ ctrlruntimeclient.Client, _ *clusterv1alpha1.Machine,
-	_ *certificates.CABundle, _ *kubermaticv1.ResourceQuota) error {
+	_ *x509.CertPool, _ *kubermaticv1.ResourceQuota) error {
 	return nil
 }
 

--- a/pkg/webhook/machine/validation/wrappers_ee.go
+++ b/pkg/webhook/machine/validation/wrappers_ee.go
@@ -20,6 +20,7 @@ package validation
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -27,15 +28,14 @@ import (
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	eemachinevalidation "k8c.io/kubermatic/v2/pkg/ee/validation/machine"
-	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 
 	"k8s.io/apimachinery/pkg/labels"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func validateQuota(ctx context.Context, log *zap.SugaredLogger, userClient ctrlruntimeclient.Client,
-	machine *clusterv1alpha1.Machine, caBundle *certificates.CABundle, resourceQuota *kubermaticv1.ResourceQuota) error {
-	return eemachinevalidation.ValidateQuota(ctx, log, userClient, machine, caBundle, resourceQuota)
+	machine *clusterv1alpha1.Machine, certPool *x509.CertPool, resourceQuota *kubermaticv1.ResourceQuota) error {
+	return eemachinevalidation.ValidateQuota(ctx, log, userClient, machine, certPool, resourceQuota)
 }
 
 func getResourceQuota(ctx context.Context, seedClient ctrlruntimeclient.Client, subjectSelector labels.Selector) (*kubermaticv1.ResourceQuota, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
To allow using `GetMachineResourceUsage` function in places where only cert pool is available, argument list has been updated to accept `x509.CertPool` instead of `CABundle` type.

**Which issue(s) this PR fixes**:
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:
We need this change in order to reuse `GetMachineResourceUsage` in the dashboard.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
