### PR TITLE
KubeVirt fix ccmClusterName feature for migrated clusters

### DIFF
--- a/pkg/webhook/cluster/mutation/mutator.go
+++ b/pkg/webhook/cluster/mutation/mutator.go
@@ -162,6 +162,13 @@ func (m *Mutator) mutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, con
 		}
 	}
 
+	// For KubeVirt, we want to mutate and always have ClusterFeatureCCMClusterName = true
+	// It's not handled by the previous loop for the migration 2.21 to 2.22
+	// as ExternalCloudProvider feature not is set for the first time.
+	if newCluster.Spec.Cloud.Kubevirt != nil {
+		newCluster.Spec.Features[kubermaticv1.ClusterFeatureCCMClusterName] = true
+	}
+
 	// just because spec.Version might say 1.23 doesn't say that the cluster is already on 1.23,
 	// so for all feature toggles and migrations we should base this on the actual, current apiserver
 	curVersion := newCluster.Status.Versions.ControlPlane


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
KubeVirt clusters upgraded to KKP 2.22 were missing `spec.features.ccmClusterName = true`.
This PR fixes this issue.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11838 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes missing ccmClusterName feature in KubeVirt clusters upgraded to KKP 2.22.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
