### PR TITLE
Bump csi external-snapshot webhook server image to v6.0.1

### DIFF
--- a/addons/csi/openstack/snapshot-webhook.yaml
+++ b/addons/csi/openstack/snapshot-webhook.yaml
@@ -45,7 +45,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: snapshot-validation
-          image: '{{ Image "registry.k8s.io/sig-storage/snapshot-validation-webhook:v5.0.1" }}' # change the image if you wish to use your own custom validation server image
+          image: '{{ Image "registry.k8s.io/sig-storage/snapshot-validation-webhook:v6.0.1" }}' # change the image if you wish to use your own custom validation server image
           imagePullPolicy: IfNotPresent
           args: ['--tls-cert-file=/etc/snapshot-validation-webhook/certs/cert.pem', '--tls-private-key-file=/etc/snapshot-validation-webhook/certs/key.pem']
           ports:


### PR DESCRIPTION
**What this PR does / why we need it**:
Validation for `VolumeSnapshotClass` was added in v6.0.1, https://github.com/kubernetes-csi/external-snapshotter/pull/674. But https://github.com/kubermatic/kubermatic/pull/11724 configured the validation for `VolumeSnapshotClass` too. This results in the OpenStack addon for cinder failing with.

```
    Failed to reconcile Addon "default-storage-class": failed to deploy the addon manifests into the cluster: failed to execute '/usr/local/bin/kubectl-1.25 --kubeconfig /tmp/cluster-oq9fh6wzxs-addon-default-storage-class-kubeconfig apply --prune --filename /tmp/cluster-oq9fh6wzxs-default-storage-class.yaml --selector kubermatic-addon=default-storage-class' for addon default-storage-class of cluster oq9fh6wzxs: exit status 1 storageclass.storage.k8s.io/cinder-csi unchanged Error from server: error when creating "/tmp/cluster-oq9fh6wzxs-default-storage-class.yaml": admission webhook "validation-webhook.snapshot.storage.k8s.io" denied the request: expect resource to be {snapshot.storage.k8s.io v1beta1 volumesnapshots} or {snapshot.storage.k8s.io v1beta1 volumesnapshotcontents} 
```


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
none

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
There doesn't appear to be anything else relevant in the deployment manifests between the releases for github.com/kubernetes-csi/external-snapshotter.
```
$ git diff v5.0.1..v6.0.1 -- ./deploy/kubernetes/webhook-example/
```
Shows only image bump and `ServiceAccount` + RBAC but that has already been take care of by https://github.com/kubermatic/kubermatic/pull/11724.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update external-snapshotter validation webhook server to v6.0.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
