### PR TITLE
VCD: fix API credential validation for clusters

### DIFF
--- a/pkg/provider/cloud/vmwareclouddirector/provider.go
+++ b/pkg/provider/cloud/vmwareclouddirector/provider.go
@@ -194,13 +194,13 @@ func GetCredentialsForCluster(cloud kubermaticv1.CloudSpec, secretKeySelector pr
 	// Check if API Token exists.
 	if apiToken == "" && cloud.VMwareCloudDirector.CredentialsReference != nil {
 		apiToken, _ = secretKeySelector(cloud.VMwareCloudDirector.CredentialsReference, resources.VMwareCloudDirectorAPIToken)
-		if apiToken != "" {
-			return &resources.VMwareCloudDirectorCredentials{
-				Organization: organization,
-				APIToken:     apiToken,
-				VDC:          vdc,
-			}, nil
-		}
+	}
+	if apiToken != "" {
+		return &resources.VMwareCloudDirectorCredentials{
+			Organization: organization,
+			APIToken:     apiToken,
+			VDC:          vdc,
+		}, nil
 	}
 
 	// Check for Username/password since API token doesn't exist.


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes cluster credentials validation for VMware Cloud Director. In the previous implementation, if `APIToken` was explicitly configured in the cloud spec than it was being ignored. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
Add one of the following kinds:
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
