### PR TITLE
[release/v2.21] Installer: make helm chart deployment skippable

### DIFF
--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -71,6 +71,8 @@ type DeployOptions struct {
 	MigrateNginx               bool
 	MigrateOpenstackCSI        bool
 	MigrateLogrotate           bool
+
+	SkipCharts []string
 }
 
 func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *cobra.Command {
@@ -124,6 +126,8 @@ func DeployCommand(logger *logrus.Logger, versions kubermaticversion.Versions) *
 	cmd.PersistentFlags().BoolVar(&opt.MigrateNginx, "migrate-upstream-nginx-ingress", false, "enable the migration procedure for nginx-ingress-controller (upgrade from v1.3.0+)")
 	cmd.PersistentFlags().BoolVar(&opt.MigrateOpenstackCSI, "migrate-openstack-csidrivers", false, "(kubermatic-seed only) enable the data migration of CSIDriver of openstack user-clusters")
 	cmd.PersistentFlags().BoolVar(&opt.MigrateLogrotate, "migrate-logrotate", false, "enable the data migration to delete the logrotate addon")
+
+	cmd.PersistentFlags().StringSliceVar(&opt.SkipCharts, "skip-charts", nil, "skip helm chart deployment (some of cert-manager, nginx-ingress-controller, dex)")
 
 	return cmd
 }
@@ -207,6 +211,7 @@ func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt 
 			DisableTelemetry:                   opt.DisableTelemetry,
 			DisableDependencyUpdate:            opt.SkipDependencies,
 			Versions:                           versions,
+			SkipCharts:                         opt.SkipCharts,
 		}
 
 		// prepapre Kubernetes and Helm clients

--- a/pkg/install/stack/kubermatic-master/certmanager.go
+++ b/pkg/install/stack/kubermatic-master/certmanager.go
@@ -44,10 +44,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/strings/slices"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func deployCertManager(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, "cert-manager") {
+		logger.Info("⏭️ Skipping cert-manager deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying cert-manager…")
 	sublogger := log.Prefix(logger, "   ")
 

--- a/pkg/install/stack/kubermatic-master/nginxingress.go
+++ b/pkg/install/stack/kubermatic-master/nginxingress.go
@@ -38,10 +38,16 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/strings/slices"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func deployNginxIngressController(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, "nginx-ingress-controller") {
+		logger.Info("⏭️ Skipping nginx-ingress-controller deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying nginx-ingress-controller…")
 	sublogger := log.Prefix(logger, "   ")
 

--- a/pkg/install/stack/kubermatic-master/stack.go
+++ b/pkg/install/stack/kubermatic-master/stack.go
@@ -39,6 +39,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/strings/slices"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -199,6 +200,11 @@ func deployStorageClass(ctx context.Context, logger *logrus.Entry, kubeClient ct
 }
 
 func deployDex(ctx context.Context, logger *logrus.Entry, kubeClient ctrlruntimeclient.Client, helmClient helm.Client, opt stack.DeployOptions) error {
+	if slices.Contains(opt.SkipCharts, "dex") {
+		logger.Info("⏭️ Skipping dex deployment.")
+		return nil
+	}
+
 	logger.Info("📦 Deploying Dex…")
 	sublogger := log.Prefix(logger, "   ")
 

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -54,6 +54,8 @@ type DeployOptions struct {
 	EnableLogrotateMigration           bool
 	DisableTelemetry                   bool
 	DisableDependencyUpdate            bool
+
+	SkipCharts []string
 }
 
 type Stack interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/kubermatic/kubermatic/pull/12059

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added --skip-charts flag to `kubermatic-installer deploy` command to make helm chart deployment skippable.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
Run `kubermatic-installer deploy --help`.
```
