### PR TITLE
Refactoring for default quota generation

### DIFF
--- a/pkg/apis/kubermatic/v1/resource_quota.go
+++ b/pkg/apis/kubermatic/v1/resource_quota.go
@@ -86,6 +86,10 @@ type ResourceDetails struct {
 	Storage *resource.Quantity `json:"storage,omitempty"`
 }
 
+func (r ResourceDetails) IsEmpty() bool {
+	return (r.CPU == nil || r.CPU.IsZero()) && (r.Memory == nil || r.Memory.IsZero()) && (r.Storage == nil || r.Storage.IsZero())
+}
+
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 

--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -92,6 +92,10 @@ type SettingSpec struct {
 	// TODO: Datacenters, presets, user management, Google Analytics and default addons.
 }
 
+func (s SettingSpec) HasDefaultProjectResourceQuota() bool {
+	return s.DefaultProjectResourceQuota != nil && !s.DefaultProjectResourceQuota.Quota.IsEmpty()
+}
+
 type CustomLinks []CustomLink
 
 type CustomLink struct {

--- a/pkg/ee/resource-quota/default-quota-controller/controller.go
+++ b/pkg/ee/resource-quota/default-quota-controller/controller.go
@@ -277,6 +277,7 @@ func enqueueProjectQuotas(client ctrlruntimeclient.Client) handler.EventHandler 
 		globalSettings := &kubermaticv1.KubermaticSetting{}
 		if err := client.Get(context.Background(), types.NamespacedName{Name: kubermaticv1.GlobalSettingsName}, globalSettings); err != nil {
 			utilruntime.HandleError(fmt.Errorf("failed to get global settings %q: %w", kubermaticv1.GlobalSettingsName, err))
+			return requests
 		}
 
 		if globalSettings.Spec.HasDefaultProjectResourceQuota() {

--- a/pkg/ee/validation/resourcequota/resourcequota.go
+++ b/pkg/ee/validation/resourcequota/resourcequota.go
@@ -109,7 +109,7 @@ func ValidateDelete(ctx context.Context,
 	}
 
 	globalSettings := &kubermaticv1.KubermaticSetting{}
-	if err := client.Get(context.Background(), types.NamespacedName{Name: kubermaticv1.GlobalSettingsName}, globalSettings); err != nil {
+	if err := client.Get(ctx, types.NamespacedName{Name: kubermaticv1.GlobalSettingsName}, globalSettings); err != nil {
 		if apierrors.IsNotFound(err) {
 			// Since KubermaticSettings don't exist, no validation is required.
 			return nil

--- a/pkg/webhook/resourcequota/validation/validation.go
+++ b/pkg/webhook/resourcequota/validation/validation.go
@@ -46,6 +46,6 @@ func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 	return validateUpdate(ctx, oldObj, newObj)
 }
 
-func (v *validator) ValidateDelete(_ context.Context, _ runtime.Object) error {
-	return nil
+func (v *validator) ValidateDelete(ctx context.Context, obj runtime.Object) error {
+	return validateDelete(ctx, obj, v.client)
 }

--- a/pkg/webhook/resourcequota/validation/wrappers_ce.go
+++ b/pkg/webhook/resourcequota/validation/wrappers_ce.go
@@ -38,3 +38,10 @@ func validateUpdate(_ context.Context,
 ) error {
 	return nil
 }
+
+func validateDelete(_ context.Context,
+	_ runtime.Object,
+	_ ctrlruntimeclient.Client,
+) error {
+	return nil
+}

--- a/pkg/webhook/resourcequota/validation/wrappers_ee.go
+++ b/pkg/webhook/resourcequota/validation/wrappers_ee.go
@@ -40,3 +40,10 @@ func validateUpdate(ctx context.Context,
 ) error {
 	return eeresourcequotavalidation.ValidateUpdate(ctx, oldObj, newObj)
 }
+
+func validateDelete(ctx context.Context,
+	obj runtime.Object,
+	client ctrlruntimeclient.Client,
+) error {
+	return eeresourcequotavalidation.ValidateDelete(ctx, obj, client)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the following changes:
1. default-quota-controller will now watch for newly created projects so that default resource quotas can be generated against them.
2. default-quota-controller will only try to update existing quotas if there is a drift between the expected and desired state.
3.  Users are prohibited from deleting default resource quotas if a global resource quota has been configured in the KubermaticSettings.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
