### PR TITLE
Support for specifying dockerTagSuffix for UI/API images

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -314,6 +314,10 @@ spec:
     config: ""
     # DockerRepository is the repository containing the Kubermatic dashboard image.
     dockerRepository: quay.io/kubermatic/dashboard
+    # DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
+    # If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
+    # With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+    dockerTagSuffix: ""
     # Replicas sets the number of pod replicas for the UI deployment.
     replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -314,6 +314,10 @@ spec:
     config: ""
     # DockerRepository is the repository containing the Kubermatic dashboard image.
     dockerRepository: quay.io/kubermatic/dashboard-ee
+    # DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
+    # If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
+    # With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+    dockerTagSuffix: ""
     # Replicas sets the number of pod replicas for the UI deployment.
     replicas: 2
     # Resources describes the requested and maximum allowed CPU/memory usage.

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -148,11 +148,16 @@ type KubermaticUIConfiguration struct {
 	// DockerRepository is the repository containing the Kubermatic dashboard image.
 	DockerRepository string `json:"dockerRepository,omitempty"`
 	// DockerTag is used to overwrite the dashboard Docker image tag and is only for development
-	// purposes. This field must not be set in production environments.
+	// purposes. This field must not be set in production environments. If DockerTag is specified then
+	// DockerTagSuffix will be ignored.
 	// ---
 	//nolint:staticcheck
 	//lint:ignore SA5008 omitgenyaml is used by the example-yaml-generator
 	DockerTag string `json:"dockerTag,omitempty,omitgenyaml"`
+	// DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
+	// If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
+	// With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+	DockerTagSuffix string `json:"dockerTagSuffix,omitempty"`
 	// Config sets flags for various dashboard features.
 	Config string `json:"config,omitempty"`
 	// Resources describes the requested and maximum allowed CPU/memory usage.

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -245,6 +245,8 @@ func APIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerNa
 			tag := versions.UI
 			if cfg.Spec.UI.DockerTag != "" {
 				tag = cfg.Spec.UI.DockerTag
+			} else if cfg.Spec.UI.DockerTagSuffix != "" {
+				tag = fmt.Sprintf("%s-%s", versions.Kubermatic, cfg.Spec.UI.DockerTagSuffix)
 			}
 
 			d.Spec.Template.Spec.Volumes = volumes

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -17,6 +17,8 @@ limitations under the License.
 package kubermatic
 
 import (
+	"fmt"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -54,6 +56,8 @@ func UIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, versions 
 			tag := versions.UI
 			if cfg.Spec.UI.DockerTag != "" {
 				tag = cfg.Spec.UI.DockerTag
+			} else if cfg.Spec.UI.DockerTagSuffix != "" {
+				tag = fmt.Sprintf("%s-%s", versions.Kubermatic, cfg.Spec.UI.DockerTagSuffix)
 			}
 
 			d.Spec.Template.Spec.Containers = []corev1.Container{

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -329,7 +329,10 @@ spec:
                       description: DockerRepository is the repository containing the Kubermatic dashboard image.
                       type: string
                     dockerTag:
-                      description: DockerTag is used to overwrite the dashboard Docker image tag and is only for development purposes. This field must not be set in production environments. ---
+                      description: DockerTag is used to overwrite the dashboard Docker image tag and is only for development purposes. This field must not be set in production environments. If DockerTag is specified then DockerTagSuffix will be ignored. ---
+                      type: string
+                    dockerTagSuffix:
+                      description: DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image. If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used. With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
                       type: string
                     replicas:
                       description: Replicas sets the number of pod replicas for the UI deployment.


### PR DESCRIPTION
**What this PR does / why we need it**:
We have support for specifying a suffix for the addons and the image in turn is evaluated as `KKP_VERSION:SUFFIX`. This simplifies the maintenance and rollout of images per KKP release(patch/minor) since those addons might change per KKP release.

A similar case can be observed for the dashboard images specifically when someone has customized themes, very common use case. They need a new custom image per KKP release(patch/minor).

Having similar support for `dockerTagSuffix` for UI would simplify things a bit for them.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support added to specify the suffix `dockerTagSuffix` for the dashboard images. With `dockerTagSuffix` the tag becomes <CURRENT_KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
