### PR TITLE
Add vSphere incompatibility for the in-tree provider with Kubernetes 1.25 or higher

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -557,6 +557,14 @@ spec:
         operation: UPGRADE
         provider: openstack
         version: '>= 1.26.0'
+      - condition: inTreeProvider
+        operation: CREATE
+        provider: vsphere
+        version: '>= 1.25.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: vsphere
+        version: '>= 1.25.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -557,6 +557,14 @@ spec:
         operation: UPGRADE
         provider: openstack
         version: '>= 1.26.0'
+      - condition: inTreeProvider
+        operation: CREATE
+        provider: vsphere
+        version: '>= 1.25.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: vsphere
+        version: '>= 1.25.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -333,6 +333,22 @@ var (
 				Condition: kubermaticv1.InTreeCloudProviderCondition,
 				Operation: kubermaticv1.UpdateOperation,
 			},
+			// In-tree cloud provider for vSphere is not supported by KKP 2.22.0 since CSI
+			// migration is on by default for Kubernetes 1.25. We want to make sure that
+			// migrations happen before upgrading to that version, so we are enforcing it.
+			// This can be removed once we drop support for Kubernetes 1.25.
+			{
+				Provider:  string(kubermaticv1.VSphereCloudProvider),
+				Version:   ">= 1.25.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.CreateOperation,
+			},
+			{
+				Provider:  string(kubermaticv1.VSphereCloudProvider),
+				Version:   ">= 1.25.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.UpdateOperation,
+			},
 		},
 	}
 

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -433,6 +433,70 @@ func TestProviderIncompatibilitiesUpdate(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "Check with InTreeCloudProvider Incompatibility for vSphere 1.25 with external CCM",
+			provider:    kubermaticv1.VSphereCloudProvider,
+			fromVersion: "1.24.0",
+			conditions:  []kubermaticv1.ConditionType{kubermaticv1.ExternalCloudProviderCondition},
+			manager: New([]*Version{
+				{
+					Version: semverlib.MustParse("1.24.0"),
+					Default: true,
+				},
+				{
+					Version: semverlib.MustParse("1.25.0"),
+					Default: false,
+				},
+			}, []*Update{
+				{
+					From:      "1.24.*",
+					To:        "1.25.*",
+					Automatic: true,
+				},
+			}, []*ProviderIncompatibility{
+				{
+					Provider:  kubermaticv1.VSphereCloudProvider,
+					Version:   "1.25.0",
+					Operation: kubermaticv1.UpdateOperation,
+					Condition: kubermaticv1.InTreeCloudProviderCondition,
+				},
+			}),
+			expectedVersions: []*Version{
+				{
+					Version: semverlib.MustParse("1.25.0"),
+				},
+			},
+		},
+		{
+			name:        "Check with InTreeCloudProvider Incompatibility for vSphere 1.25",
+			provider:    kubermaticv1.VSphereCloudProvider,
+			fromVersion: "1.24.0",
+			conditions:  []kubermaticv1.ConditionType{kubermaticv1.InTreeCloudProviderCondition},
+			manager: New([]*Version{
+				{
+					Version: semverlib.MustParse("1.24.0"),
+					Default: true,
+				},
+				{
+					Version: semverlib.MustParse("1.25.0"),
+					Default: false,
+				},
+			}, []*Update{
+				{
+					From:      "1.24.*",
+					To:        "1.25.*",
+					Automatic: true,
+				},
+			}, []*ProviderIncompatibility{
+				{
+					Provider:  kubermaticv1.VSphereCloudProvider,
+					Version:   "1.25.0",
+					Operation: kubermaticv1.UpdateOperation,
+					Condition: kubermaticv1.InTreeCloudProviderCondition,
+				},
+			}),
+			expectedVersions: []*Version{},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

We discovered that Kubernetes 1.25 turns on `CSIMigrationVsphere` by default (also see https://github.com/kubermatic/kubeone/pull/2697). We are blocking upgrades of user clusters with the in-tree provider to enforce a CSI/CCM migration done on Kubernetes 1.24 before upgrading. We are offering the migration for some time now afaik, so hopefully there aren't too many in tree clusters out there anymore.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
User clusters on vSphere need to be migrated to external CCM/CSI before upgrading to Kubernetes 1.25
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1393
```
