### PR TITLE
Hotfix: Provider name validation for provider incompatibility matrix

### DIFF
--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -427,7 +427,8 @@ type Update struct {
 type Incompatibility struct {
 	// Provider to which to apply the compatibility check.
 	// Empty string matches all providers
-	Provider ProviderType `json:"provider,omitempty"`
+	// +kubebuilder:validation:Enum="";digitalocean;hetzner;azure;vsphere;aws;openstack;packet;gcp;kubevirt;nutanix;alibaba;anexia;fake;vmwareclouddirector
+	Provider string `json:"provider,omitempty"`
 	// Version is the Kubernetes version that must be checked. Wildcards are allowed, e.g. "1.25.*".
 	Version string `json:"version,omitempty"`
 	// Condition is the cluster or datacenter condition that must be met to block a specific version

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -28,7 +28,6 @@ import (
 )
 
 // +kubebuilder:validation:Enum=digitalocean;hetzner;azure;vsphere;aws;openstack;packet;gcp;kubevirt;nutanix;alibaba;anexia;fake;vmwareclouddirector
-
 type ProviderType string
 
 // +kubebuilder:validation:Pattern:=`^((\d{1,3}\.){3}\d{1,3}\/([0-9]|[1-2][0-9]|3[0-2]))$`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -531,6 +531,7 @@ spec:
                           provider:
                             description: Provider to which to apply the compatibility check. Empty string matches all providers
                             enum:
+                              - ""
                               - digitalocean
                               - hetzner
                               - azure

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -301,19 +301,19 @@ var (
 			// we are still going to have 1.23 clusters temporarily during an upgrade,
 			// so let's keep this just to make sure.
 			{
-				Provider:  kubermaticv1.AWSCloudProvider,
+				Provider:  string(kubermaticv1.AWSCloudProvider),
 				Version:   "< 1.24.0",
 				Condition: kubermaticv1.ExternalCloudProviderCondition,
 				Operation: kubermaticv1.SupportOperation,
 			},
 			{
-				Provider:  kubermaticv1.AWSCloudProvider,
+				Provider:  string(kubermaticv1.AWSCloudProvider),
 				Version:   "< 1.24.0",
 				Condition: kubermaticv1.ExternalCloudProviderCondition,
 				Operation: kubermaticv1.CreateOperation,
 			},
 			{
-				Provider:  kubermaticv1.AWSCloudProvider,
+				Provider:  string(kubermaticv1.AWSCloudProvider),
 				Version:   "< 1.24.0",
 				Condition: kubermaticv1.ExternalCloudProviderCondition,
 				Operation: kubermaticv1.UpdateOperation,

--- a/pkg/version/manager.go
+++ b/pkg/version/manager.go
@@ -96,7 +96,7 @@ func NewFromConfiguration(config *kubermaticv1.KubermaticConfiguration) *Manager
 
 	for _, incomp := range k8s.ProviderIncompatibilities {
 		incompatibilities = append(incompatibilities, &ProviderIncompatibility{
-			Provider:  incomp.Provider,
+			Provider:  kubermaticv1.ProviderType(incomp.Provider),
 			Version:   incomp.Version,
 			Condition: incomp.Condition,
 			Operation: incomp.Operation,

--- a/pkg/version/manager_test.go
+++ b/pkg/version/manager_test.go
@@ -69,6 +69,7 @@ func TestAutomaticNodeUpdate(t *testing.T) {
 					{Version: semverlib.MustParse(tc.updates[0].To)},
 				},
 			}
+
 			version, err := m.AutomaticNodeUpdate(tc.fromVersion, tc.controlPlaneVersion)
 			// a simple err comparison considers them different, because they contain different
 			// semver pointers, even thought their value is equal


### PR DESCRIPTION
Signed-off-by: Waleed Malik <ahmedwaleedmalik@gmail.com>

**What this PR does / why we need it**:
For provider incompatibility checks in the `KubermaticConfiguration`, users can leave the `provider` field empty to apply a rule on all the cloud providers. This functionality was broken because the [kubebuilder validation](https://github.com/kubermatic/kubermatic/blob/release/v2.22/pkg/apis/kubermatic/v1/datacenter.go#L30) for that field didn't allow an empty string.

```
ERRO[0132] ❌ Operation failed: failed to apply Kubermatic Configuration: KubermaticConfiguration.kubermatic.k8c.io "kubermatic" is invalid: [spec.versions.providerIncompatibilities[0].provider: Unsupported value: "": supported values: "digitalocean", "hetzner", "azure", "vsphere", "aws", "openstack", "packet", "gcp", "kubevirt", "nutanix", "alibaba", "anexia", "fake", "vmwareclouddirector", spec.versions.providerIncompatibilities[1].provider: Unsupported value: "": supported values: "digitalocean", "hetzner", "azure", "vsphere", "aws", "openstack", "packet", "gcp", "kubevirt", "nutanix", "alibaba", "anexia", "fake", "vmwareclouddirector"].
```

This PR fixes that issue. Adding an empty string in the `ProviderType` enum was not a valid workaround since we use that struct everywhere and it shouldn't be empty. Hence I resorted to using a string type with a targetted kubebuilder marker for this use case.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug where setting a provider incompatibility rule for all providers was not working.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
