### PR TITLE
explicitly remove finalizer on kubermatic configuration reconciler

### DIFF
--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -76,6 +76,8 @@ func configReconciler(config *kubermaticv1.KubermaticConfiguration) kkpreconcili
 			c.Labels[ManagedByLabel] = ControllerName
 
 			c.Annotations = config.Annotations
+			c.Finalizers = nil
+
 			c.Spec = config.Spec
 
 			return c, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Follow up of https://github.com/kubermatic/kubermatic/pull/12131

This PR ensures seeds created with the finalizer in KKP v2.22 will be fine. 

```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
