### PR TITLE
[release/v2.21] Update machine-controller to v1.54.5

### DIFF
--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -51,7 +51,7 @@ var (
 
 const (
 	Name = "machine-controller"
-	Tag  = "v1.54.3"
+	Tag  = "v1.54.5"
 )
 
 type machinecontrollerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller-webhook.yaml
@@ -71,7 +71,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-machine-controller.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller-webhook.yaml
@@ -71,7 +71,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-machine-controller.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller-webhook.yaml
@@ -71,7 +71,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-machine-controller.yaml
@@ -74,7 +74,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller-webhook.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller-webhook.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller-webhook.yaml
@@ -77,7 +77,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-machine-controller.yaml
@@ -80,7 +80,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller-webhook.yaml
@@ -57,7 +57,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-machine-controller.yaml
@@ -60,7 +60,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller-webhook.yaml
@@ -57,7 +57,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-machine-controller.yaml
@@ -60,7 +60,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller-webhook.yaml
@@ -57,7 +57,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-machine-controller.yaml
@@ -60,7 +60,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller-webhook.yaml
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-machine-controller.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller-webhook.yaml
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-machine-controller.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller-webhook.yaml
@@ -62,7 +62,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-machine-controller.yaml
@@ -65,7 +65,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -98,7 +98,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller-webhook.yaml
@@ -98,7 +98,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -98,7 +98,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller-webhook.yaml
@@ -98,7 +98,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -98,7 +98,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller-webhook.yaml
@@ -98,7 +98,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller-webhook.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-machine-controller.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller-webhook.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-machine-controller.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller-webhook.yaml
@@ -69,7 +69,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-machine-controller.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:v1.54.3
+        image: quay.io/kubermatic/machine-controller:v1.54.5
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:

Update machine-controller to v1.54.5. This fixes an issue with Flatcar nodes not joining the cluster for clusters that don't use OSM.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update machine-controller to v1.54.5. This fixes an issue with Flatcar nodes not joining the cluster for clusters that don't use OSM
```

**Documentation**:
```documentation
NONE
```