### PR TITLE
[release/v2.21] Pull proxy-agent image from registry.k8s.io and backport tests for no k8s.gcr.io images

### DIFF
--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -574,6 +574,15 @@ func (r *TestRunner) testCluster(
 		log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
 	}
 
+	// Check for Pods with k8s.gcr.io images on user cluster
+	if err := util.JUnitWrapper("[KKP] Test container images not containing k8s.gcr.io on user cluster", report, func() error {
+		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
+			return tests.TestUserClusterNoK8sGcrImages(ctx, log, r.opts, cluster, userClusterClient)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify that no user cluster containers has k8s.gcr.io image: %v", err)
+	}
+
 	// Check security context (seccomp profiles) for control plane pods running on seed cluster
 	if err := util.JUnitWrapper("[KKP] Test pod security context on seed cluster", report, func() error {
 		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
@@ -581,6 +590,15 @@ func (r *TestRunner) testCluster(
 		})
 	}); err != nil {
 		log.Errorf("failed to verify security context for control plane pods: %v", err)
+	}
+
+	// Check for Pods with k8s.gcr.io images on user cluster
+	if err := util.JUnitWrapper("[KKP] Test container images not containing k8s.gcr.io on seed cluster", report, func() error {
+		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
+			return tests.TestNoK8sGcrImages(ctx, log, r.opts, cluster)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify that no seed cluster containers has k8s.gcr.io image: %v", err)
 	}
 
 	// Check telemetry is working

--- a/cmd/conformance-tester/pkg/tests/images.go
+++ b/cmd/conformance-tester/pkg/tests/images.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.uber.org/zap"
+
+	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster) error {
+	if !opts.Tests.Has(ctypes.K8sGcrImageTests) {
+		log.Info("Tests for k8s.gcr.io disabled, skipping.")
+		return nil
+	}
+
+	log.Infof("Testing that no k8s.gcr.io images exist in control plane ...")
+
+	pods := &corev1.PodList{}
+
+	if err := opts.SeedClusterClient.List(ctx, pods, &ctrlruntimeclient.ListOptions{Namespace: cluster.Status.NamespaceName}); err != nil {
+		return fmt.Errorf("failed to list control plane pods: %w", err)
+	}
+
+	if len(pods.Items) == 0 {
+		return fmt.Errorf("no control plane pods found")
+	}
+
+	errors := []string{}
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+
+		for _, initContainer := range pod.Spec.InitContainers {
+			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(strings.Join(errors, "\n"))
+}

--- a/cmd/conformance-tester/pkg/tests/usercluster_controller.go
+++ b/cmd/conformance-tester/pkg/tests/usercluster_controller.go
@@ -165,6 +165,64 @@ func TestUserClusterSeccompProfiles(ctx context.Context, log *zap.SugaredLogger,
 	return fmt.Errorf(strings.Join(errors, "\n"))
 }
 
+func TestUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, opts *ctypes.Options, cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client) error {
+	if !opts.Tests.Has(ctypes.UserClusterSeccompTests) {
+		log.Info("User cluster Seccomp tests disabled, skipping.")
+		return nil
+	}
+
+	pods := &corev1.PodList{}
+
+	errors := []string{}
+
+	// get all Pods running on the cluster
+	if err := userClusterClient.List(ctx, pods, &ctrlruntimeclient.ListOptions{Namespace: ""}); err != nil {
+		return fmt.Errorf("failed to list Pods in user cluster: %w", err)
+	}
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+
+		for _, initContainer := range pod.Spec.InitContainers {
+			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(strings.Join(errors, "\n"))
+}
+
 func rbacResourceNames() []string {
 	return []string{rbacusercluster.ResourceOwnerName, rbacusercluster.ResourceEditorName, rbacusercluster.ResourceViewerName}
 }

--- a/cmd/conformance-tester/pkg/types/tests.go
+++ b/cmd/conformance-tester/pkg/types/tests.go
@@ -25,6 +25,7 @@ const (
 	MetricsTests            = "metrics"
 	SecurityContextTests    = "securitycontext"
 	TelemetryTests          = "telemetry"
+	K8sGcrImageTests        = "gcr-images"
 	UserClusterRBACTests    = "usercluster-rbac"
 	UserClusterSeccompTests = "usercluster-seccomp"
 )
@@ -36,6 +37,7 @@ var AllTests = sets.NewString(
 	MetricsTests,
 	SecurityContextTests,
 	TelemetryTests,
+	K8sGcrImageTests,
 	UserClusterRBACTests,
 	UserClusterSeccompTests,
 )

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -51,7 +51,7 @@ var (
 func DeploymentCreator(kServerHost string, kServerPort int, kKeepaliveTime string, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		const (
-			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
+			name    = "kas-network-proxy/proxy-agent"
 			version = "v0.0.33"
 		)
 
@@ -78,7 +78,7 @@ func DeploymentCreator(kServerHost string, kServerPort int, kKeepaliveTime strin
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            resources.KonnectivityAgentContainer,
-					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryEUGCR), name, version),
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryK8S), name, version),
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/proxy-agent"},
 					Args: []string{

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -42,13 +42,13 @@ var (
 // ProxySidecar returns container that runs konnectivity proxy server as a sidecar in apiserver pods.
 func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Container, error) {
 	const (
-		name    = "k8s-artifacts-prod/kas-network-proxy/proxy-server"
+		name    = "kas-network-proxy/proxy-server"
 		version = "v0.0.33"
 	)
 
 	return &corev1.Container{
 		Name:            resources.KonnectivityServerContainer,
-		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryEUGCR), name, version),
+		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryK8S), name, version),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/proxy-server",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is a manual backport of #12067 combined with backporting tests to ensure that we don't use `k8s.gcr.io` images.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Pull `kas-network-proxy/proxy-server:v0.0.33` and `kas-network-proxy/proxy-agent:v0.0.33` image from `registry.k8s.io` instead of legacy GCR registry (`eu.gcr.io/k8s-artifacts-prod`)
```

**Documentation**:
```documentation
NONE
```