### PR TITLE
Mirror metering images for EE in kubermatic-installer

### DIFF
--- a/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
@@ -22,6 +22,8 @@ import (
 	"context"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,5 +31,10 @@ import (
 
 // ReconcileMeteringResources reconciles the metering related resources.
 func ReconcileMeteringResources(_ context.Context, _ ctrlruntimeclient.Client, _ *runtime.Scheme, _ *kubermaticv1.KubermaticConfiguration, _ *kubermaticv1.Seed) error {
+	return nil
+}
+
+// CronJobReconciler returns the func to create/update the metering report cronjob. Available only for ee.
+func CronJobReconciler(_ string, _ *kubermaticv1.MeteringReportConfiguration, _ string, _ registry.ImageRewriter, _ string) reconciling.NamedCronJobReconcilerFactory {
 	return nil
 }

--- a/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
@@ -23,6 +23,8 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/ee/metering"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
+	"k8c.io/reconciler/pkg/reconciling"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,4 +33,9 @@ import (
 // ReconcileMeteringResources reconciles the metering related resources.
 func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Client, scheme *runtime.Scheme, cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) error {
 	return metering.ReconcileMeteringResources(ctx, client, scheme, cfg, seed)
+}
+
+// CronJobReconciler returns the func to create/update the metering report cronjob. Available only for ee.
+func CronJobReconciler(rn string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, r registry.ImageRewriter, ns string) reconciling.NamedCronJobReconcilerFactory {
+	return metering.CronJobReconciler(rn, mrc, caBundleName, r, ns)
 }

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -39,8 +39,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-// cronJobReconciler returns the func to create/update the metering report cronjob.
-func cronJobReconciler(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.ImageRewriter, namespace string) reconciling.NamedCronJobReconcilerFactory {
+// CronJobReconciler returns the func to create/update the metering report cronjob.
+func CronJobReconciler(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.ImageRewriter, namespace string) reconciling.NamedCronJobReconcilerFactory {
 	return func() (string, reconciling.CronJobReconciler) {
 		return reportName, func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
 			var args []string

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -93,7 +93,7 @@ func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlrunti
 	var cronJobs []reconciling.NamedCronJobReconcilerFactory
 
 	for reportName, reportConf := range seed.Spec.Metering.ReportConfigurations {
-		cronJobs = append(cronJobs, cronJobReconciler(reportName, reportConf, caBundle.Name, overwriter, seed.Namespace))
+		cronJobs = append(cronJobs, CronJobReconciler(reportName, reportConf, caBundle.Name, overwriter, seed.Namespace))
 
 		if reportConf.Retention != nil {
 			config.Rules = append(config.Rules, lifecycle.Rule{

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -38,6 +38,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common/vpa"
 	masteroperator "k8c.io/kubermatic/v2/pkg/controller/operator/master/resources/kubermatic"
 	seedoperatorkubermatic "k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/kubermatic"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/metering"
 	seedoperatornodeportproxy "k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
 	kubernetescontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
@@ -314,6 +315,9 @@ func getImagesFromReconcilers(log logrus.FieldLogger, templateData *resources.Te
 	}
 
 	cronjobReconcilers := kubernetescontroller.GetCronJobReconcilers(templateData)
+	if mcjr := metering.CronJobReconciler("reportName", &kubermaticv1.MeteringReportConfiguration{}, "caBundleName", templateData.RewriteImage, mockNamespaceName); mcjr != nil {
+		cronjobReconcilers = append(cronjobReconcilers, mcjr)
+	}
 
 	var daemonsetReconcilers []reconciling.NamedDaemonSetReconcilerFactory
 	daemonsetReconcilers = append(daemonsetReconcilers, usersshkeys.DaemonSetReconciler(


### PR DESCRIPTION
**What this PR does / why we need it**:
`kubermatic-installer` misses some images in `mirror-images` subcommand. This adds the `metering` `CronJob` image for EE.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12129

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: include metering images in kubermatic-installer mirror-images
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
