### PR TITLE
installer: mla: fix flags for skipping minio-related components

### DIFF
--- a/pkg/install/stack/usercluster-mla/stack.go
+++ b/pkg/install/stack/usercluster-mla/stack.go
@@ -103,8 +103,10 @@ func (s *UserClusterMLA) Deploy(ctx context.Context, opt stack.DeployOptions) er
 		return fmt.Errorf("failed to deploy Consul: %w", err)
 	}
 
-	if err := deployMinio(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
-		return fmt.Errorf("failed to deploy Minio: %w", err)
+	if !opt.MLASkipMinio {
+		if err := deployMinio(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
+			return fmt.Errorf("failed to deploy Minio: %w", err)
+		}
 	}
 
 	if err := deployCortex(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
@@ -119,8 +121,10 @@ func (s *UserClusterMLA) Deploy(ctx context.Context, opt stack.DeployOptions) er
 		return fmt.Errorf("failed to deploy Loki: %w", err)
 	}
 
-	if err := deployMinioLifecycleMgr(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
-		return fmt.Errorf("failed to deploy Minio Bucket Lifecycle Manager: %w", err)
+	if !opt.MLASkipMinioLifecycleMgr {
+		if err := deployMinioLifecycleMgr(ctx, opt.Logger, opt.KubeClient, opt.HelmClient, opt); err != nil {
+			return fmt.Errorf("failed to deploy Minio Bucket Lifecycle Manager: %w", err)
+		}
 	}
 
 	if opt.MLAIncludeIap {


### PR DESCRIPTION
**What this PR does / why we need it**:
As reported in https://github.com/kubermatic/kubermatic/discussions/12126, skipping minio and minio-lifecycle-mgr during MLA installation was not working correctly. This fixes the problem.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
installer: mla: --mla-skip-minio and --mla-skip-minio-lifecycle-mgr work properly now
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
