### PR TITLE
Deploy iap only when configured in values

### DIFF
--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -119,8 +119,8 @@ logging)
 
 usercluster-mla)
   echodate "Running Kubermatic Installer for UserCluster MLA..."
-  # deploy iap only for hamburg seed
-  if [[ $VALUES_FILE == *"hamburg"* ]]; then
+  # deploy iap only when it is set in values file
+  if $(yq '.iap.deployments != null' ${VALUES_FILE}); then
     ./_build/kubermatic-installer deploy usercluster-mla \
       --config "$KUBERMATIC_CONFIG" \
       --helm-values "$VALUES_FILE" \


### PR DESCRIPTION
**What this PR does / why we need it**:

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/cleanup

**Special notes for your reviewer**:
This should fix the if-statement to not be dependent on the name of the values file (which gets hardcoded to /tmp/values.yaml in deploy-dev.sh anyway). Instead now we check if iap is configured and roll-out only if it is

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
