### PR TITLE
Use non-atomic Helm deployment for CNI

### DIFF
--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -331,7 +331,9 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 			}
 			app.Spec.DeployOptions = &appskubermaticv1.DeployOptions{
 				Helm: &appskubermaticv1.HelmDeployOptions{
-					Atomic: true,
+					// Use non-atomic deployment, as atomic (with fixed retries count) potentially brings more issues
+					// than benefit for CNI, e.g. during the cluster bring-up when the worker nodes join cluster too late.
+					Atomic: false,
 					Wait:   true,
 					Timeout: metav1.Duration{
 						Duration: 10 * time.Minute, // use longer timeout, as it may take some time for the CNI to be fully up


### PR DESCRIPTION
**What this PR does / why we need it**:
As it turned out during testing, is seems that non-atomic Helm deployment would be better for CNI deployment: atomic deployment has fixed retry count, which may lead to CNI not installed, e.g. if nodes join the cluster too late.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
