### PR TITLE
add --skip-seed-validation flag to installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -123,7 +123,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *
 	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
 	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "full path to the Helm 3 binary to use")
 	cmd.PersistentFlags().BoolVar(&opt.SkipDependencies, "skip-dependencies", false, "skip pulling Helm chart dependencies (requires chart dependencies to be already downloaded)")
-	cmd.PersistentFlags().Var(flagopts.SetFlag(opt.SkipSeedValidation), "skip-seed-validation", "comma-separated list of seed clusters to skip running the preflight checks on")
+	cmd.PersistentFlags().Var(flagopts.SetFlag(opt.SkipSeedValidation), "skip-seed-validation", "comma-separated list of seed clusters to skip running the preflight checks on (use with caution, as this can lead to defunct KKP setups)")
 	cmd.PersistentFlags().BoolVar(&opt.Force, "force", false, "perform Helm upgrades even when the release is up-to-date")
 
 	cmd.PersistentFlags().StringVar(&opt.StorageClass, "storageclass", "", fmt.Sprintf("type of StorageClass to create (one of %v)", sets.List(common.SupportedStorageClassProviders())))

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -39,6 +39,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/log"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/util/edition"
+	"k8c.io/kubermatic/v2/pkg/util/flagopts"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -59,11 +60,12 @@ type DeployOptions struct {
 	Kubeconfig  string
 	KubeContext string
 
-	HelmBinary       string
-	HelmValues       string
-	HelmTimeout      time.Duration
-	SkipDependencies bool
-	Force            bool
+	HelmBinary         string
+	HelmValues         string
+	HelmTimeout        time.Duration
+	SkipDependencies   bool
+	SkipSeedValidation sets.Set[string]
+	Force              bool
 
 	StorageClass       string
 	DisableTelemetry   bool
@@ -81,8 +83,9 @@ type DeployOptions struct {
 
 func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *cobra.Command {
 	opt := DeployOptions{
-		HelmTimeout: 5 * time.Minute,
-		HelmBinary:  "helm",
+		HelmTimeout:        5 * time.Minute,
+		HelmBinary:         "helm",
+		SkipSeedValidation: sets.New[string](),
 	}
 
 	cmd := &cobra.Command{
@@ -120,6 +123,7 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *
 	cmd.PersistentFlags().DurationVar(&opt.HelmTimeout, "helm-timeout", opt.HelmTimeout, "time to wait for Helm operations to finish")
 	cmd.PersistentFlags().StringVar(&opt.HelmBinary, "helm-binary", opt.HelmBinary, "full path to the Helm 3 binary to use")
 	cmd.PersistentFlags().BoolVar(&opt.SkipDependencies, "skip-dependencies", false, "skip pulling Helm chart dependencies (requires chart dependencies to be already downloaded)")
+	cmd.PersistentFlags().Var(flagopts.SetFlag(opt.SkipSeedValidation), "skip-seed-validation", "comma-separated list of seed clusters to skip running the preflight checks on")
 	cmd.PersistentFlags().BoolVar(&opt.Force, "force", false, "perform Helm upgrades even when the release is up-to-date")
 
 	cmd.PersistentFlags().StringVar(&opt.StorageClass, "storageclass", "", fmt.Sprintf("type of StorageClass to create (one of %v)", sets.List(common.SupportedStorageClassProviders())))

--- a/pkg/install/stack/kubermatic-master/validation.go
+++ b/pkg/install/stack/kubermatic-master/validation.go
@@ -124,7 +124,14 @@ func (m *MasterStack) ValidateState(ctx context.Context, opt stack.DeployOptions
 	}
 
 	for seedName, seed := range allSeeds {
-		opt.Logger.WithField("seed", seedName).Info("Checking seed cluster…")
+		seedLog := opt.Logger.WithField("seed", seedName)
+
+		if opt.SkipSeedValidation.Has(seedName) {
+			seedLog.Info("Seed validation was skipped.")
+			continue
+		}
+
+		seedLog.Info("Checking seed cluster…")
 
 		// ensure seeds are also up-to-date before we continue
 		seedVersion := seed.Status.Versions.Kubermatic

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -28,6 +28,7 @@ import (
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -41,6 +42,7 @@ type DeployOptions struct {
 	ForceHelmReleaseUpgrade    bool
 	ChartsDirectory            string
 	AllowEditionChange         bool
+	SkipSeedValidation         sets.Set[string]
 
 	SeedsGetter      provider.SeedsGetter
 	SeedClientGetter provider.SeedClientGetter

--- a/pkg/util/flagopts/set_flag.go
+++ b/pkg/util/flagopts/set_flag.go
@@ -17,14 +17,15 @@ limitations under the License.
 package flagopts
 
 import (
-	"flag"
 	"strings"
+
+	"github.com/spf13/pflag"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 // SetFlag wraps a given set so it can be used as a CLI flag.
-func SetFlag(set sets.Set[string]) flag.Value {
+func SetFlag(set sets.Set[string]) pflag.Value {
 	return &setFlag{set: set}
 }
 
@@ -50,4 +51,8 @@ func (f *setFlag) Set(value string) error {
 	}
 
 	return nil
+}
+
+func (f *setFlag) Type() string {
+	return "strings" // see pflag's flag.go
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
So far the installer always insists on validating _all_ seed clusters. This has a number of downsides:

* If the seed is not reachable from outside the KKP master cluster (e.g. because it's behind a VPN), then the installer will not be able to reach it.
* The operator will update seed-level resources _after_ the installer has completed and there are ways to prevent the operator from updating a seed (i.e. annotating it). This means there are valid cases where an admin wants to update KKP but leave one seed in a not-so-great state temporarily.
* Some admins might just want to take the risk and for example know that some clusters breaking would not be a problem.

Problem (a) could be solved by running the installer inside the master cluster, but this would require us to make its logs more easily available (live logs are one of the nice things a locally running program has to offer) and we would need to transport Helm values into the cluster.

FWIW, I am not totally against doing that (doing what sonobuoy also does), but it's quite a design change and for 2.22 it's way too late to change this. However many users, including us, would benefit from this simple flag.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `--skip-seed-validation` flag to installer to make it skip validating the given seeds (should be used with great caution only).
```

**Documentation**:
```documentation
NONE
```
