### PR TITLE
fix wrong labels in cluster/project metrics

### DIFF
--- a/pkg/collectors/cluster_test.go
+++ b/pkg/collectors/cluster_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func init() {
+	utilruntime.Must(kubermaticv1.AddToScheme(scheme.Scheme))
+}
+
+func TestClusterLabelsMetric(t *testing.T) {
+	kubermaticFakeClient := fake.
+		NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithObjects(&kubermaticv1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "cluster1",
+				Labels: map[string]string{
+					"UPPERCASE":            "123",
+					"is-credential-preset": "true",
+					"project-id":           "my-project",
+				},
+			},
+		}).
+		Build()
+
+	registry := prometheus.NewRegistry()
+	if err := registry.Register(newClusterCollector(kubermaticFakeClient)); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `
+# HELP kubermatic_cluster_labels Kubernetes labels on Cluster resources
+# TYPE kubermatic_cluster_labels gauge
+kubermatic_cluster_labels{label_is_credential_preset="true",label_project_id="my-project",label_uppercase="123",name="cluster1"} 0
+`
+
+	if err := testutil.CollectAndCompare(registry, strings.NewReader(expected), "kubermatic_cluster_labels"); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/collectors/project.go
+++ b/pkg/collectors/project.go
@@ -73,10 +73,12 @@ func (cc ProjectCollector) Collect(ch chan<- prometheus.Metric) {
 		return
 	}
 
-	kubernetesLabels := sets.New[string]()
+	kubernetesLabelSet := sets.New[string]()
 	for _, project := range projects.Items {
-		kubernetesLabels = kubernetesLabels.Union(sets.KeySet(project.Labels))
+		kubernetesLabelSet = kubernetesLabelSet.Union(sets.KeySet(project.Labels))
 	}
+
+	kubernetesLabels := caseInsensitiveSort(sets.List(kubernetesLabelSet))
 
 	prometheusLabels := convertToPrometheusLabels(kubernetesLabels)
 	labelsGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -89,7 +91,7 @@ func (cc ProjectCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 }
 
-func (cc *ProjectCollector) collectProject(ch chan<- prometheus.Metric, p *kubermaticv1.Project, kubernetesLabels sets.Set[string], labelsGaugeVec *prometheus.GaugeVec) {
+func (cc *ProjectCollector) collectProject(ch chan<- prometheus.Metric, p *kubermaticv1.Project, kubernetesLabels []string, labelsGaugeVec *prometheus.GaugeVec) {
 	owner := ""
 	for _, ref := range p.OwnerReferences {
 		if ref.APIVersion == kubermaticv1.SchemeGroupVersion.String() && ref.Kind == "User" {
@@ -112,7 +114,7 @@ func (cc *ProjectCollector) collectProject(ch chan<- prometheus.Metric, p *kuber
 	// taking special care of label key conflicts
 	projectLabels := []string{p.Name}
 	usedLabels := sets.New[string]()
-	for _, key := range sets.List(kubernetesLabels) {
+	for _, key := range kubernetesLabels {
 		prometheusLabel := convertToPrometheusLabel(key)
 		if !usedLabels.Has(prometheusLabel) {
 			projectLabels = append(projectLabels, p.Labels[key])

--- a/pkg/collectors/util.go
+++ b/pkg/collectors/util.go
@@ -18,14 +18,15 @@ package collectors
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func convertToPrometheusLabels(labelKeys sets.Set[string]) []string {
+func convertToPrometheusLabels(labelKeys []string) []string {
 	promLabels := sets.New[string]()
-	for _, key := range sets.List(labelKeys) {
+	for _, key := range labelKeys {
 		// due to conversion, different labels might result in the same Prometheus label
 		// (e.g. "foo-bar" and "foo/bar" will both be normalised to "foo_bar"), hence we
 		// use a set.
@@ -39,4 +40,13 @@ var validMetricLabel = regexp.MustCompile(`[^a-z0-9_]`)
 
 func convertToPrometheusLabel(label string) string {
 	return "label_" + validMetricLabel.ReplaceAllString(strings.ToLower(label), "_")
+}
+
+// caseInsensitiveSort sorts Kubernetes labels case-insensitive (!), as the Pprometheus
+// labels will later be lowercase and that could influence their sorting order.
+func caseInsensitiveSort(values []string) []string {
+	sort.Slice(values, func(i, j int) bool {
+		return strings.ToLower(values[i]) < strings.ToLower(values[j])
+	})
+	return values
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Uppercase Kubernetes labels got the code confused and the implicit sorting we've done would not work anymore. To fix this this PR adds an additional, explicit case-insensitive sorting, plus a unit test to ensure this doesn't happen again.

**Which issue(s) this PR fixes**:
Fixes #11941

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix wrong labels in cluster/project metrics when uppercase labels were used.
```

**Documentation**:
```documentation
NONE
```
