### PR TITLE
Validate version by checking for provider incompatibilities properly

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -264,6 +264,20 @@ func (c ClusterSpec) IsKubernetesDashboardEnabled() bool {
 	return c.KubernetesDashboard == nil || c.KubernetesDashboard.Enabled
 }
 
+// GetVersionConditions returns a kubermaticv1.ConditionType list that should be used when checking
+// for available versions in a VersionManager instance.
+func (c ClusterSpec) GetVersionConditions() []ConditionType {
+	conditions := []ConditionType{}
+
+	if c.Features[ClusterFeatureExternalCloudProvider] {
+		conditions = append(conditions, ExternalCloudProviderCondition)
+	} else {
+		conditions = append(conditions, InTreeCloudProviderCondition)
+	}
+
+	return conditions
+}
+
 // CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.
 type CNIPluginSettings struct {
 	// Type is the CNI plugin type to be used.

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -490,13 +490,7 @@ func hasOwnerRefToAny(obj ctrlruntimeclient.Object, ownerKind string, ownerNames
 }
 
 func getNextApiServerVersion(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, cluster *kubermaticv1.Cluster) (*semver.Semver, error) {
-	var updateConditions []kubermaticv1.ConditionType
-	if cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
-		updateConditions = append(updateConditions, kubermaticv1.ExternalCloudProviderCondition)
-	} else {
-		updateConditions = append(updateConditions, kubermaticv1.InTreeCloudProviderCondition)
-	}
-
+	updateConditions := cluster.Spec.GetVersionConditions()
 	updateManager := version.NewFromConfiguration(config)
 	currentVersion := cluster.Status.Versions.Apiserver.Semver()
 	targetVersion := cluster.Spec.Version.Semver()

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -79,8 +79,6 @@ const (
 
 // ValidateClusterSpec validates the given cluster spec. If this is not called from within another validation
 // routine, parentFieldPath can be nil.
-//
-//gocyclo:ignore
 func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datacenter, enabledFeatures features.FeatureGate, versionManager *version.Manager, currentVersion *semver.Semver, parentFieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -300,8 +300,13 @@ func ValidateVersion(spec *kubermaticv1.ClusterSpec, versionManager *version.Man
 
 	conditions := spec.GetVersionConditions()
 
-	// if a current version is passed, we are doing a version upgrade
-	if currentVersion != nil && !spec.Version.Equal(currentVersion) {
+	// if a current version is passed, we are doing a version upgrade.
+	if currentVersion != nil {
+		// we return early here so we don't reject ClusterSpecs if the version hasn't changed.
+		if spec.Version.Equal(currentVersion) {
+			return nil
+		}
+
 		versions, err = versionManager.GetPossibleUpdates(currentVersion.String(), kubermaticv1.ProviderType(spec.Cloud.ProviderName), conditions...)
 		if err != nil {
 			return field.InternalError(fldPath, fmt.Errorf("failed to get available version updates: %w", err))

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -1110,7 +1110,8 @@ func TestValidateVersion(t *testing.T) {
 			spec: &kubermaticv1.ClusterSpec{
 				Version: semver.Semver("1.2.0"),
 				Cloud: kubermaticv1.CloudSpec{
-					ProviderName: string(kubermaticv1.OpenstackCloudProvider)},
+					ProviderName: string(kubermaticv1.OpenstackCloudProvider),
+				},
 			},
 			versionManager: version.New(
 				[]*version.Version{

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -1128,7 +1128,8 @@ func TestValidateVersion(t *testing.T) {
 						Operation: kubermaticv1.CreateOperation,
 						Version:   ">= 1.3.0",
 					},
-				}),
+				},
+			),
 		},
 		{
 			name:  "cloud provider incompatibility version not supported",
@@ -1136,7 +1137,8 @@ func TestValidateVersion(t *testing.T) {
 			spec: &kubermaticv1.ClusterSpec{
 				Version: semver.Semver("1.3.0"),
 				Cloud: kubermaticv1.CloudSpec{
-					ProviderName: string(kubermaticv1.OpenstackCloudProvider)},
+					ProviderName: string(kubermaticv1.OpenstackCloudProvider),
+				},
 			},
 			versionManager: version.New(
 				[]*version.Version{
@@ -1146,14 +1148,16 @@ func TestValidateVersion(t *testing.T) {
 					{
 						Version: semverlib.MustParse("1.3.0"),
 					},
-				}, nil, []*version.ProviderIncompatibility{
+				}, nil,
+				[]*version.ProviderIncompatibility{
 					{
 						Provider:  kubermaticv1.OpenstackCloudProvider,
 						Condition: kubermaticv1.InTreeCloudProviderCondition,
 						Operation: kubermaticv1.CreateOperation,
 						Version:   ">= 1.3.0",
 					},
-				}),
+				},
+			),
 		},
 		{
 			name:           "cloud provider incompatibility version upgrade not supported",
@@ -1162,7 +1166,8 @@ func TestValidateVersion(t *testing.T) {
 			spec: &kubermaticv1.ClusterSpec{
 				Version: semver.Semver("1.3.0"),
 				Cloud: kubermaticv1.CloudSpec{
-					ProviderName: string(kubermaticv1.OpenstackCloudProvider)},
+					ProviderName: string(kubermaticv1.OpenstackCloudProvider),
+				},
 			},
 			versionManager: version.New(
 				[]*version.Version{
@@ -1190,7 +1195,8 @@ func TestValidateVersion(t *testing.T) {
 						Operation: kubermaticv1.UpdateOperation,
 						Version:   ">= 1.3.0",
 					},
-				}),
+				},
+			),
 		},
 	}
 

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -59,7 +59,6 @@ func TestValidateClusterSpec(t *testing.T) {
 			valid: false,
 			spec:  &kubermaticv1.ClusterSpec{},
 		},
-		{},
 	}
 
 	for _, test := range tests {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -59,13 +59,14 @@ func TestValidateClusterSpec(t *testing.T) {
 			valid: false,
 			spec:  &kubermaticv1.ClusterSpec{},
 		},
+		{},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := ValidateClusterSpec(test.spec, dc, features.FeatureGate{}, version.New([]*version.Version{{
 				Version: semverlib.MustParse("1.2.3"),
-			}}, nil, nil), nil).ToAggregate()
+			}}, nil, nil), nil, nil).ToAggregate()
 
 			if (err == nil) != test.valid {
 				t.Errorf("Extected err to be %v, got %v", test.valid, err)
@@ -1021,6 +1022,184 @@ func TestValidateEncryptionConfiguration(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			err := validateEncryptionConfiguration(test.clusterSpec, field.NewPath("spec", "encryptionConfiguration"))
 			assert.Equal(t, test.expectErr, err)
+		})
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		spec           *kubermaticv1.ClusterSpec
+		versionManager *version.Manager
+		currentVersion *semver.Semver
+		valid          bool
+	}{
+		{
+			name:  "empty spec should not cause a panic",
+			valid: false,
+			spec:  &kubermaticv1.ClusterSpec{},
+		},
+		{
+			name:  "version supported",
+			valid: true,
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.2.3"),
+			},
+			versionManager: version.New([]*version.Version{{
+				Version: semverlib.MustParse("1.2.3"),
+			}}, nil, nil),
+		},
+		{
+			name:  "version not supported",
+			valid: false,
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.2.4"),
+			},
+			versionManager: version.New([]*version.Version{{
+				Version: semverlib.MustParse("1.2.3"),
+			}}, nil, nil),
+		},
+		{
+			name:           "version update supported",
+			valid:          true,
+			currentVersion: semver.NewSemverOrDie("1.2.3"),
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.2.4"),
+			},
+			versionManager: version.New(
+				[]*version.Version{
+					{
+						Version: semverlib.MustParse("1.2.3"),
+					},
+					{
+						Version: semverlib.MustParse("1.2.4"),
+					},
+				},
+				[]*version.Update{{
+					From: "1.2.*",
+					To:   "1.2.*",
+				}}, nil),
+		},
+		{
+			name:           "version update not supported",
+			valid:          false,
+			currentVersion: semver.NewSemverOrDie("1.2.2"),
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.2.4"),
+			},
+			versionManager: version.New(
+				[]*version.Version{
+					{
+						Version: semverlib.MustParse("1.2.2"),
+					},
+					{
+						Version: semverlib.MustParse("1.2.3"),
+					},
+					{
+						Version: semverlib.MustParse("1.2.4"),
+					},
+				},
+				[]*version.Update{{
+					From: "1.2.*",
+					To:   "1.2.3",
+				}}, nil),
+		},
+		{
+			name:  "cloud provider incompatibility version supported",
+			valid: true,
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.2.0"),
+				Cloud: kubermaticv1.CloudSpec{
+					ProviderName: string(kubermaticv1.OpenstackCloudProvider)},
+			},
+			versionManager: version.New(
+				[]*version.Version{
+					{
+						Version: semverlib.MustParse("1.2.0"),
+					},
+					{
+						Version: semverlib.MustParse("1.3.0"),
+					},
+				}, nil, []*version.ProviderIncompatibility{
+					{
+						Provider:  kubermaticv1.OpenstackCloudProvider,
+						Condition: kubermaticv1.InTreeCloudProviderCondition,
+						Operation: kubermaticv1.CreateOperation,
+						Version:   ">= 1.3.0",
+					},
+				}),
+		},
+		{
+			name:  "cloud provider incompatibility version not supported",
+			valid: false,
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.3.0"),
+				Cloud: kubermaticv1.CloudSpec{
+					ProviderName: string(kubermaticv1.OpenstackCloudProvider)},
+			},
+			versionManager: version.New(
+				[]*version.Version{
+					{
+						Version: semverlib.MustParse("1.2.0"),
+					},
+					{
+						Version: semverlib.MustParse("1.3.0"),
+					},
+				}, nil, []*version.ProviderIncompatibility{
+					{
+						Provider:  kubermaticv1.OpenstackCloudProvider,
+						Condition: kubermaticv1.InTreeCloudProviderCondition,
+						Operation: kubermaticv1.CreateOperation,
+						Version:   ">= 1.3.0",
+					},
+				}),
+		},
+		{
+			name:           "cloud provider incompatibility version upgrade not supported",
+			valid:          false,
+			currentVersion: semver.NewSemverOrDie("1.2.0"),
+			spec: &kubermaticv1.ClusterSpec{
+				Version: semver.Semver("1.3.0"),
+				Cloud: kubermaticv1.CloudSpec{
+					ProviderName: string(kubermaticv1.OpenstackCloudProvider)},
+			},
+			versionManager: version.New(
+				[]*version.Version{
+					{
+						Version: semverlib.MustParse("1.2.0"),
+					},
+					{
+						Version: semverlib.MustParse("1.3.0"),
+					},
+				},
+				[]*version.Update{
+					{
+						From: "1.2.*",
+						To:   "1.2.*",
+					},
+					{
+						From: "1.2.*",
+						To:   "1.3.*",
+					},
+				},
+				[]*version.ProviderIncompatibility{
+					{
+						Provider:  kubermaticv1.OpenstackCloudProvider,
+						Condition: kubermaticv1.InTreeCloudProviderCondition,
+						Operation: kubermaticv1.UpdateOperation,
+						Version:   ">= 1.3.0",
+					},
+				}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateVersion(test.spec, test.versionManager, test.currentVersion, nil)
+
+			if (err == nil) != test.valid {
+				t.Errorf("Extected err to be %v, got %v", test.valid, err)
+			}
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR tries to fix our validation webhook, since it was not aware of
1. cluster version upgrade operations
2. provider incompatibilities

To fix this, I'm passing along the old Kubernetes version when doing a validation on a cluster spec, which changes the way the available versions are determined. In addition, we've never generated a list of version conditions, so this PR adds a method to `ClusterSpec` to unify this code in one place. Needs to be called in some dashboard code as well once this has been merged.

I'm not entirely sure this is how we want to solve it, but it keeps the current configuration options untouched and tries to support them to the extent that is possible.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11948

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The validating webhook for `Cluster` resources now properly checks for provider incompatibilities
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
