### PR TITLE
[release/v2.21] KubeVirt set storage.deleteAfterCompletion=false annotation on DV

### DIFF
--- a/pkg/provider/cloud/kubevirt/data_volume.go
+++ b/pkg/provider/cloud/kubevirt/data_volume.go
@@ -36,11 +36,18 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	dvDeleteAfterCompletionAnnotationKey = "cdi.kubevirt.io/storage.deleteAfterCompletion"
+)
+
 type StorageClassAnnotationFilter func(map[string]string) bool
 
 func dataVolumeCreator(datavolume *cdiv1beta1.DataVolume) reconciling.NamedCDIv1beta1DataVolumeCreatorGetter {
 	return func() (name string, create reconciling.CDIv1beta1DataVolumeCreator) {
 		return datavolume.Name, func(dv *cdiv1beta1.DataVolume) (*cdiv1beta1.DataVolume, error) {
+			dv.Annotations = map[string]string{
+				dvDeleteAfterCompletionAnnotationKey: "false",
+			}
 			dv.Spec = datavolume.Spec
 			return dv, nil
 		}


### PR DESCRIPTION
This fix is needed with KubeVirt infra cluster with version >=1.55.0 as the DataVolumes starting with this version are by default Garbage Collected.
The annotation `cdi.kubevirt.io/storage.deleteAfterCompletion: "false` is added to the reconciled DataColumes to prevent them from being GC.

**This fix is specific to KKP 2.21, no back port needed in previous minor releases, nor KKP 2.22.**

Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11827 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KubeVirt: prevents DataVolumes from being Garbage Collected with KubeVirt version >=1.55.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
