### PR TITLE
Use Alpine Linux 3.17 for container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 ENV KUBERMATIC_CHARTS_DIRECTORY=/opt/charts/

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 ADD ./ /addons/

--- a/cmd/alertmanager-authorization-server/Dockerfile
+++ b/cmd/alertmanager-authorization-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/alertmanager-authorization-server /

--- a/cmd/http-prober/Dockerfile
+++ b/cmd/http-prober/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/cmd/kubeletdnat-controller/Dockerfile
+++ b/cmd/kubeletdnat-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add -u --no-cache iptables

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/kubeletdnat-controller build
 
-FROM docker.io/alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add -u --no-cache iptables

--- a/cmd/network-interface-manager/Dockerfile
+++ b/cmd/network-interface-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/network-interface-manager /usr/local/bin/network-interface-manager

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/network-interface-manager build
 
-FROM docker.io/alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/network-interface-manager/_build/network-interface-manager /usr/local/bin/network-interface-manager

--- a/cmd/nodeport-proxy/Dockerfile
+++ b/cmd/nodeport-proxy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 ADD ./_build/lb-updater /

--- a/cmd/s3-exporter/Dockerfile
+++ b/cmd/s3-exporter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add --no-cache ca-certificates

--- a/cmd/s3-storeuploader/Dockerfile
+++ b/cmd/s3-storeuploader/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add --no-cache ca-certificates

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/user-ssh-keys-agent build
 
-FROM docker.io/alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/user-ssh-keys-agent/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent

--- a/hack/images/grafana-plugins/Dockerfile
+++ b/hack/images/grafana-plugins/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 RUN mkdir -p /plugins

--- a/hack/images/util/Dockerfile
+++ b/hack/images/util/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.13
+FROM docker.io/alpine:3.17
 LABEL maintainer="support@kubermatic.com"
 
 ENV MC_VERSION=RELEASE.2022-12-24T15-21-38Z \


### PR DESCRIPTION
**What this PR does / why we need it**:

Alpine 3.13 is out of support as far as I can say from https://hub.docker.com/_/alpine, so this updates all images to the latest Alpine Linux (3.17). I'm not sure it will work, but let's see.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use Alpine Linux 3.17 for container images
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
