### PR TITLE
federate node kube_node_info to metering prometheus

### DIFF
--- a/pkg/ee/metering/prometheus/configmap.go
+++ b/pkg/ee/metering/prometheus/configmap.go
@@ -416,6 +416,54 @@ scrape_configs:
         target_label: endpoint
     scheme: http
   - honor_labels: true
+    job_name: kube_node_info
+    kubernetes_sd_configs:
+      - role: endpoints
+    metrics_path: /federate
+    params:
+      match[]:
+        - '{__name__="kube_node_info"}'
+    relabel_configs:
+      - action: keep
+        regex: user
+        replacement: $1
+        separator: ;
+        source_labels:
+          - __meta_kubernetes_service_label_cluster
+      - action: keep
+        regex: web
+        replacement: $1
+        separator: ;
+        source_labels:
+          - __meta_kubernetes_endpoint_port_name
+      - action: replace
+        regex: (.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+          - __meta_kubernetes_namespace
+        target_label: Namespace
+      - action: replace
+        regex: (.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+          - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: replace
+        regex: (.*)
+        replacement: $1
+        separator: ;
+        source_labels:
+          - __meta_kubernetes_service_name
+        target_label: service
+      - action: replace
+        regex: (.*)
+        replacement: web
+        separator: ;
+        target_label: endpoint
+    scheme: http
+  - honor_labels: true
     job_name: container_cpu_usage_seconds_total
     kubernetes_sd_configs:
       - role: endpoints

--- a/pkg/ee/metering/prometheus/reconcile.go
+++ b/pkg/ee/metering/prometheus/reconcile.go
@@ -44,6 +44,7 @@ const (
 // ReconcilePrometheus reconciles the prometheus instance used as a datasource for metering.
 func ReconcilePrometheus(ctx context.Context, client ctrlruntimeclient.Client, scheme *runtime.Scheme, getRegistry registry.ImageRewriter, seed *kubermaticv1.Seed) error {
 	seedOwner := common.OwnershipModifierFactory(seed, scheme)
+	volumeLabelModifier := common.VolumeRevisionLabelsModifierFactory(ctx, client)
 
 	if err := reconciling.ReconcileServiceAccounts(ctx, []reconciling.NamedServiceAccountReconcilerFactory{
 		prometheusServiceAccount(),
@@ -71,7 +72,7 @@ func ReconcilePrometheus(ctx context.Context, client ctrlruntimeclient.Client, s
 
 	if err := reconciling.ReconcileStatefulSets(ctx, []reconciling.NamedStatefulSetReconcilerFactory{
 		prometheusStatefulSet(getRegistry, seed),
-	}, seed.Namespace, client, common.VolumeRevisionLabelsModifierFactory(ctx, client), seedOwner); err != nil {
+	}, seed.Namespace, client, common.VolumeRevisionLabelsModifierFactory(ctx, client), seedOwner, volumeLabelModifier); err != nil {
 		return fmt.Errorf("failed to reconcile StatefuleSet: %w", err)
 	}
 

--- a/pkg/ee/metering/prometheus/reconcile.go
+++ b/pkg/ee/metering/prometheus/reconcile.go
@@ -72,7 +72,7 @@ func ReconcilePrometheus(ctx context.Context, client ctrlruntimeclient.Client, s
 
 	if err := reconciling.ReconcileStatefulSets(ctx, []reconciling.NamedStatefulSetReconcilerFactory{
 		prometheusStatefulSet(getRegistry, seed),
-	}, seed.Namespace, client, common.VolumeRevisionLabelsModifierFactory(ctx, client), seedOwner, volumeLabelModifier); err != nil {
+	}, seed.Namespace, client, seedOwner, volumeLabelModifier); err != nil {
 		return fmt.Errorf("failed to reconcile StatefuleSet: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new metric to metering Prometheus 


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**

/kind bug
/kind feature


**Special notes for your reviewer**:

Release not in the corresponding metering PR: 
https://github.com/kubermatic/metering/pull/144

```release-note
NONE
```

**Documentation**:

```documentation
NONE 
```
