### PR TITLE
Set proper NodePort range in Cilium config

### DIFF
--- a/addons/cilium/cilium_v1.11.yaml
+++ b/addons/cilium/cilium_v1.11.yaml
@@ -172,6 +172,9 @@ data:
 {{ if eq .Cluster.Network.ProxyMode "ebpf" }}
   kube-proxy-replacement:  "strict"
   kube-proxy-replacement-healthz-bind-address: ""
+  {{ if ne .Cluster.Network.NodePortRange "" }}
+  node-port-range: {{ .Cluster.Network.NodePortRange | replace "-" "," | quote }}
+  {{ end }}
 {{ else }}
   kube-proxy-replacement:  "disabled"
 {{ end }}

--- a/addons/cilium/cilium_v1.12.yaml
+++ b/addons/cilium/cilium_v1.12.yaml
@@ -173,6 +173,9 @@ data:
 {{ if eq .Cluster.Network.ProxyMode "ebpf" }}
   kube-proxy-replacement:  "strict"
   kube-proxy-replacement-healthz-bind-address: ""
+  {{ if ne .Cluster.Network.NodePortRange "" }}
+  node-port-range: {{ .Cluster.Network.NodePortRange | replace "-" "," | quote }}
+  {{ end }}
 {{ else }}
   kube-proxy-replacement:  "disabled"
 {{ end }}

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -99,6 +99,7 @@ type ClusterNetwork struct {
 	NodeCIDRMaskSizeIPv4 int32
 	NodeCIDRMaskSizeIPv6 int32
 	IPAMAllocations      map[string]IPAMAllocation
+	NodePortRange        string
 }
 
 type CNIPlugin struct {

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -162,6 +162,7 @@ func NewTemplateData(
 				NodeCIDRMaskSizeIPv4: resources.GetClusterNodeCIDRMaskSizeIPv4(cluster),
 				NodeCIDRMaskSizeIPv6: resources.GetClusterNodeCIDRMaskSizeIPv6(cluster),
 				IPAMAllocations:      ipamAllocationsData,
+				NodePortRange:        cluster.Spec.ComponentsOverride.Apiserver.NodePortRange,
 			},
 			CNIPlugin: CNIPlugin{
 				Type:    cluster.Spec.CNIPlugin.Type.String(),
@@ -248,6 +249,7 @@ type ClusterNetwork struct {
 	NodeCIDRMaskSizeIPv4 int32
 	NodeCIDRMaskSizeIPv6 int32
 	IPAMAllocations      map[string]IPAMAllocation
+	NodePortRange        string
 }
 
 type IPAMAllocation struct {

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -131,6 +132,13 @@ func GetAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 		values["kubeProxyReplacement"] = "strict"
 		values["k8sServiceHost"] = cluster.Status.Address.ExternalName
 		values["k8sServicePort"] = cluster.Status.Address.Port
+
+		nodePortRange := cluster.Spec.ComponentsOverride.Apiserver.NodePortRange
+		if nodePortRange != "" && nodePortRange != resources.DefaultNodePortRange {
+			values["nodePort"] = map[string]any{
+				"range": strings.ReplaceAll(nodePortRange, "-", ","),
+			}
+		}
 	} else {
 		values["kubeProxyReplacement"] = "disabled"
 	}

--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -42,6 +42,11 @@ var testCluster = &kubermaticv1.Cluster{
 			NodeCIDRMaskSizeIPv4: pointer.Int32(16),
 			ProxyMode:            resources.EBPFProxyMode,
 		},
+		ComponentsOverride: kubermaticv1.ComponentSettings{
+			Apiserver: kubermaticv1.APIServerSettings{
+				NodePortRange: "30000-31777",
+			},
+		},
 	},
 	Status: kubermaticv1.ClusterStatus{
 		Address: kubermaticv1.ClusterAddress{
@@ -62,13 +67,13 @@ func TestGetCiliumAppInstallOverrideValues(t *testing.T) {
 			name:              "default values",
 			cluster:           testCluster,
 			overwriteRegistry: "",
-			expectedValues:    `{"cni":{"exclusive":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","operator":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
+			expectedValues:    `{"cni":{"exclusive":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","nodePort":{"range":"30000,31777"},"operator":{"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
 		},
 		{
 			name:              "default values with overwrite registry",
 			cluster:           testCluster,
 			overwriteRegistry: "myregistry.io",
-			expectedValues:    `{"certgen":{"image":{"repository":"myregistry.io/cilium/certgen","useDigest":false}},"cni":{"exclusive":false},"hubble":{"relay":{"image":{"repository":"myregistry.io/cilium/hubble-relay","useDigest":false}},"ui":{"backend":{"image":{"repository":"myregistry.io/cilium/hubble-ui-backend","useDigest":false}},"frontend":{"image":{"repository":"myregistry.io/cilium/hubble-ui","useDigest":false}}}},"image":{"repository":"myregistry.io/cilium/cilium","useDigest":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","operator":{"image":{"repository":"myregistry.io/cilium/operator","useDigest":false},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
+			expectedValues:    `{"certgen":{"image":{"repository":"myregistry.io/cilium/certgen","useDigest":false}},"cni":{"exclusive":false},"hubble":{"relay":{"image":{"repository":"myregistry.io/cilium/hubble-relay","useDigest":false}},"ui":{"backend":{"image":{"repository":"myregistry.io/cilium/hubble-ui-backend","useDigest":false}},"frontend":{"image":{"repository":"myregistry.io/cilium/hubble-ui","useDigest":false}}}},"image":{"repository":"myregistry.io/cilium/cilium","useDigest":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDR":"192.168.0.0/24"}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","nodePort":{"range":"30000,31777"},"operator":{"image":{"repository":"myregistry.io/cilium/operator","useDigest":false},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}}`,
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:

If non-default NodePort range is used for the cluster, it should be set in the Cilium configuration as well.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11938

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Set proper NodePort range in Cilium config if non-default range is used.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
