### PR TITLE
[EE] fix worker-name handling in resource-quota controller

### DIFF
--- a/pkg/ee/resource-quota/seed-controller/controller_test.go
+++ b/pkg/ee/resource-quota/seed-controller/controller_test.go
@@ -31,7 +31,6 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
-	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,11 +47,6 @@ const projectId = "project1"
 func TestReconcile(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = kubermaticv1.AddToScheme(scheme)
-
-	workerSelector, err := workerlabel.LabelSelector("")
-	if err != nil {
-		t.Fatalf("failed to build worker-name selector: %v", err)
-	}
 
 	testCases := []struct {
 		name          string
@@ -81,10 +75,9 @@ func TestReconcile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 			r := &reconciler{
-				log:                     kubermaticlog.Logger,
-				recorder:                &record.FakeRecorder{},
-				workerNameLabelSelector: workerSelector,
-				seedClient:              tc.seedClient,
+				log:        kubermaticlog.Logger,
+				recorder:   &record.FakeRecorder{},
+				seedClient: tc.seedClient,
 			}
 
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: tc.requestName}}
@@ -111,8 +104,8 @@ func genResourceQuota(name string) *kubermaticv1.ResourceQuota {
 	rq.Name = name
 	rq.Spec = kubermaticv1.ResourceQuotaSpec{
 		Subject: kubermaticv1.Subject{
-			Name: "project1",
-			Kind: "project",
+			Name: projectId,
+			Kind: kubermaticv1.ProjectSubjectKind,
 		},
 	}
 

--- a/pkg/ee/resource-quota/seed-controller/doc.go
+++ b/pkg/ee/resource-quota/seed-controller/doc.go
@@ -21,7 +21,14 @@
 */
 
 /*
-Package seedcontroller is responsible for ensuring the calculation of the local resource usage for the resource quotas by listing
-all clusters of the resource quota project and adding up their resource usage.
+Package seedcontroller is responsible for ensuring the calculation of the local
+resource usage for the resource quotas by listing all clusters of the resource
+quota project and adding up their resource usage.
+
+If a worker-name is given, this controller currently is mostly disabled, as
+Resource Quotas are attached to projects and projects contain multiple clusters,
+only some of which might have the given worker-name. Therefore this controller
+would only reconcile non-project Resource Quotas, which are not implemented
+right now.
 */
 package seedcontroller


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes some confusion regarding the worker-name handling for resource quotas (RQs).

* If a `-worker-name` flag is given by the developer, their intent is to restrict the controllers to only reconcile _their_ clusters (i.e. clusters with a matching worker-name label).
* Resource Quotas are currently built to support projects only.
* Each KKP project can contain multiple clusters, some of which might have a worker-name label, some don't.

The old controller code however lead to a race condition: A worker-named controller will still reconcile _all_ RQs, but it will only consider clusters with a matching worker-name label. Yet at the same time a non-worker-named controller would look at _all_ clusters. And so both would come to different conclusions regarding the current resource usage and then they both fight in the RQ's status and overwrite each other's results.

The worker-name concept doesn't work [well] for things that span multiple clusters at the same time. The label itself was also never meant to subdivide status information, but it was meant to allow multiple developers sharing the same dev environment and working on different controllers independently.

To fix this, the behaviour of the controller was changed as follows:

* If no worker-name is given, it will function like before. Meaning it will reconcile _all_ RQs and will every time look at _all_ clusters (even those with a worker-name label!).
* If a worker-name is given, the controller will only react to changes on clusters with that label. Importantly when looking for RQs to update, only _non-project_ RQ's are considered. Those are not implemented (yet?) and so effectively this means supplying a worker-name to the controller will make it not do anything anymore.

As this bug only affects worker-names, this should not be an issue in any production setup and so this is a non-critical bug.

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
I chose to "pre-hint at" the spots where further distinction would be needed in this PR (with for example the one commented out piece of an `if` statement). Just so that if and when we do cluster-based RQ's, it would be easy to figure out what to change in this controller. However I'd be open to remove the hints.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
[EE] Fix worker-name handing in resource-quota updates.
```

**Documentation**:
```documentation
NONE
```
