### PR TITLE
applications: limits the number of retries only if deployOptions.Helm.atomic=true

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -266,10 +266,12 @@ func (appInstallation *ApplicationInstallation) SetCondition(conditionType Appli
 }
 
 // SetReadyCondition sets the ReadyCondition and appInstallation.Status.Failures counter according to the installError.
-func (appInstallation *ApplicationInstallation) SetReadyCondition(installErr error) {
+func (appInstallation *ApplicationInstallation) SetReadyCondition(installErr error, hasLimitedRetries bool) {
 	if installErr != nil {
 		appInstallation.SetCondition(Ready, corev1.ConditionFalse, "InstallationFailed", installErr.Error())
-		appInstallation.Status.Failures++
+		if hasLimitedRetries { // increment only if limited retries to avoid overflow otherwise
+			appInstallation.Status.Failures++
+		}
 	} else {
 		appInstallation.SetCondition(Ready, corev1.ConditionTrue, "InstallationSuccessful", "application successfully installed or upgraded")
 		appInstallation.Status.Failures = 0


### PR DESCRIPTION
**What this PR does / why we need it**:
If the worker node takes time to join the cluster (eg due to quota), we may reach the max number of retries before the CNI application may be stuck in status failed even, if the workload is finally running (ref #11929)

To avoid this behavior, we limit the number of retries only is `atomic`is true. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11856


Manual tests:
Deploy apache application to force failure during installation, the image repository is overridden to a non-exisinting
repository.

| Action On applicationInstallation | atomic | wait  | repo    | test result | status.failure                                        | status.Ready |
|-----------------------------------|--------|-------|---------|-------------|-------------------------------------------------------|--------------|
| create                            | false  | false | invalid | OK          | 0   (unlimited re                                     | OK           |
| edit                              | true   | true  | invalid | OK          | increased until it reaches max retries                | KO           |
| edit to add useless values        | true   | true  | invalid | OK          | reset and then increased until it reaches max retries | KO           |
| edit                              | true   | true  | valid   | OK          | reset to 0                                            | OK           |
| edit                              | false  | true  | invalid | OK          | 0  (unlimited retries)                                | KO           |




I also test that:

- if applicationInstallation has no deployOption, then one from applicationDefintion is taken.
- created a cluster with no worker nodes (machine deployment nodes scaled to 0) and atomic=false , wait=true should. the installation  retry indefinitely, and once a worker node is added status is resolved to OK

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
applications: limits the number of retries only if deployOptions.Helm.atomic=true 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/kubermatic/pull/11927
```
