### PR TITLE
Fix OpenStack tenant fields migration

### DIFF
--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -302,6 +302,19 @@ func createOrUpdateOpenstackSecret(ctx context.Context, seedClient ctrlruntimecl
 	if spec.Domain == "" {
 		spec.Domain = oldCred.Domain
 	}
+	if spec.Username == "" {
+		spec.Username = oldCred.Username
+	}
+	if spec.Password == "" {
+		spec.Password = oldCred.Password
+	}
+	if spec.ApplicationCredentialID == "" {
+		spec.ApplicationCredentialID = oldCred.ApplicationCredentialID
+	}
+	if spec.ApplicationCredentialSecret == "" {
+		spec.ApplicationCredentialSecret = oldCred.ApplicationCredentialSecret
+	}
+
 	authToken := ""
 	if spec.UseToken {
 		if spec.Token == "" {

--- a/pkg/provider/kubernetes/credentials.go
+++ b/pkg/provider/kubernetes/credentials.go
@@ -271,13 +271,24 @@ func createOrUpdateHetznerSecret(ctx context.Context, seedClient ctrlruntimeclie
 
 func createOrUpdateOpenstackSecret(ctx context.Context, seedClient ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) (bool, error) {
 	spec := cluster.Spec.Cloud.Openstack
+	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, seedClient)
+
+	// TenantID and Tenant fields are deprecated, if we find them in the credentials reference secret
+	// then we have to trigger the secret update.
+	tenantToProjectMigrated := true
+	if val, _ := secretKeySelector(cluster.Spec.Cloud.Openstack.CredentialsReference, resources.OpenstackTenant); val != "" {
+		tenantToProjectMigrated = false
+	}
+	if val, _ := secretKeySelector(cluster.Spec.Cloud.Openstack.CredentialsReference, resources.OpenstackTenantID); val != "" {
+		tenantToProjectMigrated = false
+	}
+	clusterSpecMigrated := spec.Username == "" && spec.Password == "" && spec.Project == "" && spec.ProjectID == "" && spec.Domain == "" && spec.ApplicationCredentialID == "" && spec.ApplicationCredentialSecret == "" && !spec.UseToken
 
 	// already migrated
-	if spec.Username == "" && spec.Password == "" && spec.Project == "" && spec.ProjectID == "" && spec.Domain == "" && spec.ApplicationCredentialID == "" && spec.ApplicationCredentialSecret == "" && !spec.UseToken {
+	if tenantToProjectMigrated && clusterSpecMigrated {
 		return false, nil
 	}
 
-	secretKeySelector := provider.SecretKeySelectorValueFuncFactory(ctx, seedClient)
 	oldCred, err := openstack.GetCredentialsForCluster(cluster.Spec.Cloud, secretKeySelector)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Long story short.. if in KKP 2.20 a secret `credential-openstack-xx` have tenant fields then after the upgrade to KKP 2.21 (where MC doesn't respect the tenant fields anymore) the cluster is broken as you cannot CRUD nodes (MDs).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix OpenStack cloud provider tenant to project fields migration.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
