### PR TITLE
[release/v2.21] bump metering to version 1.0.3

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -59,7 +59,7 @@ const (
 )
 
 func getMeteringImage(overwriter registry.WithOverwriteFunc) string {
-	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v1.0.2"
+	return overwriter(resources.RegistryQuay) + "/kubermatic/metering:v1.0.3"
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.


### PR DESCRIPTION
This is a manual cherry-pick of #12035

/assign WeirdMachine

```release-note
Update Metering to v1.0.3 with the following changes: 
* Add non machine-controller managed machines to `average-cluster-machines`. Note that this is based on a new metric that will be collected together in the same release, therefore information prior this update is not available.
* Fixes a bug that leads to low CPU usage values
* Remove redundant label quotation
```

```documentation
NONE
```
