### PR TITLE
Bump Cilium 1.13.0 chart to the final release version

### DIFF
--- a/pkg/cni/cilium/cilium-mirror-chart.sh
+++ b/pkg/cni/cilium/cilium-mirror-chart.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 
 CHART_SOURCE="${CHART_SOURCE:-https://helm.cilium.io}"
 CHART_NAME=${CHART_NAME:-cilium}
-CHART_VERSION="${CHART_VERSION:-1.13.0-rc5}"
+CHART_VERSION="${CHART_VERSION:-1.13.0}"
 
 CHART_PACKAGE="${CHART_NAME}-${CHART_VERSION}.tgz"
 

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -67,7 +67,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 						Source: appskubermaticv1.ApplicationSource{
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
-								ChartVersion: "1.13.0-rc5", // TODO (rastislavs): bump to the release version once it is out
+								ChartVersion: "1.13.0",
 								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
 								Credentials:  credentials,
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:

Cilium 1.13.0 is finally out - this PR bumps Cilium 1.13.0 chart to the final release version.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Cilium CNI 1.13.0 managed by KKP Applications infra.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1329
```
