### PR TITLE
Update to Docker 23.0

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -155,7 +155,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -578,7 +578,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -616,7 +616,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -64,7 +64,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -99,7 +99,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -134,7 +134,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -167,7 +167,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -195,7 +195,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -228,7 +228,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -259,7 +259,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -295,7 +295,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: "ce"
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -69,7 +69,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-3
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-3
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-3
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-3
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -54,7 +54,7 @@ if [ -z "$GIT_HEAD_TAG" ]; then
   # only defined in presubmits); in postsubmits we check against the current branch
   UIBRANCH="${PULL_BASE_REF:-$GIT_BRANCH}"
 
-  # the dasboard only publishes Docker images for tagged releases and all
+  # the dashboard only publishes Docker images for tagged releases and all
   # main branch revisions; this means for Kubermatic tests in release branches
   # we need to use the latest tagged dashboard of the same branch
   if [ "$UIBRANCH" == "main" ]; then

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-2
+FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.17-3
 LABEL maintainer="support@kubermatic.com"
 
 # envtest binaries are not available for all k8s patch releases, so beware when updating

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-2 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-3 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-2 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-3 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-2 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-3 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -178,7 +178,7 @@ func (h HelmTemplate) Uninstall(applicationInstallation *appskubermaticv1.Applic
 //
 //	releaseName := applicationInstallation.Name[:43] + "-" + sha1Sum(applicationInstallation.Namespace )[:9]
 func getReleaseName(applicationInstallation *appskubermaticv1.ApplicationInstallation) string {
-	// tech note: in fact releaseName must respect more constrainst to be valid cf https://github.com/helm/helm/blob/v3.9.0/pkg/chartutil/validate_name.go#L66
+	// tech note: in fact releaseName must respect more constraints to be valid cf https://github.com/helm/helm/blob/v3.9.0/pkg/chartutil/validate_name.go#L66
 	namespacedName := applicationInstallation.Namespace + "-" + applicationInstallation.Name
 	if len(namespacedName) > 53 {
 		hash := sha1.New()

--- a/pkg/test/e2e/jig/cluster.go
+++ b/pkg/test/e2e/jig/cluster.go
@@ -470,7 +470,7 @@ func (j *ClusterJig) installAddons(ctx context.Context) error {
 }
 
 func (j *ClusterJig) EnsureAddon(ctx context.Context, addon Addon) error {
-	j.log.Info("Installing addon...", "addon", addon.Name)
+	j.log.Infow("Installing addon...", "addon", addon.Name)
 
 	cluster, err := j.Cluster(ctx)
 	if err != nil {

--- a/pkg/validation/application_definition_test.go
+++ b/pkg/validation/application_definition_test.go
@@ -655,7 +655,7 @@ func TestValidateHelmCredentials(t *testing.T) {
 			},
 			0,
 		},
-		"valid: username and passord are defined and RegistryConfigFile is undefined": {
+		"valid: username and password are defined and RegistryConfigFile is undefined": {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()
@@ -665,7 +665,7 @@ func TestValidateHelmCredentials(t *testing.T) {
 			},
 			0,
 		},
-		"valid: username and passord are undefined and RegistryConfigFile is defined": {
+		"valid: username and password are undefined and RegistryConfigFile is defined": {
 			appskubermaticv1.ApplicationDefinition{
 				Spec: func() appskubermaticv1.ApplicationDefinitionSpec {
 					s := spec.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:
So farr our build image shipped with Docker 20.10. The new `-3` variant of the build image ships with Docker 23.0 and this PR updates KKP accordingly. It's a standalone PR to isolate issues in case something unexpected happens.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
