### PR TITLE
Default correct feature flag for etcd-launcher

### DIFF
--- a/cmd/etcd-launcher/Makefile
+++ b/cmd/etcd-launcher/Makefile
@@ -1,0 +1,24 @@
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DOCKER_REPO ?= "quay.io/kubermatic"
+GOOS ?= $(shell go env GOOS)
+
+.PHONY: build
+build:
+	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/etcd-launcher .
+
+.PHONY: docker
+docker: build
+	docker build -t $(DOCKER_REPO)/etcd-launcher:$(TAG) .

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -75,7 +75,7 @@ spec:
   exposeStrategy: NodePort
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    etcdLauncher: true
+    EtcdLauncher: true
   # ImagePullSecret is used to authenticate against Docker registries.
   imagePullSecret: ""
   # Ingress contains settings for making the API and UI accessible remotely.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -75,7 +75,7 @@ spec:
   exposeStrategy: NodePort
   # FeatureGates are used to optionally enable certain features.
   featureGates:
-    etcdLauncher: true
+    EtcdLauncher: true
   # ImagePullSecret is used to authenticate against Docker registries.
   imagePullSecret: ""
   # Ingress contains settings for making the API and UI accessible remotely.

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -76,6 +76,10 @@ make -C cmd/nodeport-proxy docker \
   GOOS="${GOOS}" \
   DOCKER_REPO="${DOCKER_REPO}" \
   TAG="${TAG}"
+make -C cmd/etcd-launcher docker \
+  GOOS="${GOOS}" \
+  DOCKER_REPO="${DOCKER_REPO}" \
+  TAG="${TAG}"
 make -C cmd/kubeletdnat-controller docker \
   GOOS="${GOOS}" \
   DOCKER_REPO="${DOCKER_REPO}" \
@@ -102,6 +106,7 @@ time kind create cluster --name="${KIND_CLUSTER_NAME}"
 kind export kubeconfig --name=${KIND_CLUSTER_NAME}
 
 # load nodeport-proxy image
+time kind load docker-image "${DOCKER_REPO}/etcd-launcher:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/addons:${TAG}" --name "${KIND_CLUSTER_NAME}"
 time kind load docker-image "${DOCKER_REPO}/kubermatic${REPOSUFFIX}:${TAG}" --name "${KIND_CLUSTER_NAME}"

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -27,6 +27,7 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/features"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 
@@ -500,12 +501,12 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 	configCopy.Spec.Auth = auth
 
 	// default etcdLauncher feature flag if it is not set
-	if _, etcdLauncherFeatureGateSet := configCopy.Spec.FeatureGates[kubermaticv1.ClusterFeatureEtcdLauncher]; !etcdLauncherFeatureGateSet {
+	if _, etcdLauncherFeatureGateSet := configCopy.Spec.FeatureGates[features.EtcdLauncher]; !etcdLauncherFeatureGateSet {
 		if configCopy.Spec.FeatureGates == nil {
 			configCopy.Spec.FeatureGates = make(map[string]bool)
 		}
 
-		configCopy.Spec.FeatureGates[kubermaticv1.ClusterFeatureEtcdLauncher] = true
+		configCopy.Spec.FeatureGates[features.EtcdLauncher] = true
 	}
 
 	if err := defaultDockerRepo(&configCopy.Spec.API.DockerRepository, DefaultDashboardImage, "api.dockerRepository", logger); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
We were defaulting the wrong feature flag (`etcdLauncher` was incorrect, we needed `EtcdLauncher`) in #11684 and as such, no etcd-launcher is enabled by default. This was missed because dev had the flag enabled explicitly ...

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
