### PR TITLE
Remove trailing whitespace from custom scraping configuration

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/configmap.go
@@ -317,8 +317,7 @@ metrics:
 {{- with .CustomScrapeConfigs }}
     #######################################################################
     # custom scraping configurations
-
-    {{ . | indent 4 }}
+{{ . | indent 4 }}
 {{- end }}
 
 `


### PR DESCRIPTION
**What this PR does / why we need it**:
When a custom scraping configuration is added (e.g. via addons like node-exporter), the mla monitoring agent breaks. See the issue this fixes for more details, it's a pretty in depth report.

Here's the custom scraping configuration generated by current KKP:

```yaml
   #######################################################################
    # custom scraping configurations

        - job_name: kube-state-metrics
      scheme: https
      tls_config:
        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        insecure_skip_verify: true
      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
      kubernetes_sd_configs:
        - role: service
      relabel_configs:
        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app_kubernetes_io_name]
          regex: kube-system;kube-state-metrics
          action: keep
    - job_name: node-exporter
      scheme: https
      tls_config:
        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        insecure_skip_verify: true
      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
      kubernetes_sd_configs:
        - role: endpoints
      relabel_configs:
        - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_label_app_kubernetes_io_name]
          regex: kube-system;node-exporter
          action: keep
        - source_labels: [__meta_kubernetes_pod_node_name]
          action: replace
          regex: (.+)
          replacement: $1
          target_label: node_name
 ```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11973

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix mla-monitoring-agent configuration being invalid when custom scraping configuration is provided
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```