### PR TITLE
Add share cluster flag to kubermatic settings

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -311,10 +311,7 @@ spec:
   # UI configures the dashboard.
   ui:
     # Config sets flags for various dashboard features.
-    config: |-
-      {
-        "share_kubeconfig": false
-      }
+    config: ""
     # DockerRepository is the repository containing the Kubermatic dashboard image.
     dockerRepository: quay.io/kubermatic/dashboard
     # Replicas sets the number of pod replicas for the UI deployment.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -311,10 +311,7 @@ spec:
   # UI configures the dashboard.
   ui:
     # Config sets flags for various dashboard features.
-    config: |-
-      {
-        "share_kubeconfig": false
-      }
+    config: ""
     # DockerRepository is the repository containing the Kubermatic dashboard image.
     dockerRepository: quay.io/kubermatic/dashboard-ee
     # Replicas sets the number of pod replicas for the UI deployment.

--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -56,6 +56,11 @@ type SettingSpec struct {
 	// EnableWebTerminal enables the Web Terminal feature for the user clusters.
 	EnableWebTerminal bool `json:"enableWebTerminal,omitempty"`
 
+	// +kubebuilder:default=true
+
+	// EnableShareCluster enables the Share Cluster feature for the user clusters.
+	EnableShareCluster bool `json:"enableShareCluster,omitempty"`
+
 	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig"` //nolint:tagliatelle
 	// UserProjectsLimit is the maximum number of projects a user can create.
 	UserProjectsLimit           int64 `json:"userProjectsLimit"`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -112,6 +112,10 @@ spec:
                   type: boolean
                 enableOIDCKubeconfig:
                   type: boolean
+                enableShareCluster:
+                  default: true
+                  description: EnableShareCluster enables the Share Cluster feature for the user clusters.
+                  type: boolean
                 enableWebTerminal:
                   default: false
                   description: EnableWebTerminal enables the Web Terminal feature for the user clusters.

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -489,11 +489,6 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 		logger.Debugw("Defaulting field", "field", "ingress.certificateIssuer.kind", "value", configCopy.Spec.Ingress.CertificateIssuer.Kind)
 	}
 
-	if configCopy.Spec.UI.Config == "" {
-		configCopy.Spec.UI.Config = strings.TrimSpace(DefaultUIConfig)
-		logger.Debugw("Defaulting field", "field", "ui.config", "value", configCopy.Spec.UI.Config)
-	}
-
 	if configCopy.Spec.UI.Replicas == nil {
 		configCopy.Spec.UI.Replicas = pointer.Int32(DefaultUIReplicas)
 		logger.Debugw("Defaulting field", "field", "ui.replicas", "value", *configCopy.Spec.UI.Replicas)
@@ -878,11 +873,6 @@ env:
       name: kubermatic-s3-credentials
       key: SECRET_ACCESS_KEY
 `
-
-const DefaultUIConfig = `
-{
-  "share_kubeconfig": false
-}`
 
 const DefaultKubernetesAddons = `
 apiVersion: v1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a simple boolean flag to Kubermatic Settings CRD to allow to handle share cluster config from UI. This will allow to control [share cluster kubeconfig button](https://docs.kubermatic.com/kubermatic/main/tutorials-howtos/oidc-provider-configuration/share-clusters-via-delegated-oidc-authentication/) to be handled from Admin default settings page instead of providing defaulting from [UI](https://github.com/kubermatic/dashboard/pull/5764/files#diff-d82c3bf00b3add2232bb68e05398a1f829a6f9e82028938d736a6d39bf5cf3c7L6)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11934

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
 
```release-note
Introduce EnableShareCluster flag in Kubermatic Settings to toggle the share cluster feature for the dashboard.
[ACTION REQUIRED] `share_kubeconfig` field in the UI configuration for KubermaticConfiguration has been replaced with `EnableShareCluster` flag in KubermaticSettings. `share_kubeconfig` is no-op and will be ignored by the dashboard.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->

```documentation
TBD
```
