### PR TITLE
Add option to conformance-tester to run cluster updates

### DIFF
--- a/cmd/conformance-tester/README.md
+++ b/cmd/conformance-tester/README.md
@@ -1,6 +1,6 @@
 # E2E conformance tester
 
-Runs static test scenarios against a set of KKP usercllusters.
+Runs static test scenarios against a set of KKP userclusters.
 
 The conformance tester will, by default, test all supported versions on providers using all supported operating systems,
 by creting one cluster for each combination, waiting for it to become healthy, adding nodes and then executing the
@@ -23,7 +23,7 @@ The command which will execute the following tests:
 - Telemetry: Verify that telemetry data is sent by the usercluster.
 - Metrics: Verify that all components expose their expected metrics.
 
-Check `pkg/tests/` for all the invididual testcases.
+Check `pkg/tests/` for all the individual testcases.
 
 ## Caveats
 

--- a/cmd/conformance-tester/README.md
+++ b/cmd/conformance-tester/README.md
@@ -1,20 +1,29 @@
 # E2E conformance tester
 
-Runs static test scenarios against a kubermatic cluster.
+Runs static test scenarios against a set of KKP usercllusters.
 
-The conformance tester will, by default, test all supported versions on providers using all supported operating systems.
+The conformance tester will, by default, test all supported versions on providers using all supported operating systems,
+by creting one cluster for each combination, waiting for it to become healthy, adding nodes and then executing the
+selected tests. Optionally the tests can be executed in a pre-existing cluster.
+
+The conformance tester is used both in the KKP e2e tests as well as manually to perform pre-release tests.
 
 ## Tests
 
 The command which will execute the following tests:
-- Simple PVC (Only: AWS, Azure, OpenStack, vSphere)
+
+- Simple PVC (Only: AWS, Azure, OpenStack, vSphere):
   A StatefulSet with a PVC template will be created. The Pod, which mounts the PV has a ReadinessProbe in place
   which will only report ready when the pod was able to write something to the mounted PV.
   The PVC has no StorageClass set, so the default StorageClass, which gets deployed via the default kubermatic Addon `default-storage-class`, will be used.
-- Simple LB (Only: AWS & Azure)
+- Simple LB (Only: AWS & Azure):
   The [Hello Kubernetes](https://kubernetes.io/docs/tasks/access-application-cluster/service-access-application-cluster/#creating-a-service-for-an-application-running-in-two-pods) Pod will be deployed with a Service of type LoadBalancer.
   The test will wait until the LoadBalancer is available and only report a success when the "Hello Kubernetes" Pod could be reached via the LoadBalancer IP(Or DNS).
-- [Kubernetes Conformance tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md) (First all parallel, afterwards all serial tests)
+- [Kubernetes Conformance tests](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md): First all parallel, afterwards all serial tests
+- Telemetry: Verify that telemetry data is sent by the usercluster.
+- Metrics: Verify that all components expose their expected metrics.
+
+Check `pkg/tests/` for all the invididual testcases.
 
 ## Caveats
 
@@ -22,25 +31,59 @@ All providers have custom quotas. Hitting the quota is fairly easy when testing 
 
 ## Running
 
-The tester needs either a predefined login token (e.g. from copying the token cookie from your local KKP setup, after
-logging in) or username/password to perform the login itself.
+The tester needs Kube API access to a specific KKP _seed_ cluster (can be a shared master/seed). All clusters will
+be scheduled onto this given seed.
 
 Depending on the cloud provider, additional credentials must be provided. See the `hack/run-conformance-tests.sh`
 script for more information.
 
-You can specify a fixed project (`-kubermatic-project-id`) or let the tester create a temporary project on-the-fly.
+You can specify a fixed project (`-kubermatic-project`) or let the tester create a temporary project on-the-fly.
 Note that you need to cleanup projects after failed tests, like removing any added SSH keys to prevent conflicts
 on the next run.
 
 Run `./hack/run-conformance-tests.sh -help` for more information.
 
-### With Token
+### Running a full provider tests
+
+The following is an example script to help in running a variety of test scenarios on AWS. The flags are
+optimized to run a larger number of test scenarios, compared to the `hack/run-conformance-tests.sh`, which
+is geared more towards a single scenario.
+
+Note how `-exclude-tests` is used to skip the expensive and lengthy Kubernetes conformance tests.
 
 ```bash
-./hack/run-conformance-tests.sh \
-  -kubermatic-project-id=YOUR_PROJECT_ID_HERE \
-  -kubermatic-oidc-token=OIDC_TOKEN_HERE \
-  -versions=v1.19.0
+#!/usr/bin/env bash
+
+make clean conformance-tester
+
+# In a QA scenario, there is usually a Preset available with the credentials
+# for that QA environment.
+accessKey="$(kubectl get presets qa -o json | jq '.spec.aws.accessKeyID' -r)"
+secretAccessKey="$(kubectl get presets qa -o json | jq '.spec.aws.secretAccessKey' -r)"
+
+_build/conformance-tester \
+  -aws-access-key-id "$accessKey" \
+  -aws-secret-access-key "$secretAccessKey" \
+  -aws-kkp-datacenter "aws-eu-central-1a" \
+  -providers "aws" \
+  -distributions "${DISTRIBUTIONS:-}" \
+  -releases "${RELEASES:-}" \
+  -enable-osm=${OSM:-true} \
+  -container-runtimes "${RUNTIMES:-}" \
+  -client "kube" \
+  -log-format "Console" \
+  -name-prefix "qa" \
+  -exclude-tests "conformance,telemetry" \
+  -wait-for-cluster-deletion=false \
+  -kubermatic-seed-cluster "kkp-qa-env" \
+  -reports-root "$(realpath reports)" \
+  -kubermatic-parallel-clusters ${PARALLEL:-3}
+```
+
+This script can be used like so:
+
+```bash
+DISTRIBUTIONS=ubuntu,centos RELEASES=1.24 runtests.sh
 ```
 
 ### Common customizations
@@ -49,11 +92,16 @@ Run `./hack/run-conformance-tests.sh -help` for more information.
 
 Setting `-log-debug=true` will enable the debug logs.
 
-**Only test a specific provider**
+**Only test a specific provider / OS**
 
-The provider which should be covered can be set via the `-provider` flag.
+The providers which should be covered can be set via the `-providers` flag, which is a comma-separated list of
+provider names. For example, setting `-providers=aws` will only test AWS clusters.
 
-For example, setting `-provider=aws` will only test AWS clusters. This is also the default.
+The same goes for `-distributions`, which can be used like `ubuntu,centos,flatcar`.
+
+`-releases` is likewise a comma-separated list of Kubernetes releases to test (usually just major.minor).
+The tester will automatically choose the most recent version supported for each given release. You can also
+explicitly give a full version like `1.26.1`.
 
 **Parallelism**
 

--- a/cmd/conformance-tester/main.go
+++ b/cmd/conformance-tester/main.go
@@ -90,6 +90,7 @@ func main() {
 		"osm", opts.OperatingSystemManagerEnabled,
 		"dualstack", opts.DualStackEnabled,
 		"konnectivity", opts.KonnectivityEnabled,
+		"updates", opts.TestClusterUpdate,
 	)
 
 	// setup kube client, ctrl-runtime client, clientgetter, seedgetter etc.

--- a/cmd/conformance-tester/pkg/runner/result.go
+++ b/cmd/conformance-tester/pkg/runner/result.go
@@ -23,6 +23,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/scenarios"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 )
 
 type testResult struct {
@@ -30,6 +31,7 @@ type testResult struct {
 	duration time.Duration
 	err      error
 	scenario scenarios.Scenario
+	cluster  *kubermaticv1.Cluster
 }
 
 func (t *testResult) Passed() bool {

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -671,7 +671,7 @@ func (r *TestRunner) updateClusterToNextMinor(
 
 	// Wait a moment to let the controllers begin reconciling, otherwise the wait loop below
 	// might just see the current healthy state and not actually wait for the reconciliation to complete.
-	time.Sleep(3 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	clusterName := cluster.Name
 

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -139,13 +139,14 @@ func (r *TestRunner) Run(ctx context.Context, testScenarios []scenarios.Scenario
 	fmt.Println("")
 	fmt.Println("========================== RESULT ===========================")
 	fmt.Println("Parameters:")
-	fmt.Printf("  KKP Version.........: %s (%s)\n", r.opts.KubermaticConfiguration.Status.KubermaticVersion, r.opts.KubermaticConfiguration.Status.KubermaticEdition)
-	fmt.Printf("  Name Prefix.........: %q\n", r.opts.NamePrefix)
-	fmt.Printf("  OSM Enabled.........: %v\n", r.opts.OperatingSystemManagerEnabled)
-	fmt.Printf("  Dualstack Enabled...: %v\n", r.opts.DualStackEnabled)
-	fmt.Printf("  Konnectivity Enabled: %v\n", r.opts.KonnectivityEnabled)
-	fmt.Printf("  Enabled Tests.......: %v\n", sets.List(r.opts.Tests))
-	fmt.Printf("  Scenario Options....: %v\n", sets.List(r.opts.ScenarioOptions))
+	fmt.Printf("  KKP Version............: %s (%s)\n", r.opts.KubermaticConfiguration.Status.KubermaticVersion, r.opts.KubermaticConfiguration.Status.KubermaticEdition)
+	fmt.Printf("  Name Prefix............: %q\n", r.opts.NamePrefix)
+	fmt.Printf("  OSM Enabled............: %v\n", r.opts.OperatingSystemManagerEnabled)
+	fmt.Printf("  Dualstack Enabled......: %v\n", r.opts.DualStackEnabled)
+	fmt.Printf("  Konnectivity Enabled...: %v\n", r.opts.KonnectivityEnabled)
+	fmt.Printf("  Cluster Updates Enabled: %v\n", r.opts.TestClusterUpdate)
+	fmt.Printf("  Enabled Tests..........: %v\n", sets.List(r.opts.Tests))
+	fmt.Printf("  Scenario Options.......: %v\n", sets.List(r.opts.ScenarioOptions))
 	fmt.Println("")
 	fmt.Println("Test results:")
 
@@ -165,7 +166,14 @@ func (r *TestRunner) Run(ctx context.Context, testScenarios []scenarios.Scenario
 			hadFailure = true
 		}
 		duration := result.duration.Round(time.Second)
-		scenarioResultMsg := fmt.Sprintf("[%s] - %s (%s)", prefix, result.scenario.Name(), duration)
+		scenarioResultMsg := fmt.Sprintf("[%s] - %s", prefix, result.scenario.Name())
+
+		if r.opts.TestClusterUpdate && result.cluster != nil {
+			scenarioResultMsg = fmt.Sprintf("%s (updated to %s)", scenarioResultMsg, result.cluster.Spec.Version)
+		}
+
+		scenarioResultMsg = fmt.Sprintf("%s (%s)", scenarioResultMsg, duration)
+
 		if result.err != nil {
 			scenarioResultMsg = fmt.Sprintf("%s: %v", scenarioResultMsg, result.err)
 		}
@@ -182,7 +190,10 @@ func (r *TestRunner) Run(ctx context.Context, testScenarios []scenarios.Scenario
 
 func (r *TestRunner) scenarioWorker(ctx context.Context, scenarios <-chan scenarios.Scenario, results chan<- testResult) {
 	for s := range scenarios {
-		var report *reporters.JUnitTestSuite
+		var (
+			report  *reporters.JUnitTestSuite
+			cluster *kubermaticv1.Cluster
+		)
 
 		scenarioLog := s.NamedLog(r.log)
 		scenarioLog.Info("Starting to test scenario...")
@@ -191,7 +202,7 @@ func (r *TestRunner) scenarioWorker(ctx context.Context, scenarios <-chan scenar
 
 		err := metrics.MeasureTime(metrics.ScenarioRuntimeMetric.With(prometheus.Labels{"scenario": s.Name()}), scenarioLog, func() error {
 			var err error
-			report, err = r.executeScenario(ctx, scenarioLog, s)
+			report, cluster, err = r.executeScenario(ctx, scenarioLog, s)
 			return err
 		})
 		if err != nil {
@@ -205,11 +216,12 @@ func (r *TestRunner) scenarioWorker(ctx context.Context, scenarios <-chan scenar
 			duration: time.Since(start),
 			scenario: s,
 			err:      err,
+			cluster:  cluster,
 		}
 	}
 }
 
-func (r *TestRunner) executeScenario(ctx context.Context, log *zap.SugaredLogger, scenario scenarios.Scenario) (*reporters.JUnitTestSuite, error) {
+func (r *TestRunner) executeScenario(ctx context.Context, log *zap.SugaredLogger, scenario scenarios.Scenario) (*reporters.JUnitTestSuite, *kubermaticv1.Cluster, error) {
 	report := &reporters.JUnitTestSuite{
 		Name: scenario.Name(),
 	}
@@ -218,7 +230,7 @@ func (r *TestRunner) executeScenario(ctx context.Context, log *zap.SugaredLogger
 	// We'll store the report there and all kinds of logs
 	scenarioFolder := path.Join(r.opts.ReportsRoot, scenario.Name())
 	if err := os.MkdirAll(scenarioFolder, os.ModePerm); err != nil {
-		return nil, fmt.Errorf("failed to create the scenario folder %q: %w", scenarioFolder, err)
+		return nil, nil, fmt.Errorf("failed to create the scenario folder %q: %w", scenarioFolder, err)
 	}
 
 	// We need the closure to defer the evaluation of the time.Since(totalStart) call
@@ -242,14 +254,19 @@ func (r *TestRunner) executeScenario(ctx context.Context, log *zap.SugaredLogger
 	// create a cluster if no existing one should be used
 	cluster, err := r.ensureCluster(ctx, log, scenario, report)
 	if err != nil {
-		return report, err
+		return report, nil, err
 	}
 
 	log = log.With("cluster", cluster.Name)
 	testError := r.executeTests(ctx, log, cluster, report, scenario)
 
+	// refresh the variable with the latest state
+	if err := r.opts.SeedClusterClient.Get(ctx, types.NamespacedName{Name: cluster.Name}, cluster); err != nil {
+		return nil, nil, err
+	}
+
 	if !r.opts.DeleteClusterAfterTests {
-		return report, testError
+		return report, cluster, testError
 	}
 
 	deleteTimeout := 15 * time.Minute
@@ -279,7 +296,7 @@ func (r *TestRunner) executeScenario(ctx context.Context, log *zap.SugaredLogger
 		errs = append(errs, projectDeleteError)
 	}
 
-	return report, kerrors.NewAggregate(errs)
+	return report, cluster, kerrors.NewAggregate(errs)
 }
 
 func (r *TestRunner) ensureCluster(ctx context.Context, log *zap.SugaredLogger, scenario scenarios.Scenario, report *reporters.JUnitTestSuite) (*kubermaticv1.Cluster, error) {
@@ -694,7 +711,7 @@ func (r *TestRunner) updateClusterToNextMinor(
 	}
 
 	// Wait for all nodes to reach the new version.
-	err = wait.PollLog(ctx, log, 15*time.Second, r.opts.NodeReadyTimeout, func() (transient error, terminal error) {
+	err = wait.PollLog(ctx, log, 30*time.Second, 2*r.opts.NodeReadyTimeout, func() (transient error, terminal error) {
 		nodeList := &corev1.NodeList{}
 		if err := userClusterClient.List(ctx, nodeList); err != nil {
 			return fmt.Errorf("failed to list nodes: %w", err), nil

--- a/cmd/conformance-tester/pkg/types/options.go
+++ b/cmd/conformance-tester/pkg/types/options.go
@@ -69,6 +69,7 @@ type Options struct {
 	DualStackEnabled              bool
 	KonnectivityEnabled           bool
 	ScenarioOptions               sets.Set[string]
+	TestClusterUpdate             bool
 
 	// additional settings
 
@@ -159,6 +160,7 @@ func (o *Options) AddFlags() {
 	flag.BoolVar(&o.OperatingSystemManagerEnabled, "enable-osm", true, "When set, enables Operating System Manager in the user cluster")
 	flag.BoolVar(&o.DualStackEnabled, "enable-dualstack", false, "When set, enables dualstack (IPv4+IPv6 networking) in the user cluster")
 	flag.BoolVar(&o.KonnectivityEnabled, "enable-konnectivity", false, "When set, enables Konnectivity (proxy service for control plane communication) in the user cluster. When set to false, OpenVPN is used")
+	flag.BoolVar(&o.TestClusterUpdate, "update-cluster", false, "When set, will first run the selected tests, then update the cluster and nodes to their next minor release and then run the same tests again")
 	flag.StringVar(&o.PushgatewayEndpoint, "pushgateway-endpoint", "", "host:port of a Prometheus Pushgateway to send runtime metrics to")
 	o.Secrets.AddFlags()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new `-update-cluster` flag, which will modify the test behaviour like so:

* After all the selected tests are successfully done, the cluster will be updated.
  * The latest version for the next minor release is chosen; if none exists, that's an error.
  * After the control plane is updated, all nodes are updated.
  * Once all nodes are ready, testing can continue.
* Once the update is done, the same set of selected tests is executed again.

Note that the intent is not to run all the pre-minor-release QA checks with this flag enabled, but instead that for a ticket like #11779, the conformance-tester is used twice.

1. Run the full set of possible combinations of OS/release (e.g. vsphere-ubuntu-1.25, vsphere-ubuntu-1.26, vsphere-centos-1.25, ...).
2. Run limited set of tests, one per release, with `-update-clusters`, so we test that e.g. vsphere 1.24 => 1.25 works, vsphere 1.25 => 1.26 works etc.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
