### PR TITLE
Explicitly unset SA for metering CronJob

### DIFF
--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -58,6 +58,8 @@ func cronJobReconciler(reportName string, mrc *kubermaticv1.MeteringReportConfig
 
 			job.Spec.Schedule = mrc.Schedule
 			job.Spec.JobTemplate.Spec.Parallelism = pointer.Int32(1)
+			job.Spec.JobTemplate.Spec.Template.Spec.ServiceAccountName = ""
+			job.Spec.JobTemplate.Spec.Template.Spec.DeprecatedServiceAccount = ""
 			job.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
 			job.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In older KKP versions before https://github.com/kubermatic/kubermatic/pull/10721, metering `CronJob` used to have dedicated `ServiceAccount`. Old metering `CronJobs` created before v2.22 still keep the `ServiceAccountName` in spec because https://github.com/kubermatic/kubermatic/pull/10721#discussion_r1157468124 applies only to newly created `CronJobs` resulting in following error
```
  Warning  FailedCreate  4m56s (x1533 over 6d8h)  job-controller  Error creating: pods "kubermatic-metering-report-weekly-27998280-" is forbidden: error looking up service account kubermatic/kubermatic-metering: serviceaccount "kubermatic-metering" not found
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
internal ticket

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix metering CronJobs after KKP upgrades
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
