### PR TITLE
Upgrade Anexia CCM to v1.5.2

### DIFF
--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 presubmits:
-  - name: pre-kubermatic-e2e-anexia-flatcar-1.26
+  - name: pre-kubermatic-e2e-anexia-flatcar-1.25
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     always_run: false
@@ -35,7 +35,7 @@ presubmits:
             - name: KUBERMATIC_EDITION
               value: ee
             - name: RELEASES_TO_TEST
-              value: "1.26"
+              value: "1.25"
             - name: PROVIDER
               value: "anexia"
             - name: DISTRIBUTIONS

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -56,7 +56,7 @@ func anexiaDeploymentReconciler(data *resources.TemplateData) reconciling.NamedD
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: registry.Must(data.RewriteImage(resources.RegistryAnexia + "/anexia/anx-cloud-controller-manager:1.5.1")),
+					Image: registry.Must(data.RewriteImage(resources.RegistryAnexia + "/anexia/anx-cloud-controller-manager:1.5.2")),
 					Command: []string{
 						"/app/ccm",
 						"--cloud-provider=anexia",


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade Anexia CCM to v1.5.2.


**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:
- Release notes: https://github.com/anexia-it/k8s-anexia-ccm/releases/tag/v1.5.2
- Please backport to v2.21 & v2.20 after this PR was accepted.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Anexia CCM (cloud-controller-manager) to version 1.5.2
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
