### PR TITLE
[release/v2.20] Update MLA to v0.2.6

### DIFF
--- a/hack/ci/setup-mla.sh
+++ b/hack/ci/setup-mla.sh
@@ -29,7 +29,7 @@ source hack/lib.sh
 URL="https://github.com/kubermatic/mla.git"
 
 # Frozen for KKP v2.20.x
-REF="v0.2.5"
+REF="v0.2.6"
 
 # Ensure Github's host key is available and disable IP checking.
 # ensure_github_host_pubkey


### PR DESCRIPTION
**What this PR does / why we need it**:
We just released [MLA 0.2.6](https://github.com/kubermatic/mla/releases/tag/v0.2.6), so this updates KKP CI to use the latest release.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[User Cluster MLA 0.2.6](https://github.com/kubermatic/mla/releases/tag/v0.2.6) has been released and requires manual updating by re-running [User Cluster MLA Installation](https://docs.kubermatic.com/kubermatic/v2.20/tutorials-howtos/monitoring-logging-alerting/user-cluster/admin-guide/#installation)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
