### PR TITLE
Output machine-readable test results in conformance-tester

### DIFF
--- a/cmd/conformance-tester/pkg/runner/result.go
+++ b/cmd/conformance-tester/pkg/runner/result.go
@@ -17,53 +17,233 @@ limitations under the License.
 package runner
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
 	"time"
 
 	"github.com/onsi/ginkgo/reporters"
 
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/scenarios"
+	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/semver"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-type testResult struct {
-	report   *reporters.JUnitTestSuite
-	duration time.Duration
-	err      error
-	scenario scenarios.Scenario
-	cluster  *kubermaticv1.Cluster
+type ScenarioStatus string
+
+const (
+	ScenarioPassed  ScenarioStatus = "passed"
+	ScenarioFailed  ScenarioStatus = "failed"
+	ScenarioSkipped ScenarioStatus = "skipped"
+)
+
+type Results struct {
+	Options   *types.Options
+	Scenarios []ScenarioResult
 }
 
-func (t *testResult) Passed() bool {
-	if t.err != nil {
-		return false
-	}
-
-	if t.report == nil {
-		return false
-	}
-
-	if len(t.report.TestCases) == 0 {
-		return false
-	}
-
-	if t.report.Errors > 0 || t.report.Failures > 0 {
-		return false
+func (r *Results) HasFailures() bool {
+	for _, scenario := range r.Scenarios {
+		if scenario.Status == ScenarioFailed {
+			return false
+		}
 	}
 
 	return true
 }
 
-func printDetailedReport(report *reporters.JUnitTestSuite) {
+func (r *Results) PrintSummary() {
+	fmt.Println("")
+	fmt.Println("========================== RESULT ===========================")
+	fmt.Println("Parameters:")
+	fmt.Printf("  KKP Version............: %s (%s)\n", r.Options.KubermaticConfiguration.Status.KubermaticVersion, r.Options.KubermaticConfiguration.Status.KubermaticEdition)
+	fmt.Printf("  Name Prefix............: %q\n", r.Options.NamePrefix)
+	fmt.Printf("  OSM Enabled............: %v\n", r.Options.OperatingSystemManagerEnabled)
+	fmt.Printf("  Dualstack Enabled......: %v\n", r.Options.DualStackEnabled)
+	fmt.Printf("  Konnectivity Enabled...: %v\n", r.Options.KonnectivityEnabled)
+	fmt.Printf("  Cluster Updates Enabled: %v\n", r.Options.TestClusterUpdate)
+	fmt.Printf("  Enabled Tests..........: %v\n", sets.List(r.Options.Tests))
+	fmt.Printf("  Scenario Options.......: %v\n", sets.List(r.Options.ScenarioOptions))
+	fmt.Println("")
+	fmt.Println("Test results:")
+
+	// sort results alphabetically
+	sort.Slice(r.Scenarios, func(i, j int) bool {
+		iname := r.Scenarios[i].scenarioName
+		jname := r.Scenarios[j].scenarioName
+
+		return iname < jname
+	})
+
+	for _, result := range r.Scenarios {
+		var prefix string
+
+		switch result.Status {
+		case ScenarioPassed:
+			prefix = " OK "
+		case ScenarioFailed:
+			prefix = "FAIL"
+		case ScenarioSkipped:
+			prefix = "SKIP"
+		default:
+			prefix = string(result.Status)
+		}
+
+		scenarioResultMsg := fmt.Sprintf("[%s] - %s", prefix, result.scenarioName)
+
+		if r.Options.TestClusterUpdate && result.cluster != nil {
+			scenarioResultMsg = fmt.Sprintf("%s (updated to %s)", scenarioResultMsg, result.cluster.Spec.Version)
+		}
+
+		scenarioResultMsg = fmt.Sprintf("%s (%s)", scenarioResultMsg, result.Duration.Round(time.Second))
+
+		if result.Message != "" {
+			scenarioResultMsg = fmt.Sprintf("%s: %v", scenarioResultMsg, result.Message)
+		}
+
+		fmt.Println(scenarioResultMsg)
+	}
+}
+
+func (r *Results) PrintJUnitDetails() {
+	for _, result := range r.Scenarios {
+		result.PrintJUnitDetails()
+	}
+}
+
+func MergeResults(previous *ResultsFile, current *Results) *Results {
+	output := &Results{
+		Options:   current.Options,
+		Scenarios: previous.Results,
+	}
+
+	for _, currentScenarioResult := range current.Scenarios {
+		found := false
+
+		for j, previousResult := range output.Scenarios {
+			// found a matching result from a previous run; update it with
+			// the new test results
+			if previousResult.Equals(currentScenarioResult) {
+				// we only want to _improve_ test results, i.e. never go back
+				// back from a successful scenario to one that failed due to a flake
+				if currentScenarioResult.BetterThan(previousResult) {
+					output.Scenarios[j] = currentScenarioResult
+				}
+
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			output.Scenarios = append(output.Scenarios, currentScenarioResult)
+		}
+	}
+
+	return output
+}
+
+func (r *Results) WriteToFile(filename string) error {
+	output := ResultsFile{
+		Configuration: TestConfiguration{
+			OSMEnabled:          r.Options.OperatingSystemManagerEnabled,
+			DualstackEnabled:    r.Options.DualStackEnabled,
+			KonnectivityEnabled: r.Options.KonnectivityEnabled,
+			TestClusterUpdate:   r.Options.TestClusterUpdate,
+			Tests:               sets.List(r.Options.Tests),
+		},
+		Results: r.Scenarios,
+	}
+
+	// sort results alphabetically
+	sort.Slice(output.Results, func(i, j int) bool {
+		iname := output.Results[i].scenarioName
+		jname := output.Results[j].scenarioName
+
+		return iname < jname
+	})
+
+	f, err := os.Create(filename)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	encoder := json.NewEncoder(f)
+	encoder.SetIndent("", "  ")
+
+	if err := encoder.Encode(output); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type ScenarioResult struct {
+	report       *reporters.JUnitTestSuite
+	cluster      *kubermaticv1.Cluster
+	scenarioName string
+
+	CloudProvider     kubermaticv1.ProviderType      `json:"cloudProvider"`
+	OperatingSystem   providerconfig.OperatingSystem `json:"operatingSystem"`
+	ContainerRuntime  string                         `json:"containerRuntime"`
+	KubernetesRelease string                         `json:"kubernetesRelease"`
+	KubernetesVersion semver.Semver                  `json:"kubernetesVersion"`
+	KubermaticVersion string                         `json:"kubermaticVersion"`
+	Duration          time.Duration                  `json:"duration"`
+	ClusterName       string                         `json:"clusterName"`
+	Status            ScenarioStatus                 `json:"status"`
+	Message           string                         `json:"message"`
+}
+
+func (sr *ScenarioResult) BetterThan(other ScenarioResult) bool {
+	switch sr.Status {
+	case ScenarioFailed:
+		return other.Status == ScenarioSkipped || other.Status == ScenarioFailed
+	case ScenarioSkipped:
+		return other.Status == ScenarioSkipped
+	case ScenarioPassed:
+		return true
+	}
+
+	return false
+}
+
+func (sr *ScenarioResult) Equals(other ScenarioResult) bool {
+	return true &&
+		other.CloudProvider == sr.CloudProvider &&
+		other.OperatingSystem == sr.OperatingSystem &&
+		other.ContainerRuntime == sr.ContainerRuntime &&
+		other.KubernetesVersion == sr.KubernetesVersion
+}
+
+func (sr *ScenarioResult) MatchesScenario(scenario scenarios.Scenario) bool {
+	return true &&
+		scenario.CloudProvider() == sr.CloudProvider &&
+		scenario.OperatingSystem() == sr.OperatingSystem &&
+		scenario.ContainerRuntime() == sr.ContainerRuntime &&
+		scenario.ClusterVersion() == sr.KubernetesVersion
+}
+
+func (r *ScenarioResult) PrintJUnitDetails() {
+	if r.report == nil {
+		return
+	}
+
 	const separator = "============================================================="
 
 	fmt.Println(separator)
-	fmt.Printf("Test results for: %s\n", report.Name)
+	fmt.Printf("Test results for: %s\n", r.report.Name)
 
 	// Only print details errors in case we have a testcase which failed.
 	// Printing everything which has an error will print the errors from retried tests as for each attempt a TestCase entry exists.
-	if report.Failures > 0 || report.Errors > 0 {
-		for _, t := range report.TestCases {
+	if r.report.Failures > 0 || r.report.Errors > 0 {
+		for _, t := range r.report.TestCases {
 			if t.FailureMessage == nil {
 				continue
 			}
@@ -74,7 +254,35 @@ func printDetailedReport(report *reporters.JUnitTestSuite) {
 	}
 
 	fmt.Println("----------------------------")
-	fmt.Printf("Passed: %d\n", report.Tests-report.Failures)
-	fmt.Printf("Failed: %d\n", report.Failures)
+	fmt.Printf("Passed: %d\n", r.report.Tests-r.report.Failures)
+	fmt.Printf("Failed: %d\n", r.report.Failures)
 	fmt.Println(separator)
+}
+
+type ResultsFile struct {
+	Configuration TestConfiguration `json:"configuration"`
+	Results       []ScenarioResult  `json:"results"`
+}
+
+type TestConfiguration struct {
+	OSMEnabled          bool     `json:"osmEnabled"`
+	DualstackEnabled    bool     `json:"dualstackEnabled"`
+	KonnectivityEnabled bool     `json:"konnectivityEnabled"`
+	TestClusterUpdate   bool     `json:"testClusterUpdate"`
+	Tests               []string `json:"tests"`
+}
+
+func LoadResultsFile(filename string) (*ResultsFile, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	output := ResultsFile{}
+	if err := json.NewDecoder(f).Decode(&output); err != nil {
+		return nil, err
+	}
+
+	return &output, err
 }

--- a/cmd/conformance-tester/pkg/scenarios/alibaba.go
+++ b/cmd/conformance-tester/pkg/scenarios/alibaba.go
@@ -39,7 +39,7 @@ func (s *alibabaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 				AccessKeyID:     secrets.Alibaba.AccessKeyID,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/anexia.go
+++ b/cmd/conformance-tester/pkg/scenarios/anexia.go
@@ -18,8 +18,7 @@ package scenarios
 
 import (
 	"context"
-
-	"go.uber.org/zap"
+	"errors"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -38,17 +37,16 @@ type anexiaScenario struct {
 	baseScenario
 }
 
-func (s *anexiaScenario) IsValid(opts *types.Options, log *zap.SugaredLogger) bool {
-	if !s.baseScenario.IsValid(opts, log) {
-		return false
+func (s *anexiaScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
 	}
 
 	if s.operatingSystem != providerconfig.OperatingSystemFlatcar {
-		s.Log(log).Debug("Skipping because provider only supports Flatcar.")
-		return false
+		return errors.New("provider only supports Flatcar")
 	}
 
-	return true
+	return nil
 }
 
 func (s *anexiaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
@@ -60,7 +58,7 @@ func (s *anexiaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 				Token: secrets.Anexia.Token,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -53,7 +53,7 @@ func (s *awsScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 				AccessKeyID:     secrets.AWS.AccessKeyID,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/azure.go
+++ b/cmd/conformance-tester/pkg/scenarios/azure.go
@@ -46,7 +46,7 @@ func (s *azureScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec
 				LoadBalancerSKU: kubermaticv1.AzureStandardLBSKU,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/digitalocean.go
+++ b/cmd/conformance-tester/pkg/scenarios/digitalocean.go
@@ -18,11 +18,15 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -31,6 +35,24 @@ const (
 
 type digitaloceanScenario struct {
 	baseScenario
+}
+
+func (s *digitaloceanScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	supported := sets.New(
+		string(providerconfig.OperatingSystemCentOS),
+		string(providerconfig.OperatingSystemRockyLinux),
+		string(providerconfig.OperatingSystemUbuntu),
+	)
+
+	if !supported.Has(string(s.operatingSystem)) {
+		return fmt.Errorf("provider only supports %v", sets.List(supported))
+	}
+
+	return nil
 }
 
 func (s *digitaloceanScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
@@ -42,7 +64,7 @@ func (s *digitaloceanScenario) Cluster(secrets types.Secrets) *kubermaticv1.Clus
 				Token: secrets.Digitalocean.Token,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/google.go
+++ b/cmd/conformance-tester/pkg/scenarios/google.go
@@ -19,8 +19,7 @@ package scenarios
 import (
 	"context"
 	"encoding/base64"
-
-	"go.uber.org/zap"
+	"errors"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -33,17 +32,16 @@ type googleScenario struct {
 	baseScenario
 }
 
-func (s *googleScenario) IsValid(opts *types.Options, log *zap.SugaredLogger) bool {
-	if !s.baseScenario.IsValid(opts, log) {
-		return false
+func (s *googleScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
 	}
 
 	if s.operatingSystem != providerconfig.OperatingSystemUbuntu {
-		s.Log(log).Debug("Skipping because provider only supports Ubuntu.")
-		return false
+		return errors.New("provider only supports Ubuntu")
 	}
 
-	return true
+	return nil
 }
 
 func (s *googleScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
@@ -57,7 +55,7 @@ func (s *googleScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 				Subnetwork:     secrets.GCP.Subnetwork,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/hetzner.go
+++ b/cmd/conformance-tester/pkg/scenarios/hetzner.go
@@ -18,11 +18,15 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -31,6 +35,24 @@ const (
 
 type hetznerScenario struct {
 	baseScenario
+}
+
+func (s *hetznerScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	supported := sets.New(
+		string(providerconfig.OperatingSystemCentOS),
+		string(providerconfig.OperatingSystemRockyLinux),
+		string(providerconfig.OperatingSystemUbuntu),
+	)
+
+	if !supported.Has(string(s.operatingSystem)) {
+		return fmt.Errorf("provider only supports %v", sets.List(supported))
+	}
+
+	return nil
 }
 
 func (s *hetznerScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
@@ -42,7 +64,7 @@ func (s *hetznerScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 				Token: secrets.Hetzner.Token,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -55,7 +55,7 @@ func (s *kubevirtScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterS
 				},
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/nutanix.go
+++ b/cmd/conformance-tester/pkg/scenarios/nutanix.go
@@ -53,7 +53,7 @@ func (s *nutanixScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 				ProjectName: secrets.Nutanix.ProjectName,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/openstack.go
+++ b/cmd/conformance-tester/pkg/scenarios/openstack.go
@@ -51,7 +51,7 @@ func (s *openStackScenario) Cluster(secrets types.Secrets) *kubermaticv1.Cluster
 				FloatingIPPool: openStackFloatingIPPool,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/packet.go
+++ b/cmd/conformance-tester/pkg/scenarios/packet.go
@@ -18,11 +18,15 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -31,6 +35,25 @@ const (
 
 type packetScenario struct {
 	baseScenario
+}
+
+func (s *packetScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	supported := sets.New(
+		string(providerconfig.OperatingSystemCentOS),
+		string(providerconfig.OperatingSystemFlatcar),
+		string(providerconfig.OperatingSystemRockyLinux),
+		string(providerconfig.OperatingSystemUbuntu),
+	)
+
+	if !supported.Has(string(s.operatingSystem)) {
+		return fmt.Errorf("provider only supports %v", sets.List(supported))
+	}
+
+	return nil
 }
 
 func (s *packetScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
@@ -43,7 +66,7 @@ func (s *packetScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpe
 				ProjectID: secrets.Packet.ProjectID,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -18,8 +18,10 @@ package scenarios
 
 import (
 	"context"
+	"errors"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
@@ -39,6 +41,18 @@ type vmwareCloudDirectorScenario struct {
 	baseScenario
 }
 
+func (s *vmwareCloudDirectorScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	if s.operatingSystem != providerconfig.OperatingSystemUbuntu {
+		return errors.New("provider only supports Flatcar")
+	}
+
+	return nil
+}
+
 func (s *vmwareCloudDirectorScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	spec := &kubermaticv1.ClusterSpec{
 		ContainerRuntime: s.containerRuntime,
@@ -55,7 +69,7 @@ func (s *vmwareCloudDirectorScenario) Cluster(secrets types.Secrets) *kubermatic
 				},
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 
 	return spec

--- a/cmd/conformance-tester/pkg/scenarios/vsphere.go
+++ b/cmd/conformance-tester/pkg/scenarios/vsphere.go
@@ -44,7 +44,7 @@ func (s *vSphereScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 				Datastore: s.datacenter.Spec.VSphere.DefaultDatastore,
 			},
 		},
-		Version: s.version,
+		Version: s.clusterVersion,
 	}
 
 	if s.customFolder {

--- a/cmd/conformance-tester/pkg/types/options.go
+++ b/cmd/conformance-tester/pkg/types/options.go
@@ -63,6 +63,11 @@ type Options struct {
 	Tests                sets.Set[string]
 	ContainerRuntimes    sets.Set[string]
 
+	// The tester can export the result status for all executed scenarios
+	// into a JSON file and then re-read that to retry failed runs.
+	ResultsFile          string
+	RetryFailedScenarios bool
+
 	// additional settings identical for all scenarios
 
 	OperatingSystemManagerEnabled bool
@@ -162,6 +167,8 @@ func (o *Options) AddFlags() {
 	flag.BoolVar(&o.KonnectivityEnabled, "enable-konnectivity", true, "When set, enables Konnectivity (proxy service for control plane communication) in the user cluster. When set to false, OpenVPN is used")
 	flag.BoolVar(&o.TestClusterUpdate, "update-cluster", false, "When set, will first run the selected tests, then update the cluster and nodes to their next minor release and then run the same tests again")
 	flag.StringVar(&o.PushgatewayEndpoint, "pushgateway-endpoint", "", "host:port of a Prometheus Pushgateway to send runtime metrics to")
+	flag.StringVar(&o.ResultsFile, "results-file", "", "path to a JSON file where the test result will be written to / read from (when also using --retry)")
+	flag.BoolVar(&o.RetryFailedScenarios, "retry", false, "when using --results-file, will filter the given scenarios to only run those that previously failed")
 	o.Secrets.AddFlags()
 }
 

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -142,4 +142,5 @@ timeout -s 9 "${maxDuration}m" ./_build/conformance-tester $EXTRA_ARGS \
   -exclude-distributions="${EXCLUDE_DISTRIBUTIONS:-}" \
   -exclude-tests="${EXCLUDE_TESTS:-}" \
   -enable-osm=${KUBERMATIC_OSM_ENABLED:-true} \
-  -pushgateway-endpoint="pushgateway.monitoring.svc.cluster.local.:9091"
+  -pushgateway-endpoint="pushgateway.monitoring.svc.cluster.local.:9091" \
+  -results-file "$ARTIFACTS/conformance-tester-results.json"


### PR DESCRIPTION
**What this PR does / why we need it**:
During the QA phase we collect test results for our provider tests in individual Github tickets, like #11777. This is a bit annoying and hard to get an overview of, so this PR is meant to improve this.

The PR adds a new "results file" to the conformance-tester that will contain, well, the scenario test results, like so (it's JSON, but that was changed late in the PR's lifetime and so all I have here is a YAML example):

```yaml
configuration:
  osmEnabled: true
  dualstackEnabled: false
  konnectivityEnabled: false
  testClusterUpdate: false
  tests:
    - gcr-images
    - loadbalancer
    - metrics
    - securitycontext
    - storage
    - usercluster-gcr-images
    - usercluster-rbac
    - usercluster-seccomp
results:
  - cloudProvider: hetzner
    operatingSystem: centos
    containerRuntime: containerd
    kubernetesRelease: "1.24"
    kubernetesVersion: 1.24.10
    kubermaticVersion: v2.22.0-alpha.1-2-g1209d452a
    duration: 8m28.55953715s
    clusterName: groucho-fzhh7
    status: passed
    message: ""
  - cloudProvider: hetzner
    operatingSystem: flatcar
    containerRuntime: containerd
    kubernetesRelease: "1.24"
    kubernetesVersion: 1.24.10
    kubermaticVersion: ""
    duration: 0s
    clusterName: ""
    status: skipped
    message: 'Skipped: provider only supports [centos rockylinux ubuntu]'
  - cloudProvider: openstack
    operatingSystem: flatcar
    containerRuntime: containerd
    kubernetesRelease: "1.26"
    kubernetesVersion: 1.26.1
    kubermaticVersion: ""
    duration: 320.678198ms
    clusterName: ""
    status: failed
    message: 'failed to create cluster: failed to create cluster: admission webhook "clusters.kubermatic.io" denied the request: cloud: Invalid value: "<redacted>": failed to create a authenticated openstack client: Authentication failed'
```

This file has 2 purposes:

1. It can be used to automatically retry failed scenarios. Just run the tested with `--results-file foo.json --retry` and on the 2nd run (i.e. once the `foo.json` already exists) the conformance-tester will only run those jobs again that were not successful the last time. And it will then update the results file accordingly, so in theory, you can run the tester in an endless loop until everthing's green.
1. In order to collect test results I was playing around with InfluxDB+Grafana and the datastructure shown above is close to what I would need in my InfluxDB to store the results. Grafana can then show a nice, sortable, filterable table. The actual upload of the data is still TBD and will most likely not be part of the conformance-tester (maybe not even part of this repo).

We _could_ use the data in our e2e tests, but I would not be sure what for and where to upload it. I endabled the `--results-file` thing anyway just to exercise the code behind it.

In order to have skipped tests in the results file as well, the validity checks have been moved to happen much later. Previously the scenario generator would already skip some of the scenarios it deemed invalid, but in order for all of them to appear in the results, I moved this check to the runner instead. In general the code for the result handling in the runner has been restructured a bit.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
