### PR TITLE
Fix finalizer handling for KubermaticConfigurations on remote seeds

### DIFF
--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -18,6 +18,8 @@ package seedsync
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -66,20 +68,28 @@ func seedReconciler(seed *kubermaticv1.Seed) kkpreconciling.NamedSeedReconcilerF
 	}
 }
 
-func configReconciler(config *kubermaticv1.KubermaticConfiguration) kkpreconciling.NamedKubermaticConfigurationReconcilerFactory {
+func configReconciler(configOnMaster *kubermaticv1.KubermaticConfiguration) kkpreconciling.NamedKubermaticConfigurationReconcilerFactory {
 	return func() (string, kkpreconciling.KubermaticConfigurationReconciler) {
-		return config.Name, func(c *kubermaticv1.KubermaticConfiguration) (*kubermaticv1.KubermaticConfiguration, error) {
-			c.Labels = config.Labels
-			if c.Labels == nil {
-				c.Labels = make(map[string]string)
+		return configOnMaster.Name, func(configOnSeed *kubermaticv1.KubermaticConfiguration) (*kubermaticv1.KubermaticConfiguration, error) {
+			configOnSeed.Labels = configOnMaster.Labels
+			if configOnSeed.Labels == nil {
+				configOnSeed.Labels = make(map[string]string)
 			}
-			c.Labels[ManagedByLabel] = ControllerName
+			configOnSeed.Labels[ManagedByLabel] = ControllerName
 
-			c.Annotations = config.Annotations
+			configOnSeed.Annotations = configOnMaster.Annotations
+			configOnSeed.Spec = configOnMaster.Spec
 
-			c.Spec = config.Spec
+			// Fix KKP 2.22 finalizers: In previous KKP releases we accidentally synchronized the
+			// cleanup finalizer down from the master to the seed clusters, but never cared to
+			// clean it up upon deletion, making the seed being stuck.
+			// This snippet of code will remove a stray cleanup finalizer, but ONLY if it's actually
+			// a copy of the config (i.e. a dedicated seed cluster, not a shared master/seed system).
+			if configOnMaster.UID != configOnSeed.UID {
+				kubernetes.RemoveFinalizer(configOnSeed, common.CleanupFinalizer)
+			}
 
-			return c, nil
+			return configOnSeed, nil
 		}
 	}
 }

--- a/pkg/controller/master-controller-manager/seed-sync/resources.go
+++ b/pkg/controller/master-controller-manager/seed-sync/resources.go
@@ -76,7 +76,6 @@ func configReconciler(config *kubermaticv1.KubermaticConfiguration) kkpreconcili
 			c.Labels[ManagedByLabel] = ControllerName
 
 			c.Annotations = config.Annotations
-			c.Finalizers = nil
 
 			c.Spec = config.Spec
 

--- a/pkg/controller/operator/seed-init/reconciler.go
+++ b/pkg/controller/operator/seed-init/reconciler.go
@@ -110,9 +110,6 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, seed
 		return fmt.Errorf("failed to get KubermaticConfiguration: %w", err)
 	}
 
-	// Deleting the KubermaticConfiguration inside a Seed does not trigger nor require any finalizer cleanup
-	config.Finalizers = nil
-
 	if err := r.createInitialCRDs(ctx, seed, seedClient, log); err != nil {
 		return fmt.Errorf("failed to create CRDs: %w", err)
 	}

--- a/pkg/controller/operator/seed-init/reconciler.go
+++ b/pkg/controller/operator/seed-init/reconciler.go
@@ -206,6 +206,11 @@ func (r *Reconciler) createOnSeed(ctx context.Context, obj ctrlruntimeclient.Obj
 	objCopy.SetUID("")
 	objCopy.SetGeneration(0)
 
+	// Never duplicate finalizers, as we cannot ensure that a finalizer on an object gets
+	// actually processed on a different cluster, as the component that owns the finalizer
+	// might only run on the master cluster.
+	objCopy.SetFinalizers(nil)
+
 	err := client.Create(ctx, objCopy)
 
 	// An AlreadyExists error can occur on shared master/seed systems.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR reverts #12131 and #12137 and replaces them with better code.

The problem with the PRs above was that they lead to an infinite loop: Because the seed-sync controller _always_ removed _all_ finalizers, it was constantly removing them, only for the operator to bring them back, triggering the seed-sync again which removed the finalizer again:

![screenshot-2023-04-13-111324](https://user-images.githubusercontent.com/127499/231726376-ce167062-4714-4002-8a6d-3b1d47982b81.png)

This happens because master and seed _can_ be the same cluster.

This PR improves the situation by

* making the original "do not copy finalizers down" method a bit broader by applying it to all resources in the seed-init controller,
* making the reconciler a bit more careful and only change finalizers if we are sure we don't reconcile a shared master/seed; checking UIDs is considered cheating and please look away. In general our codebase tries not to make assumptions and we purposefully have no API to ask "is this a shared master/seed?". Keeping the careful reconciler allows us to migrate existing KKP systems to remove the bad finalizer.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
