### PR TITLE
do not use Hetzner for feature e2e tests anymore

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -18,13 +18,12 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-hetzner: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
-      preset-vault: "true"
       preset-goproxy: "true"
       preset-e2e-ssh: "true"
     spec:
@@ -59,7 +58,6 @@ presubmits:
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
-      preset-vault: "true"
       preset-goproxy: "true"
       preset-e2e-ssh: "true"
     spec:
@@ -94,7 +92,6 @@ presubmits:
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
-      preset-vault: "true"
       preset-goproxy: "true"
       preset-e2e-ssh: "true"
     spec:
@@ -129,7 +126,6 @@ presubmits:
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
-      preset-vault: "true"
       preset-goproxy: "true"
       preset-e2e-ssh: "true"
     spec:
@@ -184,13 +180,12 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-hetzner: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
-      preset-vault: "true"
       preset-goproxy: "true"
       preset-e2e-ssh: "true"
     spec:
@@ -248,13 +243,12 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-hetzner: "true"
+      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"
       preset-docker-push: "true"
       preset-kind-volume-mounts: "true"
-      preset-vault: "true"
       preset-goproxy: "true"
       preset-e2e-ssh: "true"
     spec:

--- a/hack/ci/run-ipam-e2e-tests.sh
+++ b/hack/ci/run-ipam-e2e-tests.sh
@@ -57,7 +57,7 @@ echodate "Running IPAM tests..."
 
 go_test ipam_e2e -timeout 45m -tags ipam -v ./pkg/test/e2e/ipam \
   -kubeconfig "$KUBECONFIG" \
-  -hetzner-kkp-datacenter hetzner-nbg1 \
+  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
   -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -41,11 +41,9 @@ source hack/ci/setup-kubermatic-in-kind.sh
 
 export GIT_HEAD_HASH="$(git rev-parse HEAD | tr -d '\n')"
 
-echodate "Getting secrets from Vault"
-retry 5 vault_ci_login
-
 if [ -z "${E2E_SSH_PUBKEY:-}" ]; then
   echodate "Getting default SSH pubkey for machines from Vault"
+  retry 5 vault_ci_login
   E2E_SSH_PUBKEY="$(mktemp)"
   vault kv get -field=pubkey dev/e2e-machine-controller-ssh-key > "${E2E_SSH_PUBKEY}"
 else
@@ -56,15 +54,10 @@ fi
 
 echodate "SSH public key will be $(head -c 25 ${E2E_SSH_PUBKEY})...$(tail -c 25 ${E2E_SSH_PUBKEY})"
 
-export AWS_E2E_TESTS_KEY_ID=$(vault kv get -field=accessKeyID dev/e2e-aws-kkp)
-export AWS_E2E_TESTS_SECRET=$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)
-
-echodate "Successfully got secrets for dev from Vault"
-
 echodate "Running Konnectivity tests..."
 
 go_test konnectivity_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity \
-  -aws-kkp-datacenter aws-eu-central-1a \
+  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
   -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Konnectivity tests done."

--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -70,7 +70,7 @@ echodate "Running MLA tests..."
 
 go_test mla_e2e -timeout 30m -tags mla -v ./pkg/test/e2e/mla \
   -kubeconfig "$KUBECONFIG" \
-  -hetzner-kkp-datacenter hetzner-nbg1 \
+  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
   -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Tests completed successfully!"

--- a/hack/ci/run-opa-e2e-tests.sh
+++ b/hack/ci/run-opa-e2e-tests.sh
@@ -55,7 +55,7 @@ source hack/ci/setup-kubermatic-in-kind.sh
 echodate "Running OPA tests..."
 
 go_test opa_e2e -timeout 30m -tags e2e,ee -v ./pkg/test/e2e/opa \
-  -hetzner-kkp-datacenter hetzner-nbg1 \
+  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
   -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Tests completed successfully!"

--- a/pkg/test/e2e/ipam/ipam_test.go
+++ b/pkg/test/e2e/ipam/ipam_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 var (
-	credentials jig.HetznerCredentials
+	credentials jig.AWSCredentials
 	logOptions  = utils.DefaultLogOptions
 )
 
@@ -260,7 +260,7 @@ func createUserCluster(
 	seedClient ctrlruntimeclient.Client,
 	name string,
 ) (*kubermaticv1.Cluster, ctrlruntimeclient.Client, func(), error) {
-	testJig := jig.NewHetznerCluster(seedClient, log, credentials, 1)
+	testJig := jig.NewAWSCluster(seedClient, log, credentials, 1, nil)
 	testJig.ProjectJig.WithHumanReadableName("IPAM test")
 	testJig.ClusterJig.
 		WithTestName(name).

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -68,7 +68,7 @@ alertmanager_config: |
 )
 
 var (
-	credentials jig.HetznerCredentials
+	credentials jig.AWSCredentials
 	logOptions  = utils.DefaultLogOptions
 )
 
@@ -92,7 +92,7 @@ func TestMLAIntegration(t *testing.T) {
 	}
 
 	// create test environment
-	testJig := jig.NewHetznerCluster(seedClient, logger, credentials, 1)
+	testJig := jig.NewAWSCluster(seedClient, logger, credentials, 1, nil)
 	testJig.ClusterJig.WithTestName("mla")
 
 	project, cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -49,7 +49,7 @@ import (
 )
 
 var (
-	credentials jig.HetznerCredentials
+	credentials jig.AWSCredentials
 
 	logOptions            = utils.DefaultLogOptions
 	ctKind                = "RequiredLabels"
@@ -81,7 +81,7 @@ func TestOPAIntegration(t *testing.T) {
 	utilruntime.Must(constrainttemplatev1.AddToScheme(seedClient.Scheme()))
 
 	// create test environment
-	testJig := jig.NewHetznerCluster(seedClient, logger, credentials, 1)
+	testJig := jig.NewAWSCluster(seedClient, logger, credentials, 1, nil)
 	testJig.ClusterJig.WithTestName("opa")
 
 	_, cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)


### PR DESCRIPTION
**What this PR does / why we need it**:
Hetzner is currently very unreliable and creates many false negative test results. With spot pricing, running tests should not be more expensive on AWS, so this PR moves the Hetzner-based feature tests (not the conformance tests, of course) to AWS. The prow jobs were also harmonized and do not rely on Vault anymore, but on their presets.

**What type of PR is this?**
/kind failing-test
/kind flake

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
