### PR TITLE
add short names for application crds

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -204,7 +204,7 @@ type ApplicationDefinitionSpec struct {
 }
 
 //+kubebuilder:object:root=true
-//+kubebuilder:resource:scope=Cluster
+//+kubebuilder:resource:scope=Cluster,shortName=appdef
 
 // ApplicationDefinition is the Schema for the applicationdefinitions API.
 type ApplicationDefinition struct {

--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -37,6 +37,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:resource:shortName=appinstall
 
 // ApplicationInstallation describes a single installation of an Application.
 type ApplicationInstallation struct {

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ApplicationDefinition
     listKind: ApplicationDefinitionList
     plural: applicationdefinitions
+    shortNames:
+      - appdef
     singular: applicationdefinition
   scope: Cluster
   versions:

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -13,6 +13,8 @@ spec:
     kind: ApplicationInstallation
     listKind: ApplicationInstallationList
     plural: applicationinstallations
+    shortNames:
+      - appinstall
     singular: applicationinstallation
   scope: Namespaced
   versions:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11882 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add short name for  Application  crds:
* `applicationdefinition` -> `appdef`.  e.g:  `kubectl get appdef`
* `applicationinstallation` -> `appinstall`.  e.g:  `kubectl get appinstall`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
