### PR TITLE
[release/v2.20] Pull proxy-agent image from registry.k8s.io and backport tests for no k8s.gcr.io images

### DIFF
--- a/cmd/conformance-tests/runner.go
+++ b/cmd/conformance-tests/runner.go
@@ -764,6 +764,24 @@ func (r *testRunner) testCluster(
 		log.Errorf("failed to verify that pods have a seccomp profile: %v", err)
 	}
 
+	// Check for Pods with k8s.gcr.io images on user cluster
+	if err := junitReporterWrapper("[KKP] Test container images not containing k8s.gcr.io on user cluster", report, func() error {
+		return retryNAttempts(maxTestAttempts, func(attempt int) error {
+			return r.testUserClusterNoK8sGcrImages(ctx, log, cluster, userClusterClient)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify that no seed cluster containers has k8s.gcr.io image: %v", err)
+	}
+
+	// Check for Pods with k8s.gcr.io images on user cluster
+	if err := junitReporterWrapper("[KKP] Test container images not containing k8s.gcr.io on seed cluster", report, func() error {
+		return retryNAttempts(maxTestAttempts, func(attempt int) error {
+			return r.testNoK8sGcrImages(ctx, log, cluster)
+		})
+	}); err != nil {
+		log.Errorf("failed to verify that no seed cluster containers has k8s.gcr.io image: %v", err)
+	}
+
 	return nil
 }
 

--- a/cmd/conformance-tests/usercluster_controller_tests.go
+++ b/cmd/conformance-tests/usercluster_controller_tests.go
@@ -154,6 +154,59 @@ func (r *testRunner) testUserClusterSeccompProfiles(ctx context.Context, log *za
 	return fmt.Errorf(strings.Join(errors, "\n"))
 }
 
+func (r *testRunner) testUserClusterNoK8sGcrImages(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, userClusterClient ctrlruntimeclient.Client) error {
+	pods := &corev1.PodList{}
+
+	errors := []string{}
+
+	// get all Pods running on the cluster
+	if err := userClusterClient.List(ctx, pods, &ctrlruntimeclient.ListOptions{Namespace: ""}); err != nil {
+		return fmt.Errorf("failed to list Pods in user cluster: %w", err)
+	}
+
+	for _, pod := range pods.Items {
+		for _, container := range pod.Spec.Containers {
+			if strings.HasPrefix(container.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(container.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", container.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+
+		for _, initContainer := range pod.Spec.InitContainers {
+			if strings.HasPrefix(initContainer.Image, resources.RegistryK8SGCR) {
+				errors = append(
+					errors,
+					fmt.Sprintf("InitContainer %s in Pod %s/%s has image from k8s.gcr.io and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+			if strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryEUGCR)) ||
+				strings.HasPrefix(initContainer.Image, fmt.Sprintf("%s/k8s-", resources.RegistryUSGCR)) {
+				errors = append(
+					errors,
+					fmt.Sprintf("Container %s in Pod %s/%s has image from gcr.io/k8s-* and should be using registry.k8s.io instead", initContainer.Name, pod.Namespace, pod.Name),
+				)
+			}
+		}
+	}
+
+	if len(errors) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf(strings.Join(errors, "\n"))
+}
+
 func rbacResourceNames() []string {
 	return []string{rbacusercluster.ResourceOwnerName, rbacusercluster.ResourceEditorName, rbacusercluster.ResourceViewerName}
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity/deployment.go
@@ -51,7 +51,7 @@ var (
 func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrite registry.WithOverwriteFunc) reconciling.NamedDeploymentCreatorGetter {
 	return func() (string, reconciling.DeploymentCreator) {
 		const (
-			name    = "k8s-artifacts-prod/kas-network-proxy/proxy-agent"
+			name    = "kas-network-proxy/proxy-agent"
 			version = "v0.0.33"
 		)
 
@@ -78,8 +78,8 @@ func DeploymentCreator(kServerHost string, kServerPort int, registryWithOverwrit
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            resources.KonnectivityAgentContainer,
-					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryEUGCR), name, version),
-					ImagePullPolicy: corev1.PullAlways,
+					Image:           fmt.Sprintf("%s/%s:%s", registryWithOverwrite(resources.RegistryK8S), name, version),
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         []string{"/proxy-agent"},
 					Args: []string{
 						"--logtostderr=true",

--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -42,14 +42,14 @@ var (
 // ProxySidecar returns container that runs konnectivity proxy server as a sidecar in apiserver pods.
 func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Container, error) {
 	const (
-		name    = "k8s-artifacts-prod/kas-network-proxy/proxy-server"
+		name    = "kas-network-proxy/proxy-server"
 		version = "v0.0.33"
 	)
 
 	return &corev1.Container{
 		Name:            resources.KonnectivityServerContainer,
-		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryEUGCR), name, version),
-		ImagePullPolicy: corev1.PullAlways,
+		Image:           fmt.Sprintf("%s/%s:%s", data.ImageRegistry(resources.RegistryK8S), name, version),
+		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command: []string{
 			"/proxy-server",
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #12069 which in turn was a manual backport of #12067.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Pull `kas-network-proxy/proxy-server:v0.0.33` and `kas-network-proxy/proxy-agent:v0.0.33` image from `registry.k8s.io` instead of legacy GCR registry (`eu.gcr.io/k8s-artifacts-prod`)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
