### PR TITLE
bump node-exporter to 1.5.0

### DIFF
--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v1.2.2
+    app.kubernetes.io/version: v1.5.0
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -38,7 +38,7 @@ spec:
       serviceAccountName: node-exporter
       containers:
       - name: node-exporter
-        image: '{{ Image "quay.io/prometheus/node-exporter:v1.2.2" }}'
+        image: '{{ Image "quay.io/prometheus/node-exporter:v1.5.0" }}'
         args:
         - '--path.procfs=/host/proc'
         - '--path.sysfs=/host/sys'
@@ -64,11 +64,9 @@ spec:
           mountPropagation: HostToContainer
 
       - name: kube-rbac-proxy
-        image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.11.0" }}'
+        image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.14.0" }}'
         args:
-        - '--logtostderr'
         - '--secure-listen-address=$(IP):9100'
-        - '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256'
         - '--upstream=http://127.0.0.1:9100/'
         env:
         - name: IP

--- a/addons/node-exporter/networkpolicy.yaml
+++ b/addons/node-exporter/networkpolicy.yaml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 {{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
-
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/monitoring/node-exporter/Chart.yaml
+++ b/charts/monitoring/node-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: node-exporter
 version: v9.9.9-dev
-appVersion: v1.4.0
+appVersion: v1.5.0
 description: Prometheus Node Exporter for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/node-exporter/templates/daemonset.yaml
+++ b/charts/monitoring/node-exporter/templates/daemonset.yaml
@@ -63,9 +63,7 @@ spec:
       - name: kube-rbac-proxy
         image: "{{ .Values.nodeExporter.rbacProxy.image.repository }}:{{ .Values.nodeExporter.rbacProxy.image.tag }}"
         args:
-        - "--logtostderr"
         - "--secure-listen-address=$(IP):9100"
-        - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
         - "--upstream=http://127.0.0.1:9100/"
         env:
         - name: IP
@@ -92,6 +90,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 65532
         runAsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
       nodeSelector:
 {{ toYaml .Values.nodeExporter.nodeSelector | indent 8 }}
       affinity:

--- a/charts/monitoring/node-exporter/values.yaml
+++ b/charts/monitoring/node-exporter/values.yaml
@@ -15,7 +15,7 @@
 nodeExporter:
   image:
     repository: quay.io/prometheus/node-exporter
-    tag: v1.4.0
+    tag: v1.5.0
   resources:
     requests:
       cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a maintenance update for the seed-level stuff (1.4.0 => 1.5.0), but for userclusters it's quite a big jump (1.2.2 => 1.5.0). I also updated the kube-rbac-proxy and removed the explicit TLS cipher suites. I do not know why I ever added them, the original PR (#3085) did not mention explicitly _why_. I checked upstream, but even there no explicit ciphers would be configured.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update node-exporter Helm chart (seed clusters) and addon (user clusters) to 1.5.0
```

**Documentation**:
```documentation
NONE
```
