### PR TITLE
Fix usercluster manager oom

### DIFF
--- a/pkg/applications/helmclient/client_integration_test.go
+++ b/pkg/applications/helmclient/client_integration_test.go
@@ -107,6 +107,8 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installShouldFailedIfAlreadyInstalledTest(t, ctx, ns, chartArchiveV1Path, map[string]interface{}{})
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"}})
 			},
 		},
 		{
@@ -115,6 +117,8 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installShouldFailedIfAlreadyInstalledTest(t, ctx, ns, chartDirV1Path, map[string]interface{}{})
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"}})
 			},
 		},
 		{
@@ -123,6 +127,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -131,6 +140,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -139,6 +153,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -147,6 +166,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -155,6 +179,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -163,6 +192,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		// tests for https://github.com/kubermatic/kubermatic/issues/11864
@@ -172,6 +206,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
 				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -180,6 +219,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
 				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -201,6 +245,10 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installOrUpgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, 1)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+				})
 			},
 		},
 		{
@@ -208,6 +256,10 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installOrUpgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, 1)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+				})
 			},
 		},
 		{
@@ -216,6 +268,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installOrUpgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -224,6 +281,11 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				installOrUpgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, 2)
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -254,6 +316,12 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
 				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true, 2)
+
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -262,6 +330,12 @@ func TestHelmClient(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true)
 				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false, 2)
+
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 
@@ -284,6 +358,11 @@ func TestHelmClient(t *testing.T) {
 				// check that even if install has failed (timeout), workload has been deployed.
 				test.CheckConfigMap(t, ctx, client, ns, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
 				checkServiceDeployed(t, ctx, client, ns)
+
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+				})
 			},
 		},
 		{
@@ -304,6 +383,9 @@ func TestHelmClient(t *testing.T) {
 
 				// check atomic has removed resources
 				checkServiceDeleted(t, ctx, client, ns)
+
+				// no release should be stored as install failed and atomic=true
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{})
 			},
 		},
 		{
@@ -326,6 +408,12 @@ func TestHelmClient(t *testing.T) {
 				// check that even if upgrade has failed (timeout), workload has been updated.
 				test.CheckConfigMap(t, ctx, client, ns, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
 				checkServiceDeployed(t, ctx, client, ns)
+
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+				})
 			},
 		},
 		{
@@ -348,6 +436,47 @@ func TestHelmClient(t *testing.T) {
 				// check atomic flag has revert release to previous version.
 				test.CheckConfigMap(t, ctx, client, ns, test.DefaultData, test.DefaultVerionLabel, false)
 				checkServiceDeleted(t, ctx, client, ns)
+
+				// check only desired release are stored on cluster
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{
+					{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"},
+					{Name: "sh.helm.release.v1." + releaseName + ".v3", Version: "3"}, // this one is due to the rollback (atomic= true)
+				})
+			},
+		},
+		// tests for https://github.com/kubermatic/kubermatic/issues/12078
+		{
+			name: "release history should be prune after an upgrade",
+			testFunc: func(t *testing.T) {
+				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
+				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false, 2)
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"}, {Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"}})
+
+				// history limit is 2 so these next upgrades should trigger a clean up of old helm release
+				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false, 3)
+				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false, 4)
+
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v3", Version: "3"}, {Name: "sh.helm.release.v1." + releaseName + ".v4", Version: "4"}})
+			},
+		},
+
+		{
+			name: "release history should be prune after an InstallOrupgrade",
+			testFunc: func(t *testing.T) {
+				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
+				installOrUpgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, 1)
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"}})
+
+				// upgrade
+				installOrUpgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, 2)
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"}, {Name: "sh.helm.release.v1." + releaseName + ".v2", Version: "2"}})
+
+				// history limit is 2 so these next upgrades should trigger a clean up of old helm release
+				installOrUpgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, 3)
+				installOrUpgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, 4)
+				checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v3", Version: "3"}, {Name: "sh.helm.release.v1." + releaseName + ".v4", Version: "4"}})
 			},
 		},
 	}
@@ -376,6 +505,7 @@ func installTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Cli
 	}
 
 	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel, enableDNS)
+	checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{{Name: "sh.helm.release.v1." + releaseName + ".v1", Version: "1"}})
 }
 
 func installShouldFailedIfAlreadyInstalledTest(t *testing.T, ctx context.Context, ns *corev1.Namespace, chartPath string, values map[string]interface{}) {
@@ -460,6 +590,9 @@ func uninstallTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.C
 	}) {
 		t.Fatal("configMap has not been removed by helm unsintall")
 	}
+
+	// check release has been remove from cluster
+	checkExpectedReleases(t, ctx, client, ns, []test.ReleaseStorageInfo{})
 }
 
 // buildHelClient creates Helm client and returns it with the full path of the chart.
@@ -540,6 +673,18 @@ func checkServiceDeployed(t *testing.T, ctx context.Context, client ctrlruntimec
 	}) {
 		t.Fatalf("service has not been deployed: %s", err)
 	}
+}
+
+// checkExpectedReleases checks that only expected releases are stored on the clusters.
+// Helm releases are stored in secrets (because we use the secret driver) labeled with name=<the name of the release>, version=<the version of the release> and owner=helm.
+func checkExpectedReleases(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, expectedReleases []test.ReleaseStorageInfo) {
+	t.Helper()
+
+	secrets := &corev1.SecretList{}
+	if err := client.List(ctx, secrets, &ctrlruntimeclient.ListOptions{Namespace: ns.Name}, &ctrlruntimeclient.MatchingLabels{"name": releaseName, "owner": "helm"}); err != nil {
+		t.Fatalf("failed to list secrets: %s", err)
+	}
+	test.AssertContainsExactly(t, "", test.MapToReleaseStorageInfo(secrets.Items), expectedReleases)
 }
 
 func TestDownloadChart(t *testing.T) {

--- a/pkg/applications/helmclient/client_integration_test.go
+++ b/pkg/applications/helmclient/client_integration_test.go
@@ -122,7 +122,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
-				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false, 2)
 			},
 		},
 		{
@@ -130,7 +130,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
-				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
+				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false, 2)
 			},
 		},
 		{
@@ -138,7 +138,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
-				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false, 2)
 			},
 		},
 		{
@@ -146,7 +146,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
-				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false)
+				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{}, test.DefaultDataV2, test.DefaultVerionLabelV2, false, 2)
 			},
 		},
 		{
@@ -154,7 +154,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
-				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false, 2)
 			},
 		},
 		{
@@ -162,7 +162,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
-				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false)
+				upgradeTest(t, ctx, client, ns, chartDirV2Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo-version-2": "bar-version-2"}, "another-version", false, 2)
 			},
 		},
 		// tests for https://github.com/kubermatic/kubermatic/issues/11864
@@ -171,7 +171,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
-				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false, 2)
 			},
 		},
 		{
@@ -179,7 +179,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{test.CmDataKey: map[string]interface{}{"hello": "world"}, test.VersionLabelKey: "another-version"}, map[string]string{"hello": "world", "foo": "bar"}, "another-version", false)
-				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartDirV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false, 2)
 			},
 		},
 		{
@@ -253,7 +253,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
-				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true, 2)
 			},
 		},
 		{
@@ -261,7 +261,7 @@ func TestHelmClient(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ns := test.CreateNamespaceWithCleanup(t, ctx, client)
 				installTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, true)
-				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false)
+				upgradeTest(t, ctx, client, ns, chartArchiveV1Path, map[string]interface{}{}, test.DefaultData, test.DefaultVerionLabel, false, 2)
 			},
 		},
 
@@ -388,7 +388,7 @@ func installShouldFailedIfAlreadyInstalledTest(t *testing.T, ctx context.Context
 	}
 }
 
-func upgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, chartPath string, values map[string]interface{}, expectedData map[string]string, expectedVersionLabel string, enableDNS bool) {
+func upgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Client, ns *corev1.Namespace, chartPath string, values map[string]interface{}, expectedData map[string]string, expectedVersionLabel string, enableDNS bool, expectedReleaseVersion int) {
 	helmClient, chartFullPath := buildHelClient(t, ctx, ns, chartPath)
 	deployOpts, err := NewDeployOpts(false, 0, false, enableDNS)
 	if err != nil {
@@ -400,8 +400,8 @@ func upgradeTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.Cli
 		t.Fatalf("helm upgrade failed :%s", err)
 	}
 
-	if releaseInfo.Version != 2 {
-		t.Fatalf("invalid helm release version. expected 2, got %v", releaseInfo.Version)
+	if releaseInfo.Version != expectedReleaseVersion {
+		t.Fatalf("invalid helm release version. expected %v, got %v", expectedReleaseVersion, releaseInfo.Version)
 	}
 
 	test.CheckConfigMap(t, ctx, client, ns, expectedData, expectedVersionLabel, enableDNS)

--- a/pkg/applications/test/kubernetes.go
+++ b/pkg/applications/test/kubernetes.go
@@ -180,3 +180,58 @@ func isExpectedDnsValue(value string, enableDns bool) bool {
 	}
 	return len(value) == 0
 }
+
+// AssertContainsExactly failed the test if the actual slice does not contain exactly the element of the expected slice.
+func AssertContainsExactly[T comparable](t *testing.T, prefixMsg string, actual []T, expected []T) {
+	t.Helper()
+
+	missing := map[T]struct{}{}
+	notExpected := map[T]struct{}{}
+	for _, val := range expected {
+		missing[val] = struct{}{}
+	}
+
+	for _, val := range actual {
+		notExpected[val] = struct{}{}
+	}
+
+	for _, val := range actual {
+		if _, found := missing[val]; found {
+			delete(missing, val)
+			delete(notExpected, val)
+		}
+	}
+	if len(missing) != 0 || len(notExpected) != 0 {
+		t.Fatalf("%s. expect %+v, to contains only %+v.\nMissing elements %+v\nUnexpected elements %+v", prefixMsg, actual, expected, keys(missing), keys(notExpected))
+	}
+}
+
+// keys return the keys of the map.
+func keys[T comparable](dict map[T]struct{}) []T {
+	var res []T
+	for k := range dict {
+		res = append(res, k)
+	}
+	return res
+}
+
+// ReleaseStorageInfo holds information about the secret storing the Helm release information.
+type ReleaseStorageInfo struct {
+	// Name of the secret containing release information.
+	Name string
+
+	// Version of the release.
+	Version string
+}
+
+// MapToReleaseStorageInfo maps the secrets containing the Helm release information to a smaller struct only containing the Name of the secret and the release version.
+func MapToReleaseStorageInfo(secrets []corev1.Secret) []ReleaseStorageInfo {
+	res := []ReleaseStorageInfo{}
+	for _, secret := range secrets {
+		res = append(res, ReleaseStorageInfo{
+			Name:    secret.Name,
+			Version: secret.Labels["version"],
+		})
+	}
+	return res
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
After an upgrade, Helm will purge the release history.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
ref #12078

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
the backport in 2.22 will be done manually as it required an additional step to overcome the OOM kill.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
applications: fix OOM on usercluster-controller by limiting the history of helm releases.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
