### PR TITLE
clear config finalizer in init seed

### DIFF
--- a/pkg/controller/operator/seed-init/reconciler.go
+++ b/pkg/controller/operator/seed-init/reconciler.go
@@ -110,6 +110,9 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 		return fmt.Errorf("failed to get KubermaticConfiguration: %w", err)
 	}
 
+	// Deleting the KubermaticConfiguration inside a Seed does not trigger nor require any finalizer cleanup
+	config.Finalizers = nil
+
 	if err := r.createInitialCRDs(ctx, seed, seedClient, log); err != nil {
 		return fmt.Errorf("failed to create CRDs: %w", err)
 	}

--- a/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -145,7 +145,6 @@ func Add(
 	sourceChannel := make(chan event.GenericEvent)
 	reconciler.enqueue = func() {
 		sourceChannel <- event.GenericEvent{
-			// TODO: Is it needed to fill this?
 			Object: &kubermaticv1.Seed{},
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

Dedicated Seeds are stuck in deletion.

This happens because the Controller in the master cluster expects the KubermaticConfiguration to be gone in the Seed cluster. However this is not happening as the KubermaticConfiguration has a finalizer set that never disappears. 

As the KubermaticConfiguration in the Seed is just a copy and does not require any cleanup, nor will any controller be triggered to do the cleanup the finalizer blocks deletion. 

When a new dedicated Seed is created the master controller syncs the Seed and KubermaticConfiguration to the Seed cluster. This is done in 2 different components. 

One is the seed init component that creates the initial resources on the new added Seed. This one was adjusted in the PR. 

The other one is the seed sync reconciler.

https://github.com/kubermatic/kubermatic/blob/release/v2.22/pkg/controller/master-controller-manager/seed-sync/resources.go#L69


The  seed sync reconciler does not copy the finalizer but seed init does.

Affected version: v2.22

Workaround: Remove the finalizer of the KubermaticConfiguration in the Seed cluster manually. 

**What type of PR is this?**

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug that causes dedicated Seeds to be stuck in deletion.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
