### PR TITLE
Fix RBAC issue for OSM migration

### DIFF
--- a/pkg/resources/usercluster/rbac.go
+++ b/pkg/resources/usercluster/rbac.go
@@ -124,6 +124,12 @@ func ClusterRole() reconciling.NamedClusterRoleReconcilerFactory {
 					Resources: []string{"customresourcedefinitions"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				// This should be removed with KKP 2.23 when we remove the Migration for OSM.
+				{
+					APIGroups: []string{"operatingsystemmanager.k8c.io"},
+					Resources: []string{"operatingsystemprofiles", "operatingsystemconfigs"},
+					Verbs:     []string{"*"},
+				},
 				{
 					APIGroups: []string{appskubermaticv1.GroupName},
 					Resources: []string{appskubermaticv1.ApplicationDefinitionResourceName},


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
This PR adds missing RBAC for user-cluster-controller-manager to access OSM resources in the seed cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11834

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
