### PR TITLE
Update kube-state-metrics to 2.8.1

### DIFF
--- a/addons/kube-state-metrics/deployment.yaml
+++ b/addons/kube-state-metrics/deployment.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.1.1
+    app.kubernetes.io/version: 2.8.1
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -34,7 +34,7 @@ spec:
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.1.1
+        app.kubernetes.io/version: 2.8.1
     spec:
       containers:
         - args:
@@ -42,7 +42,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: '{{ Image "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.1.1" }}'
+          image: '{{ Image "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.1" }}'
           name: kube-state-metrics
           resources:
             limits:
@@ -54,11 +54,9 @@ spec:
           securityContext:
             runAsUser: 65534
         - args:
-            - --logtostderr
             - --secure-listen-address=:8443
-            - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
             - --upstream=http://127.0.0.1:8081/
-          image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.11.0" }}'
+          image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.14.0" }}'
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443
@@ -71,8 +69,8 @@ spec:
               cpu: 20m
               memory: 20Mi
           securityContext:
-            runAsGroup: 65532
             runAsNonRoot: true
+            runAsGroup: 65532
             runAsUser: 65532
       nodeSelector:
         kubernetes.io/os: linux

--- a/addons/kube-state-metrics/networkpolicy.yaml
+++ b/addons/kube-state-metrics/networkpolicy.yaml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 {{ if .Cluster.Features.Has "kubeSystemNetworkPolicies" }}
-
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/addons/kube-state-metrics/rbac.yaml
+++ b/addons/kube-state-metrics/rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.1.1
+    app.kubernetes.io/version: 2.8.1
   name: kube-state-metrics
   namespace: kube-system
 
@@ -29,7 +29,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.1.1
+    app.kubernetes.io/version: 2.8.1
   name: kube-state-metrics
 rules:
   - apiGroups:
@@ -140,7 +140,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.1.1
+    app.kubernetes.io/version: 2.8.1
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: kube-state-metrics
 version: v9.9.9-dev
-appVersion: v2.5.0
+appVersion: v2.8.1
 description: Kube-State-Metrics for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -56,17 +56,6 @@ spec:
 
       - name: addon-resizer
         image: {{ .Values.kubeStateMetrics.resizer.image.repository }}:{{ .Values.kubeStateMetrics.resizer.image.tag }}
-        resources:
-{{ toYaml .Values.kubeStateMetrics.resizer.resources | indent 10 }}
-        env:
-        - name: MY_POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
-        - name: MY_POD_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
         command:
           - /pod_nanny
           - --container=kube-state-metrics
@@ -76,6 +65,25 @@ spec:
           - --extra-memory=30Mi
           - --threshold=5
           - --deployment=kube-state-metrics
+          - --pod=$(MY_POD_NAME)
+          - --namespace=$(MY_POD_NAMESPACE)
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        livenessProbe:
+          httpGet:
+            path: /health-check
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        resources:
+{{ toYaml .Values.kubeStateMetrics.resizer.resources | indent 10 }}
       nodeSelector:
 {{ toYaml .Values.kubeStateMetrics.nodeSelector | indent 8 }}
       affinity:

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -15,7 +15,7 @@
 kubeStateMetrics:
   image:
     repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-    tag: v2.5.0
+    tag: v2.8.1
   resources:
     requests:
       # Rationalized based on real world usage
@@ -28,7 +28,7 @@ kubeStateMetrics:
   resizer:
     image:
       repository: registry.k8s.io/autoscaling/addon-resizer
-      tag: '1.8.14'
+      tag: '1.8.16'
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
This does a loooong overdue update on kube-state-metrics (last time we bumped the addon was in summer 2021). The old version 2.1.1 for example was only officially compatible with Kubernetes 1.17 to 1.21...

Once this and #11984 are merged, I will take a look at updating our Grafana and its dashboards.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update kube-state-metrics to 2.8.1
```

**Documentation**:
```documentation
NONE
```
