### PR TITLE
[release/v2.19] fully deploy vsphere csi webhook for migrated clusters

### DIFF
--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -30,12 +30,14 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1"
+	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/crd/kubermatic/v1/helper"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/util/yaml"
 	"k8c.io/kubermatic/v2/pkg/version/cni"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
@@ -108,7 +110,7 @@ func NewTemplateData(
 		storagePolicy = cluster.Spec.Cloud.VSphere.StoragePolicy
 	}
 
-	_, csiMigration := cluster.Annotations[kubermaticv1.CSIMigrationNeededAnnotation]
+	csiMigration := metav1.HasAnnotation(cluster.ObjectMeta, kubermaticv1.CSIMigrationNeededAnnotation) || kubermaticv1helper.CCMMigrationCompleted(cluster)
 
 	return &TemplateData{
 		DatacenterName: cluster.Spec.Cloud.DatacenterName,


### PR DESCRIPTION
This is a manual cherry-pick of #11899

/assign WeirdMachine

```release-note
Fix a bug where ccm/csi migrated clusters on vsphere have a partially deployed csi validating webhook.
```