### PR TITLE
Ensure that tunneling-agent-ip is always passed to the usercluster-controller

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/address.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/address.go
@@ -43,10 +43,6 @@ func (r *Reconciler) syncAddress(ctx context.Context, log *zap.SugaredLogger, cl
 	}
 
 	b := address.NewModifiersBuilder(log)
-	// we only need providing the agentIP if the Tunneling strategy is used.
-	if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
-		b.TunnelingAgentIP(cluster.Spec.ClusterNetwork.TunnelingAgentIP)
-	}
 	modifiers, err := b.
 		Cluster(cluster).
 		Client(r.Client).

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -227,6 +227,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		WithEtcdDiskSize(r.etcdDiskSize).
 		WithUserClusterMLAEnabled(r.userClusterMLAEnabled).
 		WithKonnectivityEnabled(konnectivityEnabled).
+		WithTunnelingAgentIP(r.tunnelingAgentIP).
 		WithCABundle(r.caBundle).
 		WithOIDCIssuerURL(r.oidcIssuerURL).
 		WithOIDCIssuerClientID(r.oidcIssuerClientID).

--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -44,8 +44,6 @@ type ModifiersBuilder struct {
 	externalURL string
 	// used to ease unit tests
 	lookupFunction lookupFunction
-	// ip used by tunneling agents (tunneling expose strategy only)
-	tunnelingAgentIP string
 }
 
 func NewModifiersBuilder(log *zap.SugaredLogger) *ModifiersBuilder {
@@ -72,11 +70,6 @@ func (m *ModifiersBuilder) Seed(s *kubermaticv1.Seed) *ModifiersBuilder {
 
 func (m *ModifiersBuilder) ExternalURL(e string) *ModifiersBuilder {
 	m.externalURL = e
-	return m
-}
-
-func (m *ModifiersBuilder) TunnelingAgentIP(ip string) *ModifiersBuilder {
-	m.tunnelingAgentIP = ip
 	return m
 }
 

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -337,7 +337,6 @@ func TestSyncClusterAddress(t *testing.T) {
 				Seed(seed).
 				ExternalURL(fakeExternalURL).
 				lookupFunc(testLookupFunction).
-				TunnelingAgentIP(resources.DefaultTunnelingAgentIP).
 				Build(context.Background())
 			if err != nil {
 				if tc.errExpected {

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -88,6 +88,8 @@ type TemplateData struct {
 
 	userClusterMLAEnabled bool
 	isKonnectivityEnabled bool
+
+	tunnelingAgentIP string
 }
 
 type TemplateDataBuilder struct {
@@ -215,6 +217,11 @@ func (td *TemplateDataBuilder) WithMachineControllerImageTag(tag string) *Templa
 
 func (td *TemplateDataBuilder) WithMachineControllerImageRepository(repository string) *TemplateDataBuilder {
 	td.data.machineControllerImageRepository = repository
+	return td
+}
+
+func (td *TemplateDataBuilder) WithTunnelingAgentIP(tunnelingAgentIP string) *TemplateDataBuilder {
+	td.data.tunnelingAgentIP = tunnelingAgentIP
 	return td
 }
 
@@ -451,6 +458,16 @@ func (d *TemplateData) GetKonnectivityKeepAliveTime() string {
 		return t
 	}
 	return kubermaticv1.DefaultKonnectivityKeepaliveTime
+}
+
+func (d *TemplateData) GetTunnelingAgentIP() string {
+	if ip := d.Cluster().Spec.ClusterNetwork.TunnelingAgentIP; ip != "" {
+		return ip
+	}
+	if d.tunnelingAgentIP != "" {
+		return d.tunnelingAgentIP
+	}
+	return DefaultTunnelingAgentIP
 }
 
 // GetMLAGatewayPort returns the NodePort of the external MLA Gateway service.

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -68,6 +68,7 @@ type userclusterControllerData interface {
 	GetOpenVPNServerPort() (int32, error)
 	GetKonnectivityServerPort() (int32, error)
 	GetKonnectivityKeepAliveTime() string
+	GetTunnelingAgentIP() string
 	GetMLAGatewayPort() (int32, error)
 	KubermaticAPIImage() string
 	KubermaticDockerTag() string
@@ -188,7 +189,7 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 			}
 
 			if data.Cluster().Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
-				args = append(args, "-tunneling-agent-ip", data.Cluster().Spec.ClusterNetwork.TunnelingAgentIP)
+				args = append(args, "-tunneling-agent-ip", data.GetTunnelingAgentIP())
 				args = append(args, "-kas-secure-port", fmt.Sprint(resources.APIServerSecurePort))
 			}
 


### PR DESCRIPTION
Signed-off-by: Rastislav Szabo <rastislav@kubermatic.com>

**What this PR does / why we need it**:
Ensures that tunneling-agent-ip is always passed to the usercluster-controller, even is it is not present in cluster's `Spec.ClusterNetwork.TunnelingAgent`, which may happen for existing clusters after KKP version upgrade.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11835 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
Also cleans up passing the tunneling agent IP to the `pkg/resources/address`, as it is not used there anymore.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
