### PR TITLE
Improve StorageClass creation in installer

### DIFF
--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -167,7 +167,6 @@ parameters:
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  namespace: kube-system
   name: hcloud-volumes
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -21,7 +21,6 @@ export CGO_ENABLED=0
 
 .PHONY: build
 build:
-	go env
 	go build $(GOTOOLFLAGS) -tags "$(KUBERMATIC_EDITION)" -o ./_build/user-ssh-keys-agent
 
 .PHONY: docker

--- a/pkg/install/stack/common/storageclass.go
+++ b/pkg/install/stack/common/storageclass.go
@@ -96,6 +96,9 @@ var (
 					sc.VolumeBindingMode = class.VolumeBindingMode
 					sc.AllowedTopologies = class.AllowedTopologies
 
+					delete(sc.Annotations, "storageclass.kubernetes.io/is-default-class")
+					delete(sc.Annotations, "storageclass.beta.kubernetes.io/is-default-class")
+
 					return nil
 				}
 			}

--- a/pkg/install/stack/common/storageclass.go
+++ b/pkg/install/stack/common/storageclass.go
@@ -120,12 +120,11 @@ var (
 		kubermaticv1.AWSCloudProvider: func(_ context.Context, _ *logrus.Entry, _ ctrlruntimeclient.Client, sc *storagev1.StorageClass, csiDriverName string) error {
 			if csiDriverName == "" { // = in-tree CSI
 				sc.Provisioner = "kubernetes.io/aws-ebs"
-				sc.Parameters["type"] = "gp2"
 			} else { // out-of-tree CSI
 				sc.Provisioner = csiDriverName
-				sc.Parameters["type"] = "gp3"
 			}
 
+			sc.Parameters["type"] = "io1"
 			sc.VolumeBindingMode = &waitForFirstCustomer
 
 			return nil

--- a/pkg/install/stack/common/storageclass.go
+++ b/pkg/install/stack/common/storageclass.go
@@ -125,6 +125,7 @@ var (
 			}
 
 			sc.Parameters["type"] = "io1"
+			sc.Parameters["iopsPerGB"] = "25"
 			sc.VolumeBindingMode = &waitForFirstCustomer
 
 			return nil

--- a/pkg/install/stack/common/storageclass.go
+++ b/pkg/install/stack/common/storageclass.go
@@ -136,9 +136,9 @@ var (
 			} else { // out-of-tree CSI
 				sc.Provisioner = csiDriverName
 				sc.AllowVolumeExpansion = pointer.Bool(true)
-				sc.VolumeBindingMode = &waitForFirstCustomer
 			}
 
+			sc.VolumeBindingMode = &waitForFirstCustomer
 			sc.Parameters["storageaccounttype"] = "Standard_LRS"
 			sc.Parameters["kind"] = "managed"
 
@@ -162,6 +162,7 @@ var (
 
 			sc.Provisioner = csiDriverName
 			sc.AllowVolumeExpansion = pointer.Bool(true)
+			sc.VolumeBindingMode = &waitForFirstCustomer
 
 			return nil
 		},
@@ -182,6 +183,7 @@ var (
 				sc.Parameters["diskformat"] = "thin"
 			} else { // out-of-tree CSI
 				sc.Provisioner = csiDriverName
+				sc.VolumeBindingMode = &waitForFirstCustomer
 			}
 
 			return nil

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -173,12 +173,12 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	// If no suitable CSIDriver was found, we have to rely on the user to tell us about their provider
 	// and then we assume an in-tree (legacy) provider should be used.
 	if csiDriverName == "" {
-		sublogger.Warnf("The %s StorageClass does not exist yet and no suitable CSIDriver was detected.", common.StorageClassName)
-		sublogger.Warn("Depending on your environment, the installer can auto-create a class for you,")
-		sublogger.Warn("see the --storageclass CLI flag (should only be used when in-tree CSI driver is still used).")
-		sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
-
 		if opt.StorageClassProvider == "" {
+			sublogger.Warnf("The %s StorageClass does not exist yet and no suitable CSIDriver was detected.", common.StorageClassName)
+			sublogger.Warn("Depending on your environment, the installer can auto-create a class for you,")
+			sublogger.Warn("see the --storageclass CLI flag (should only be used when in-tree CSI driver is still used).")
+			sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
+
 			return errors.New("no --storageclass flag given")
 		}
 
@@ -191,7 +191,7 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	} else {
 		// Even if a CSI Driver was found, the user might not want us to blindly create our
 		// own StorageClass, but instead copy the default. So if --storageclass=copy-default,
-		// this has precendence over the detected cloud provider.
+		// this has precedence over the detected cloud provider.
 		if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
 			cloudProvider = common.CopyDefaultCloudProvider
 		}

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -190,6 +190,13 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 		}
 
 		cloudProvider = kubermaticv1.ProviderType(chosenProvider)
+	} else {
+		// Even if a CSI Driver was found, the user might not want us to blindly create our
+		// own StorageClass, but instead copy the default. So if --storageclass=copy-default,
+		// this has precendence over the detected cloud provider.
+		if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
+			cloudProvider = common.CopyDefaultCloudProvider
+		}
 	}
 
 	factory, err := common.StorageClassCreator(cloudProvider)

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -188,13 +188,11 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 		}
 
 		cloudProvider = kubermaticv1.ProviderType(chosenProvider)
-	} else {
+	} else if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
 		// Even if a CSI Driver was found, the user might not want us to blindly create our
 		// own StorageClass, but instead copy the default. So if --storageclass=copy-default,
 		// this has precedence over the detected cloud provider.
-		if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
-			cloudProvider = common.CopyDefaultCloudProvider
-		}
+		cloudProvider = common.CopyDefaultCloudProvider
 	}
 
 	factory, err := common.StorageClassCreator(cloudProvider)

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -67,8 +67,6 @@ const (
 	TelemetryNamespace   = "telemetry-system"
 
 	NodePortProxyService = "nodeport-proxy"
-
-	StorageClassName = "kubermatic-fast"
 )
 
 type MasterStack struct{}
@@ -150,19 +148,19 @@ func deployTelemetry(ctx context.Context, logger *logrus.Entry, kubeClient ctrlr
 }
 
 func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, opt stack.DeployOptions) error {
-	logger.Infof("💾 Deploying %s StorageClass…", StorageClassName)
+	logger.Infof("💾 Deploying %s StorageClass…", common.StorageClassName)
 	sublogger := log.Prefix(logger, "   ")
 
 	// Check if the StorageClass exists already.
 	cls := storagev1.StorageClass{}
-	err := kubeClient.Get(ctx, types.NamespacedName{Name: StorageClassName}, &cls)
+	err := kubeClient.Get(ctx, types.NamespacedName{Name: common.StorageClassName}, &cls)
 	if err == nil {
 		logger.Info("✅ StorageClass exists, nothing to do.")
 		return nil
 	}
 
 	if !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to check for StorageClass %s: %w", StorageClassName, err)
+		return fmt.Errorf("failed to check for StorageClass %s: %w", common.StorageClassName, err)
 	}
 
 	// Class does not yet exist. We can automatically create it based on CSIDrivers if the
@@ -175,7 +173,7 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	// If no suitable CSIDriver was found, we have to rely on the user to tell us about their provider
 	// and then we assume an in-tree (legacy) provider should be used.
 	if csiDriverName == "" {
-		sublogger.Warnf("The %s StorageClass does not exist yet and no suitable CSIDriver was detected.", StorageClassName)
+		sublogger.Warnf("The %s StorageClass does not exist yet and no suitable CSIDriver was detected.", common.StorageClassName)
 		sublogger.Warn("Depending on your environment, the installer can auto-create a class for you,")
 		sublogger.Warn("see the --storageclass CLI flag (should only be used when in-tree CSI driver is still used).")
 		sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
@@ -207,7 +205,7 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	storageClass := storagev1.StorageClass{
 		Parameters: map[string]string{},
 	}
-	storageClass.Name = StorageClassName
+	storageClass.Name = common.StorageClassName
 
 	if err := factory(ctx, sublogger, kubeClient, &storageClass, csiDriverName); err != nil {
 		return fmt.Errorf("failed to define StorageClass: %w", err)

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -107,12 +107,12 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	// If no suitable CSIDriver was found, we have to rely on the user to tell us about their provider
 	// and then we assume an in-tree (legacy) provider should be used.
 	if csiDriverName == "" {
-		sublogger.Warnf("The %s StorageClass does not exist yet and no suitable CSIDriver was detected.", common.StorageClassName)
-		sublogger.Warn("Depending on your environment, the installer can auto-create a class for you,")
-		sublogger.Warn("see the --storageclass CLI flag (should only be used when in-tree CSI driver is still used).")
-		sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
-
 		if opt.StorageClassProvider == "" {
+			sublogger.Warnf("The %s StorageClass does not exist yet and no suitable CSIDriver was detected.", common.StorageClassName)
+			sublogger.Warn("Depending on your environment, the installer can auto-create a class for you,")
+			sublogger.Warn("see the --storageclass CLI flag (should only be used when in-tree CSI driver is still used).")
+			sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
+
 			return errors.New("no --storageclass flag given")
 		}
 
@@ -125,7 +125,7 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	} else {
 		// Even if a CSI Driver was found, the user might not want us to blindly create our
 		// own StorageClass, but instead copy the default. So if --storageclass=copy-default,
-		// this has precendence over the detected cloud provider.
+		// this has precedence over the detected cloud provider.
 		if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
 			cloudProvider = common.CopyDefaultCloudProvider
 		}

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -122,13 +122,11 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 		}
 
 		cloudProvider = kubermaticv1.ProviderType(chosenProvider)
-	} else {
+	} else if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
 		// Even if a CSI Driver was found, the user might not want us to blindly create our
 		// own StorageClass, but instead copy the default. So if --storageclass=copy-default,
 		// this has precedence over the detected cloud provider.
-		if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
-			cloudProvider = common.CopyDefaultCloudProvider
-		}
+		cloudProvider = common.CopyDefaultCloudProvider
 	}
 
 	factory, err := common.StorageClassCreator(cloudProvider)

--- a/pkg/install/stack/kubermatic-seed/stack.go
+++ b/pkg/install/stack/kubermatic-seed/stack.go
@@ -18,6 +18,7 @@ package kubermaticseed
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -84,17 +85,9 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 	logger.Infof("💾 Deploying %s StorageClass…", common.StorageClassName)
 	sublogger := log.Prefix(logger, "   ")
 
-	chosenProvider := opt.StorageClassProvider
-	if chosenProvider != "" && !common.SupportedStorageClassProviders().Has(chosenProvider) {
-		return fmt.Errorf("invalid provider %q given", chosenProvider)
-	}
-
+	// Check if the StorageClass exists already.
 	cls := storagev1.StorageClass{}
-	key := types.NamespacedName{Name: common.StorageClassName}
-
-	err := kubeClient.Get(ctx, key, &cls)
-
-	// storage class exists already
+	err := kubeClient.Get(ctx, types.NamespacedName{Name: common.StorageClassName}, &cls)
 	if err == nil {
 		logger.Info("✅ StorageClass exists, nothing to do.")
 		return nil
@@ -104,25 +97,55 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 		return fmt.Errorf("failed to check for StorageClass %s: %w", common.StorageClassName, err)
 	}
 
-	if opt.StorageClassProvider == "" {
-		sublogger.Warnf("The %s StorageClass does not exist yet. Depending on your environment,", common.StorageClassName)
-		sublogger.Warn("the installer can auto-create a class for you, see the --storageclass CLI flag.")
-		sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
-
-		return fmt.Errorf("no %s StorageClass found", common.StorageClassName)
+	// Class does not yet exist. We can automatically create it based on CSIDrivers if the
+	// cluster is already using out-of-tree CSI drivers.
+	csiDriverName, cloudProvider, err := common.GetPreferredCSIDriver(ctx, kubeClient)
+	if err != nil {
+		return fmt.Errorf("failed to determine existing CSIDrivers: %w", err)
 	}
 
-	factory, err := common.StorageClassCreator(opt.StorageClassProvider)
+	// If no suitable CSIDriver was found, we have to rely on the user to tell us about their provider
+	// and then we assume an in-tree (legacy) provider should be used.
+	if csiDriverName == "" {
+		sublogger.Warnf("The %s StorageClass does not exist yet and no suitable CSIDriver was detected.", common.StorageClassName)
+		sublogger.Warn("Depending on your environment, the installer can auto-create a class for you,")
+		sublogger.Warn("see the --storageclass CLI flag (should only be used when in-tree CSI driver is still used).")
+		sublogger.Warn("Alternatively, please manually create a StorageClass and then re-run the installer to continue.")
+
+		if opt.StorageClassProvider == "" {
+			return errors.New("no --storageclass flag given")
+		}
+
+		chosenProvider := opt.StorageClassProvider
+		if !common.SupportedStorageClassProviders().Has(chosenProvider) {
+			return fmt.Errorf("invalid --storageclass flag %q given", chosenProvider)
+		}
+
+		cloudProvider = kubermaticv1.ProviderType(chosenProvider)
+	} else {
+		// Even if a CSI Driver was found, the user might not want us to blindly create our
+		// own StorageClass, but instead copy the default. So if --storageclass=copy-default,
+		// this has precendence over the detected cloud provider.
+		if opt.StorageClassProvider == string(common.CopyDefaultCloudProvider) {
+			cloudProvider = common.CopyDefaultCloudProvider
+		}
+	}
+
+	factory, err := common.StorageClassCreator(cloudProvider)
 	if err != nil {
 		return fmt.Errorf("invalid StorageClass provider: %w", err)
 	}
 
-	sc, err := factory(ctx, sublogger, kubeClient, common.StorageClassName)
-	if err != nil {
+	storageClass := storagev1.StorageClass{
+		Parameters: map[string]string{},
+	}
+	storageClass.Name = common.StorageClassName
+
+	if err := factory(ctx, sublogger, kubeClient, &storageClass, csiDriverName); err != nil {
 		return fmt.Errorf("failed to define StorageClass: %w", err)
 	}
 
-	if err := kubeClient.Create(ctx, &sc); err != nil {
+	if err := kubeClient.Create(ctx, &storageClass); err != nil {
 		return fmt.Errorf("failed to create StorageClass: %w", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR improves how the installer finds and creates the `kubermatic-fast` StorageClass.

It works like this now:

1. Scan for all available CSIDrivers.
1. If a _known_ CSIDriver exist, use that as both the provisioner and the cloud provider (i.e. this detects an AWS cluster).
1. If no CSIDriver was found (cluster probably still uses in-tree CCM/CSI), everything is as before: The installer relies on the user to specify `--storageclass aws` or `--storageclass copy-default`.
1. If a CSIDriver was found (yay!) it is the same as if the user had specified `--storageclass ...`. The installer will use the found CSIDriver as the provisioner by default. However users can still override this via `--storageclass copy-default` in case their StorageClass has special customizations (e.g. VSphere's StoragePolicy).

For most common providers this should eliminate the need to specify `--storageclass` at all. Sadly, `kind` does not come with a dedicated CSIDriver, so all our scripts continue to use the `copy-default` mechanism.

**Which issue(s) this PR fixes**:
Fixes #11740

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The `kubermatic-installer` now recognizes CSIDrivers automatically and will use them when creating the `kubermatic-fast` StorageClass. Admins can still choose to simply copy the default StorageClass if it's heavily customized by continuing to specify `--storageclass copy-default`.
ACTION REQUIRED: The flag value `gce` was renamed to `gcp` for `--storageclass`.
```

**Documentation**:
```documentation
NONE
```
