### PR TITLE
make changelog-gen.sh actually work

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -37,7 +37,7 @@ This section covers the process to create a new Kubermatic release. Reflects the
     - Tag the matching release in `kubermatic` repo
     - Ensure it's built and pushed successfully
 1. Documentation:
-    - Update changelog (using https://github.com/kubermatic/gchl in `main` branch of Kubermatic repo)
+    - Update changelog (using `hack/changelog-gen.sh`)
       - Remember to include changes from the `dashboard` repo as well, if any
     - Copy it over to matching chapters and branches in docs
       - Strip the Github links from the GCHL version

--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -28,32 +28,6 @@ WORKERS=''
 
 start_docker_daemon_ci
 
-# Make debugging a bit better
-echodate "Configuring bash"
-cat << EOF >> ~/.bashrc
-# Gets set to the CI clusters kubeconfig from a preset
-unset KUBECONFIG
-
-cn() {
-  kubectl config set-context --current --namespace=\$1
-}
-
-kubeconfig() {
-  TMP_KUBECONFIG=\$(mktemp);
-  kubectl get secret admin-kubeconfig -o go-template='{{ index .data "kubeconfig" }}' | base64 -d > \$TMP_KUBECONFIG;
-  export KUBECONFIG=\$TMP_KUBECONFIG;
-  cn kube-system
-}
-
-# this alias makes it so that watch can be used with other aliases, like "watch k get pods"
-alias watch='watch '
-alias k=kubectl
-alias ll='ls -lh --file-type --group-directories-first'
-alias lll='ls -lahF --group-directories-first'
-source <(k completion bash )
-source <(k completion bash | sed s/kubectl/k/g)
-EOF
-
 # Create kind cluster
 TEST_NAME="Create kind cluster"
 


### PR DESCRIPTION
**What this PR does / why we need it**:
`gchl` has changed quite a bit around 2.21 and the script's approach to generating the changelog _and_ committing and pushing is not how our release process actually works, so I removed those parts from the script.

I also removed the unnecessary bash configuration stuff, as the build Docker image already comes with an identical bashrc for maaaany months now.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
