### PR TITLE
Update AWS CCM/CSI/Node Termination Handler

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -40,7 +40,7 @@ aws-node-termination-handler:
 	helm repo update
 	cat aws-node-termination-handler/_header.txt > $(OUTPUT_FILE)
 	helm template aws-node-termination-handler eks/aws-node-termination-handler \
-	  --version 0.18.2 \
+	  --version 0.21.0 \
 	  --namespace kube-system \
 	  --values values-aws-node-termination-handler.yaml \
 	  >> $(OUTPUT_FILE)

--- a/addons/Makefile
+++ b/addons/Makefile
@@ -55,11 +55,12 @@ aws-ebs-csi-driver:
 	mkdir -p csi/aws-ebs
 	cat csi/aws-ebs/_header.txt > $(OUTPUT_FILE)
 	helm --namespace kube-system template aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
-	  --version 2.11.1 \
+	  --version 2.17.1 \
 	  --set 'controller.k8sTagClusterId=\{{ .Cluster.Name }}' \
 	  --set 'node.securityContext.seccompProfile.type=RuntimeDefault' \
 	  --set 'controller.securityContext.seccompProfile.type=RuntimeDefault' \
 	  --api-versions 'policy/v1/PodDisruptionBudget' \
+	  --skip-tests \
 	  >> $(OUTPUT_FILE)
 	cat csi/aws-ebs/_footer.txt >> $(OUTPUT_FILE)
 	sed -i 's/public.ecr.aws/{{ Registry "public.ecr.aws" }}/g' $(OUTPUT_FILE)

--- a/addons/Makefile
+++ b/addons/Makefile
@@ -63,8 +63,7 @@ aws-ebs-csi-driver:
 	  --skip-tests \
 	  >> $(OUTPUT_FILE)
 	cat csi/aws-ebs/_footer.txt >> $(OUTPUT_FILE)
-	sed -i 's/public.ecr.aws/{{ Registry "public.ecr.aws" }}/g' $(OUTPUT_FILE)
-	sed -i 's/k8s.gcr.io/{{ Registry "registry.k8s.io" }}/g' $(OUTPUT_FILE)
+	./templatify-images.sh $(OUTPUT_FILE)
 
 .PHONY: gcp-csi-driver
 gcp-csi-driver: OUTPUT_FILE=csi/gcp/driver.yaml

--- a/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
+++ b/addons/aws-node-termination-handler/aws-node-termination-handler.yaml
@@ -26,10 +26,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.16.2"
+    app.kubernetes.io/version: "1.19.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.18.2
+    helm.sh/chart: aws-node-termination-handler-0.21.0
 ---
 # Source: aws-node-termination-handler/templates/clusterrole.yaml
 kind: ClusterRole
@@ -39,10 +39,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.16.2"
+    app.kubernetes.io/version: "1.19.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.18.2
+    helm.sh/chart: aws-node-termination-handler-0.21.0
 rules:
 - apiGroups:
     - ""
@@ -87,10 +87,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.16.2"
+    app.kubernetes.io/version: "1.19.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.18.2
+    helm.sh/chart: aws-node-termination-handler-0.21.0
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -109,10 +109,10 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-node-termination-handler
     app.kubernetes.io/instance: aws-node-termination-handler
-    app.kubernetes.io/version: "1.16.2"
+    app.kubernetes.io/version: "1.19.0"
     app.kubernetes.io/part-of: aws-node-termination-handler
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: aws-node-termination-handler-0.18.2
+    helm.sh/chart: aws-node-termination-handler-0.21.0
     app.kubernetes.io/component: daemonset
 spec:
   updateStrategy:
@@ -150,7 +150,7 @@ spec:
             runAsGroup: 1000
             runAsNonRoot: true
             runAsUser: 1000
-          image: {{ Image "public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.16.2" }}
+          image: {{ Image "public.ecr.aws/aws-ec2/aws-node-termination-handler:v1.19.0" }}
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME
@@ -175,6 +175,8 @@ spec:
               value: "info"
             - name: JSON_LOGGING
               value: "false"
+            - name: LOG_FORMAT_VERSION
+              value: "1"
             - name: ENABLE_PROMETHEUS_SERVER
               value: "false"
             - name: PROMETHEUS_SERVER_PORT
@@ -202,7 +204,7 @@ spec:
             - name: ENABLE_SPOT_INTERRUPTION_DRAINING
               value: "true"
             - name: ENABLE_SCHEDULED_EVENT_DRAINING
-              value: "false"
+              value: "true"
             - name: ENABLE_REBALANCE_MONITORING
               value: "false"
             - name: ENABLE_REBALANCE_DRAINING

--- a/addons/csi/aws-ebs/driver.yaml
+++ b/addons/csi/aws-ebs/driver.yaml
@@ -391,7 +391,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ebs-plugin
-          image: {{ Registry "public.ecr.aws" }}/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1
+          image: {{ Image "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1" }}
           imagePullPolicy: IfNotPresent
           args:
             - node
@@ -437,7 +437,7 @@ spec:
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar
-          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/node-driver-registrar:v2.7.0-eks-1-25-latest
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.7.0-eks-1-25-latest" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -465,7 +465,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -577,7 +577,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ebs-plugin
-          image: {{ Registry "public.ecr.aws" }}/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1
+          image: {{ Image "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1" }}
           imagePullPolicy: IfNotPresent
           args:
             - controller
@@ -645,7 +645,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/external-provisioner:v3.4.0-eks-1-25-latest
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.4.0-eks-1-25-latest" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -672,7 +672,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-attacher
-          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/external-attacher:v4.1.0-eks-1-25-latest
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.1.0-eks-1-25-latest" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -696,7 +696,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-resizer
-          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/external-resizer:v1.7.0-eks-1-25-latest
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.7.0-eks-1-25-latest" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -720,7 +720,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock

--- a/addons/csi/aws-ebs/driver.yaml
+++ b/addons/csi/aws-ebs/driver.yaml
@@ -27,8 +27,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -48,8 +48,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 ---
@@ -62,8 +62,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 ---
@@ -75,8 +75,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -104,8 +104,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -121,8 +121,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -165,8 +165,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -202,8 +202,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -235,8 +235,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -256,8 +256,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -277,8 +277,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -298,8 +298,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -319,8 +319,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -342,8 +342,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -362,8 +362,8 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.11.1
-        app.kubernetes.io/version: "1.11.3"
+        helm.sh/chart: aws-ebs-csi-driver-2.17.1
+        app.kubernetes.io/version: "1.16.1"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -391,12 +391,12 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ebs-plugin
-          image: {{ Registry "public.ecr.aws" }}/ebs-csi-driver/aws-ebs-csi-driver:v1.11.3
+          image: {{ Registry "public.ecr.aws" }}/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1
           imagePullPolicy: IfNotPresent
           args:
             - node
             - --endpoint=$(CSI_ENDPOINT)
-            - --logtostderr
+            - --logging-format=text
             - --v=2
           env:
             - name: CSI_ENDPOINT
@@ -426,11 +426,18 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-node-driver-registrar:v2.5.1
+          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/node-driver-registrar:v2.7.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -447,11 +454,18 @@ spec:
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0
+          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -459,6 +473,13 @@ spec:
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -490,12 +511,16 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
   replicas: 2
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
   selector:
     matchLabels:
       app: ebs-csi-controller
@@ -507,8 +532,8 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.11.1
-        app.kubernetes.io/version: "1.11.3"
+        helm.sh/chart: aws-ebs-csi-driver-2.17.1
+        app.kubernetes.io/version: "1.16.1"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -516,11 +541,32 @@ spec:
         kubernetes.io/os: linux
       serviceAccountName: ebs-csi-controller-sa
       priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+            weight: 1
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - ebs-csi-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 100
       tolerations:
         - key: CriticalAddonsOnly
           operator: Exists
-        - operator: Exists
-          effect: NoExecute
+        - effect: NoExecute
+          operator: Exists
           tolerationSeconds: 300
       securityContext:
         fsGroup: 1000
@@ -531,13 +577,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ebs-plugin
-          image: {{ Registry "public.ecr.aws" }}/ebs-csi-driver/aws-ebs-csi-driver:v1.11.3
+          image: {{ Registry "public.ecr.aws" }}/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1
           imagePullPolicy: IfNotPresent
           args:
             - controller
             - --endpoint=$(CSI_ENDPOINT)
             - --k8s-tag-cluster-id={{ .Cluster.Name }}
-            - --logtostderr
+            - --logging-format=text
             - --v=2
           env:
             - name: CSI_ENDPOINT
@@ -588,11 +634,18 @@ spec:
             timeoutSeconds: 3
             periodSeconds: 10
             failureThreshold: 5
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-provisioner:v3.1.0
+          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/external-provisioner:v3.4.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -608,11 +661,18 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-attacher
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-attacher:v3.4.0
+          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/external-attacher:v4.1.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -625,11 +685,18 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-resizer
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/csi-resizer:v1.4.0
+          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/external-resizer:v1.7.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -642,11 +709,18 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: {{ Registry "registry.k8s.io" }}/sig-storage/livenessprobe:v2.6.0
+          image: {{ Registry "public.ecr.aws" }}/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -654,6 +728,13 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          resources:
+            limits:
+              cpu: 100m
+              memory: 256Mi
+            requests:
+              cpu: 10m
+              memory: 40Mi
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -669,8 +750,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.11.1
-    app.kubernetes.io/version: "1.11.3"
+    helm.sh/chart: aws-ebs-csi-driver-2.17.1
+    app.kubernetes.io/version: "1.16.1"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/addons/csi/digitalocean/csi-driver.yaml
+++ b/addons/csi/digitalocean/csi-driver.yaml
@@ -29,9 +29,6 @@
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
 {{ $version = "v4.3.0"}}
 {{ end }}
-{{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v4.3.0"}}
-{{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
 {{ $version = "v4.4.1"}}
 {{ end }}

--- a/pkg/resources/cloudcontroller/aws.go
+++ b/pkg/resources/cloudcontroller/aws.go
@@ -140,11 +140,13 @@ func awsDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDepl
 }
 
 func getAWSCCMVersion(version semver.Semver) string {
+	// https://github.com/kubernetes/cloud-provider-aws/releases
+
 	switch version.MajorMinor() {
 	case v124:
 		return "v1.24.4"
 	case v125:
-		return "v1.25.1"
+		return "v1.25.3"
 	case v126:
 		fallthrough
 	//	By default return latest version

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: secretAccessKey
               name: cloud-credentials
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.1
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.25.3
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR bumps auxiliary AWS components:

* AWS CCM for 1.25 got updated to 1.25.3.
* AWS CSI Driver was updated.
* Node Termination Handler was updated.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update AWS CCM for Kubernetes 1.25 to 1.25.3
Update AWS CSI to 2.17.1
Update AWS Node Termination Handler to 1.19.0
```

**Documentation**:
```documentation
NONE
```
