### PR TITLE
KubeVirt fix upgrade issue from KKP 2.21 to KKP 2.22 for CSI access

### DIFF
--- a/pkg/provider/cloud/kubevirt/csi.go
+++ b/pkg/provider/cloud/kubevirt/csi.go
@@ -120,8 +120,8 @@ func reconcileCSIRoleRoleBinding(ctx context.Context, namespace string, client c
 	return nil
 }
 
-// reconcileInfraTokenAccess generates a service account token for KubeVirt CSI access.
-func reconcileInfraTokenAccess(ctx context.Context, namespace string, client ctrlruntimeclient.Client) error {
+// ReconcileInfraTokenAccess generates a service account token for KubeVirt CSI access.
+func ReconcileInfraTokenAccess(ctx context.Context, namespace string, client ctrlruntimeclient.Client) error {
 	saReconcilers := []reconciling.NamedServiceAccountReconcilerFactory{
 		csiServiceAccountReconciler(csiResourceName, namespace),
 	}

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -130,7 +130,7 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 		return cluster, err
 	}
 
-	err = reconcileInfraTokenAccess(ctx, cluster.Status.NamespaceName, client)
+	err = ReconcileInfraTokenAccess(ctx, cluster.Status.NamespaceName, client)
 	if err != nil {
 		return cluster, err
 	}

--- a/pkg/resources/csi/kubevirt/secret.go
+++ b/pkg/resources/csi/kubevirt/secret.go
@@ -54,6 +54,12 @@ func InfraAccessSecretReconciler(ctx context.Context, data *resources.TemplateDa
 				return nil, err
 			}
 
+			// Ensure reconciliation of csi SA and secret token
+			err = kubevirt.ReconcileInfraTokenAccess(ctx, data.Cluster().Status.NamespaceName, infraClient)
+			if err != nil {
+				return nil, err
+			}
+
 			// Get the infra csi SA and compute csiKubeConfig from it
 			csiSA := corev1.ServiceAccount{}
 			err = infraClient.Get(ctx, types.NamespacedName{Name: resources.KubeVirtCSIServiceAccountName, Namespace: data.Cluster().Status.NamespaceName}, &csiSA)


### PR DESCRIPTION
Signed-off-by: Helene Durand <helene@kubermatic.com>

**What this PR does / why we need it**:
Fixes a reconciliation error when upgrading from KKP 2.21 to 2.22 (KubeVirt CSI driver SA not created).

**NO backport needed, this is new in KKP 2.22**

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11880 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
