### PR TITLE
use seed proxy settings for the seed deployed webhook

### DIFF
--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -210,7 +210,6 @@ func WebhookDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, vers
 				envVars = append(envVars, SeedProxyEnvironmentVars(seed.Spec.ProxySettings)...)
 				withSeed = true
 			} else if d != nil && len(d.Spec.Template.Spec.Containers) > 0 {
-
 				// check if the old Deployment had a seed env var and is deployed on a Seed or Master+Seed combination.
 				withSeed = false
 				for _, e := range d.Spec.Template.Spec.Containers[0].Env {
@@ -220,13 +219,13 @@ func WebhookDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, vers
 					}
 				}
 
-				// If the webhook is deployed without a Seed it will use the Kubermatic Configuration Proxy settings.
-				// Otherwise, we reuse the existing env to copy seedNameEnvVariable and Proxy Settings that where set
-				// before based on the Seed Proxy Settings.
-				if !withSeed {
-					envVars = KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy)
-				} else {
+				if withSeed {
+					// The webhook is deployed with a Seed, so it reuses the existing env to keep
+					// seedNameEnvVariable and Proxy Settings that where set before based on the actual Seed.
 					envVars = d.Spec.Template.Spec.Containers[0].Env
+				} else {
+					// The webhook is deployed without a Seed and will use the Kubermatic Configuration Proxy settings.
+					envVars = KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy)
 				}
 			}
 

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -197,34 +197,44 @@ func WebhookDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, vers
 				args = append(args, "-v=2")
 			}
 
-			// This Deployment lives on master and seed clusters. On seed clusters
-			// we need to add -seed-name. On a shared master+seed cluster, we must
-			// ensure that the 2 controllers will not overwrite each other (master-operator
-			// removing the -seed-name flag, seed-operator adding it again). Instead
-			// of fiddling with CLI flags, we just use an env variable to store the seed.
-			envVars := KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy)
+			var envVars []corev1.EnvVar
 
-			if !removeSeed {
-				seedName := ""
-				if seed != nil {
-					seedName = seed.Name
-				} else if d != nil && len(d.Spec.Template.Spec.Containers) > 0 {
-					// check if the old Deployment had a seed env var
-					for _, e := range d.Spec.Template.Spec.Containers[0].Env {
-						if e.Name == seedNameEnvVariable {
-							seedName = e.Value
-							break
-						}
+			// The information weather a Seed is present or not is stored in the seedNameEnvVariable.
+			// This impacts the -seed-name flag and proxy settings.
+			withSeed := false
+			if seed != nil {
+				envVars = append(envVars, corev1.EnvVar{
+					Name:  seedNameEnvVariable,
+					Value: seed.Name,
+				})
+				envVars = append(envVars, SeedProxyEnvironmentVars(seed.Spec.ProxySettings)...)
+				withSeed = true
+			} else if d != nil && len(d.Spec.Template.Spec.Containers) > 0 {
+
+				// check if the old Deployment had a seed env var and is deployed on a Seed or Master+Seed combination.
+				withSeed = false
+				for _, e := range d.Spec.Template.Spec.Containers[0].Env {
+					if e.Name == seedNameEnvVariable {
+						withSeed = true
+						break
 					}
 				}
 
-				if seedName != "" {
-					args = append(args, "-seed-name=$(SEED_NAME)")
-					envVars = append(envVars, corev1.EnvVar{
-						Name:  seedNameEnvVariable,
-						Value: seedName,
-					})
+				// If the webhook is deployed without a Seed it will use the Kubermatic Configuration Proxy settings.
+				// Otherwise, we reuse the existing env to copy seedNameEnvVariable and Proxy Settings that where set
+				// before based on the Seed Proxy Settings.
+				if !withSeed {
+					envVars = KubermaticProxyEnvironmentVars(&cfg.Spec.Proxy)
+				} else {
+					envVars = d.Spec.Template.Spec.Containers[0].Env
 				}
+			}
+
+			// On seed clusters we need to add -seed-name flag. On a shared master+seed cluster,
+			// we must ensure that the 2 controllers will not overwrite each other (master-operator
+			// removing the -seed-name flag, seed-operator adding it again).
+			if !removeSeed && withSeed {
+				args = append(args, "-seed-name=$(SEED_NAME)")
 			}
 
 			volumes := []corev1.Volume{

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -199,7 +199,7 @@ func WebhookDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, vers
 
 			var envVars []corev1.EnvVar
 
-			// The information weather a Seed is present or not is stored in the seedNameEnvVariable.
+			// The information if a Seed is present or not is stored in the seedNameEnvVariable.
 			// This impacts the -seed-name flag and proxy settings.
 			withSeed := false
 			if seed != nil {
@@ -211,7 +211,6 @@ func WebhookDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, vers
 				withSeed = true
 			} else if d != nil && len(d.Spec.Template.Spec.Containers) > 0 {
 				// check if the old Deployment had a seed env var and is deployed on a Seed or Master+Seed combination.
-				withSeed = false
 				for _, e := range d.Spec.Template.Spec.Containers[0].Env {
 					if e.Name == seedNameEnvVariable {
 						withSeed = true


### PR DESCRIPTION
**What this PR does / why we need it**:

This should have been fixed in https://github.com/kubermatic/kubermatic/pull/11561 but I used the wrong proxy configuration for the seed webhook.

The webhook can be deployed in master and seed. In a dedicated Seed we need to use the seed proxy configuration
The proxy in Kubermatic configuration should only be used for master cluster deployments. 


**What type of PR is this?**

/kind bug
/kind regression


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use seed proxy configuration for seed deployed webhook.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
