### PR TITLE
update cert-manager to 0.11

### DIFF
--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: cert-manager
 version: v9.9.9-dev
-appVersion: v1.10.1
+appVersion: v1.11.0
 description: A Helm chart for cert-manager
 keywords:
   - kubermatic
@@ -31,4 +31,4 @@ maintainers:
 dependencies:
   - repository: https://charts.jetstack.io
     name: cert-manager
-    version: 1.10.1
+    version: 1.11.0

--- a/charts/cert-manager/test/default.yaml.out
+++ b/charts/cert-manager/test/default.yaml.out
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,9 +27,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -43,9 +43,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-config.yaml
 apiVersion: v1
@@ -58,6 +58,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.11.0"
+    app.kubernetes.io/managed-by: Helm
+    helm.sh/chart: cert-manager-v1.11.0
 data:
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -70,9 +73,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -104,9 +107,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -132,9 +135,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -160,9 +163,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -197,9 +200,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -237,9 +240,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -299,9 +302,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -338,9 +341,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -362,9 +365,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -389,9 +392,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -411,9 +414,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -439,9 +442,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -457,9 +460,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -479,9 +482,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -501,9 +504,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -523,9 +526,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -545,9 +548,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -567,9 +570,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -589,9 +592,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -611,9 +614,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -633,9 +636,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -655,9 +658,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -680,9 +683,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -708,9 +711,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -731,9 +734,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -758,9 +761,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -783,9 +786,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -807,9 +810,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -831,9 +834,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 spec:
   type: ClusterIP
   ports:
@@ -857,9 +860,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 spec:
   type: ClusterIP
   ports:
@@ -883,9 +886,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 spec:
   replicas: 1
   selector:
@@ -900,9 +903,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.10.1"
+        app.kubernetes.io/version: "v1.11.0"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.10.1
+        helm.sh/chart: cert-manager-v1.11.0
     spec:
       serviceAccountName: release-name-cert-manager-cainjector
       securityContext:
@@ -911,7 +914,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.10.1"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.11.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -940,9 +943,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 spec:
   replicas: 1
   selector:
@@ -957,9 +960,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.10.1"
+        app.kubernetes.io/version: "v1.11.0"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.10.1
+        helm.sh/chart: cert-manager-v1.11.0
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -972,12 +975,14 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.10.1"
+          image: "quay.io/jetstack/cert-manager-controller:v1.11.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.11.0
+          - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
             name: http-metrics
@@ -1006,9 +1011,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 spec:
   replicas: 1
   selector:
@@ -1023,9 +1028,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.10.1"
+        app.kubernetes.io/version: "v1.11.0"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.10.1
+        helm.sh/chart: cert-manager-v1.11.0
     spec:
       serviceAccountName: release-name-cert-manager-webhook
       securityContext:
@@ -1034,7 +1039,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.10.1"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.11.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1095,9 +1100,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1138,9 +1143,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1196,9 +1201,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
 ---
 # Source: cert-manager/charts/cert-manager/templates/startupapicheck-rbac.yaml
 # create certificate role
@@ -1212,9 +1217,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1235,9 +1240,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1262,9 +1267,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.10.1"
+    app.kubernetes.io/version: "v1.11.0"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.10.1
+    helm.sh/chart: cert-manager-v1.11.0
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1278,9 +1283,9 @@ spec:
         app.kubernetes.io/name: startupapicheck
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "startupapicheck"
-        app.kubernetes.io/version: "v1.10.1"
+        app.kubernetes.io/version: "v1.11.0"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.10.1
+        helm.sh/chart: cert-manager-v1.11.0
     spec:
       restartPolicy: OnFailure
       serviceAccountName: release-name-cert-manager-startupapicheck
@@ -1290,7 +1295,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-startupapicheck
-          image: "quay.io/jetstack/cert-manager-ctl:v1.10.1"
+          image: "quay.io/jetstack/cert-manager-ctl:v1.11.0"
           imagePullPolicy: IfNotPresent
           args:
           - check


### PR DESCRIPTION
**What this PR does / why we need it**:
There are no breaking changes: https://cert-manager.io/docs/installation/upgrading/upgrading-1.10-1.11

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update cert-manager to 0.11
```

**Documentation**:
```documentation
NONE
```
