### PR TITLE
Update kube-state-metrics to v2.8.2

### DIFF
--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: kube-state-metrics
 version: v9.9.9-dev
-appVersion: v2.8.1
+appVersion: v2.8.2
 description: Kube-State-Metrics for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/kube-state-metrics/templates/cluster-role-binding.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/cluster-role-binding.yaml
@@ -15,6 +15,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.8.2
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -15,6 +15,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.8.2
   name: kube-state-metrics
 rules:
 - apiGroups:
@@ -25,6 +29,7 @@ rules:
   - nodes
   - pods
   - services
+  - serviceaccounts
   - resourcequotas
   - replicationcontrollers
   - limitranges
@@ -87,6 +92,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - storage.k8s.io
   resources:
   - storageclasses
@@ -106,6 +118,7 @@ rules:
   - networking.k8s.io
   resources:
   - networkpolicies
+  - ingressclasses
   - ingresses
   verbs:
   - list
@@ -114,6 +127,16 @@ rules:
   - coordination.k8s.io
   resources:
   - leases
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  - rolebindings
+  - roles
   verbs:
   - list
   - watch

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -19,13 +19,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/component: exporter
-      app.kubernetes.io/name: kube-state-metrics
-      app.kubernetes.io/version: 2.8.2
+      app: kube-state-metrics
   replicas: 1
   template:
     metadata:
       labels:
+        app: kube-state-metrics
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/version: 2.8.2

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -19,12 +19,16 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: kube-state-metrics
+      app.kubernetes.io/component: exporter
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/version: 2.8.2
   replicas: 1
   template:
     metadata:
       labels:
-        app: kube-state-metrics
+        app.kubernetes.io/component: exporter
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/version: 2.8.2
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8080'
@@ -32,6 +36,7 @@ spec:
         fluentbit.io/parser: glog
     spec:
       serviceAccountName: kube-state-metrics
+      automountServiceAccountToken: true
       containers:
       - name: kube-state-metrics
         image: '{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}'
@@ -41,16 +46,29 @@ spec:
         args:
         - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
         ports:
-        - name: http-metrics
-          containerPort: 8080
-        - name: telemetry
-          containerPort: 8081
+        - containerPort: 8080
+          name: http-metrics
+        - containerPort: 8081
+          name: telemetry
         readinessProbe:
+          httpGet:
+            path: /
+            port: 8081
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        livenessProbe:
           httpGet:
             path: /healthz
             port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsUser: 65534
         resources:
 {{ toYaml .Values.kubeStateMetrics.resources | indent 10 }}
 

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -85,6 +85,7 @@ spec:
           - --deployment=kube-state-metrics
           - --pod=$(MY_POD_NAME)
           - --namespace=$(MY_POD_NAMESPACE)
+          - --healthcheck-address=":8088"
         env:
         - name: MY_POD_NAME
           valueFrom:
@@ -97,7 +98,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /health-check
-            port: 8080
+            port: 8088
           initialDelaySeconds: 10
           periodSeconds: 10
         resources:

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
           - --deployment=kube-state-metrics
           - --pod=$(MY_POD_NAME)
           - --namespace=$(MY_POD_NAMESPACE)
-          - --healthcheck-address=":8088"
+          - --healthcheck-address=:8088
         env:
         - name: MY_POD_NAME
           valueFrom:

--- a/charts/monitoring/kube-state-metrics/templates/role.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/role.yaml
@@ -21,8 +21,8 @@ rules:
   resources:
   - pods
   verbs: ["get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   resourceNames: ["kube-state-metrics"]
-  verbs: ["get", "update"]
+  verbs: ["get", "update", "patch"]

--- a/charts/monitoring/kube-state-metrics/templates/service-account.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/service-account.yaml
@@ -13,6 +13,11 @@
 # limitations under the License.
 
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
+  labels:
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.8.2
   name: kube-state-metrics

--- a/charts/monitoring/kube-state-metrics/templates/service.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/service.yaml
@@ -15,19 +15,19 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-state-metrics
   labels:
-    app: kube-state-metrics
+    app.kubernetes.io/component: exporter
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/version: 2.8.2
+  name: kube-state-metrics
 spec:
   clusterIP: None
   ports:
   - name: http-metrics
     port: 8080
     targetPort: http-metrics
-    protocol: TCP
   - name: telemetry
     port: 8081
     targetPort: telemetry
-    protocol: TCP
   selector:
-    app: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -15,7 +15,7 @@
 kubeStateMetrics:
   image:
     repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-    tag: v2.8.1
+    tag: v2.8.2
   resources:
     requests:
       # Rationalized based on real world usage


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubermatic/kubermatic/pull/11987 caused the addon-reseizer to crashloop:

`ERROR: logging before flag.Parse: I0329 07:49:41.921690       1 pod_nanny.go:70] Invoked by [/pod_nanny --container=kube-state-metrics --cpu=100m --extra-cpu=2m --memory=150Mi --extra-memory=30Mi --threshold=5 --deployment=kube-state-metrics --pod=kube-state-metrics-85b778874b-wz5cv --namespace=monitoring]
ERROR: logging before flag.Parse: I0329 07:49:41.921814       1 pod_nanny.go:71] Version: 1.8.16
ERROR: logging before flag.Parse: I0329 07:49:41.921839       1 pod_nanny.go:87] Watching namespace: monitoring, pod: kube-state-metrics-85b778874b-wz5cv, container: kube-state-metrics.
ERROR: logging before flag.Parse: I0329 07:49:41.921861       1 pod_nanny.go:88] storage: MISSING, extra_storage: 0Gi
ERROR: logging before flag.Parse: I0329 07:49:41.924243       1 pod_nanny.go:195] Failed to read data from config file "MISSING/NannyConfiguration": open MISSING/NannyConfiguration: no such file or directory, using default parameters
ERROR: logging before flag.Parse: I0329 07:49:41.924270       1 pod_nanny.go:118] cpu: 100m, extra_cpu: 2m, memory: 150Mi, extra_memory: 30Mi
ERROR: logging before flag.Parse: I0329 07:49:41.924294       1 pod_nanny.go:147] Resources: [{Base:{i:{value:100 scale:-3} d:{Dec:<nil>} s:100m Format:DecimalSI} ExtraPerNode:{i:{value:2 scale:-3} d:{Dec:<nil>} s:2m Format:DecimalSI} Name:cpu} {Base:{i:{value:157286400 scale:0} d:{Dec:<nil>} s:150Mi Format:BinarySI} ExtraPerNode:{i:{value:31457280 scale:0} d:{Dec:<nil>} s:30Mi Format:BinarySI} Name:memory}]
ERROR: logging before flag.Parse: F0329 07:49:41.925377       1 healthcheck.go:54] Failed to start health check: listen tcp :8080: bind: address already in use
goroutine 6 [running]:
github.com/golang/glog.stacks(0xc0001a8000, 0xc0004e4000, 0x7e, 0xcc)
	/go/src/k8s.io/autoscaler/addon-resizer/vendor/github.com/golang/glog/glog.go:769 +0xb9
github.com/golang/glog.(*loggingT).output(0x22ca080, 0xc000000003, 0xc000476700, 0x1c45ead, 0xe, 0x36, 0x0)
	/go/src/k8s.io/autoscaler/addon-resizer/vendor/github.com/golang/glog/glog.go:720 +0x3b3
github.com/golang/glog.(*loggingT).printf(0x22ca080, 0x3, 0x1791a1f, 0x20, 0xc000184fb8, 0x1, 0x1)
	/go/src/k8s.io/autoscaler/addon-resizer/vendor/github.com/golang/glog/glog.go:655 +0x153
github.com/golang/glog.Fatalf(...)
	/go/src/k8s.io/autoscaler/addon-resizer/vendor/github.com/golang/glog/glog.go:1148
k8s.io/autoscaler/addon-resizer/healthcheck.(*HealthCheck).Serve.func1(0xc0004b64c0)
	/go/src/k8s.io/autoscaler/addon-resizer/healthcheck/healthcheck.go:54 +0x12c
created by k8s.io/autoscaler/addon-resizer/healthcheck.(*HealthCheck).Serve
	/go/src/k8s.io/autoscaler/addon-resizer/healthcheck/healthcheck.go:51 +0x3f
`

In addition I found that the resizer is not working properly because of permission issues with the role.

This PR 

* updates kube-state-metrics
* fixes the health port binding issue
* fixes kube-state-metrics-resizer role


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**

/kind bug
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
