### PR TITLE
Revert "[release/v2.22] explicitly remove finalizer on kubermatic configuration reconciler"

### DIFF
--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -76,8 +76,6 @@ func configReconciler(config *kubermaticv1.KubermaticConfiguration) kkpreconcili
 			c.Labels[ManagedByLabel] = ControllerName
 
 			c.Annotations = config.Annotations
-			c.Finalizers = nil
-
 			c.Spec = config.Spec
 
 			return c, nil


### PR DESCRIPTION
Reverts kubermatic/kubermatic#12138. See #12172 for why.

/kind regression
/kind bug

```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```