### PR TITLE
[release/v2.20] Include tunneling agent IP in apiserver's TLS cert SAN

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -209,6 +209,7 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		WithEtcdDiskSize(r.etcdDiskSize).
 		WithUserClusterMLAEnabled(r.userClusterMLAEnabled).
 		WithKonnectivityEnabled(konnectivityEnabled).
+		WithTunnelingAgentIP(r.tunnelingAgentIP).
 		WithCABundle(r.caBundle).
 		WithOIDCIssuerURL(r.oidcIssuerURL).
 		WithOIDCIssuerClientID(r.oidcIssuerClientID).

--- a/pkg/resources/apiserver/tls-serving-certificate.go
+++ b/pkg/resources/apiserver/tls-serving-certificate.go
@@ -34,6 +34,7 @@ import (
 type tlsServingCertCreatorData interface {
 	Cluster() *kubermaticv1.Cluster
 	GetRootCA() (*triple.KeyPair, error)
+	GetTunnelingAgentIP() string
 }
 
 // TLSServingCertificateCreator returns a function to create/update the secret with the apiserver tls certificate used to serve https.
@@ -86,6 +87,8 @@ func TLSServingCertificateCreator(data tlsServingCertCreatorData) reconciling.Na
 					return nil, errors.New("no external IP")
 				}
 				altNames.IPs = append(altNames.IPs, externalIPParsed)
+			} else {
+				altNames.IPs = append(altNames.IPs, net.ParseIP(data.GetTunnelingAgentIP()))
 			}
 
 			if b, exists := se.Data[resources.ApiserverTLSCertSecretKey]; exists {

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -84,6 +84,8 @@ type TemplateData struct {
 
 	userClusterMLAEnabled bool
 	isKonnectivityEnabled bool
+
+	tunnelingAgentIP string
 }
 
 type TemplateDataBuilder struct {
@@ -206,6 +208,11 @@ func (td *TemplateDataBuilder) WithMachineControllerImageTag(tag string) *Templa
 
 func (td *TemplateDataBuilder) WithMachineControllerImageRepository(repository string) *TemplateDataBuilder {
 	td.data.machineControllerImageRepository = repository
+	return td
+}
+
+func (td *TemplateDataBuilder) WithTunnelingAgentIP(tunnelingAgentIP string) *TemplateDataBuilder {
+	td.data.tunnelingAgentIP = tunnelingAgentIP
 	return td
 }
 
@@ -432,6 +439,10 @@ func (d *TemplateData) GetKonnectivityServerPort() (int32, error) {
 	}
 
 	return service.Spec.Ports[0].NodePort, nil
+}
+
+func (d *TemplateData) GetTunnelingAgentIP() string {
+	return d.tunnelingAgentIP
 }
 
 // GetMLAGatewayPort returns the NodePort of the external MLA Gateway service.


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a manual backport of https://github.com/kubermatic/kubermatic/pull/11932 (https://github.com/kubermatic/kubermatic/pull/11933)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11930 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Include tunneling agent IP in apiserver's TLS cert SANs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
