### PR TITLE
Fix dashboard CPU utilisation graphs for multi-core nodes

### DIFF
--- a/charts/mla/grafana/files/kkp-kubernetes-nodes-overview.json
+++ b/charts/mla/grafana/files/kkp-kubernetes-nodes-overview.json
@@ -51,7 +51,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (node_name) (sum by (node_name) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg by (node_name) (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ node_name }}",
@@ -162,7 +162,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg (sum by (node_name) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"

--- a/charts/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
@@ -51,7 +51,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (node_name) (sum by (node_name) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg by (node_name) (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ node_name }}",
@@ -162,7 +162,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg (sum by (node_name) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"


### PR DESCRIPTION
**What this PR does / why we need it**:

This was reported by a customer - CPU utilisation graphs appear to be incorrect, and it seems this happens due to multi-core nodes (which would be the default I suppose) reporting metrics in a way that the query does not anticipate correctly.

Trying to explain the underlying issue: `irate(node_cpu_seconds_total{job="node-exporter", mode!="idle", node_name=~"$nodes"}[2m])` reports a rate over how many CPU seconds were not spent on idling. However, this is producing multiple series per CPU per node per CPU mode. When it's a single CPU, the sum over all modes per node could be considered a percentage, but with multiple CPUs it becomes kind of a mess.

This PR rebuilds the query in question:

- `100 - (irate(node_cpu_seconds_total{app="node-exporter", mode="idle", node_name=~"$nodes"}[2m]) * 100)`: this calculates the percentage that a single CPU is idling each second as recorded by the `irate` query over the `node_cpu_seconds_total` counter. This sub-query produces a metric per node and CPU, so each node will have x results with x being the number of cores. This is sourced from [robustperception.io](https://www.robustperception.io/understanding-machine-cpu-usage/).
- `avg by (node_name)` averages over the calculated idle percentages for all CPUs of a single node.

My problem here is that this produces different graphs than the "Node Resource Usage" dashboard graph called "CPU utilisation". It's based on a pre-recorded metric called `node:cluster_cpu_utilisation:ratio`. I also need to investigate that recording rule to see what's going on.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12036

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix calculation of node CPU utilisation in Grafana dashboards for multi-core nodes
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
