### PR TITLE
fix k8s feature gates not depending on the correct cluster version

### DIFF
--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -431,7 +431,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		)
 	}
 
-	if fg := data.GetCSIMigrationFeatureGates(); len(fg) > 0 {
+	if fg := data.GetCSIMigrationFeatureGates(cluster.Status.Versions.Apiserver.Semver()); len(fg) > 0 {
 		flags = append(flags, "--feature-gates")
 		flags = append(flags, strings.Join(fg, ","))
 	}

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -259,7 +259,7 @@ func getFlags(data *resources.TemplateData, version *semverlib.Version) ([]strin
 	}
 
 	featureGates := []string{"RotateKubeletServerCertificate=true"}
-	featureGates = append(featureGates, data.GetCSIMigrationFeatureGates()...)
+	featureGates = append(featureGates, data.GetCSIMigrationFeatureGates(cluster.Status.Versions.ControllerManager.Semver())...)
 
 	flags = append(flags, "--feature-gates")
 	flags = append(flags, strings.Join(featureGates, ","))

--- a/pkg/resources/data_test.go
+++ b/pkg/resources/data_test.go
@@ -143,7 +143,7 @@ func TestGetCSIMigrationFeatureGates(t *testing.T) {
 			td := NewTemplateDataBuilder().
 				WithCluster(tc.cluster).
 				Build()
-			if a, e := sets.New(td.GetCSIMigrationFeatureGates()...), tc.wantFeatureGates; !a.Equal(e) {
+			if a, e := sets.New(td.GetCSIMigrationFeatureGates(nil)...), tc.wantFeatureGates; !a.Equal(e) {
 				t.Errorf("Want feature gates %v, but got %v", e, a)
 			}
 		})

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	semverlib "github.com/Masterminds/semver/v3"
+
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -65,7 +67,7 @@ type machinecontrollerData interface {
 	DC() *kubermaticv1.Datacenter
 	NodeLocalDNSCacheEnabled() bool
 	Seed() *kubermaticv1.Seed
-	GetCSIMigrationFeatureGates() []string
+	GetCSIMigrationFeatureGates(version *semverlib.Version) []string
 	MachineControllerImageTag() string
 	MachineControllerImageRepository() string
 	GetEnvVars() ([]corev1.EnvVar, error)

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -74,7 +74,7 @@ func WebhookDeploymentReconciler(data machinecontrollerData) reconciling.NamedDe
 				args = append(args, "-node-external-cloud-provider")
 			}
 
-			featureGates := data.GetCSIMigrationFeatureGates()
+			featureGates := data.GetCSIMigrationFeatureGates(nil)
 			if len(featureGates) > 0 {
 				args = append(args, "-node-kubelet-feature-gates", strings.Join(featureGates, ","))
 			}

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	semverlib "github.com/Masterminds/semver/v3"
+
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
@@ -64,7 +66,7 @@ type operatingSystemManagerData interface {
 	Cluster() *kubermaticv1.Cluster
 	RewriteImage(string) (string, error)
 	NodeLocalDNSCacheEnabled() bool
-	GetCSIMigrationFeatureGates() []string
+	GetCSIMigrationFeatureGates(version *semverlib.Version) []string
 	DC() *kubermaticv1.Datacenter
 	ComputedNodePortRange() string
 	OperatingSystemManagerImageTag() string
@@ -170,7 +172,7 @@ func DeploymentReconcilerWithoutInitWrapper(data operatingSystemManagerData) rec
 					Name:    Name,
 					Image:   repository + ":" + tag,
 					Command: []string{"/usr/local/bin/osm-controller"},
-					Args:    getFlags(data.DC().Node, cs, data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider], data.GetCSIMigrationFeatureGates(), data.Cluster().Spec.ImagePullSecret),
+					Args:    getFlags(data.DC().Node, cs, data.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider], data.GetCSIMigrationFeatureGates(nil), data.Cluster().Spec.ImagePullSecret),
 					Env:     envVars,
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{


### PR DESCRIPTION
**What this PR does / why we need it**:
When _updating_ a GCP cluster from 1.24 to 1.25, KKP was updating the apiserver Deployment first (correct). But during that we change the Docker image to 1.25.x (correct) _but_ we deduced the feature gates based on the control plane version (which was at that time still 1.24.x). Since the new 1.25 pods crashlooped with 

> Error: invalid argument "CSIMigrationGCE=false" for "--feature-gates" flag: cannot set feature gate CSIMigrationGCE to false, feature is locked to true

... the cluster never reaches 1.25.x as its control plane version and so the update is stuck.

This PR makes the feature flag code dependent on an explicit version and functions like the apiserver reconciler now explicitly provide the correct version. Since this only ever affected updates, this fix is not visible in `pkg/resources/test/` fixtures.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix updating GCP clusters from 1.24 to 1.25.
```

**Documentation**:
```documentation
NONE
```
