### PR TITLE
Add "PodSecurityPolicy" admission plugin validation for Cluster webhook

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -49,6 +49,9 @@ var (
 	// ErrCloudChangeNotAllowed describes that it is not allowed to change the cloud provider.
 	ErrCloudChangeNotAllowed  = errors.New("not allowed to change the cloud provider")
 	azureLoadBalancerSKUTypes = sets.New("", string(kubermaticv1.AzureStandardLBSKU), string(kubermaticv1.AzureBasicLBSKU))
+
+	gte125Constraint, _                                  = semverlib.NewConstraint(">= 1.25.0")
+	errPodSecurityPolicyAdmissionPluginWithVersionGte125 = errors.New("admissin plugin \"PodSecurityPolicy\" is not supported in Kubernetes v1.25 and later")
 )
 
 const (
@@ -70,6 +73,8 @@ const (
 
 	// EARKeyLength is required key length for encryption at rest.
 	EARKeyLength = 32
+
+	podSecurityPolicyAdmissionPluginName = "PodSecurityPolicy"
 )
 
 // ValidateClusterSpec validates the given cluster spec. If this is not called from within another validation
@@ -106,6 +111,10 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 
 		if !versionValid {
 			allErrs = append(allErrs, field.NotSupported(parentFieldPath.Child("version"), spec.Version.String(), validVersions))
+		}
+
+		if err := validatePodSecurityPolicyAdmissionPluginForVersion(spec); err != nil {
+			allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("admissionPlugins"), err.Error()))
 		}
 	}
 
@@ -1233,4 +1242,20 @@ func checkVersionConstraint(version *semverlib.Version, constraint string) bool 
 		return false
 	}
 	return c.Check(version)
+}
+
+func validatePodSecurityPolicyAdmissionPluginForVersion(spec *kubermaticv1.ClusterSpec) error {
+	isK8sVersionGte125 := gte125Constraint.Check(spec.Version.Semver())
+
+	// Admissin plugin "PodSecurityPolicy" was removed in Kubernetes v1.25 and is no longer supported.
+	if spec.UsePodSecurityPolicyAdmissionPlugin && isK8sVersionGte125 {
+		return errPodSecurityPolicyAdmissionPluginWithVersionGte125
+	}
+	for _, admissionPlugin := range spec.AdmissionPlugins {
+		if admissionPlugin == podSecurityPolicyAdmissionPluginName && isK8sVersionGte125 {
+			return errPodSecurityPolicyAdmissionPluginWithVersionGte125
+		}
+	}
+
+	return nil
 }

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -51,7 +51,7 @@ var (
 	azureLoadBalancerSKUTypes = sets.New("", string(kubermaticv1.AzureStandardLBSKU), string(kubermaticv1.AzureBasicLBSKU))
 
 	gte125Constraint, _                                  = semverlib.NewConstraint(">= 1.25.0")
-	errPodSecurityPolicyAdmissionPluginWithVersionGte125 = errors.New("admissin plugin \"PodSecurityPolicy\" is not supported in Kubernetes v1.25 and later")
+	errPodSecurityPolicyAdmissionPluginWithVersionGte125 = errors.New("admission plugin \"PodSecurityPolicy\" is not supported in Kubernetes v1.25 and later")
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
Starting from Kubernetes v1.25, support for pod security policy has been removed. If a user cluster has "PodSecurityPolicy" admission plugin enabled and they try to upgrade to v1.25, they'll end up with a broken cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11763

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Admission plugin "PodSecurityPolicy" is not supported anymore on Kubernetes version 1.25 and later.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1347
```
