### PR TITLE
fix conformance-tester always succeeding

### DIFF
--- a/cmd/conformance-tester/main.go
+++ b/cmd/conformance-tester/main.go
@@ -176,7 +176,12 @@ func main() {
 	}
 
 	if err != nil {
-		log.Fatalw("Test failed", zap.Error(err))
+		log.Fatalw("Failed to execute tests", zap.Error(err))
+	}
+
+	if results.HasFailures() {
+		// Fatalw() because Fatal() trips up the linter because of the previous defer.
+		log.Fatalw("Not all tests have passed")
 	}
 
 	log.Infow("Test suite has completed successfully", "runtime", time.Since(start))

--- a/cmd/conformance-tester/pkg/runner/result.go
+++ b/cmd/conformance-tester/pkg/runner/result.go
@@ -149,6 +149,15 @@ func MergeResults(previous *ResultsFile, current *Results) *Results {
 }
 
 func (r *Results) WriteToFile(filename string) error {
+	for i, scenario := range r.Scenarios {
+		// when saving a previously loaded result back, the
+		// duration is not set and getting the seconds would
+		// overwrite the previously read value
+		if scenario.Duration > 0 {
+			r.Scenarios[i].DurationSeconds = int(scenario.Duration.Seconds())
+		}
+	}
+
 	output := ResultsFile{
 		Configuration: TestConfiguration{
 			OSMEnabled:          r.Options.OperatingSystemManagerEnabled,
@@ -195,7 +204,8 @@ type ScenarioResult struct {
 	KubernetesRelease string                         `json:"kubernetesRelease"`
 	KubernetesVersion semver.Semver                  `json:"kubernetesVersion"`
 	KubermaticVersion string                         `json:"kubermaticVersion"`
-	Duration          time.Duration                  `json:"duration"`
+	Duration          time.Duration                  `json:"-"`
+	DurationSeconds   int                            `json:"durationInSeconds"`
 	ClusterName       string                         `json:"clusterName"`
 	Status            ScenarioStatus                 `json:"status"`
 	Message           string                         `json:"message"`

--- a/cmd/conformance-tester/pkg/runner/result.go
+++ b/cmd/conformance-tester/pkg/runner/result.go
@@ -50,11 +50,11 @@ type Results struct {
 func (r *Results) HasFailures() bool {
 	for _, scenario := range r.Scenarios {
 		if scenario.Status == ScenarioFailed {
-			return false
+			return true
 		}
 	}
 
-	return true
+	return false
 }
 
 func (r *Results) PrintSummary() {


### PR DESCRIPTION
**What this PR does / why we need it**:
In #11890 I changed the logic of the `testRunner` to only return an error when executing the tests has failed, not if any test itself has failed. This then unfortunately broke the failure detection, making the conformance-tester always succeed (e.g. in https://public-prow.loodse.com/view/gs/prow-dev-public-data/pr-logs/pull/kubermatic_kubermatic/12002/pre-kubermatic-e2e-nutanix-ubuntu-1.26/1633161426526801920).

I also mixed up the logic in HasFailures() :see_no_evil: 

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
