### PR TITLE
[release/v2.21] Set proper NodePort range in Cilium config

### DIFF
--- a/addons/cilium/cilium_v1.11.yaml
+++ b/addons/cilium/cilium_v1.11.yaml
@@ -172,6 +172,9 @@ data:
 {{ if eq .Cluster.Network.ProxyMode "ebpf" }}
   kube-proxy-replacement:  "strict"
   kube-proxy-replacement-healthz-bind-address: ""
+  {{ if ne .Cluster.Network.NodePortRange "" }}
+  node-port-range: {{ .Cluster.Network.NodePortRange | replace "-" "," | quote }}
+  {{ end }}
 {{ else }}
   kube-proxy-replacement:  "disabled"
 {{ end }}

--- a/addons/cilium/cilium_v1.12.yaml
+++ b/addons/cilium/cilium_v1.12.yaml
@@ -171,6 +171,9 @@ data:
 {{ if eq .Cluster.Network.ProxyMode "ebpf" }}
   kube-proxy-replacement:  "strict"
   kube-proxy-replacement-healthz-bind-address: ""
+  {{ if ne .Cluster.Network.NodePortRange "" }}
+  node-port-range: {{ .Cluster.Network.NodePortRange | replace "-" "," | quote }}
+  {{ end }}
 {{ else }}
   kube-proxy-replacement:  "disabled"
 {{ end }}

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -99,6 +99,7 @@ type ClusterNetwork struct {
 	NodeCIDRMaskSizeIPv4 int32
 	NodeCIDRMaskSizeIPv6 int32
 	IPAMAllocations      map[string]IPAMAllocation
+	NodePortRange        string
 }
 
 type CNIPlugin struct {

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -161,6 +161,7 @@ func NewTemplateData(
 				NodeCIDRMaskSizeIPv4: resources.GetClusterNodeCIDRMaskSizeIPv4(cluster),
 				NodeCIDRMaskSizeIPv6: resources.GetClusterNodeCIDRMaskSizeIPv6(cluster),
 				IPAMAllocations:      ipamAllocationsData,
+				NodePortRange:        cluster.Spec.ComponentsOverride.Apiserver.NodePortRange,
 			},
 			CNIPlugin: CNIPlugin{
 				Type:    cluster.Spec.CNIPlugin.Type.String(),
@@ -247,6 +248,7 @@ type ClusterNetwork struct {
 	NodeCIDRMaskSizeIPv4 int32
 	NodeCIDRMaskSizeIPv6 int32
 	IPAMAllocations      map[string]IPAMAllocation
+	NodePortRange        string
 }
 
 type IPAMAllocation struct {


### PR DESCRIPTION
This is a manual cherry-pick of #11963

/kind bug

```release-note
Set proper NodePort range in Cilium config if non-default range is used.
```