### PR TITLE
Fix cluster access issue while cluster is upgrading

### DIFF
--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -445,7 +445,7 @@ func (r *reconciler) importAction(
 			log.Errorw("failed to import kubeone cluster", zap.Error(err))
 			return err
 		}
-	} else if externalCluster.Spec.KubeconfigReference != nil {
+	} else if externalCluster.Spec.KubeconfigReference != nil && externalCluster.Status.Condition.Phase == kubermaticv1.ExternalClusterPhaseRunning {
 		// checking if cluster is accessible using client
 		clusterClient, err := kuberneteshelper.GetClusterClient(ctx, externalCluster, r.Client)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix cluster access issue while the cluster is upgrading by fetching status only when cluster is in Running state

**Which issue(s) this PR fixes**:
This specific check helps to ensure in the imported kubeone cluster lifecycle that `Running` status does not just depends on the condition `if kubeconfigref is present in the external kubeone cluster custom resource` but also checking if the cluster is actually accessible using the client generated from stored kubeconfig.

This condition should not be checked when cluster is in upgrade state as it can cause issues like this:
`Error: Get "https://34.107.46.244:6443/version": dial tcp 34.107.46.244:6443: connect: connection refused`

Note: The state is handled for upgrading clusters here: https://github.com/kubermatic/kubermatic/blob/main/pkg/controller/master-controller-manager/kubeone/controller.go#L621

<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
