### PR TITLE
Fix invalid project dereference in user grafana controller

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -339,7 +339,7 @@ func (r *userGrafanaController) ensureGrafanaUser(ctx context.Context, user *kub
 			project, ok := projectMap[projectName]
 			if !ok {
 				// don't stop reconciling if there is an upb/gbp which was not cleaned up properly
-				r.log.Warnw("user-bound project not found", "user", user.Name, "project", project.Name)
+				r.log.Warnw("user-bound project not found", "user", user.Name, "project", projectName)
 				continue
 			}
 			if err := ensureOrgUser(ctx, grafanaClient, project, user.Spec.Email, role); err != nil {


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Fixes potentail kubermatic-seed-controller-manager crash due to invalid dereference of the `project` that was not found in the `projectMap`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
