### PR TITLE
openstack: filter empty security group

### DIFF
--- a/pkg/machine/provider/openstack.go
+++ b/pkg/machine/provider/openstack.go
@@ -130,6 +130,7 @@ func CompleteOpenstackProviderSpec(config *openstack.RawConfig, cluster *kuberma
 			config.Subnet.Value = cluster.Spec.Cloud.Openstack.SubnetID
 		}
 
+		config.SecurityGroups = filterEmptyValues(config.SecurityGroups)
 		if len(config.SecurityGroups) == 0 && len(cluster.Spec.Cloud.Openstack.SecurityGroups) > 0 {
 			config.SecurityGroups = []providerconfig.ConfigVarString{{Value: cluster.Spec.Cloud.Openstack.SecurityGroups}}
 		}
@@ -147,4 +148,14 @@ func CompleteOpenstackProviderSpec(config *openstack.RawConfig, cluster *kuberma
 	}
 
 	return config, nil
+}
+
+func filterEmptyValues(vals []providerconfig.ConfigVarString) []providerconfig.ConfigVarString {
+	var filtered []providerconfig.ConfigVarString
+	for _, val := range vals {
+		if len(val.Value) > 0 {
+			filtered = append(filtered, val)
+		}
+	}
+	return filtered
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

when creating to cluster through the UI we got the error 
```
failed to create initial MachineDeployment: admission webhook "machine-controller.kubermatic.io-machinedeployments" denied the request: validation failed: failed to get security group "": not found
```

When UI creates the cluster object `Spec.Cloud.Openstack.SecurityGroups` is empty (not created yet by our controller). So it set the   `kubermatic.io/initial-machinedeployment-request` annotation  with security group as an array with an empty string (`"securityGroups":[""]`)

When we complete the MachineDeployment spec, we test   `len(config.SecurityGroups) == 0`, which is  false (array contains an empty element),  consequently the security group is not defaulted with `Spec.Cloud.Openstack.SecurityGroups` and keep an invalid value.



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
ref #11858

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
Should we also make a PR on API to avoid set an empty security group in `kubermatic.io/initial-machinedeployment-request` annotation ?

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
