### PR TITLE
produce vx.y-latest container images for non-tagged revisions in release branches

### DIFF
--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -28,9 +28,16 @@ GIT_HEAD_TAG="$(git tag -l "$PULL_BASE_REF")"
 GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 TAGS="$GIT_HEAD_HASH $GIT_HEAD_TAG"
 
-# we only want to create the "latest" tag if we're building the main branch
 if [ "$GIT_BRANCH" == "main" ]; then
+  # we only want to create the "latest" tag if we're building the main branch
   TAGS="$TAGS latest"
+elif [[ "$GIT_BRANCH" =~ release/v[0-9]+.* ]]; then
+  # the dashboard e2e jobs in a release branch rely on a "latest" tag being
+  # available for KKP, so we turn "release/v2.21" into "v2.21-latest"
+  RELEASE_LATEST="${GIT_BRANCH#release/}"
+  RELEASE_LATEST="${RELEASE_LATEST//\//-}-latest"
+
+  TAGS="$TAGS $RELEASE_LATEST"
 fi
 
 apt install time -y


### PR DESCRIPTION
**What this PR does / why we need it**:
The KKP dashboard uses the KKP container image for whatever KKP version it refers to in its `go.mod` file. This is so that during normal development, changes to KKP won't accidentally break the dashboard.

However for release branches, [this logic](https://github.com/kubermatic/dashboard/blob/release/v2.22/hack/ci/setup-kubermatic-in-kind.sh#L36) does not apply and instead the dashboard is built to use the _latest_ release commit available, so that when individual backports happen, it's not necessary to bump the dashboard's KKP dependency every time. The reason to allow this is that the chances of something breaking in the release branch are much lower than on `main`.

This means the dashboard needs container images like `kubermatic/kubermatic:v2.22-latest` to be available and this PR makes this happen.

**What type of PR is this?**
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
