### PR TITLE
vSphere tags finalizer fixes

### DIFF
--- a/pkg/provider/cloud/vsphere/folder.go
+++ b/pkg/provider/cloud/vsphere/folder.go
@@ -51,7 +51,7 @@ func reconcileFolder(ctx context.Context, s *Session, restSession *RESTSession, 
 		cluster.Spec.Cloud.VSphere.Folder = clusterFolder
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to add finalizer %s on vsphere cluster object: %w", tagCleanupFinalizer, err)
+		return nil, fmt.Errorf("failed to add finalizer %s on vsphere cluster object: %w", folderCleanupFinalizer, err)
 	}
 	return cluster, nil
 }

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -80,7 +80,7 @@ func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 	}
 
 	if cluster.Spec.Cloud.VSphere.Tags != nil {
-		cluster, err = reconcileTags(ctx, restSession, cluster)
+		cluster, err = reconcileTags(ctx, restSession, cluster, update)
 		if err != nil {
 			return nil, fmt.Errorf("failed to reconcile cluster tags: %w", err)
 		}

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -35,7 +35,7 @@ const (
 	folderCleanupFinalizer = "kubermatic.k8c.io/cleanup-vsphere-folder"
 	// tagCleanupFinalizer will instruct the deletion of the default category tag.
 	tagCleanupFinalizer = "kubermatic.k8c.io/cleanup-vsphere-tags"
-	// tagCategoryCleanupFinalizer is a legacy finalizer that needs to be removed unconditionally
+	// tagCategoryCleanupFinalizer is a legacy finalizer that needs to be removed unconditionally.
 	tagCategoryCleanupFinalizer = "kubermatic.k8c.io/cleanup-vsphere-tag-category"
 )
 

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -35,6 +35,8 @@ const (
 	folderCleanupFinalizer = "kubermatic.k8c.io/cleanup-vsphere-folder"
 	// tagCleanupFinalizer will instruct the deletion of the default category tag.
 	tagCleanupFinalizer = "kubermatic.k8c.io/cleanup-vsphere-tags"
+	// tagCategoryCleanupFinalizer is a legacy finalizer that needs to be removed unconditionally
+	tagCategoryCleanupFinalizer = "kubermatic.k8c.io/cleanup-vsphere-tag-category"
 )
 
 // VSphere represents the vsphere provider.
@@ -227,6 +229,16 @@ func (v *VSphere) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv
 	if kuberneteshelper.HasFinalizer(cluster, tagCleanupFinalizer) {
 		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 			kuberneteshelper.RemoveFinalizer(cluster, tagCleanupFinalizer)
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// remove orphaned Category finalizer
+	if kuberneteshelper.HasFinalizer(cluster, tagCategoryCleanupFinalizer) {
+		cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+			kuberneteshelper.RemoveFinalizer(cluster, tagCategoryCleanupFinalizer)
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

With the switch from managing only tags instead of categories the finalizer was renamed without taking care of clusters that had the now orphaned finalizer `kubermatic.k8c.io/cleanup-vsphere-tag-category`  set leading to cluster stuck in termination. 

In addition code that formerly set the finalizer `kubermatic.k8c.io/cleanup-vsphere-tag-category` was removed. Part of the code was to attach the finalizer to the cluster, this logic was not moved for tags. Therefore the new finalizer `kubermatic.k8c.io/cleanup-vsphere-tags` is never set on a cluster object.


This PR intends to delete the oprthaned finalizer  `kubermatic.k8c.io/cleanup-vsphere-tag-category`  unconditionally and set the new finalizer `kubermatic.k8c.io/cleanup-vsphere-tags`  on clusters with tags/categories used. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11916

/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
