### PR TITLE
[release/v2.22] Include Kubernetes patch releases for April 2023

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -614,11 +614,14 @@ spec:
       - v1.24.8
       - v1.24.9
       - v1.24.10
+      - v1.24.13
       - v1.25.2
       - v1.25.4
       - v1.25.5
       - v1.25.6
+      - v1.25.9
       - v1.26.1
+      - v1.26.4
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -510,7 +510,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.25.6
+    default: v1.25.9
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -614,11 +614,14 @@ spec:
       - v1.24.8
       - v1.24.9
       - v1.24.10
+      - v1.24.13
       - v1.25.2
       - v1.25.4
       - v1.25.5
       - v1.25.6
+      - v1.25.9
       - v1.26.1
+      - v1.26.4
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -510,7 +510,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.25.6
+    default: v1.25.9
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -217,7 +217,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.25.6"),
+		Default: semver.NewSemverOrDie("v1.25.9"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -232,13 +232,16 @@ var (
 			newSemver("v1.24.8"),
 			newSemver("v1.24.9"),
 			newSemver("v1.24.10"),
+            newSemver("v1.24.13"),
 			// Kubernetes 1.25
 			newSemver("v1.25.2"),
 			newSemver("v1.25.4"),
 			newSemver("v1.25.5"),
 			newSemver("v1.25.6"),
+            newSemver("v1.25.9"),
 			// Kubernetes 1.26
 			newSemver("v1.26.1"),
+            newSemver("v1.26.4"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.23 =======

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -232,16 +232,16 @@ var (
 			newSemver("v1.24.8"),
 			newSemver("v1.24.9"),
 			newSemver("v1.24.10"),
-            newSemver("v1.24.13"),
+			newSemver("v1.24.13"),
 			// Kubernetes 1.25
 			newSemver("v1.25.2"),
 			newSemver("v1.25.4"),
 			newSemver("v1.25.5"),
 			newSemver("v1.25.6"),
-            newSemver("v1.25.9"),
+			newSemver("v1.25.9"),
 			// Kubernetes 1.26
 			newSemver("v1.26.1"),
-            newSemver("v1.26.4"),
+			newSemver("v1.26.4"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.23 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of #12165. To be un-drafted once Kubernetes releases are out.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Kubernetes 1.24.13, 1.25.9 and 1.26.4. Update default version to 1.25.9
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
