### PR TITLE
[release/v2.21] Remove promtail sidecar from user cluster MLA that sets `fs.inotify.max_user_instances`

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
@@ -90,21 +90,7 @@ func DaemonSetCreator(overrides *corev1.ResourceRequirements, registryWithOverwr
 					Type: corev1.SeccompProfileTypeRuntimeDefault,
 				},
 			}
-			ds.Spec.Template.Spec.InitContainers = []corev1.Container{
-				{
-					Name:            "init-inotify",
-					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryDocker), initImageName, initImageTag),
-					ImagePullPolicy: corev1.PullAlways,
-					Command: []string{
-						"sh",
-						"-c",
-						fmt.Sprintf("sysctl -w fs.inotify.max_user_instances=%d", inotifyMaxUserInstances),
-					},
-					SecurityContext: &corev1.SecurityContext{
-						Privileged: pointer.BoolPtr(true),
-					},
-				},
-			}
+			ds.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            containerName,

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/promtail/daemonset.go
@@ -35,8 +35,6 @@ import (
 const (
 	imageName     = "grafana/promtail"
 	imageTag      = "2.5.0"
-	initImageName = "busybox"
-	initImageTag  = "1.34"
 	appName       = "mla-promtail"
 	containerName = "promtail"
 
@@ -50,8 +48,6 @@ const (
 	podVolumeName            = "pods"
 	podVolumeMountPath       = "/var/log/pods"
 	metricsPortName          = "http-metrics"
-
-	inotifyMaxUserInstances = 256
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
We removed a `inotify` setting sidecar, but missed this one as part of user cluster MLA. This PR fixes that oversight. A fix for 2.22 and `main` is not necessary because we are using a different agent there.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11946

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove promtail sidecar from user cluster MLA that sets `fs.inotify.max_user_instances`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
