### PR TITLE
Change kubeconfig context name from default to cluster ID

### DIFF
--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -369,7 +369,7 @@ func (r *TestRunner) executeTests(
 	healthCheck := func() error {
 		log.Info("Waiting for cluster to be successfully reconciled...")
 
-		return wait.PollLog(ctx, log, 5*time.Second, 50*time.Minute, func() (transient error, terminal error) {
+		return wait.PollLog(ctx, log, 5*time.Second, 5*time.Minute, func() (transient error, terminal error) {
 			if err := r.opts.SeedClusterClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
 				return err, nil
 			}

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -369,7 +369,7 @@ func (r *TestRunner) executeTests(
 	healthCheck := func() error {
 		log.Info("Waiting for cluster to be successfully reconciled...")
 
-		return wait.PollLog(ctx, log, 5*time.Second, 5*time.Minute, func() (transient error, terminal error) {
+		return wait.PollLog(ctx, log, 5*time.Second, 50*time.Minute, func() (transient error, terminal error) {
 			if err := r.opts.SeedClusterClient.Get(ctx, types.NamespacedName{Name: clusterName}, cluster); err != nil {
 				return err, nil
 			}

--- a/pkg/cluster/client/client.go
+++ b/pkg/cluster/client/client.go
@@ -122,7 +122,7 @@ func (p *Provider) GetClientConfig(ctx context.Context, c *kubermaticv1.Cluster,
 
 	iconfig := clientcmd.NewNonInteractiveClientConfig(
 		*cfg,
-		resources.KubeconfigDefaultContextKey,
+		c.Name,
 		&clientcmd.ConfigOverrides{},
 		nil,
 	)

--- a/pkg/resources/kubeconfig.go
+++ b/pkg/resources/kubeconfig.go
@@ -54,7 +54,7 @@ func AdminKubeconfigReconciler(data adminKubeconfigReconcilerData) reconciling.N
 			address := data.Cluster().Status.Address
 			config := GetBaseKubeconfig(ca.Cert, address.URL, data.Cluster().Name)
 			config.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-				KubeconfigDefaultContextKey: {
+				KubeconfigDefaultAuthInfoKey: {
 					Token: address.AdminToken,
 				},
 			}
@@ -90,7 +90,7 @@ func ViewerKubeconfigReconciler(data *TemplateData) reconciling.NamedSecretRecon
 				return nil, fmt.Errorf("failed to get token: %w", err)
 			}
 			config.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-				KubeconfigDefaultContextKey: {
+				KubeconfigDefaultAuthInfoKey: {
 					Token: token,
 				},
 			}
@@ -166,7 +166,7 @@ func buildNewKubeconfig(ca *triple.KeyPair, server, commonName string, organizat
 	}
 
 	baseKubconfig.AuthInfos = map[string]*clientcmdapi.AuthInfo{
-		KubeconfigDefaultContextKey: {
+		KubeconfigDefaultAuthInfoKey: {
 			ClientCertificateData: triple.EncodeCertPEM(kp.Cert),
 			ClientKeyData:         triple.EncodePrivateKeyPEM(kp.Key),
 		},
@@ -189,7 +189,7 @@ func GetBaseKubeconfig(caCert *x509.Certificate, server, clusterName string) *cl
 		Contexts: map[string]*clientcmdapi.Context{
 			clusterName: {
 				Cluster:  clusterName,
-				AuthInfo: KubeconfigDefaultContextKey,
+				AuthInfo: KubeconfigDefaultAuthInfoKey,
 			},
 		},
 	}
@@ -207,7 +207,7 @@ func IsValidKubeconfig(kubeconfigBytes []byte, caCert *x509.Certificate, server,
 
 	baseKubeconfig := GetBaseKubeconfig(caCert, server, clusterName)
 
-	authInfo := existingKubeconfig.AuthInfos[KubeconfigDefaultContextKey]
+	authInfo := existingKubeconfig.AuthInfos[KubeconfigDefaultAuthInfoKey]
 	if authInfo == nil {
 		return false, nil
 	}

--- a/pkg/resources/kubeconfig.go
+++ b/pkg/resources/kubeconfig.go
@@ -185,9 +185,9 @@ func GetBaseKubeconfig(caCert *x509.Certificate, server, clusterName string) *cl
 				Server:                   server,
 			},
 		},
-		CurrentContext: KubeconfigDefaultContextKey,
+		CurrentContext: clusterName,
 		Contexts: map[string]*clientcmdapi.Context{
-			KubeconfigDefaultContextKey: {
+			clusterName: {
 				Cluster:  clusterName,
 				AuthInfo: KubeconfigDefaultContextKey,
 			},

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -573,9 +573,6 @@ const (
 	EtcdRestoreS3EndpointKey      = "ENDPOINT"
 	EtcdRestoreDefaultS3SEndpoint = "s3.amazonaws.com"
 
-	// KubeconfigDefaultAuthInfoKey is the Auth Info key used for all kubeconfigs.
-	KubeconfigDefaultAuthInfoKey = "default"
-
 	// ApiserverEtcdClientCertificateCertSecretKey apiserver-etcd-client.crt.
 	ApiserverEtcdClientCertificateCertSecretKey = "apiserver-etcd-client.crt"
 	// ApiserverEtcdClientCertificateKeySecretKey apiserver-etcd-client.key.

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -573,8 +573,8 @@ const (
 	EtcdRestoreS3EndpointKey      = "ENDPOINT"
 	EtcdRestoreDefaultS3SEndpoint = "s3.amazonaws.com"
 
-	// KubeconfigDefaultContextKey is the context key used for all kubeconfigs.
-	KubeconfigDefaultContextKey = "default"
+	// KubeconfigDefaultAuthInfoKey is the Auth Info key used for all kubeconfigs.
+	KubeconfigDefaultAuthInfoKey = "default"
 
 	// ApiserverEtcdClientCertificateCertSecretKey apiserver-etcd-client.crt.
 	ApiserverEtcdClientCertificateCertSecretKey = "apiserver-etcd-client.crt"


### PR DESCRIPTION
**What this PR does / why we need it**:
Assign a unique identifier i.e. cluster ID for the `context` specified in the OIDC kubeconfig. Having it set as `default` makes it difficult to differentiate and switch context between multiple clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/dashboard/issues/5745

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The context name for admin Kubeconfig has been changed to the cluster ID from `default`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
