### PR TITLE
only reconcile KKP managed folders in vSphere

### DIFF
--- a/pkg/provider/cloud/vsphere/folder.go
+++ b/pkg/provider/cloud/vsphere/folder.go
@@ -33,10 +33,9 @@ type Folder struct {
 	Path string
 }
 
-// reconcileFolder reconciles a vSphere folder
+// reconcileFolder reconciles a vSphere folder.
 func reconcileFolder(ctx context.Context, s *Session, folderPath string,
 	cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-
 	err := createVMFolder(ctx, s, folderPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the VM folder %q: %w", folderPath, err)

--- a/pkg/provider/cloud/vsphere/folder.go
+++ b/pkg/provider/cloud/vsphere/folder.go
@@ -33,14 +33,13 @@ type Folder struct {
 	Path string
 }
 
-func reconcileFolder(ctx context.Context, s *Session, restSession *RESTSession, rootPath string,
+// reconcileFolder reconciles a vSphere folder
+func reconcileFolder(ctx context.Context, s *Session, folderPath string,
 	cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	// If the user did not specify a folder, we create a own folder for this cluster to improve
-	// the VM management in vCenter
-	clusterFolder := path.Join(rootPath, cluster.Name)
-	err := createVMFolder(ctx, s, clusterFolder)
+
+	err := createVMFolder(ctx, s, folderPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the VM folder %q: %w", clusterFolder, err)
+		return nil, fmt.Errorf("failed to create the VM folder %q: %w", folderPath, err)
 	}
 
 	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
@@ -48,7 +47,7 @@ func reconcileFolder(ctx context.Context, s *Session, restSession *RESTSession, 
 			kuberneteshelper.AddFinalizer(cluster, folderCleanupFinalizer)
 		}
 
-		cluster.Spec.Cloud.VSphere.Folder = clusterFolder
+		cluster.Spec.Cloud.VSphere.Folder = folderPath
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add finalizer %s on vsphere cluster object: %w", folderCleanupFinalizer, err)

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -63,10 +63,10 @@ func NewCloudProvider(dc *kubermaticv1.Datacenter, secretKeyGetter provider.Secr
 var _ provider.ReconcilingCloudProvider = &VSphere{}
 
 func (v *VSphere) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return v.reconcileCluster(ctx, cluster, update, true)
+	return v.reconcileCluster(ctx, cluster, update)
 }
 
-func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, force bool) (*kubermaticv1.Cluster, error) {
+func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	logger := v.log.With("cluster", cluster.Name)
 
 	username, password, err := getCredentialsForCluster(cluster.Spec.Cloud, v.secretKeySelector, v.dc)
@@ -93,7 +93,7 @@ func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 	defer session.Logout(ctx)
 
 	rootPath := getVMRootPath(v.dc)
-	if force || cluster.Spec.Cloud.VSphere.Folder == "" {
+	if cluster.Spec.Cloud.VSphere.Folder == "" {
 		logger.Infow("reconciling vsphere folder", "folder", cluster.Spec.Cloud.VSphere.Folder)
 		session, err := newSession(ctx, v.dc, username, password, v.caBundle)
 		if err != nil {
@@ -112,7 +112,7 @@ func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 
 // InitializeCloudProvider initializes the vsphere cloud provider by setting up vm folders for the cluster.
 func (v *VSphere) InitializeCloudProvider(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
-	return v.reconcileCluster(ctx, cluster, update, false)
+	return v.reconcileCluster(ctx, cluster, update)
 }
 
 // DefaultCloudSpec adds defaults to the cloud spec.


### PR DESCRIPTION
**What this PR does / why we need it**:

Folder creation is enforced in the usual vsphere provider reconcile. This leads to a folder updated although the folder was set earlier to a custom folder. As this updated happens on the same time the finalizer is added KKP throws following error:
```
{"level":"info","time":"2023-02-28T12:43:40.282Z","logger":"kkp-cloud-controller","caller":"cloud/cloud_controller.go:193","msg":"Reconciling cloud provider for cluster","cluster":"idd58fqft5"}
{"level":"info","time":"2023-02-28T12:43:40.810Z","caller":"vsphere/provider.go:97","msg":"reconciling vsphere folder","cluster":"idd58fqft5","folder":"/Hamburg/vm/sig-infra/chief/uc"}
{"level":"error","time":"2023-02-28T12:43:41.269Z","logger":"kkp-cloud-controller","caller":"cloud/cloud_controller.go:125","msg":"Reconciling failed","cluster":"idd58fqft5","error":"failed cloud provider init: failed to reconcile cluster folder: failed to add finalizer [kubermatic.k8c.io/cleanup-vsphere-folder](http://kubermatic.k8c.io/cleanup-vsphere-folder) on vsphere cluster object: admission webhook \"[clusters.kubermatic.io](http://clusters.kubermatic.io/)\" denied the request: spec.cloud: Forbidden: updating vSphere folder is not supported (was /Hamburg/vm/sig-infra/chief/uc, updated to /Hamburg/vm/sig-infra/chief/uc/idd58fqft5)","errorCauses":[{"error":"failed cloud provider init: failed to reconcile cluster folder: failed to add finalizer [kubermatic.k8c.io/cleanup-vsphere-folder](http://kubermatic.k8c.io/cleanup-vsphere-folder) on vsphere cluster object: admission webhook \"[clusters.kubermatic.io](http://clusters.kubermatic.io/)\" denied the request: spec.cloud: Forbidden: updating vSphere folder is not supported (was /Hamburg/vm/sig-infra/chief/uc, updated to /Hamburg/vm/sig-infra/chief/uc/idd58fqft5)"}]}
```

This also prevents creating new clusters in custom folders.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**


/kind bug


**Special notes for your reviewer**:

This PR stop enforcing the KKP folder path and only reconciles folders if they are "KKP Managed".
KKP Managed folder is defined as `clusterFolder := path.Join(rootPath, cluster.Name)`

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where KKP managed vSphere folders are enforced but shouldn't
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
