### PR TITLE
[release/v2.20] Set proper NodePort range in Cilium config

### DIFF
--- a/addons/cilium/cilium.yaml
+++ b/addons/cilium/cilium.yaml
@@ -166,6 +166,9 @@ data:
 {{ if eq .Cluster.Network.ProxyMode "ebpf" }}
   kube-proxy-replacement:  "strict"
   kube-proxy-replacement-healthz-bind-address: ""
+  {{ if ne .Cluster.Network.NodePortRange "" }}
+  node-port-range: {{ .Cluster.Network.NodePortRange | replace "-" "," | quote }}
+  {{ end }}
 {{ else }}
   kube-proxy-replacement:  "disabled"
 {{ end }}

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -83,6 +83,7 @@ type ClusterNetwork struct {
 	ServiceCIDRBlocks []string
 	ProxyMode         string
 	StrictArp         bool
+	NodePortRange     string
 }
 
 type CNIPlugin struct {

--- a/pkg/addon/template.go
+++ b/pkg/addon/template.go
@@ -134,6 +134,7 @@ func NewTemplateData(
 				ServiceCIDRBlocks: cluster.Spec.ClusterNetwork.Services.CIDRBlocks,
 				ProxyMode:         cluster.Spec.ClusterNetwork.ProxyMode,
 				StrictArp:         *cluster.Spec.ClusterNetwork.IPVS.StrictArp,
+				NodePortRange:     cluster.Spec.ComponentsOverride.Apiserver.NodePortRange,
 			},
 			CNIPlugin: CNIPlugin{
 				Type:    cluster.Spec.CNIPlugin.Type.String(),
@@ -209,6 +210,7 @@ type ClusterNetwork struct {
 	ServiceCIDRBlocks []string
 	ProxyMode         string
 	StrictArp         bool
+	NodePortRange     string
 }
 
 type CNIPlugin struct {


### PR DESCRIPTION
This is a manual cherry-pick of #11963

```release-note
Set proper NodePort range in Cilium config if non-default range is used.
```