### PR TITLE
Include tunneling agent IP in apiserver's TLS cert SAN

### DIFF
--- a/pkg/resources/apiserver/tls-serving-certificate.go
+++ b/pkg/resources/apiserver/tls-serving-certificate.go
@@ -34,6 +34,7 @@ import (
 type tlsServingCertReconcilerData interface {
 	Cluster() *kubermaticv1.Cluster
 	GetRootCA() (*triple.KeyPair, error)
+	GetTunnelingAgentIP() string
 }
 
 // TLSServingCertificateReconciler returns a function to create/update the secret with the apiserver tls certificate used to serve https.
@@ -87,6 +88,8 @@ func TLSServingCertificateReconciler(data tlsServingCertReconcilerData) reconcil
 					return nil, errors.New("no external IP")
 				}
 				altNames.IPs = append(altNames.IPs, externalIPParsed)
+			} else {
+				altNames.IPs = append(altNames.IPs, net.ParseIP(data.GetTunnelingAgentIP()))
 			}
 
 			if b, exists := se.Data[resources.ApiserverTLSCertSecretKey]; exists {


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that some apps are attempting to access the `kubernetes` service endpoint in the cluster not via its DNS name, nor via it's `ClusterIP`, but via the actual service endpoint IP. For this to work properly, we were missing the tunneling agent's IP in the apiserver's TLS cert SANs.

Older KKP releases are also affected, those will need a manual backport of this fix.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11930 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Include tunneling agent IP in apiserver's TLS cert SANs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
