### PR TITLE
Add support for Kubernetes v1.24.10, v1.25.6, and v1.26.1

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -506,7 +506,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.25.5
+    default: v1.25.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -570,7 +570,7 @@ spec:
         # To is the version to which an update is allowed.
         # Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
         # Can be a wildcard otherwise, e.g. "1.20.*".
-        to: 1.24.9
+        to: 1.24.10
       - from: 1.24.*
         to: 1.24.*
       - automatic: true
@@ -593,10 +593,12 @@ spec:
       - v1.24.6
       - v1.24.8
       - v1.24.9
+      - v1.24.10
       - v1.25.2
       - v1.25.4
       - v1.25.5
-      - v1.26.0
+      - v1.25.6
+      - v1.26.1
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -506,7 +506,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.25.5
+    default: v1.25.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -570,7 +570,7 @@ spec:
         # To is the version to which an update is allowed.
         # Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
         # Can be a wildcard otherwise, e.g. "1.20.*".
-        to: 1.24.9
+        to: 1.24.10
       - from: 1.24.*
         to: 1.24.*
       - automatic: true
@@ -593,10 +593,12 @@ spec:
       - v1.24.6
       - v1.24.8
       - v1.24.9
+      - v1.24.10
       - v1.25.2
       - v1.25.4
       - v1.25.5
-      - v1.26.0
+      - v1.25.6
+      - v1.26.1
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/hack/images/util/Dockerfile
+++ b/hack/images/util/Dockerfile
@@ -16,7 +16,7 @@ FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
 ENV MC_VERSION=RELEASE.2022-12-24T15-21-38Z \
-    KUBECTL_VERSION=v1.24.9 \
+    KUBECTL_VERSION=v1.25.6 \
     HELM_VERSION=v3.10.3 \
     VAULT_VERSION=1.12.2 \
     YQ_VERSION=4.30.6

--- a/hack/images/web-terminal/Dockerfile
+++ b/hack/images/web-terminal/Dockerfile
@@ -15,7 +15,7 @@
 FROM alpine:3.13
 LABEL maintainer="support@kubermatic.com"
 
-ENV KUBECTL_VERSION=v1.24.9 \
+ENV KUBECTL_VERSION=v1.25.6 \
     HELM_VERSION=v3.10.3
 
 RUN apk add --no-cache -U \

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.25.5"),
+		Default: semver.NewSemverOrDie("v1.25.6"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -230,19 +230,21 @@ var (
 			newSemver("v1.24.6"),
 			newSemver("v1.24.8"),
 			newSemver("v1.24.9"),
+			newSemver("v1.24.10"),
 			// Kubernetes 1.25
 			newSemver("v1.25.2"),
 			newSemver("v1.25.4"),
 			newSemver("v1.25.5"),
+			newSemver("v1.25.6"),
 			// Kubernetes 1.26
-			newSemver("v1.26.0"),
+			newSemver("v1.26.1"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.23 =======
 			{
 				// Auto-upgrade unsupported clusters.
 				From:      "1.23.*",
-				To:        "1.24.9",
+				To:        "1.24.10",
 				Automatic: pointer.Bool(true),
 			},
 			// ======= 1.24 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for Kubernetes v1.24.10, v1.25.6, and v1.26.1.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Kubernetes v1.24.10, v1.25.6, and v1.26.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
