### PR TITLE
Enable Loki compactor retention and rotation

### DIFF
--- a/charts/logging/loki/values.yaml
+++ b/charts/logging/loki/values.yaml
@@ -47,6 +47,7 @@ loki:
       enforce_metric_name: false
       reject_old_samples: true
       reject_old_samples_max_age: 144h
+      retention_period: 720h
     schema_config:
       configs:
       - from: 2018-04-15
@@ -83,6 +84,12 @@ loki:
     compactor:
       working_directory: /data/loki/boltdb-shipper-compactor
       shared_store: filesystem
+      compaction_interval: 10m
+      retention_enabled: true
+      retention_delete_delay: 10m
+      retention_delete_worker_count: 150
+      max_compaction_parallelism: 10
+
 
   ## The app name of loki clients
   client: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Our current configuration doesn't enable Loki compactor. This PR enables the compactor by default to rotate old file and avoid running out of disk space.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable Loki Compactor rotation and set retention to 1 month by default. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
