### PR TITLE
bump metering to version 1.0.3

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -56,7 +56,7 @@ const (
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {
-	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.2"))
+	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.3"))
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore


```release-note
Update Metering to v1.0.3 with the following changes: 
* Add non machine-controller managed machines to `average-cluster-machines`. Note that this is based on a new metric that will be collected together in the same release, therefore information prior this update is not available.
* Fixes a bug that leads to low CPU usage values
* Remove redundant label quotation
```

**Documentation**:
```documentation
NONE
```
