### PR TITLE
document why we push user-ssh-keys-agent for kind test setup

### DIFF
--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -96,6 +96,7 @@ beforeDockerBuild=$(nowms)
   make build
   IMAGE_NAME="quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
+  # we use docker push here as the ssh-agent works independently of the kind cluster and therefore needs to be available publicly
   time retry 5 docker push "${IMAGE_NAME}"
 )
 (

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -96,7 +96,7 @@ beforeDockerBuild=$(nowms)
   make build
   IMAGE_NAME="quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  # we use docker push here as the ssh-agent works independently of the kind cluster and therefore needs to be available publicly
+  # we use docker push here as the agent is pulled by the worker nodes and therefore needs to be available on quay
   time retry 5 docker push "${IMAGE_NAME}"
 )
 (

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -96,7 +96,7 @@ beforeDockerBuild=$(nowms)
   make build
   IMAGE_NAME="quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
+  time retry 5 docker push "${IMAGE_NAME}"
 )
 (
   echodate "Building etcd-launcher image"

--- a/hack/ci/setup-kubermatic-in-kind.sh
+++ b/hack/ci/setup-kubermatic-in-kind.sh
@@ -96,7 +96,7 @@ beforeDockerBuild=$(nowms)
   make build
   IMAGE_NAME="quay.io/kubermatic/user-ssh-keys-agent:$KUBERMATIC_VERSION"
   time retry 5 docker build -t "${IMAGE_NAME}" .
-  time retry 5 docker push "${IMAGE_NAME}"
+  time retry 5 kind load docker-image "$IMAGE_NAME" --name "$KIND_CLUSTER_NAME"
 )
 (
   echodate "Building etcd-launcher image"


### PR DESCRIPTION
**What this PR does / why we need it**:

This should clarify why the image needs to be pushed instead of directly loaded into kind

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
→
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
