### PR TITLE
applications: don't reuse values when upgrading

### DIFF
--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -278,6 +278,11 @@ func (h HelmClient) Upgrade(chartLoc, releaseName string, values map[string]inte
 	upgradeClient.Timeout = deployOpts.timeout
 	upgradeClient.Atomic = deployOpts.atomic
 
+	// Don't reuse values from the previous release.
+	// By default, Helm will merge values with the ones of the last release. This behavior may be helpful to for CLI but
+	// as CR is the source of truth, we don't want that.
+	upgradeClient.ResetValues = true
+
 	rel, err := upgradeClient.RunWithContext(h.ctx, releaseName, chartToUpgrade, values)
 	if err != nil {
 		// even if an error occurred release may be not null (e.g if timeout is reached)

--- a/pkg/applications/helmclient/client_integration_test.go
+++ b/pkg/applications/helmclient/client_integration_test.go
@@ -160,6 +160,23 @@ func TestHelmClient(t *testing.T) {
 				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version")
 			},
 		},
+		// tests for https://github.com/kubermatic/kubermatic/issues/11864
+		{
+			name: "upgrade from archive with no values should upgrade chart with default values",
+			testFunc: func(t *testing.T) {
+				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+			},
+		},
+		{
+			name: "upgrade from dir with no values should upgrade chart with default values",
+			testFunc: func(t *testing.T) {
+				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
+				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+			},
+		},
 		{
 			name: "upgrade from archive should failed if not already installed",
 			testFunc: func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

By default, Helm will merge values with the ones of the last release. This behavior may be helpful to for CLI but as CR is the source of truth, we don't want that.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11864

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
applications: don't reuse values when upgrading. The values defined in the ApplicationInstallation CR are the source of truth.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
