### PR TITLE
Pull proxy-agent image from registry.k8s.io

### DIFF
--- a/cmd/conformance-tester/pkg/tests/images.go
+++ b/cmd/conformance-tester/pkg/tests/images.go
@@ -59,6 +59,14 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
 				)
 			}
+			if strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
 		}
 
 		for _, initContainer := range pod.Spec.InitContainers {
@@ -66,6 +74,14 @@ func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctype
 				errors = append(
 					errors,
 					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
 				)
 			}
 		}

--- a/cmd/conformance-tester/pkg/tests/usercluster_controller.go
+++ b/cmd/conformance-tester/pkg/tests/usercluster_controller.go
@@ -188,6 +188,14 @@ func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, 
 					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
 				)
 			}
+			if strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
 		}
 
 		for _, initContainer := range pod.Spec.InitContainers {
@@ -195,6 +203,14 @@ func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, 
 				errors = append(
 					errors,
 					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
 				)
 			}
 		}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -51,7 +51,7 @@ var (
 func DeploymentReconciler(kServerHost string, kServerPort int, kKeepaliveTime string, imageRewriter registry.ImageRewriter) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		const (
-			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
+			name    = "kas-network-proxy/proxy-agent"
 			version = "v0.0.35"
 		)
 
@@ -78,7 +78,7 @@ func DeploymentReconciler(kServerHost string, kServerPort int, kKeepaliveTime st
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            resources.KonnectivityAgentContainer,
-					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryEUGCR, name, version))),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryK8S, name, version))),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/proxy-agent"},
 					Args: []string{

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -43,13 +43,13 @@ var (
 // ProxySidecar returns container that runs konnectivity proxy server as a sidecar in apiserver pods.
 func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Container, error) {
 	const (
-		name    = "k8s-artifacts-prod/kas-network-proxy/proxy-server"
+		name    = "kas-network-proxy/proxy-server"
 		version = "v0.0.35"
 	)
 
 	return &corev1.Container{
 		Name:            resources.KonnectivityServerContainer,
-		Image:           registry.Must(data.RewriteImage(fmt.Sprintf("%s/%s:%s", resources.RegistryEUGCR, name, version))),
+		Image:           registry.Must(data.RewriteImage(fmt.Sprintf("%s/%s:%s", resources.RegistryK8S, name, version))),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/proxy-server",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that we pull the `proxy-agent` image from registry.k8s.io instead of `eu.gcr.io/k8s-artifacts-prod`. The legacy registry will be frozen soon and no new images will be pushed there.

**Which issue(s) this PR fixes**:
xref https://github.com/kubermatic/kubermatic/discussions/12065

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Pull `kas-network-proxy/proxy-server:v0.0.35` and `kas-network-proxy/proxy-agent:v0.0.35` image from `registry.k8s.io` instead of legacy GCR registry (`eu.gcr.io/k8s-artifacts-prod`)
```

**Documentation**:
```documentation
NONE
```

/assign @rastislavs @embik @ahmedwaleedmalik 