### PR TITLE
Sync RuleGroup CRD to Seeds

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -68,7 +68,7 @@ locationMap='{
   "presets.kubermatic.k8c.io": "master,seed",
   "projects.kubermatic.k8c.io": "master,seed",
   "resourcequotas.kubermatic.k8c.io": "master,seed",
-  "rulegroups.kubermatic.k8c.io": "master",
+  "rulegroups.kubermatic.k8c.io": "master,seed",
   "seeds.kubermatic.k8c.io": "master,seed",
   "userprojectbindings.kubermatic.k8c.io": "master,seed",
   "usersshkeys.kubermatic.k8c.io": "master,seed",

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_rulegroups.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
-    kubermatic.k8c.io/location: master
+    kubermatic.k8c.io/location: master,seed
   creationTimestamp: null
   name: rulegroups.kubermatic.k8c.io
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Missed this CRD in #12117. The mla-controller on a freshly installed Seed complains:

```json
{"level":"error","time":"2023-04-14T06:32:24.319Z","caller":"controller/controller.go:274","msg":"Reconciler error","controller":"kkp-mla-controller","object":{"name":"identifier"},"namespace":"","name":"identifier","reconcileID":"98831fbd-ca5b-465e-af73-8bd5ec8fc5c2","error":"unable to cleanup: no matches for kind \"RuleGroup\" in version \"kubermatic.k8c.io/v1\""}
```


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
