### PR TITLE
Generate a token for hack/run-user-cluster-controller-manager.sh

### DIFF
--- a/hack/run-user-cluster-controller-manager.sh
+++ b/hack/run-user-cluster-controller-manager.sh
@@ -47,10 +47,8 @@ kubectl --namespace "$NAMESPACE" get secret admin-kubeconfig --output json |
     > $KUBECONFIG_USERCLUSTER_CONTROLLER_FILE
 echo "Using kubeconfig $KUBECONFIG_USERCLUSTER_CONTROLLER_FILE"
 
-SEED_SERVICEACCOUNT_TOKEN="$(kubectl --namespace "$NAMESPACE" get secret -o json |
-  jq -r '.items[]|select(.metadata.annotations["kubernetes.io/service-account.name"] == "kubermatic-usercluster-controller-manager")|.data.token' |
-  base64 -d)"
 SEED_KUBECONFIG=$(mktemp)
+SEED_SERVICEACCOUNT_TOKEN="$(kubectl --namespace "$NAMESPACE" create token kubermatic-usercluster-controller-manager --duration=8h)"
 kubectl config view --flatten --minify -ojson |
   jq --arg token "$SEED_SERVICEACCOUNT_TOKEN" 'del(.users[0].user)|.users[0].user.token = $token' > $SEED_KUBECONFIG
 


### PR DESCRIPTION
**What this PR does / why we need it**:

`hack/run-user-cluster-controller-manager.sh` tried to fetch a token for the ServiceAccount by looking for token `Secrets`. However, this no longer works with recent Kubernetes versions as no Secrets are generated anymore. This uses a command provided by `kubectl` to create a token with 8h TTL to insert into the kubeconfig instead.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
