### PR TITLE
Add upgrade incomptability for OpenStack with in-tree provider

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -549,6 +549,14 @@ spec:
         operation: UPGRADE
         provider: aws
         version: < 1.24.0
+      - condition: inTreeProvider
+        operation: CREATE
+        provider: openstack
+        version: '> 1.26.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: openstack
+        version: '> 1.26.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -552,11 +552,11 @@ spec:
       - condition: inTreeProvider
         operation: CREATE
         provider: openstack
-        version: '> 1.26.0'
+        version: '>= 1.26.0'
       - condition: inTreeProvider
         operation: UPGRADE
         provider: openstack
-        version: '> 1.26.0'
+        version: '>= 1.26.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -549,6 +549,14 @@ spec:
         operation: UPGRADE
         provider: aws
         version: < 1.24.0
+      - condition: inTreeProvider
+        operation: CREATE
+        provider: openstack
+        version: '> 1.26.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: openstack
+        version: '> 1.26.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -552,11 +552,11 @@ spec:
       - condition: inTreeProvider
         operation: CREATE
         provider: openstack
-        version: '> 1.26.0'
+        version: '>= 1.26.0'
       - condition: inTreeProvider
         operation: UPGRADE
         provider: openstack
-        version: '> 1.26.0'
+        version: '>= 1.26.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// +kubebuilder:validation:Enum=always;externalCloudProvider
+// +kubebuilder:validation:Enum=always;externalCloudProvider;inTreeProvider
 
 // ConditionType is the type defining the cluster or datacenter condition that must be met to block a specific version.
 type ConditionType string

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -33,7 +33,7 @@ const (
 	AlwaysCondition ConditionType = "always"
 	// ExternalCloudProviderCondition is an incompatibility condition that represents the usage of the external Cloud Provider.
 	ExternalCloudProviderCondition ConditionType = ClusterFeatureExternalCloudProvider
-	// InTreeCloudProviderCondition is an incompatibility condition that represents the usage of the external Cloud Provider.
+	// InTreeCloudProviderCondition is an incompatibility condition that represents the usage of the in-tree Cloud Provider.
 	InTreeCloudProviderCondition ConditionType = "inTreeProvider"
 )
 

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -33,6 +33,8 @@ const (
 	AlwaysCondition ConditionType = "always"
 	// ExternalCloudProviderCondition is an incompatibility condition that represents the usage of the external Cloud Provider.
 	ExternalCloudProviderCondition ConditionType = ClusterFeatureExternalCloudProvider
+	// InTreeCloudProviderCondition is an incompatibility condition that represents the usage of the external Cloud Provider.
+	InTreeCloudProviderCondition ConditionType = "inTreeProvider"
 )
 
 // +kubebuilder:validation:Enum=CREATE;UPGRADE;SUPPORT

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -493,6 +493,8 @@ func getNextApiServerVersion(ctx context.Context, config *kubermaticv1.Kubermati
 	var updateConditions []kubermaticv1.ConditionType
 	if cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 		updateConditions = append(updateConditions, kubermaticv1.ExternalCloudProviderCondition)
+	} else {
+		updateConditions = append(updateConditions, kubermaticv1.InTreeCloudProviderCondition)
 	}
 
 	updateManager := version.NewFromConfiguration(config)

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -520,6 +520,7 @@ spec:
                             enum:
                               - always
                               - externalCloudProvider
+                              - inTreeProvider
                             type: string
                           operation:
                             description: Operation is the operation triggering the compatibility check (CREATE or UPDATE)

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -322,19 +322,13 @@ var (
 			// This can be removed once we drop support for Kubernetes 1.26 (note: not for 1.25, because
 			// at that point we still might have clusters that needs to be upgraded from 1.25 to 1.26).
 			{
-				Provider:  kubermaticv1.OpenstackCloudProvider,
-				Version:   "> 1.26.0",
-				Condition: kubermaticv1.InTreeCloudProviderCondition,
-				Operation: kubermaticv1.SupportOperation,
-			},
-			{
-				Provider:  kubermaticv1.OpenstackCloudProvider,
+				Provider:  string(kubermaticv1.OpenstackCloudProvider),
 				Version:   "> 1.26.0",
 				Condition: kubermaticv1.InTreeCloudProviderCondition,
 				Operation: kubermaticv1.CreateOperation,
 			},
 			{
-				Provider:  kubermaticv1.OpenstackCloudProvider,
+				Provider:  string(kubermaticv1.OpenstackCloudProvider),
 				Version:   "> 1.26.0",
 				Condition: kubermaticv1.InTreeCloudProviderCondition,
 				Operation: kubermaticv1.UpdateOperation,

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -318,6 +318,27 @@ var (
 				Condition: kubermaticv1.ExternalCloudProviderCondition,
 				Operation: kubermaticv1.UpdateOperation,
 			},
+			// In-tree cloud provider for OpenStack is not supported starting with Kubernetes 1.26.
+			// This can be removed once we drop support for Kubernetes 1.26 (note: not for 1.25, because
+			// at that point we still might have clusters that needs to be upgraded from 1.25 to 1.26).
+			{
+				Provider:  kubermaticv1.OpenstackCloudProvider,
+				Version:   "> 1.26.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.SupportOperation,
+			},
+			{
+				Provider:  kubermaticv1.OpenstackCloudProvider,
+				Version:   "> 1.26.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.CreateOperation,
+			},
+			{
+				Provider:  kubermaticv1.OpenstackCloudProvider,
+				Version:   "> 1.26.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.UpdateOperation,
+			},
 		},
 	}
 

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -323,13 +323,13 @@ var (
 			// at that point we still might have clusters that needs to be upgraded from 1.25 to 1.26).
 			{
 				Provider:  string(kubermaticv1.OpenstackCloudProvider),
-				Version:   "> 1.26.0",
+				Version:   ">= 1.26.0",
 				Condition: kubermaticv1.InTreeCloudProviderCondition,
 				Operation: kubermaticv1.CreateOperation,
 			},
 			{
 				Provider:  string(kubermaticv1.OpenstackCloudProvider),
-				Version:   "> 1.26.0",
+				Version:   ">= 1.26.0",
 				Condition: kubermaticv1.InTreeCloudProviderCondition,
 				Operation: kubermaticv1.UpdateOperation,
 			},

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -688,7 +688,10 @@ func GetCSIMigrationFeatureGates(cluster *kubermaticv1.Cluster, version *semverl
 		if cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 			featureFlags = append(featureFlags, "CSIMigration=true", "ExpandCSIVolumes=true")
 		}
-		if cluster.Spec.Cloud.Openstack != nil {
+
+		// This flag is GA since 1.24 and enabled by default; it seems to be gone
+		// from Kubernetes 1.26, so we don't need to set it anymore.
+		if cluster.Spec.Cloud.Openstack != nil && lt25.Check(version) {
 			featureFlags = append(featureFlags, "CSIMigrationOpenStack=true")
 		}
 		if cluster.Spec.Cloud.VSphere != nil {

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -369,6 +369,70 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "Check with InTreeCloudProvider Incompatibility for OpenStack 1.26",
+			provider:    kubermaticv1.OpenstackCloudProvider,
+			fromVersion: "1.25.0",
+			conditions:  []kubermaticv1.ConditionType{kubermaticv1.InTreeCloudProviderCondition},
+			manager: New([]*Version{
+				{
+					Version: semverlib.MustParse("1.25.0"),
+					Default: true,
+				},
+				{
+					Version: semverlib.MustParse("1.26.0"),
+					Default: false,
+				},
+			}, []*Update{
+				{
+					From:      "1.25.*",
+					To:        "1.26.*",
+					Automatic: true,
+				},
+			}, []*ProviderIncompatibility{
+				{
+					Provider:  kubermaticv1.OpenstackCloudProvider,
+					Version:   "1.26.0",
+					Operation: kubermaticv1.UpdateOperation,
+					Condition: kubermaticv1.InTreeCloudProviderCondition,
+				},
+			}),
+			expectedVersions: []*Version{},
+		},
+		{
+			name:        "Check with InTreeCloudProvider Incompatibility for OpenStack 1.26 with external CCM",
+			provider:    kubermaticv1.OpenstackCloudProvider,
+			fromVersion: "1.25.0",
+			conditions:  []kubermaticv1.ConditionType{kubermaticv1.ExternalCloudProviderCondition},
+			manager: New([]*Version{
+				{
+					Version: semverlib.MustParse("1.25.0"),
+					Default: true,
+				},
+				{
+					Version: semverlib.MustParse("1.26.0"),
+					Default: false,
+				},
+			}, []*Update{
+				{
+					From:      "1.25.*",
+					To:        "1.26.*",
+					Automatic: true,
+				},
+			}, []*ProviderIncompatibility{
+				{
+					Provider:  kubermaticv1.OpenstackCloudProvider,
+					Version:   "1.26.0",
+					Operation: kubermaticv1.UpdateOperation,
+					Condition: kubermaticv1.InTreeCloudProviderCondition,
+				},
+			}),
+			expectedVersions: []*Version{
+				{
+					Version: semverlib.MustParse("1.26.0"),
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds an incompatibility for OpenStack user clusters with Kubernetes 1.26, since the in-tree provider was removed. It also drops the `CSIMigrationOpenStack` flag since it is GA since 1.24 and doesn't seem to exist in 1.26 anymore (even though I couldn't find it mentioned in release notes).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11940

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
User clusters on OpenStack need to be migrated to external CCM/CSI before upgrading to Kubernetes 1.26
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1393
```
