### PR TITLE
Disable RHEL in Cilium dualstack e2e test

### DIFF
--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -120,7 +120,7 @@ var (
 		{
 			cloudProvider: kubermaticv1.AWSCloudProvider,
 			operatingSystems: []providerconfig.OperatingSystem{
-				providerconfig.OperatingSystemRHEL,
+				// providerconfig.OperatingSystemRHEL, // TODO: disabled due to "BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer"
 				providerconfig.OperatingSystemUbuntu,
 				providerconfig.OperatingSystemFlatcar,
 				providerconfig.OperatingSystemRockyLinux,


### PR DESCRIPTION
**What this PR does / why we need it**:

Cilium does not run on RHEL version in AWS dues to:
```
failed to start: daemon creation failed: unable to initialize kube-proxy replacement options: BPF host reachable services for UDP needs kernel 4.19.57, 5.1.16, 5.2.0 or newer
```

OS version currently used in AWS: 
```
Red Hat Enterprise Linux 8.1 (Ootpa)                 4.18.0-147.80.1.el8_1.x86_64 
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
