### PR TITLE
[release/v2.21] Unblock etcd backup/restore reconciliation

### DIFF
--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -826,13 +826,17 @@ type MeteringReportConfiguration struct {
 	Types []string `json:"type,omitempty"`
 }
 
-// IsDefaultEtcdAutomaticBackupEnabled returns true if etcd automatic backup is configured for the seed.
-func (s *Seed) IsDefaultEtcdAutomaticBackupEnabled() bool {
+// IsEtcdAutomaticBackupEnabled returns true if etcd automatic backup is configured for the seed.
+func (s *Seed) IsEtcdAutomaticBackupEnabled() bool {
 	if cfg := s.Spec.EtcdBackupRestore; cfg != nil {
-		return len(cfg.Destinations) > 0 && cfg.DefaultDestination != ""
+		return len(cfg.Destinations) > 0
 	}
-
 	return false
+}
+
+// IsDefaultEtcdAutomaticBackupEnabled returns true if etcd automatic backup with default destination is configured for the seed.
+func (s *Seed) IsDefaultEtcdAutomaticBackupEnabled() bool {
+	return s.IsEtcdAutomaticBackupEnabled() && s.Spec.EtcdBackupRestore.DefaultDestination != ""
 }
 
 func (s *Seed) GetEtcdBackupDestination(destinationName string) *BackupDestination {

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -106,7 +106,7 @@ func (c *clusterBackupCollector) collect(ctx context.Context, ch chan<- promethe
 	// only configures full BackupContainerSpecs.
 	// Because of that, this collector can only work with the
 	// new backup/restore mechanism.
-	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
+	if !seed.IsEtcdAutomaticBackupEnabled() {
 		return nil
 	}
 

--- a/pkg/controller/seed-controller-manager/backup/backup_controller.go
+++ b/pkg/controller/seed-controller-manager/backup/backup_controller.go
@@ -234,15 +234,15 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 		return fmt.Errorf("failed to create backup cleanup container: %w", err)
 	}
 
-	// the etcdbackup/etcdrestore controllers are enabled (at least for this seed), so we
+	// the new etcdbackup/etcdrestore controllers are enabled (at least for this seed), so we
 	// only perform cleanup for older clusters when needed
-	controllerEnabled := !seed.IsDefaultEtcdAutomaticBackupEnabled()
+	legacyControllerEnabled := !seed.IsEtcdAutomaticBackupEnabled()
 
 	// Cluster got deleted - regardless if the cluster was ever running, we cleanup
 	if cluster.DeletionTimestamp != nil {
 		// Need to cleanup
 		if kuberneteshelper.HasFinalizer(cluster, cleanupFinalizer) {
-			if controllerEnabled {
+			if legacyControllerEnabled {
 				if err := r.Create(ctx, r.cleanupJob(cluster, backupCleanupContainer)); err != nil {
 					// Otherwise we end up in a loop when we are able to create the job but not
 					// remove the finalizer.
@@ -269,7 +269,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 	}
 
 	// Always add the finalizer first
-	if controllerEnabled {
+	if legacyControllerEnabled {
 		if err := kuberneteshelper.TryAddFinalizer(ctx, r, cluster, cleanupFinalizer); err != nil {
 			return fmt.Errorf("failed to add finalizer: %w", err)
 		}
@@ -283,7 +283,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, conf
 		return fmt.Errorf("failed to reconcile configmaps: %w", err)
 	}
 
-	if !controllerEnabled {
+	if !legacyControllerEnabled {
 		return r.deleteCronJob(ctx, cluster)
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -195,7 +195,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// this feature is not enabled for this seed, do nothing
-	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
+	if !seed.IsEtcdAutomaticBackupEnabled() {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -124,7 +124,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	// this feature is not enabled for this seed, do nothing
-	if !seed.IsDefaultEtcdAutomaticBackupEnabled() {
+	if !seed.IsEtcdAutomaticBackupEnabled() {
 		return reconcile.Result{}, nil
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Unblock etcd backup/restore reconciliation upon missing default backup destination.

This is a manual update as cherry-picking conflicted.

**Which issue(s) this PR fixes**:
Fixes #11833 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Unblock etcd backup controller's reconciliation loop in case `defaultDestination` field is missing on Seed CR.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
