### PR TITLE
[release/v2.21] Persist annotations when upgrading a cluster

### DIFF
--- a/pkg/handler/common/cluster.go
+++ b/pkg/handler/common/cluster.go
@@ -1060,6 +1060,7 @@ func ConvertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, dat
 		ObjectMeta: apiv1.ObjectMeta{
 			ID:                internalCluster.Name,
 			Name:              internalCluster.Spec.HumanReadableName,
+			Annotations:       internalCluster.Annotations,
 			CreationTimestamp: apiv1.NewTime(internalCluster.CreationTimestamp.Time),
 			DeletionTimestamp: func() *apiv1.Time {
 				if internalCluster.DeletionTimestamp != nil {
@@ -1106,15 +1107,8 @@ func ConvertInternalClusterToExternal(internalCluster *kubermaticv1.Cluster, dat
 	if filterSystemLabels {
 		cluster.Labels = label.FilterLabels(label.ClusterResourceType, internalCluster.Labels)
 	}
-	// Add preset annotations
-	cluster.Annotations = make(map[string]string)
-	if internalCluster.Annotations != nil {
-		if value, ok := internalCluster.Annotations[kubermaticv1.PresetNameAnnotation]; ok {
-			cluster.Annotations[kubermaticv1.PresetNameAnnotation] = value
-		}
-		if value, ok := internalCluster.Annotations[kubermaticv1.PresetInvalidatedAnnotation]; ok {
-			cluster.Annotations[kubermaticv1.PresetInvalidatedAnnotation] = value
-		}
+	if cluster.Annotations == nil {
+		cluster.Annotations = make(map[string]string)
 	}
 
 	return cluster


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a manual backport to the `release/v2.21` branch of the API change introduced in https://github.com/kubermatic/dashboard/pull/5666.

**Which issue(s) this PR fixes**:
xref https://github.com/kubermatic/kubermatic/issues/11832
xref https://github.com/kubermatic/kubermatic/issues/11688

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Persist annotations when upgrading a cluster
```

**Documentation**:
```documentation
NONE
```

/assign @ahmedwaleedmalik 