### PR TITLE
applications: add EnableDns options

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -100,6 +100,11 @@ type HelmDeployOptions struct {
 	// Atomic corresponds to the --atomic flag on Helm cli.
 	// if set, the installation process deletes the installation on failure; the upgrade process rolls back changes made in case of failed upgrade.
 	Atomic bool `json:"atomic,omitempty"`
+
+	// EnableDNS  corresponds to the --enable-dns flag on Helm cli.
+	// enable DNS lookups when rendering templates.
+	// if you enable this flag, you have to verify that helm template function 'getHostByName' is not being used in a chart to disclose any information you do not want to be passed to DNS servers.(c.f. CVE-2023-25165)
+	EnableDNS bool `json:"enableDNS,omitempty"`
 }
 
 // AppNamespaceSpec describe the desired state of the namespace where application will be created.

--- a/pkg/applications/helmclient/client_integration_test.go
+++ b/pkg/applications/helmclient/client_integration_test.go
@@ -72,35 +72,35 @@ func TestHelmClient(t *testing.T) {
 			name: "installation from archive with default values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 			},
 		},
 		{
 			name: "installation from dir with default values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 			},
 		},
 		{
 			name: "installation from archive with custom values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
 			},
 		},
 		{
 			name: "installation from dir with custom values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
 			},
 		},
 		{
 			name: "installation from archive should failed if already installed",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installShouldFailedIfAlreadyInstalledTest(t, ctx, ns, chartArchiveV1Path, map[string]interface{}{})
 			},
 		},
@@ -108,7 +108,7 @@ func TestHelmClient(t *testing.T) {
 			name: "installation from dir should failed if already installed",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installShouldFailedIfAlreadyInstalledTest(t, ctx, ns, chartDirV1Path, map[string]interface{}{})
 			},
 		},
@@ -116,48 +116,48 @@ func TestHelmClient(t *testing.T) {
 			name: "upgrade from archive with same version and different values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
-				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
 			},
 		},
 		{
 			name: "upgrade from dir with same version and different values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
-				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
 			},
 		},
 		{
 			name: "upgrade from archive with new version and default values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
-				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
 			},
 		},
 		{
 			name: "upgrade from dir with new version and default values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
-				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2)
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
 			},
 		},
 		{
 			name: "upgrade from archive with new version and custom values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
-				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version")
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false)
 			},
 		},
 		{
 			name: "upgrade from dir with new version and custom values should be successful",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
-				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version")
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false)
 			},
 		},
 		// tests for https://github.com/kubermatic/kubermatic/issues/11864
@@ -165,16 +165,16 @@ func TestHelmClient(t *testing.T) {
 			name: "upgrade from archive with no values should upgrade chart with default values",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
-				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 			},
 		},
 		{
 			name: "upgrade from dir with no values should upgrade chart with default values",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version")
-				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
+				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 			},
 		},
 		{
@@ -209,7 +209,7 @@ func TestHelmClient(t *testing.T) {
 			name: "installOrUpgrade from archive should upgrades chart when it already installed",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installOrUpgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, 2)
 			},
 		},
@@ -217,7 +217,7 @@ func TestHelmClient(t *testing.T) {
 			name: "installOrUpgrade from archive should upgrades chart when it already installed",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installOrUpgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, 2)
 			},
 		},
@@ -225,7 +225,7 @@ func TestHelmClient(t *testing.T) {
 			name: "uninstall should be successful when chart is already installed",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				uninstallTest(t, ctx, client, ns)
 			},
 		},
@@ -237,12 +237,36 @@ func TestHelmClient(t *testing.T) {
 			},
 		},
 		{
+			name: "install should be successful when enabledDns is enabled",
+			testFunc: func(t *testing.T) {
+				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true)
+			},
+		},
+		{
+			name: "upgrade should be successful when enabledDns is switched to true",
+			testFunc: func(t *testing.T) {
+				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true)
+			},
+		},
+		{
+			name: "upgrade should be successful when enabledDns is switched to false",
+			testFunc: func(t *testing.T) {
+				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+			},
+		},
+
+		{
 			name: "install should fail when timeout is exceeded",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				helmClient, chartFullPath := buildHelClient(t, ctx, ns, chartDirV2Path)
 
-				deployOpts, err := NewDeployOpts(true, 5*time.Second, false)
+				deployOpts, err := NewDeployOpts(true, 5*time.Second, false, false)
 				if err != nil {
 					t.Fatalf("failed to build DeployOpts: %s", err)
 				}
@@ -253,18 +277,17 @@ func TestHelmClient(t *testing.T) {
 				checkReleaseFailedWithTimemout(t, releaseInfo, err)
 
 				// check that even if install has failed (timeout), workload has been deployed.
-				test.CheckConfigMap(t, ctx, client, ns, test.DefaultDataV2, test.DefaultVerionLabelV2)
+				test.CheckConfigMap(t, ctx, client, ns, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
 				checkServiceDeployed(t, ctx, client, ns)
 			},
 		},
-
 		{
 			name: "install should fail and workloard should be reverted when timeout is exceeded and atomic=true",
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				helmClient, chartFullPath := buildHelClient(t, ctx, ns, chartDirV2Path)
 
-				deployOpts, err := NewDeployOpts(true, 5*time.Second, true)
+				deployOpts, err := NewDeployOpts(true, 5*time.Second, true, false)
 				if err != nil {
 					t.Fatalf("failed to build DeployOpts: %s", err)
 				}
@@ -283,20 +306,20 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				helmClient, chartFullPath := buildHelClient(t, ctx, ns, chartDirV2Path)
-				deployOpts, err := NewDeployOpts(true, 5*time.Second, false)
+				deployOpts, err := NewDeployOpts(true, 5*time.Second, false, false)
 				if err != nil {
 					t.Fatalf("failed to build DeployOpts: %s", err)
 				}
 
 				// test install chart and run upgrade.
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				releaseInfo, err := helmClient.Upgrade(chartFullPath, releaseName, map[string]interface{}{test.DeploySvcKey: true}, *deployOpts, AuthSettings{})
 
 				// check helm operation has failed.
 				checkReleaseFailedWithTimemout(t, releaseInfo, err)
 
 				// check that even if upgrade has failed (timeout), workload has been updated.
-				test.CheckConfigMap(t, ctx, client, ns, test.DefaultDataV2, test.DefaultVerionLabelV2)
+				test.CheckConfigMap(t, ctx, client, ns, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
 				checkServiceDeployed(t, ctx, client, ns)
 			},
 		},
@@ -305,20 +328,20 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				helmClient, chartFullPath := buildHelClient(t, ctx, ns, chartDirV2Path)
-				deployOpts, err := NewDeployOpts(true, 5*time.Second, true)
+				deployOpts, err := NewDeployOpts(true, 5*time.Second, true, false)
 				if err != nil {
 					t.Fatalf("failed to build DeployOpts: %s", err)
 				}
 
 				// test install chart and run upgrade.
-				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel)
+				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				releaseInfo, err := helmClient.Upgrade(chartFullPath, releaseName, map[string]interface{}{test.DeploySvcKey: true}, *deployOpts, AuthSettings{})
 
 				// check helm operation has failed.
 				checkReleaseFailedWithTimemout(t, releaseInfo, err)
 
 				// check atomic flag has revert release to previous version.
-				test.CheckConfigMap(t, ctx, client, ns, test.DefaultData, test.DefaultVerionLabel)
+				test.CheckConfigMap(t, ctx, client, ns, test.DefaultData, test.DefaultVerionLabel, false)
 				checkServiceDeleted(t, ctx, client, ns)
 			},
 		},
@@ -329,10 +352,15 @@ func TestHelmClient(t *testing.T) {
 	}
 }
 
-func installTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, chartPath string, values map[string]interface{}, expectedData map[string]string, expectedVersionLabel string) {
+func installTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, chartPath string, values map[string]interface{}, expectedData map[string]string, expectedVersionLabel string, enableDNS bool) {
 	helmClient, chartFullPath := buildHelClient(t, ctx, ns, chartPath)
 
-	releaseInfo, err := helmClient.Install(chartFullPath, releaseName, values, *defaultDeployOpts(t), AuthSettings{})
+	deployOpts, err := NewDeployOpts(false, 0, false, enableDNS)
+	if err != nil {
+		t.Fatalf("failed to build DeployOpts: %s", err)
+	}
+
+	releaseInfo, err := helmClient.Install(chartFullPath, releaseName, values, *deployOpts, AuthSettings{})
 
 	if err != nil {
 		t.Fatalf("helm install failed :%s", err)
@@ -342,7 +370,7 @@ func installTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Cli
 		t.Fatalf("invalid helm release version. expected 1, got %v", releaseInfo.Version)
 	}
 
-	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel)
+	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel, enableDNS)
 }
 
 func installShouldFailedIfAlreadyInstalledTest(t *testing.T, ctx context.Context, ns *corev1.Namespace, chartPath string, values map[string]interface{}) {
@@ -355,10 +383,13 @@ func installShouldFailedIfAlreadyInstalledTest(t *testing.T, ctx context.Context
 	}
 }
 
-func upgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, chartPath string, values map[string]interface{}, expectedData map[string]string, expectedVersionLabel string) {
+func upgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, chartPath string, values map[string]interface{}, expectedData map[string]string, expectedVersionLabel string, enableDNS bool) {
 	helmClient, chartFullPath := buildHelClient(t, ctx, ns, chartPath)
-
-	releaseInfo, err := helmClient.Upgrade(chartFullPath, releaseName, values, *defaultDeployOpts(t), AuthSettings{})
+	deployOpts, err := NewDeployOpts(false, 0, false, enableDNS)
+	if err != nil {
+		t.Fatalf("failed to build DeployOpts: %s", err)
+	}
+	releaseInfo, err := helmClient.Upgrade(chartFullPath, releaseName, values, *deployOpts, AuthSettings{})
 
 	if err != nil {
 		t.Fatalf("helm upgrade failed :%s", err)
@@ -368,7 +399,7 @@ func upgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Cli
 		t.Fatalf("invalid helm release version. expected 2, got %v", releaseInfo.Version)
 	}
 
-	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel)
+	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel, enableDNS)
 }
 
 func upgradeShouldFailedIfNotAlreadyInstalledTest(t *testing.T, ctx context.Context, ns *corev1.Namespace, chartPath string, values map[string]interface{}) {
@@ -394,7 +425,7 @@ func installOrUpgradeTest(t *testing.T, ctx context.Context, client ctrlruntimec
 		t.Fatalf("invalid helm release version. expected %v, got %v", expectedRelVersion, releaseInfo.Version)
 	}
 
-	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel)
+	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel, false)
 }
 
 func uninstallTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace) {
@@ -463,7 +494,7 @@ func buildHelClient(t *testing.T, ctx context.Context, ns *corev1.Namespace, cha
 
 // defaultDeployOpts creates DeployOpts with wait=false and atomic=false.
 func defaultDeployOpts(t *testing.T) *DeployOpts {
-	deployOpts, err := NewDeployOpts(false, 0, false)
+	deployOpts, err := NewDeployOpts(false, 0, false, false)
 	if err != nil {
 		t.Fatalf("failed to build default deployOpts: %s", err)
 	}

--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -473,69 +473,106 @@ func TestBuildDependencies(t *testing.T) {
 
 func TestNewDeploySettings(t *testing.T) {
 	tests := []struct {
-		name    string
-		wait    bool
-		timeout time.Duration
-		atomic  bool
-		want    *DeployOpts
-		wantErr bool
+		name      string
+		wait      bool
+		timeout   time.Duration
+		atomic    bool
+		enableDns bool
+		want      *DeployOpts
+		wantErr   bool
 	}{
 		{
-			name:    "test valid: no wait, timeout and atomic",
-			wait:    false,
-			timeout: 0,
-			atomic:  false,
+			name:      "test valid: no wait, timeout, atomic and enableDNS",
+			wait:      false,
+			timeout:   0,
+			atomic:    false,
+			enableDns: false,
 			want: &DeployOpts{
-				wait:    false,
-				timeout: 0,
-				atomic:  false,
+				wait:      false,
+				timeout:   0,
+				atomic:    false,
+				enableDNS: false,
 			},
 			wantErr: false,
 		},
 		{
-			name:    "test valid: wait=true timeout=10s and no atomic",
-			wait:    true,
-			timeout: 10 * time.Second,
-			atomic:  false,
+			name:      "test valid: wait=true timeout=10s and no atomic",
+			wait:      true,
+			timeout:   10 * time.Second,
+			atomic:    false,
+			enableDns: false,
 			want: &DeployOpts{
-				wait:    true,
-				timeout: 10 * time.Second,
-				atomic:  false,
+				wait:      true,
+				timeout:   10 * time.Second,
+				atomic:    false,
+				enableDNS: false,
 			},
 			wantErr: false,
 		},
 		{
-			name:    "test valid: wait=true timeout=10s atomic=true",
-			wait:    true,
-			timeout: 10 * time.Second,
-			atomic:  true,
+			name:      "test valid: wait=true timeout=10s atomic=true",
+			wait:      true,
+			timeout:   10 * time.Second,
+			atomic:    true,
+			enableDns: false,
 			want: &DeployOpts{
-				wait:    true,
-				timeout: 10 * time.Second,
-				atomic:  true,
+				wait:      true,
+				timeout:   10 * time.Second,
+				atomic:    true,
+				enableDNS: false,
 			},
 			wantErr: false,
 		},
 		{
-			name:    "test invalid: wait=true without timeout",
-			wait:    true,
-			timeout: 0,
-			atomic:  false,
-			want:    nil,
-			wantErr: true,
+			name:      "test valid: wait=true timeout=10s atomic=true enableDns=true",
+			wait:      true,
+			timeout:   10 * time.Second,
+			atomic:    true,
+			enableDns: true,
+			want: &DeployOpts{
+				wait:      true,
+				timeout:   10 * time.Second,
+				atomic:    true,
+				enableDNS: true,
+			},
+			wantErr: false,
 		},
 		{
-			name:    "test invalid: atomic=true without wait",
-			wait:    false,
-			timeout: 10 * time.Second,
-			atomic:  true,
-			want:    nil,
-			wantErr: true,
+			name:      "test valid: wait=false timeout=0 atomic=false enableDns=true",
+			wait:      false,
+			timeout:   0,
+			atomic:    false,
+			enableDns: true,
+			want: &DeployOpts{
+				wait:      false,
+				timeout:   0,
+				atomic:    false,
+				enableDNS: true,
+			},
+			wantErr: false,
+		},
+		{
+			name:      "test invalid: wait=true without timeout",
+			wait:      true,
+			timeout:   0,
+			atomic:    false,
+			enableDns: false,
+			want:      nil,
+			wantErr:   true,
+		},
+		{
+			name:      "test invalid: atomic=true without wait",
+			wait:      false,
+			timeout:   10 * time.Second,
+			atomic:    true,
+			enableDns: false,
+			want:      nil,
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewDeployOpts(tt.wait, tt.timeout, tt.atomic)
+			got, err := NewDeployOpts(tt.wait, tt.timeout, tt.atomic, tt.enableDns)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("NewDeployOpts() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -548,6 +585,9 @@ func TestNewDeploySettings(t *testing.T) {
 				}
 				if tt.want.atomic != got.atomic {
 					t.Errorf("want DeployOpts.atomic=%v, got %v", tt.want.atomic, got.atomic)
+				}
+				if tt.want.enableDNS != got.enableDNS {
+					t.Errorf("want DeployOpts.enableDNS=%v, got %v", tt.want.enableDNS, got.enableDNS)
 				}
 			}
 		})

--- a/pkg/applications/helmclient/testdata/examplechart-v2/templates/configmap.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart-v2/templates/configmap.yaml
@@ -17,6 +17,7 @@ kind: ConfigMap
 metadata:
   name: testcm
   labels:
+    enableDNSLabel: {{ getHostByName "kubermatic.com"  | quote }}
 {{ if .Values.versionLabel }}
     versionLabel: {{ .Values.versionLabel | quote}}
 {{ end }}

--- a/pkg/applications/helmclient/testdata/examplechart/templates/configmap.yaml
+++ b/pkg/applications/helmclient/testdata/examplechart/templates/configmap.yaml
@@ -17,6 +17,7 @@ kind: ConfigMap
 metadata:
   name: testcm
   labels:
+    enableDNSLabel: {{ getHostByName "kubermatic.com"  | quote }}
 {{ if .Values.versionLabel }}
     versionLabel: {{ .Values.versionLabel | quote}}
 {{ end }}

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -200,14 +200,14 @@ func getReleaseName(applicationInstallation *appskubermaticv1.ApplicationInstall
 func getDeployOpts(appDefinition *appskubermaticv1.ApplicationDefinition, appInstall *appskubermaticv1.ApplicationInstallation) (*helmclient.DeployOpts, error) {
 	// Read options from applicationInstallation.
 	if appInstall.Spec.DeployOptions != nil && appInstall.Spec.DeployOptions.Helm != nil {
-		return helmclient.NewDeployOpts(appInstall.Spec.DeployOptions.Helm.Wait, appInstall.Spec.DeployOptions.Helm.Timeout.Duration, appInstall.Spec.DeployOptions.Helm.Atomic)
+		return helmclient.NewDeployOpts(appInstall.Spec.DeployOptions.Helm.Wait, appInstall.Spec.DeployOptions.Helm.Timeout.Duration, appInstall.Spec.DeployOptions.Helm.Atomic, appInstall.Spec.DeployOptions.Helm.EnableDNS)
 	}
 
 	// Fallback to options defined in ApplicationDefinition.
 	if appDefinition.Spec.DefaultDeployOptions != nil && appDefinition.Spec.DefaultDeployOptions.Helm != nil {
-		return helmclient.NewDeployOpts(appDefinition.Spec.DefaultDeployOptions.Helm.Wait, appDefinition.Spec.DefaultDeployOptions.Helm.Timeout.Duration, appDefinition.Spec.DefaultDeployOptions.Helm.Atomic)
+		return helmclient.NewDeployOpts(appDefinition.Spec.DefaultDeployOptions.Helm.Wait, appDefinition.Spec.DefaultDeployOptions.Helm.Timeout.Duration, appDefinition.Spec.DefaultDeployOptions.Helm.Atomic, appDefinition.Spec.DefaultDeployOptions.Helm.EnableDNS)
 	}
 
 	// Fallback to default options.
-	return helmclient.NewDeployOpts(false, 0, false)
+	return helmclient.NewDeployOpts(false, 0, false, false)
 }

--- a/pkg/applications/providers/template/helm_test.go
+++ b/pkg/applications/providers/template/helm_test.go
@@ -86,19 +86,21 @@ func TestGetDeployOps(t *testing.T) {
 			name: "case 1: deployOpts defined at applicationInstallation have priority (appDef.spec.DefaultDeployOptions.helm is defined)",
 			appDefinition: &appskubermaticv1.ApplicationDefinition{
 				Spec: appskubermaticv1.ApplicationDefinitionSpec{DefaultDeployOptions: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
-					Wait:    false,
-					Timeout: metav1.Duration{Duration: 0},
-					Atomic:  false,
+					Wait:      false,
+					Timeout:   metav1.Duration{Duration: 0},
+					Atomic:    false,
+					EnableDNS: false,
 				}}},
 			},
 			appInstall: &appskubermaticv1.ApplicationInstallation{
 				Spec: appskubermaticv1.ApplicationInstallationSpec{DeployOptions: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
-					Wait:    true,
-					Timeout: metav1.Duration{Duration: 1000},
-					Atomic:  true,
+					Wait:      true,
+					Timeout:   metav1.Duration{Duration: 1000},
+					Atomic:    true,
+					EnableDNS: true,
 				}}},
 			},
-			want:    newDeployOpts(t, true, 1000, true),
+			want:    newDeployOpts(t, true, 1000, true, true),
 			wantErr: false,
 		},
 		{
@@ -108,12 +110,13 @@ func TestGetDeployOps(t *testing.T) {
 			},
 			appInstall: &appskubermaticv1.ApplicationInstallation{
 				Spec: appskubermaticv1.ApplicationInstallationSpec{DeployOptions: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
-					Wait:    true,
-					Timeout: metav1.Duration{Duration: 1000},
-					Atomic:  true,
+					Wait:      true,
+					Timeout:   metav1.Duration{Duration: 1000},
+					Atomic:    true,
+					EnableDNS: true,
 				}}},
 			},
-			want:    newDeployOpts(t, true, 1000, true),
+			want:    newDeployOpts(t, true, 1000, true, true),
 			wantErr: false,
 		},
 		{
@@ -123,42 +126,45 @@ func TestGetDeployOps(t *testing.T) {
 			},
 			appInstall: &appskubermaticv1.ApplicationInstallation{
 				Spec: appskubermaticv1.ApplicationInstallationSpec{DeployOptions: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
-					Wait:    true,
-					Timeout: metav1.Duration{Duration: 1000},
-					Atomic:  true,
+					Wait:      true,
+					Timeout:   metav1.Duration{Duration: 1000},
+					Atomic:    true,
+					EnableDNS: true,
 				}}},
 			},
-			want:    newDeployOpts(t, true, 1000, true),
+			want:    newDeployOpts(t, true, 1000, true, true),
 			wantErr: false,
 		},
 		{
 			name: "case 4: fallback to deployOpts defined in applicationDefinition when deployOpts is not defined in applicationInstallation (appInstall.spec.DefaultDeployOptions.helm is nil)",
 			appDefinition: &appskubermaticv1.ApplicationDefinition{
 				Spec: appskubermaticv1.ApplicationDefinitionSpec{DefaultDeployOptions: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
-					Wait:    true,
-					Timeout: metav1.Duration{Duration: 500},
-					Atomic:  false,
+					Wait:      true,
+					Timeout:   metav1.Duration{Duration: 500},
+					Atomic:    false,
+					EnableDNS: true,
 				}}},
 			},
 			appInstall: &appskubermaticv1.ApplicationInstallation{
 				Spec: appskubermaticv1.ApplicationInstallationSpec{DeployOptions: &appskubermaticv1.DeployOptions{Helm: nil}},
 			},
-			want:    newDeployOpts(t, true, 500, false),
+			want:    newDeployOpts(t, true, 500, false, true),
 			wantErr: false,
 		},
 		{
 			name: "case 5: fallback to deployOpts defined in applicationDefinition when deployOpts is not defined in applicationInstallation(appInstall.spec.DefaultDeployOptions is nil)",
 			appDefinition: &appskubermaticv1.ApplicationDefinition{
 				Spec: appskubermaticv1.ApplicationDefinitionSpec{DefaultDeployOptions: &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{
-					Wait:    true,
-					Timeout: metav1.Duration{Duration: 500},
-					Atomic:  false,
+					Wait:      true,
+					Timeout:   metav1.Duration{Duration: 500},
+					Atomic:    false,
+					EnableDNS: true,
 				}}},
 			},
 			appInstall: &appskubermaticv1.ApplicationInstallation{
 				Spec: appskubermaticv1.ApplicationInstallationSpec{DeployOptions: nil},
 			},
-			want:    newDeployOpts(t, true, 500, false),
+			want:    newDeployOpts(t, true, 500, false, true),
 			wantErr: false,
 		},
 		{
@@ -169,7 +175,7 @@ func TestGetDeployOps(t *testing.T) {
 			appInstall: &appskubermaticv1.ApplicationInstallation{
 				Spec: appskubermaticv1.ApplicationInstallationSpec{DeployOptions: nil},
 			},
-			want:    newDeployOpts(t, false, 0, false),
+			want:    newDeployOpts(t, false, 0, false, false),
 			wantErr: false,
 		},
 		{
@@ -216,9 +222,9 @@ func TestGetDeployOps(t *testing.T) {
 	}
 }
 
-func newDeployOpts(t *testing.T, wait bool, timeout time.Duration, atomic bool) *helmclient.DeployOpts {
+func newDeployOpts(t *testing.T, wait bool, timeout time.Duration, atomic bool, enableDns bool) *helmclient.DeployOpts {
 	t.Helper()
-	deployOps, err := helmclient.NewDeployOpts(wait, timeout, atomic)
+	deployOps, err := helmclient.NewDeployOpts(wait, timeout, atomic, enableDns)
 	if err != nil {
 		t.Fatalf("failed to build deployOpts: %s", err)
 	}

--- a/pkg/applications/test/helm.go
+++ b/pkg/applications/test/helm.go
@@ -60,6 +60,9 @@ const (
 	// DefaultVerionLabelV2 is the default value of the version label the configmap deployed by pkg/applications/helmclient/testdata/examplechart-v2 chart.
 	DefaultVerionLabelV2 = "2.0"
 
+	// EnableDNSLabelKey is the label key on cmData examplechart that allow test the enableDns deployOption.
+	EnableDNSLabelKey = "enableDNSLabel"
+
 	// SvcName is the name of the service deployed by chart chart-with-lb.
 	SvcName = "svc-1"
 

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -41,6 +41,9 @@ spec:
                         atomic:
                           description: Atomic corresponds to the --atomic flag on Helm cli. if set, the installation process deletes the installation on failure; the upgrade process rolls back changes made in case of failed upgrade.
                           type: boolean
+                        enableDNS:
+                          description: EnableDNS  corresponds to the --enable-dns flag on Helm cli. enable DNS lookups when rendering templates. if you enable this flag, you have to verify that helm template function 'getHostByName' is not being used in a chart to disclose any information you do not want to be passed to DNS servers.(c.f. CVE-2023-25165)
+                          type: boolean
                         timeout:
                           description: Timeout corresponds to the --timeout flag on Helm cli. time to wait for any individual Kubernetes operation.
                           type: string

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -56,6 +56,9 @@ spec:
                         atomic:
                           description: Atomic corresponds to the --atomic flag on Helm cli. if set, the installation process deletes the installation on failure; the upgrade process rolls back changes made in case of failed upgrade.
                           type: boolean
+                        enableDNS:
+                          description: EnableDNS  corresponds to the --enable-dns flag on Helm cli. enable DNS lookups when rendering templates. if you enable this flag, you have to verify that helm template function 'getHostByName' is not being used in a chart to disclose any information you do not want to be passed to DNS servers.(c.f. CVE-2023-25165)
+                          type: boolean
                         timeout:
                           description: Timeout corresponds to the --timeout flag on Helm cli. time to wait for any individual Kubernetes operation.
                           type: string


### PR DESCRIPTION
**What this PR does / why we need it**:
This is the follow-up of #11863. It adds a new `enableDNS` field to deployOptions allowing the usage of  helm template function [getHostByName](https://helm.sh/docs/chart_template_guide/function_list/#network-functions). 




**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required on applications; helm has been bumped to version 3.11. Due to a [CVE](https://github.com/helm/helm/security/advisories/GHSA-pwcw-6f5g-gxf8) in the previous version, the helm template function [getHostByName](https://helm.sh/docs/chart_template_guide/function_list/#network-functions has been disabled (function will return an empty string).  If you want to enable this function, you have to set `deployOptions.helm.enableDNS` to true and *verify* this function 'getHostByName' is not being used in a chart to disclose any information you do not want to be passed to DNS servers.(c.f. CVE-2023-25165)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1360
```
