### PR TITLE
Test vSphere CCM migration on Kubernetes 1.24

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -76,8 +76,11 @@ presubmits:
               value: ee
             - name: PROVIDER
               value: vsphere
+            # KKP 2.22+ does not support Kubernetes >= 1.25 with in-tree, so we only
+            # need to support the CCM migration for 1.24. This test can be removed once
+            # 1.24 support is dropped.
             - name: VERSION_TO_TEST
-              value: '1.25'
+              value: '1.24'
             - name: SERVICE_ACCOUNT_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
**What this PR does / why we need it**:
#11996 uncovered that our CCM migration test for vSphere was running on Kubernetes 1.25, a version we do not support for the in-tree cloud provider anymore (#11951). As such, the PR makes the migration test fail, as it tries to create a vSphere in-tree provider 1.25 cluster.

This updates the test to use 1.24, the only version we support the migration on.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
