### PR TITLE
Add option to disable default network policies in KubeVirt cluster

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -193,9 +193,10 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 							ZoneSuffixes: []string{},
 						},
 						Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
-							DNSPolicy: "",
-							DNSConfig: &corev1.PodDNSConfig{},
-							Images:    kubermaticv1.KubeVirtImageSources{HTTP: &kubevirtHTTPSource},
+							DNSPolicy:                    "",
+							DNSConfig:                    &corev1.PodDNSConfig{},
+							Images:                       kubermaticv1.KubeVirtImageSources{HTTP: &kubevirtHTTPSource},
+							EnableDefaultNetworkPolicies: pointer.Bool(true),
 							CustomNetworkPolicies: []*kubermaticv1.CustomNetworkPolicy{
 								{
 									Name: "deny-ingress",

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -113,7 +113,7 @@ spec:
           network: ""
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
-          # CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed
+          # Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
           # in the dedicated infra KubeVirt cluster. They are added to the defaults.
           customNetworkPolicies:
             - # Name is the name of the Custom Network Policy.
@@ -143,6 +143,9 @@ spec:
           # 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the
           # policy selected with DNSPolicy.
           dnsPolicy: ""
+          # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
+          # Defaults to true.
+          enableDefaultNetworkPolicies: true
           # Images represents standard VM Image sources.
           images:
             # HTTP represents a http source.
@@ -159,7 +162,7 @@ spec:
                   <<version>>: <<url>>
                 ubuntu:
                   <<version>>: <<url>>
-          # InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names
+          # Optional: InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names
           # that will be used to initialise StorageClasses in the tenant cluster.
           # In the tenant cluster, the created StorageClass name will have as name:
           # kubevirt-<infra-storageClass-name>

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -113,7 +113,7 @@ spec:
           network: ""
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
-          # CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed
+          # Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
           # in the dedicated infra KubeVirt cluster. They are added to the defaults.
           customNetworkPolicies:
             - # Name is the name of the Custom Network Policy.
@@ -143,6 +143,9 @@ spec:
           # 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the
           # policy selected with DNSPolicy.
           dnsPolicy: ""
+          # Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
+          # Defaults to true.
+          enableDefaultNetworkPolicies: true
           # Images represents standard VM Image sources.
           images:
             # HTTP represents a http source.
@@ -159,7 +162,7 @@ spec:
                   <<version>>: <<url>>
                 ubuntu:
                   <<version>>: <<url>>
-          # InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names
+          # Optional: InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names
           # that will be used to initialise StorageClasses in the tenant cluster.
           # In the tenant cluster, the created StorageClass name will have as name:
           # kubevirt-<infra-storageClass-name>

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1230,10 +1230,9 @@ type KubevirtCloudSpec struct {
 	// The cluster's kubeconfig file, encoded with base64.
 	Kubeconfig    string `json:"kubeconfig,omitempty"`
 	CSIKubeconfig string `json:"csiKubeconfig,omitempty"`
-	// PreAllocatedDataVolumes represents a list of DataVolumes that are tied to cluster lifecycle and can be referenced by machines.
 	// Custom Images are a good example of this use case.
 	PreAllocatedDataVolumes []PreAllocatedDataVolume `json:"preAllocatedDataVolumes,omitempty"`
-	// Deprecated: in favor of InfraStorageClasses.
+	// Deprecated: in favor of StorageClasses.
 	// InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
 	InfraStorageClasses []string `json:"infraStorageClasses,omitempty"`

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -704,14 +704,18 @@ type DatacenterSpecKubevirt struct {
 	// configuration based on DNSPolicy.
 	DNSConfig *corev1.PodDNSConfig `json:"dnsConfig,omitempty"`
 
-	// CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed
+	// Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation.
+	// Defaults to true.
+	EnableDefaultNetworkPolicies *bool `json:"enableDefaultNetworkPolicies,omitempty"`
+
+	// Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
 	// in the dedicated infra KubeVirt cluster. They are added to the defaults.
 	CustomNetworkPolicies []*CustomNetworkPolicy `json:"customNetworkPolicies,omitempty"`
 
 	// Images represents standard VM Image sources.
 	Images KubeVirtImageSources `json:"images,omitempty"`
 
-	// InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names
+	// Optional: InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names
 	// that will be used to initialise StorageClasses in the tenant cluster.
 	// In the tenant cluster, the created StorageClass name will have as name:
 	// kubevirt-<infra-storageClass-name>

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -2159,6 +2159,11 @@ func (in *DatacenterSpecKubevirt) DeepCopyInto(out *DatacenterSpecKubevirt) {
 		*out = new(corev1.PodDNSConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.EnableDefaultNetworkPolicies != nil {
+		in, out := &in.EnableDefaultNetworkPolicies, &out.EnableDefaultNetworkPolicies
+		*out = new(bool)
+		**out = **in
+	}
 	if in.CustomNetworkPolicies != nil {
 		in, out := &in.CustomNetworkPolicies, &out.CustomNetworkPolicies
 		*out = make([]*CustomNetworkPolicy, len(*in))

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -577,7 +577,7 @@ spec:
                           description: ImageCloningEnabled flag enable/disable cloning for a cluster.
                           type: boolean
                         infraStorageClasses:
-                          description: 'Deprecated: in favor of InfraStorageClasses. InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)'
+                          description: 'Deprecated: in favor of StorageClasses. InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)'
                           items:
                             type: string
                           type: array
@@ -585,7 +585,7 @@ spec:
                           description: The cluster's kubeconfig file, encoded with base64.
                           type: string
                         preAllocatedDataVolumes:
-                          description: PreAllocatedDataVolumes represents a list of DataVolumes that are tied to cluster lifecycle and can be referenced by machines. Custom Images are a good example of this use case.
+                          description: Custom Images are a good example of this use case.
                           items:
                             properties:
                               annotations:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -572,7 +572,7 @@ spec:
                           description: ImageCloningEnabled flag enable/disable cloning for a cluster.
                           type: boolean
                         infraStorageClasses:
-                          description: 'Deprecated: in favor of InfraStorageClasses. InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)'
+                          description: 'Deprecated: in favor of StorageClasses. InfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)'
                           items:
                             type: string
                           type: array
@@ -580,7 +580,7 @@ spec:
                           description: The cluster's kubeconfig file, encoded with base64.
                           type: string
                         preAllocatedDataVolumes:
-                          description: PreAllocatedDataVolumes represents a list of DataVolumes that are tied to cluster lifecycle and can be referenced by machines. Custom Images are a good example of this use case.
+                          description: Custom Images are a good example of this use case.
                           items:
                             properties:
                               annotations:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -208,7 +208,7 @@ spec:
                             description: Kubevirt configures a KubeVirt datacenter.
                             properties:
                               customNetworkPolicies:
-                                description: CustomNetworkPolicies (optional) allows to add some extra custom NetworkPolicies, that are deployed in the dedicated infra KubeVirt cluster. They are added to the defaults.
+                                description: 'Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed in the dedicated infra KubeVirt cluster. They are added to the defaults.'
                                 items:
                                   description: CustomNetworkPolicy contains a name and the Spec of a NetworkPolicy.
                                   properties:
@@ -520,6 +520,9 @@ spec:
                                   - Default
                                   - None
                                 type: string
+                              enableDefaultNetworkPolicies:
+                                description: 'Optional: EnableDefaultNetworkPolicies enables deployment of default network policies like cluster isolation. Defaults to true.'
+                                type: boolean
                               images:
                                 description: Images represents standard VM Image sources.
                                 properties:
@@ -539,7 +542,7 @@ spec:
                                     type: object
                                 type: object
                               infraStorageClasses:
-                                description: 'InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names that will be used to initialise StorageClasses in the tenant cluster. In the tenant cluster, the created StorageClass name will have as name: kubevirt-<infra-storageClass-name>'
+                                description: 'Optional: InfraStorageClasses contains a list of KubeVirt infra cluster StorageClasses names that will be used to initialise StorageClasses in the tenant cluster. In the tenant cluster, the created StorageClass name will have as name: kubevirt-<infra-storageClass-name>'
                                 items:
                                   properties:
                                     isDefaultClass:


### PR DESCRIPTION
**What this PR does / why we need it**:
There use cases where default network policies like cluster isolation should not be deployed by default.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add option to disable deployment of default network policies in KubeVirt cluster
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
