### PR TITLE
applicationInstallation is in deleting, don't check that applicationDefinition exists.

### DIFF
--- a/pkg/defaulting/application_installation_test.go
+++ b/pkg/defaulting/application_installation_test.go
@@ -119,7 +119,7 @@ func TestDefaultApplicationInstallation(t *testing.T) {
 			}
 
 			// test that mutate object is valid
-			if errs := validation.ValidateApplicationInstallationSpec(context.Background(), fakeClient, tc.appInstall.Spec); len(errs) > 0 {
+			if errs := validation.ValidateApplicationInstallationSpec(context.Background(), fakeClient, *tc.appInstall); len(errs) > 0 {
 				t.Fatalf("mutated applicationInstllation does not pass validation: %v", errs)
 			}
 		})

--- a/pkg/validation/application_installation_test.go
+++ b/pkg/validation/application_installation_test.go
@@ -199,7 +199,7 @@ func TestValidateApplicationInstallationSpec(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			err := ValidateApplicationInstallationSpec(context.Background(), fakeClient, testCase.ai.Spec)
+			err := ValidateApplicationInstallationSpec(context.Background(), fakeClient, *testCase.ai)
 			if fmt.Sprint(err) != testCase.expectedError {
 				if testCase.expectedError == "[]" {
 					testCase.expectedError = "nil"
@@ -222,6 +222,7 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 
 	ai := getApplicationInstallation(defaultAppName, defaultAppName, defaultAppVersion, nil)
 
+	aiVersionDoesExist := getApplicationInstallation(defaultAppName, defaultAppName, "0.0.0-does-not-exist", nil)
 	testCases := []struct {
 		name          string
 		ai            *appskubermaticv1.ApplicationInstallation
@@ -238,6 +239,17 @@ func TestValidateApplicationInstallationUpdate(t *testing.T) {
 					spec.ApplicationRef.Version = defaultAppSecondaryVersion
 					return *spec
 				}(),
+			},
+			expectedError: "[]",
+		},
+		{
+			name: "Update deleting ApplicationInstallation Success (app def version does not exist)",
+			ai:   aiVersionDoesExist,
+			updatedAI: &appskubermaticv1.ApplicationInstallation{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{Time: time.Now()},
+				},
+				Spec: *aiVersionDoesExist.Spec.DeepCopy(),
 			},
 			expectedError: "[]",
 		},

--- a/pkg/webhook/application/applicationinstallation/validation/validation.go
+++ b/pkg/webhook/application/applicationinstallation/validation/validation.go
@@ -73,7 +73,7 @@ func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequ
 		if err := h.decoder.Decode(req, ad); err != nil {
 			return webhook.Errored(http.StatusBadRequest, err)
 		}
-		allErrs = append(allErrs, validation.ValidateApplicationInstallationSpec(ctx, h.client, ad.Spec)...)
+		allErrs = append(allErrs, validation.ValidateApplicationInstallationSpec(ctx, h.client, *ad)...)
 
 	case admissionv1.Update:
 		if err := h.decoder.Decode(req, ad); err != nil {


### PR DESCRIPTION

**What this PR does / why we need it**:

if the applicationDefinition is removed, then all applicationInstallations are removed to ensure only desired version of an application are installed in clusters. However, when we delete the finalizer from the applicationInstallation it raises an Update event. In this case, we should not check if the applicationDefinition version exists, otherwise, we get the error:

`{"level":"error","time":"2023-02-13T16:20:13.260Z","caller":"controller/controller.go:274","msg":"Reconciler error","controller":"kkp-app-installation-controller","object":{"name":"my-apache","namespace":"default"},"namespace":"default","name":"my-apache","reconcileID":"19c3ec84-d138-4968-a36a-6b791f0050be","error":"handling deletion of application installation: failed to remove application installation finalizer my-apache: failed to remove finalizers [kubermatic.k8c.io/cleanup-application-installation] from ApplicationInstallation default/my-apache: admission webhook \"applicationinstallations.apps.kubermatic.k8c.io\" denied the request: ApplicationInstallation validation request 434af079-3d59-4318-9ead-e40289845550 denied: [spec.applicationRef.name: Not found: \"apache\"]"}`





**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
applications: fix bug preventing deletion of an ApplicationInstallation if the ApplicationDefinition was removed before
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
