### PR TITLE
Allow viewer and editors to GET secrets

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -659,6 +659,10 @@ func generateVerbsForNamedResourceInNamespace(groupName, resourceKind, namespace
 			return []string{"get", "update", "delete"}, nil
 		case strings.HasPrefix(groupName, ProjectManagerGroupNamePrefix) && resourceKind == secretV1Kind:
 			return []string{"get", "update", "delete"}, nil
+		case strings.HasPrefix(groupName, EditorGroupNamePrefix) && resourceKind == secretV1Kind:
+			return []string{"get"}, nil
+		case strings.HasPrefix(groupName, ViewerGroupNamePrefix) && resourceKind == secretV1Kind:
+			return []string{"get"}, nil
 		case resourceKind == secretV1Kind:
 			return nil, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**: Allow viewer and editors to GET secrets
This change is required as  a Editor/Viewer project member should be able to get kubeconfig or for an Editor to get credentials to make changes in an externalcluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11960

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This issue was not faced earlier with externalcluster as when the feature was getting implemented, the code was using manager client , not it has been changed to impersonation client

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
