### PR TITLE
Fix synchronisation for default resource quotas

### DIFF
--- a/pkg/ee/resource-quota/default-quota-controller/controller.go
+++ b/pkg/ee/resource-quota/default-quota-controller/controller.go
@@ -33,8 +33,11 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	utilpredicate "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -111,83 +114,71 @@ func (r *reconciler) reconcile(ctx context.Context, setting *kubermaticv1.Kuberm
 		return fmt.Errorf("failed to list resource quotas: %w", err)
 	}
 
-	projectQuotas := pairProjectQuotas(projects, resourceQuotas)
-	// if the setting is nil, remove all default resource quotas
+	// Delete all default project quotas if user didn't specify any default project quota.
 	if setting.Spec.DefaultProjectResourceQuota == nil {
-		if err := r.handleDeletion(ctx, projectQuotas); err != nil {
-			return fmt.Errorf("error deleting default project quotas %w", err)
-		}
-		return nil
+		return r.handleDeletion(ctx)
 	}
 
-	for _, pQuota := range projectQuotas {
-		if err := r.ensureDefaultProjectQuota(ctx, setting, &pQuota.project, pQuota.quota); err != nil {
-			return fmt.Errorf("error ensuring default project quotas: %w", err)
-		}
-	}
-
-	return nil
+	return r.synchronizeResourceQuotas(ctx, setting.Spec.DefaultProjectResourceQuota, projects, resourceQuotas)
 }
 
-func (r *reconciler) handleDeletion(ctx context.Context, quotas map[string]*projectQuota) error {
-	for _, pQuota := range quotas {
-		if pQuota.quota != nil {
-			if err := r.masterClient.Delete(ctx, pQuota.quota); err != nil {
-				return fmt.Errorf("error deleting default quota %q: %w", pQuota.quota.Name, err)
-			}
-		}
-	}
-	return nil
-}
+func (r *reconciler) synchronizeResourceQuotas(ctx context.Context, defaultResourceQuota *kubermaticv1.DefaultProjectResourceQuota, projects *kubermaticv1.ProjectList, quotas *kubermaticv1.ResourceQuotaList) error {
+	// We need to synchronize default resource quotas.
+	var defaultResourceQuotas []reconciling.NamedResourceQuotaReconcilerFactory
 
-type projectQuota struct {
-	project kubermaticv1.Project
-	quota   *kubermaticv1.ResourceQuota
-}
-
-func pairProjectQuotas(projects *kubermaticv1.ProjectList, quotas *kubermaticv1.ResourceQuotaList) map[string]*projectQuota {
-	projectQuotaMap := map[string]*projectQuota{}
-	for _, project := range projects.Items {
-		projectQuotaMap[project.Name] = &projectQuota{project: project}
-	}
-
+	// Create a lookup for projects with resource quotas.
+	resourceQuotaLookup := map[string]kubermaticv1.ResourceQuota{}
 	for _, quota := range quotas.Items {
 		if quota.Spec.Subject.Kind == kubermaticv1.ProjectSubjectKind {
-			// prune projects with custom quotas
-			if quota.Labels == nil || !(quota.Labels[DefaultProjectResourceQuotaKey] == DefaultProjectResourceQuotaValue) {
-				delete(projectQuotaMap, quota.Spec.Subject.Name)
-				continue
-			}
-
-			pQuota, ok := projectQuotaMap[quota.Spec.Subject.Name]
-			if !ok {
-				// skip if quota does not have project, should not happen but maybe in a race during deletion it could
-				continue
-			}
-			pQuota.quota = &quota
+			resourceQuotaLookup[quota.Spec.Subject.Name] = quota
 		}
 	}
-	return projectQuotaMap
-}
 
-func (r *reconciler) ensureDefaultProjectQuota(ctx context.Context, settings *kubermaticv1.KubermaticSetting,
-	project *kubermaticv1.Project, quota *kubermaticv1.ResourceQuota) error {
-	// if missing, create
-	if quota == nil {
-		newQuota := genDefaultResourceQuota(settings, project)
-		if err := r.masterClient.Create(ctx, newQuota); err != nil {
-			return fmt.Errorf("error creating default resource quota: %w", err)
+	// Iterate over all the projects and synchronize projects with their default quotas.
+	for _, project := range projects.Items {
+		// Ignore projects that are queued for deletion.
+		if project.DeletionTimestamp == nil {
+			continue
 		}
-	} else {
-		quota.Spec.Quota = settings.Spec.DefaultProjectResourceQuota.Quota
-		if err := r.masterClient.Update(ctx, quota); err != nil {
-			return fmt.Errorf("error updating default resource quota: %w", err)
+
+		quota, ok := resourceQuotaLookup[project.Name]
+		if !ok {
+			// Default resource quota doesn't exist.
+			resourceQuota := genDefaultResourceQuota(defaultResourceQuota, &project)
+			defaultResourceQuotas = append(defaultResourceQuotas, projectQuotaReconcilerFactory(resourceQuota))
+			continue
 		}
+		// Quota already exists and we need to update it.
+		quota.Spec.Quota = defaultResourceQuota.Quota
+		defaultResourceQuotas = append(defaultResourceQuotas, projectQuotaReconcilerFactory(&quota))
+	}
+
+	// Create or Update the resource quotas.
+	if err := reconciling.ReconcileResourceQuotas(ctx, defaultResourceQuotas, "", r.masterClient); err != nil {
+		return fmt.Errorf("failed to reconcile ResourceQuotas: %w", err)
 	}
 	return nil
 }
 
-func genDefaultResourceQuota(settings *kubermaticv1.KubermaticSetting, project *kubermaticv1.Project) *kubermaticv1.ResourceQuota {
+func (r *reconciler) handleDeletion(ctx context.Context) error {
+	req, err := labels.NewRequirement(DefaultProjectResourceQuotaKey, selection.Equals, []string{DefaultProjectResourceQuotaValue})
+	if err != nil {
+		return err
+	}
+	listOpts := ctrlruntimeclient.ListOptions{
+		LabelSelector: labels.NewSelector().Add(*req),
+	}
+	deleteAllOfOptions := &ctrlruntimeclient.DeleteAllOfOptions{
+		ListOptions: listOpts,
+	}
+
+	if err = r.masterClient.DeleteAllOf(ctx, &kubermaticv1.ResourceQuota{}, deleteAllOfOptions); err != nil {
+		return fmt.Errorf("failed to delete defalt ResourceQuotas: %w", err)
+	}
+	return nil
+}
+
+func genDefaultResourceQuota(defaultResourceQuota *kubermaticv1.DefaultProjectResourceQuota, project *kubermaticv1.Project) *kubermaticv1.ResourceQuota {
 	quota := &kubermaticv1.ResourceQuota{}
 	quota.Labels = map[string]string{
 		DefaultProjectResourceQuotaKey: DefaultProjectResourceQuotaValue,
@@ -196,7 +187,7 @@ func genDefaultResourceQuota(settings *kubermaticv1.KubermaticSetting, project *
 		Name: project.Name,
 		Kind: kubermaticv1.ProjectSubjectKind,
 	}
-	quota.Spec.Quota = settings.Spec.DefaultProjectResourceQuota.Quota
+	quota.Spec.Quota = defaultResourceQuota.Quota
 	quota.Name = buildNameFromSubject(quota.Spec.Subject)
 	return quota
 }
@@ -228,5 +219,13 @@ func withSettingsEventFilter() predicate.Predicate {
 		GenericFunc: func(e event.GenericEvent) bool {
 			return false
 		},
+	}
+}
+
+func projectQuotaReconcilerFactory(q *kubermaticv1.ResourceQuota) reconciling.NamedResourceQuotaReconcilerFactory {
+	return func() (name string, create reconciling.ResourceQuotaReconciler) {
+		return q.Name, func(existing *kubermaticv1.ResourceQuota) (*kubermaticv1.ResourceQuota, error) {
+			return existing, nil
+		}
 	}
 }

--- a/pkg/ee/resource-quota/default-quota-controller/controller.go
+++ b/pkg/ee/resource-quota/default-quota-controller/controller.go
@@ -232,8 +232,25 @@ func projectQuotaReconcilerFactory(resourceQuota *kubermaticv1.ResourceQuota) re
 	return func() (string, reconciling.ResourceQuotaReconciler) {
 		return resourceQuota.Name, func(existing *kubermaticv1.ResourceQuota) (*kubermaticv1.ResourceQuota, error) {
 			existing.Spec = resourceQuota.Spec
-			existing.Labels = resourceQuota.Labels
-			existing.Annotations = resourceQuota.Annotations
+
+			if resourceQuota.Labels != nil {
+				if existing.Labels == nil {
+					existing.Labels = map[string]string{}
+				}
+				for k, v := range resourceQuota.Labels {
+					existing.Labels[k] = v
+				}
+			}
+
+			if resourceQuota.Annotations != nil {
+				if existing.Annotations == nil {
+					existing.Annotations = map[string]string{}
+				}
+				for k, v := range resourceQuota.Annotations {
+					existing.Annotations[k] = v
+				}
+			}
+
 			return existing, nil
 		}
 	}

--- a/pkg/ee/resource-quota/default-quota-controller/controller_test.go
+++ b/pkg/ee/resource-quota/default-quota-controller/controller_test.go
@@ -171,6 +171,8 @@ func TestReconcile(t *testing.T) {
 			// remove resource version
 			for _, rq := range rqs.Items {
 				rq.SetResourceVersion("")
+				rq.Kind = ""
+				rq.APIVersion = ""
 				resultRqs = append(resultRqs, rq)
 			}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, there are a lot of issues with how default project quotas are being synchronized. This PR revamps and simplifies those parts.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
