### PR TITLE
Unblock reconciliation loop if default backup destination is not set

### DIFF
--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -944,13 +944,17 @@ type OIDCProviderConfiguration struct {
 	SkipTLSVerify *bool `json:"skipTLSVerify,omitempty"`
 }
 
-// IsDefaultEtcdAutomaticBackupEnabled returns true if etcd automatic backup is configured for the seed.
-func (s *Seed) IsDefaultEtcdAutomaticBackupEnabled() bool {
+// IsEtcdAutomaticBackupEnabled returns true if etcd automatic backup is configured for the seed.
+func (s *Seed) IsEtcdAutomaticBackupEnabled() bool {
 	if cfg := s.Spec.EtcdBackupRestore; cfg != nil {
-		return len(cfg.Destinations) > 0 && cfg.DefaultDestination != ""
+		return len(cfg.Destinations) > 0
 	}
-
 	return false
+}
+
+// IsDefaultEtcdAutomaticBackupEnabled returns true if etcd automatic backup with default destination is configured for the seed.
+func (s *Seed) IsDefaultEtcdAutomaticBackupEnabled() bool {
+	return s.IsEtcdAutomaticBackupEnabled() && s.Spec.EtcdBackupRestore.DefaultDestination != ""
 }
 
 func (s *Seed) GetEtcdBackupDestination(destinationName string) *BackupDestination {

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -106,10 +106,8 @@ func (c *clusterBackupCollector) collect(ctx context.Context, ch chan<- promethe
 	// only configures full BackupContainerSpecs.
 	// Because of that, this collector can only work with the
 	// new backup/restore mechanism.
-	if etcdBkpCfg := seed.Spec.EtcdBackupRestore; etcdBkpCfg != nil {
-		if len(etcdBkpCfg.Destinations) > 0 {
-			return nil
-		}
+	if !seed.IsEtcdAutomaticBackupEnabled() {
+		return nil
 	}
 
 	clusterList := &kubermaticv1.ClusterList{}

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -106,8 +106,10 @@ func (c *clusterBackupCollector) collect(ctx context.Context, ch chan<- promethe
 	// only configures full BackupContainerSpecs.
 	// Because of that, this collector can only work with the
 	// new backup/restore mechanism.
-	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
-		return nil
+	if etcdBkpCfg := seed.Spec.EtcdBackupRestore; etcdBkpCfg != nil {
+		if len(etcdBkpCfg.Destinations) > 0 {
+			return nil
+		}
 	}
 
 	clusterList := &kubermaticv1.ClusterList{}

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -236,7 +236,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 
 	// the etcdbackup/etcdrestore controllers are enabled (at least for this seed), so we
 	// only perform cleanup for older clusters when needed
-	controllerEnabled := !seed.IsDefaultEtcdAutomaticBackupEnabled()
+	controllerEnabled := seed.IsEtcdAutomaticBackupEnabled()
 
 	// Cluster got deleted - regardless if the cluster was ever running, we cleanup
 	if cluster.DeletionTimestamp != nil {

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -234,15 +234,15 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 		return fmt.Errorf("failed to create backup cleanup container: %w", err)
 	}
 
-	// the etcdbackup/etcdrestore controllers are enabled (at least for this seed), so we
+	// the new etcdbackup/etcdrestore controllers are enabled (at least for this seed), so we
 	// only perform cleanup for older clusters when needed
-	controllerEnabled := seed.IsEtcdAutomaticBackupEnabled()
+	legacyControllerEnabled := !seed.IsEtcdAutomaticBackupEnabled()
 
 	// Cluster got deleted - regardless if the cluster was ever running, we cleanup
 	if cluster.DeletionTimestamp != nil {
 		// Need to cleanup
 		if kuberneteshelper.HasFinalizer(cluster, cleanupFinalizer) {
-			if controllerEnabled {
+			if legacyControllerEnabled {
 				// IgnoreAlreadyExists, otherwise we end up in a loop when we are able to
 				// create the job but not remove the finalizer.
 				if err := r.Create(ctx, r.cleanupJob(cluster, backupCleanupContainer)); ctrlruntimeclient.IgnoreAlreadyExists(err) != nil {
@@ -267,7 +267,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 	}
 
 	// Always add the finalizer first
-	if controllerEnabled {
+	if legacyControllerEnabled {
 		if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, cleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to add finalizer: %w", err)
 		}
@@ -281,7 +281,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 		return fmt.Errorf("failed to reconcile configmaps: %w", err)
 	}
 
-	if !controllerEnabled {
+	if !legacyControllerEnabled {
 		return r.deleteCronJob(ctx, cluster)
 	}
 

--- a/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
@@ -129,17 +129,7 @@ func TestEnsureBackupCronJob(t *testing.T) {
 		caBundle:             certificates.NewFakeCABundle(),
 		configGetter:         configGetter,
 		seedGetter: func() (*kubermaticv1.Seed, error) {
-			return generator.GenTestSeed(func(seed *kubermaticv1.Seed) {
-				seed.Spec.EtcdBackupRestore = &kubermaticv1.EtcdBackupRestore{
-					DefaultDestination: "minio",
-					Destinations: map[string]*kubermaticv1.BackupDestination{
-						"s3": {
-							Endpoint:   "http://minio.minio.svc.cluster.local:9000",
-							BucketName: "testbackups",
-						},
-					},
-				}
-			}), nil
+			return generator.GenTestSeed(), nil
 		},
 	}
 

--- a/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller_test.go
@@ -129,7 +129,17 @@ func TestEnsureBackupCronJob(t *testing.T) {
 		caBundle:             certificates.NewFakeCABundle(),
 		configGetter:         configGetter,
 		seedGetter: func() (*kubermaticv1.Seed, error) {
-			return generator.GenTestSeed(), nil
+			return generator.GenTestSeed(func(seed *kubermaticv1.Seed) {
+				seed.Spec.EtcdBackupRestore = &kubermaticv1.EtcdBackupRestore{
+					DefaultDestination: "minio",
+					Destinations: map[string]*kubermaticv1.BackupDestination{
+						"s3": {
+							Endpoint:   "http://minio.minio.svc.cluster.local:9000",
+							BucketName: "testbackups",
+						},
+					},
+				}
+			}), nil
 		},
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -195,7 +195,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// this feature is not enabled for this seed, do nothing
-	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
+	if !seed.IsEtcdAutomaticBackupEnabled() {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// this feature is not enabled for this seed, do nothing
-	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
+	if !seed.IsEtcdAutomaticBackupEnabled() {
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Unblock reconciliation loop if default backup destination is not set

**Which issue(s) this PR fixes**:
Fixes #11833 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Unblock etcd backup controller's reconciliation loop in case `defaultDestination` field is missing on Seed CR.
```

**Documentation**:
```documentation
NONE
```
