### PR TITLE
use strenv instead of env to set imagePullSecret to deploy dev

### DIFF
--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -136,7 +136,7 @@ usercluster-mla)
 kubermatic)
   if [ -n "${IMAGE_PULL_SECRET:-}" ]; then
     export IMAGE_PULL_SECRET_CONTENT="$(cat $IMAGE_PULL_SECRET)"
-    yq --inplace ".kubermaticOperator.imagePullSecret = env(IMAGE_PULL_SECRET_CONTENT)" charts/kubermatic-operator/values.yaml
+    yq --inplace ".kubermaticOperator.imagePullSecret = strenv(IMAGE_PULL_SECRET_CONTENT)" charts/kubermatic-operator/values.yaml
   fi
 
   # Kubermatic


### PR DESCRIPTION
**What this PR does / why we need it**:

This hopefully prevents the error:

`time="2023-02-14T11:09:40Z" level=error msg="❌ Operation failed: failed to deploy Kubermatic Operator: failed to deploy Helm release: failed to install: coalesce.go:220: warning: cannot overwrite table with non table for kubermatic-operator.kubermaticOperator.imagePullSecret (map[auths:map[quay.io:map[email:]]])\nError: UPGRADE FAILED: release kubermatic-operator failed, and has been rolled back due to atomic being set: timed out waiting for the condition." `

from happening. 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
