### PR TITLE
bump Digitalocean CCM to 0.1.42

### DIFF
--- a/pkg/resources/cloudcontroller/digitalocean.go
+++ b/pkg/resources/cloudcontroller/digitalocean.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	DigitalOceanCCMDeploymentName = "digitalocean-cloud-controller-manager"
-	DigitalOceanCCMVersion        = "v0.1.40"
+	DigitalOceanCCMVersion        = "v0.1.42"
 )
 
 var (

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.40
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.42
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.40
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.42
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.40
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.42
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Nothing too special in the changelog: https://github.com/digitalocean/digitalocean-cloud-controller-manager/compare/v0.1.40...v0.1.42

The CSI driver has no newer versions available.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Digitalocean CCM to 0.1.42
```

**Documentation**:
```documentation
NONE
```
