### PR TITLE
[KKP3] Refactor MLA e2e tests

### DIFF
--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -18,7 +18,6 @@ presubmits:
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
-      preset-aws-e2e-kkp: "true"
       preset-kubeconfig-ci: "true"
       preset-docker-mirror: "true"
       preset-docker-pull: "true"

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -35,6 +35,7 @@ import (
 	"k8c.io/kubermatic/v3/pkg/install/stack/common"
 	kubermaticmaster "k8c.io/kubermatic/v3/pkg/install/stack/kubermatic-master"
 	kubermaticseed "k8c.io/kubermatic/v3/pkg/install/stack/kubermatic-seed"
+	userclustermla "k8c.io/kubermatic/v3/pkg/install/stack/usercluster-mla"
 	"k8c.io/kubermatic/v3/pkg/log"
 	"k8c.io/kubermatic/v3/pkg/util/flagopts"
 	kubermaticversion "k8c.io/kubermatic/v3/pkg/version/kubermatic"
@@ -185,8 +186,8 @@ func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt 
 
 		var kubermaticStack stack.Stack
 		switch stackName {
-		// case "usercluster-mla":
-		// 	kubermaticStack = userclustermla.NewStack()
+		case "usercluster-mla":
+			kubermaticStack = userclustermla.NewStack()
 		case "kubermatic-seed":
 			kubermaticStack = kubermaticseed.NewStack()
 		case "kubermatic-master", "":

--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -47,9 +47,10 @@ export KUBERMATIC_YAML=hack/ci/testdata/kubermatic.yaml
 
 source hack/ci/setup-kind-cluster.sh
 
-# gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+# gather the logs of all things in the cluster control plane and in the Kubermatic namespace, plus the MLA components
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/mla" --namespace mla > /dev/null 2>&1 &
 
 source hack/ci/setup-kubermatic-mla-in-kind.sh
 

--- a/hack/ci/run-mla-e2e-tests.sh
+++ b/hack/ci/run-mla-e2e-tests.sh
@@ -71,7 +71,7 @@ echodate "Running MLA tests..."
 
 go_test mla_e2e -timeout 30m -tags mla -v ./pkg/test/e2e/mla \
   -kubeconfig "$KUBECONFIG" \
-  -aws-kkp-datacenter "$AWS_E2E_TESTS_DATACENTER" \
+  -byo-kkp-datacenter byo-kubernetes \
   -ssh-pub-key "$(cat "$E2E_SSH_PUBKEY")"
 
 echodate "Tests completed successfully!"

--- a/hack/ci/setup-kubermatic-mla-in-kind.sh
+++ b/hack/ci/setup-kubermatic-mla-in-kind.sh
@@ -176,7 +176,7 @@ EOF
 ./_build/kubermatic-installer deploy usercluster-mla \
   --config "$KUBERMATIC_CONFIG" \
   --helm-values "$MLA_HELM_VALUES_FILE" \
-  --helm-timeout 1500s
+  --helm-timeout 25m
 
 sleep 5
 echodate "Waiting for MLA to deploy Seed components..."

--- a/pkg/controller/seed-controller-manager/mla-controller/grafana/client.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/grafana/client.go
@@ -63,6 +63,8 @@ type Client interface {
 	DeleteOrgUser(ctx context.Context, orgID uint, userID uint) (grafanasdk.StatusMessage, error)
 	DeleteGlobalUser(ctx context.Context, userID uint) (grafanasdk.StatusMessage, error)
 
+	UpdateUserPermissions(ctx context.Context, permissions grafanasdk.UserPermissions, userID uint) (grafanasdk.StatusMessage, error)
+
 	CreateDatasource(ctx context.Context, ds grafanasdk.Datasource) (grafanasdk.StatusMessage, error)
 	GetDatasourceByName(ctx context.Context, name string) (grafanasdk.Datasource, error)
 	GetDatasourceByUID(ctx context.Context, uid string) (grafanasdk.Datasource, error)
@@ -189,5 +191,6 @@ func NewClientProvider(client ctrlruntimeclient.Client, httpClient *http.Client,
 }
 
 func IsNotFoundErr(err error) bool {
-	return errors.Is(err, grafanasdk.ErrNotFound{})
+	// do not use errors.Is(), as it would also compare error messages
+	return errors.As(err, &grafanasdk.ErrNotFound{})
 }

--- a/pkg/controller/seed-controller-manager/mla-controller/grafana/fake.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/grafana/fake.go
@@ -147,6 +147,21 @@ func (f *FakeGrafana) GetOrgUsers(_ context.Context, orgID uint) ([]grafanasdk.O
 	return result, nil
 }
 
+func (f *FakeGrafana) GetOrgUser(ctx context.Context, orgID, userID uint) (*grafanasdk.OrgUser, error) {
+	users, err := f.GetOrgUsers(ctx, orgID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, user := range users {
+		if user.ID == userID {
+			return &user, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (f *FakeGrafana) getUserByID(userID uint) *grafanasdk.User {
 	for _, user := range f.Database.Users {
 		if user.ID == userID {

--- a/pkg/controller/seed-controller-manager/mla-controller/grafana/fake.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/grafana/fake.go
@@ -66,7 +66,7 @@ func (f *FakeGrafana) CreateDefaultOrg(org grafanasdk.Org) error {
 		return err
 	}
 
-	f.Database.DefaultOrg = *status.ID
+	f.Database.DefaultOrg = *status.OrgID
 
 	return nil
 }
@@ -79,7 +79,7 @@ func (f *FakeGrafana) CreateOrg(_ context.Context, org grafanasdk.Org) (grafanas
 	org.ID = uint(len(f.Database.Orgs) + 1)
 	f.Database.Orgs[org.Name] = org
 
-	return grafanasdk.StatusMessage{ID: &org.ID}, nil
+	return grafanasdk.StatusMessage{OrgID: &org.ID}, nil
 }
 
 func (f *FakeGrafana) GetOrgByOrgName(_ context.Context, name string) (grafanasdk.Org, error) {
@@ -241,6 +241,18 @@ func (f *FakeGrafana) DeleteGlobalUser(ctx context.Context, userID uint) (grafan
 	}
 
 	delete(f.Database.Users, user.Email) // after this, `user` points to junk
+
+	return grafanasdk.StatusMessage{}, nil
+}
+
+func (f *FakeGrafana) UpdateUserPermissions(ctx context.Context, permissions grafanasdk.UserPermissions, userID uint) (grafanasdk.StatusMessage, error) {
+	user := f.getUserByID(userID)
+	if user == nil {
+		return grafanasdk.StatusMessage{}, grafanasdk.ErrNotFound{}
+	}
+
+	user.IsGrafanaAdmin = permissions.IsGrafanaAdmin
+	f.Database.Users[user.Email] = *user
 
 	return grafanasdk.StatusMessage{}, nil
 }

--- a/pkg/controller/seed-controller-manager/mla-controller/mla.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/mla.go
@@ -126,7 +126,7 @@ func Add(
 	return nil
 }
 
-func getDatasourceUIDForCluster(datasourceType string, cluster *kubermaticv1.Cluster) string {
+func DatasourceUIDForCluster(datasourceType grafana.DatasourceType, cluster *kubermaticv1.Cluster) string {
 	return fmt.Sprintf("%s-%s", datasourceType, cluster.Name)
 }
 

--- a/pkg/controller/seed-controller-manager/mla-controller/reconciler_cleanup.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/reconciler_cleanup.go
@@ -35,7 +35,7 @@ import (
 )
 
 type cleaner interface {
-	Cleanup(context.Context) error
+	Cleanup(context.Context, *zap.SugaredLogger) error
 }
 
 // cleanupReconciler is a "meta" reconciler which is used when MLA is globally disabled;
@@ -93,7 +93,7 @@ func (r *cleanupReconciler) Reconcile(ctx context.Context, request reconcile.Req
 
 func (r *cleanupReconciler) reconcile(ctx context.Context) error {
 	for _, cleaner := range r.cleaners {
-		if err := cleaner.Cleanup(ctx); err != nil {
+		if err := cleaner.Cleanup(ctx, r.log); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/seed-controller-manager/mla-controller/reconciler_cortex_ratelimit.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/reconciler_cortex_ratelimit.go
@@ -181,7 +181,7 @@ func (r *cortexRatelimitReconciler) ensureLimits(ctx context.Context, mlaAdminSe
 	return r.seedClient.Update(ctx, configMap)
 }
 
-func (r *cortexRatelimitReconciler) Cleanup(ctx context.Context) error {
+func (r *cortexRatelimitReconciler) Cleanup(ctx context.Context, log *zap.SugaredLogger) error {
 	mlaAdminSettingList := &kubermaticv1.MLAAdminSettingList{}
 	if err := r.seedClient.List(ctx, mlaAdminSettingList); err != nil {
 		return fmt.Errorf("Failed to list mlaAdminSetting: %w", err)

--- a/pkg/controller/seed-controller-manager/mla-controller/reconciler_grafana_org.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/reconciler_grafana_org.go
@@ -129,12 +129,13 @@ func (r *grafanaOrgReconciler) ensureOrganization(ctx context.Context, log *zap.
 		return existingOrg.ID, nil
 	}
 
+	log.Info("Creating Grafana organization")
 	status, err := gClient.CreateOrg(ctx, expected)
 	if err != nil {
 		return 0, fmt.Errorf("failed to create organization: %w", err)
 	}
 
-	return *status.ID, nil
+	return *status.OrgID, nil
 }
 
 func (r *grafanaOrgReconciler) ensureDashboards(ctx context.Context, log *zap.SugaredLogger, orgID uint, gClient grafana.Client) error {

--- a/pkg/controller/seed-controller-manager/mla-controller/reconciler_grafana_user.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/reconciler_grafana_user.go
@@ -196,24 +196,9 @@ func getRoleForUser(user *kubermaticv1.User) grafanasdk.RoleType {
 	return grafanasdk.ROLE_EDITOR
 }
 
-func getGrafanaOrgUser(ctx context.Context, gClient grafana.Client, orgID, userID uint) (*grafanasdk.OrgUser, error) {
-	users, err := gClient.GetOrgUsers(ctx, orgID)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, user := range users {
-		if user.ID == userID {
-			return &user, nil
-		}
-	}
-
-	return nil, nil
-}
-
 func ensureUserInOrgWithRole(ctx context.Context, gClient grafana.Client, org grafanasdk.Org, user *grafanasdk.User, role grafanasdk.RoleType) error {
 	// check if user already exists in the corresponding organization
-	orgUser, err := getGrafanaOrgUser(ctx, gClient, org.ID, user.ID)
+	orgUser, err := gClient.GetOrgUser(ctx, org.ID, user.ID)
 	if err != nil {
 		return fmt.Errorf("failed to get user: %w", err)
 	}

--- a/pkg/controller/seed-controller-manager/mla-controller/reconciler_grafana_user.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/reconciler_grafana_user.go
@@ -114,14 +114,14 @@ func (r *grafanaUserReconciler) Reconcile(ctx context.Context, request reconcile
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
-	if err := r.ensureGrafanaUser(ctx, user, gClient); err != nil {
+	if err := r.ensureGrafanaUser(ctx, log, user, gClient); err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to ensure Grafana User: %w", err)
 	}
 
 	return reconcile.Result{}, nil
 }
 
-func (r *grafanaUserReconciler) Cleanup(ctx context.Context) error {
+func (r *grafanaUserReconciler) Cleanup(ctx context.Context, log *zap.SugaredLogger) error {
 	userList := &kubermaticv1.UserList{}
 	if err := r.seedClient.List(ctx, userList); err != nil {
 		return err
@@ -156,11 +156,14 @@ func (r *grafanaUserReconciler) handleDeletion(ctx context.Context, user *kuberm
 	return kubernetes.TryRemoveFinalizer(ctx, r.seedClient, user, mlaFinalizer)
 }
 
-func (r *grafanaUserReconciler) ensureGrafanaUser(ctx context.Context, user *kubermaticv1.User, gClient grafana.Client) error {
+func (r *grafanaUserReconciler) ensureGrafanaUser(ctx context.Context, log *zap.SugaredLogger, user *kubermaticv1.User, gClient grafana.Client) error {
+	userLog := log.With("email", user.Spec.Email)
+
 	// get user
 	grafanaUser, err := gClient.LookupUser(ctx, user.Spec.Email)
 	if err != nil {
 		// user does not yet, create them
+		userLog.Info("Creating Grafana OAuth user")
 		newUser, err := gClient.CreateOAuthUser(ctx, user.Spec.Email)
 		if err != nil {
 			return fmt.Errorf("failed to create global Grafana user: %w", err)
@@ -169,19 +172,32 @@ func (r *grafanaUserReconciler) ensureGrafanaUser(ctx context.Context, user *kub
 		grafanaUser = *newUser
 
 		// remove user from default organization
+		userLog.Info("Removing new Grafana user from default organization")
 		if _, err := gClient.DeleteOrgUser(ctx, grafana.DefaultOrgID, newUser.ID); err != nil {
 			return fmt.Errorf("failed to delete new user from default organization: %w", err)
+		}
+	}
+
+	if grafanaUser.IsGrafanaAdmin != user.Spec.IsAdmin {
+		userLog.Infow("Updating Grafana user permissions", "admin", user.Spec.IsAdmin)
+		if _, err := gClient.UpdateUserPermissions(ctx, grafanasdk.UserPermissions{IsGrafanaAdmin: user.Spec.IsAdmin}, grafanaUser.ID); err != nil {
+			return fmt.Errorf("failed to update user permissions: %w", err)
 		}
 	}
 
 	// get org
 	org, err := gClient.GetOrgByOrgName(ctx, GrafanaOrganization)
 	if err != nil {
+		if grafana.IsNotFoundErr(err) {
+			log.Debug("Organization not found.")
+			return nil
+		}
+
 		return fmt.Errorf("failed to get Grafana organization %q: %w", GrafanaOrganization, err)
 	}
 
 	// add user to org
-	if err := ensureUserInOrgWithRole(ctx, gClient, org, &grafanaUser, getRoleForUser(user)); err != nil {
+	if err := ensureUserInOrgWithRole(ctx, userLog, gClient, org, &grafanaUser, getRoleForUser(user)); err != nil {
 		return fmt.Errorf("failed to get Grafana organization %q: %w", GrafanaOrganization, err)
 	}
 
@@ -196,7 +212,7 @@ func getRoleForUser(user *kubermaticv1.User) grafanasdk.RoleType {
 	return grafanasdk.ROLE_EDITOR
 }
 
-func ensureUserInOrgWithRole(ctx context.Context, gClient grafana.Client, org grafanasdk.Org, user *grafanasdk.User, role grafanasdk.RoleType) error {
+func ensureUserInOrgWithRole(ctx context.Context, log *zap.SugaredLogger, gClient grafana.Client, org grafanasdk.Org, user *grafanasdk.User, role grafanasdk.RoleType) error {
 	// check if user already exists in the corresponding organization
 	orgUser, err := gClient.GetOrgUser(ctx, org.ID, user.ID)
 	if err != nil {
@@ -210,6 +226,7 @@ func ensureUserInOrgWithRole(ctx context.Context, gClient grafana.Client, org gr
 			Role:         string(role),
 		}
 
+		log.Infow("Adding Grafana user to organization", "role", role)
 		if _, err := gClient.AddOrgUser(ctx, userRole, org.ID); err != nil {
 			return fmt.Errorf("failed to add grafana user to org: %w", err)
 		}
@@ -222,6 +239,7 @@ func ensureUserInOrgWithRole(ctx context.Context, gClient grafana.Client, org gr
 			LoginOrEmail: user.Email,
 			Role:         string(role),
 		}
+		log.Infow("Updating Grafana user's role in organization", "role", role)
 		if _, err := gClient.UpdateOrgUser(ctx, userRole, org.ID, orgUser.ID); err != nil {
 			return fmt.Errorf("failed to update grafana user role: %w", err)
 		}

--- a/pkg/controller/seed-controller-manager/mla-controller/reconciler_rulegroup_sync.go
+++ b/pkg/controller/seed-controller-manager/mla-controller/reconciler_rulegroup_sync.go
@@ -132,7 +132,7 @@ func (r *ruleGroupSyncReconciler) Reconcile(ctx context.Context, request reconci
 	return reconcile.Result{}, nil
 }
 
-func (r *ruleGroupSyncReconciler) Cleanup(ctx context.Context) error {
+func (r *ruleGroupSyncReconciler) Cleanup(ctx context.Context, log *zap.SugaredLogger) error {
 	ruleGroupList := &kubermaticv1.RuleGroupList{}
 	if err := r.seedClient.List(ctx, ruleGroupList, ctrlruntimeclient.InNamespace(r.mlaNamespace)); err != nil {
 		return err

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -76,7 +76,7 @@ alertmanager_config: |
 )
 
 var (
-	credentials jig.AWSCredentials
+	credentials jig.BYOCredentials
 	logOptions  = utils.DefaultLogOptions
 )
 
@@ -100,7 +100,7 @@ func TestMLAIntegration(t *testing.T) {
 	}
 
 	// create test environment
-	testJig := jig.NewAWSCluster(seedClient, logger, credentials, 1, nil)
+	testJig := jig.NewBYOCluster(seedClient, logger, credentials)
 	testJig.ClusterJig.WithTestName("mla")
 
 	cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -19,14 +19,13 @@ limitations under the License.
 package mla
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"net/http"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -36,8 +35,11 @@ import (
 
 	grafanasdk "github.com/kubermatic/grafanasdk"
 	kubermaticv1 "k8c.io/api/v3/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v3/pkg/controller/seed-controller-manager/mla-controller"
+	mlacontroller "k8c.io/kubermatic/v3/pkg/controller/seed-controller-manager/mla-controller"
+	"k8c.io/kubermatic/v3/pkg/controller/seed-controller-manager/mla-controller/cortex"
+	"k8c.io/kubermatic/v3/pkg/controller/seed-controller-manager/mla-controller/grafana"
 	"k8c.io/kubermatic/v3/pkg/log"
+	"k8c.io/kubermatic/v3/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v3/pkg/resources"
 	"k8c.io/kubermatic/v3/pkg/test/e2e/jig"
 	"k8c.io/kubermatic/v3/pkg/test/e2e/utils"
@@ -65,6 +67,12 @@ alertmanager_config: |
       - to: 'test@example.org'
 
 `
+
+	grafanaSecret   = "mla/grafana"
+	grafanaURL      = "http://localhost:3000"
+	alertmanagerURL = "http://localhost:3001"
+	rulerURL        = "http://localhost:3002"
+	lokiURL         = "http://localhost:3003"
 )
 
 var (
@@ -95,7 +103,7 @@ func TestMLAIntegration(t *testing.T) {
 	testJig := jig.NewAWSCluster(seedClient, logger, credentials, 1, nil)
 	testJig.ClusterJig.WithTestName("mla")
 
-	project, cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)
+	cluster, err := testJig.Setup(ctx, jig.WaitForReadyPods)
 	defer testJig.Cleanup(ctx, t, true)
 	if err != nil {
 		t.Fatalf("failed to setup test environment: %v", err)
@@ -106,60 +114,58 @@ func TestMLAIntegration(t *testing.T) {
 		t.Fatalf("failed to enable MLA: %v", err)
 	}
 
-	logger.Info("Waiting for project to get Grafana org annotation...")
-	p := &kubermaticv1.Project{}
-	orgID := ""
-	timeout := 5 * time.Minute
-	if !utils.WaitFor(1*time.Second, timeout, func() (ok bool) {
-		if err := seedClient.Get(ctx, types.NamespacedName{Name: project.Name}, p); err != nil {
-			t.Fatalf("failed to get project: %v", err)
-		}
-
-		orgID, ok = p.GetAnnotations()[mla.GrafanaOrgAnnotationKey]
-		return ok
-	}) {
-		t.Fatalf("waiting for project annotation %+v", p)
-	}
-
-	id, err := strconv.ParseUint(orgID, 10, 32)
-	if err != nil {
-		t.Fatalf("unable to parse uint from %s", orgID)
-	}
-
 	logger.Info("Creating Grafana client for user cluster...")
-	grafanaClient, err := getGrafanaClient(ctx, seedClient)
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	cortexClient := cortex.NewClient(httpClient, alertmanagerURL, rulerURL, lokiURL)
+
+	grafanaClientProvider, err := grafana.NewClientProvider(seedClient, httpClient, grafanaSecret, grafanaURL, true)
 	if err != nil {
-		t.Fatalf("unable to initialize Grafana client")
+		t.Fatalf("failed to initialize Grafana client: %v", err)
 	}
 
-	logger.Info("Fetching Grafana organization...")
-	org, err := grafanaClient.GetOrgById(ctx, uint(id))
+	grafanaClient, err := grafanaClientProvider(ctx)
 	if err != nil {
-		t.Fatalf("error while getting Grafana org: %v", err)
+		t.Fatalf("failed to initialize Grafana client: %v", err)
 	}
+
+	logger.Info("Waiting for Grafana organization...")
+	var org *grafanasdk.Org
+	err = wait.PollLog(ctx, logger, 5*time.Second, 3*time.Minute, func() (transient error, terminal error) {
+		organization, err := grafanaClient.GetOrgByOrgName(ctx, mlacontroller.GrafanaOrganization)
+		if err != nil {
+			return err, nil
+		}
+		org = &organization
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("failed to reconcile, Grafana organization never appeared: %v", err)
+	}
+
 	grafanaClient.SetOrgIDHeader(org.ID)
 
 	if err := verifyGrafanaDatasource(ctx, logger, grafanaClient, cluster); err != nil {
-		t.Errorf("failed to verify grafana datasource: %v", err)
+		t.Errorf("failed to verify Grafana datasource: %v", err)
 	}
 
-	if err := verifyGrafanaUser(ctx, logger, grafanaClient, &org); err != nil {
-		t.Errorf("failed to verify grafana user: %v", err)
+	kkpUser, err := verifyGrafanaUser(ctx, logger, seedClient, grafanaClient, org)
+	if err != nil {
+		t.Errorf("failed to verify Grafana user: %v", err)
 	}
 
-	if err := verifyLogRuleGroup(ctx, logger, seedClient, p, cluster); err != nil {
+	if err := verifyLogsRuleGroup(ctx, logger, seedClient, cortexClient, cluster); err != nil {
 		t.Errorf("failed to verify logs RuleGroup: %v", err)
 	}
 
-	if err := verifyMetricsRuleGroup(ctx, logger, seedClient, p, cluster); err != nil {
+	if err := verifyMetricsRuleGroup(ctx, logger, seedClient, cortexClient, cluster); err != nil {
 		t.Errorf("failed to verify metrics RuleGroup: %v", err)
 	}
 
-	if err := verifyAlertmanager(ctx, logger, seedClient, p, cluster); err != nil {
+	if err := verifyAlertmanager(ctx, logger, seedClient, cortexClient, cluster); err != nil {
 		t.Errorf("failed to verify Alertmanager: %v", err)
 	}
 
-	if err := verifyRateLimits(ctx, logger, seedClient, p, cluster); err != nil {
+	if err := verifyRateLimits(ctx, logger, seedClient, cluster); err != nil {
 		t.Errorf("failed to verify rate limits: %v", err)
 	}
 
@@ -173,43 +179,30 @@ func TestMLAIntegration(t *testing.T) {
 		t.Fatalf("cluster did not get healthy: %v", err)
 	}
 
-	logger.Info("Waiting for Grafana org to be gone...")
-	if !utils.WaitFor(1*time.Second, timeout, func() bool {
-		_, err = grafanaClient.GetOrgById(ctx, org.ID)
-		return err != nil
-	}) {
-		t.Fatal("grafana org not cleaned up")
-	}
-
 	logger.Info("Waiting for Grafana user to be gone...")
-	if !utils.WaitFor(1*time.Second, timeout, func() bool {
-		_, err = grafanaClient.LookupUser(ctx, "roxy-admin@kubermatic.com")
-		return errors.As(err, &grafanasdk.ErrNotFound{})
-	}) {
-		t.Fatal("grafana user not cleaned up")
-	}
-
-	logger.Info("Waiting for project to get rid of grafana org annotation")
-	if !utils.WaitFor(1*time.Second, timeout, func() bool {
-		if err := seedClient.Get(ctx, types.NamespacedName{Name: project.Name}, p); err != nil {
-			t.Fatalf("failed to get project: %v", err)
+	err = wait.PollLog(ctx, logger, 3*time.Second, 5*time.Minute, func() (transient error, terminal error) {
+		if _, err := grafanaClient.LookupUser(ctx, kkpUser.Spec.Email); err == nil {
+			return errors.New("user still exists"), nil
 		}
-
-		_, ok := p.GetAnnotations()[mla.GrafanaOrgAnnotationKey]
-		return !ok
-	}) {
-		t.Fatal("project still has the grafana org annotation")
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatal("cleanup did not complete successfully")
 	}
 }
 
-func verifyGrafanaDatasource(ctx context.Context, log *zap.SugaredLogger, grafanaClient *grafanasdk.Client, cluster *kubermaticv1.Cluster) (err error) {
+func verifyGrafanaDatasource(ctx context.Context, log *zap.SugaredLogger, grafanaClient grafana.Client, cluster *kubermaticv1.Cluster) error {
+	datasource := mlacontroller.DatasourceUIDForCluster(grafana.DatasourceTypePrometheus, cluster)
+
+	log = log.With("datasource", datasource)
 	log.Info("Waiting for datasource to be added to Grafana...")
 
-	if !utils.WaitFor(1*time.Second, 5*time.Minute, func() bool {
-		_, err := grafanaClient.GetDatasourceByUID(ctx, fmt.Sprintf("%s-%s", mla.PrometheusType, cluster.Name))
-		return err == nil
-	}) {
-		return fmt.Errorf("timed out waiting for grafana datasource %s-%s", mla.PrometheusType, cluster.Name)
+	err := wait.PollImmediateLog(ctx, log, 3*time.Second, 3*time.Minute, func() (transient error, terminal error) {
+		_, err := grafanaClient.GetDatasourceByUID(ctx, datasource)
+		return err, nil
+	})
+	if err != nil {
+		return errors.New("timed out waiting for datasource")
 	}
 
 	log.Info("Grafana datasource successfully verified.")
@@ -217,42 +210,49 @@ func verifyGrafanaDatasource(ctx context.Context, log *zap.SugaredLogger, grafan
 	return nil
 }
 
-func verifyGrafanaUser(ctx context.Context, log *zap.SugaredLogger, grafanaClient *grafanasdk.Client, org *grafanasdk.Org) error {
+func verifyGrafanaUser(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, grafanaClient grafana.Client, org *grafanasdk.Org) (*kubermaticv1.User, error) {
 	log.Info("Checking that an admin user was added to Grafana...")
 
+	users := kubermaticv1.UserList{}
+	if err := client.List(ctx, &users); err != nil {
+		return nil, fmt.Errorf("failed to list users: %w", err)
+	}
+	if len(users.Items) != 1 {
+		return nil, fmt.Errorf("expected to find exactly 1 KKP User, but found %d", len(users.Items))
+	}
+
+	kkpUser := users.Items[0]
+	log = log.With("email", kkpUser.Spec.Email)
+
 	user := grafanasdk.User{}
-	err := wait.Poll(ctx, 1*time.Second, 2*time.Minute, func() (transient error, terminal error) {
-		user, transient = grafanaClient.LookupUser(ctx, "roxy-admin@kubermatic.com")
-		if transient != nil {
-			return errors.New("user does not yet exist in Grafana"), nil
-		}
-
-		if user.IsGrafanaAdmin != true || user.OrgID != org.ID {
-			return fmt.Errorf("user expected to be Grafana Admin and have orgID %d", org.ID), nil
-		}
-
-		return nil, nil
+	err := wait.PollLog(ctx, log, 3*time.Second, 1*time.Minute, func() (transient error, terminal error) {
+		user, transient = grafanaClient.LookupUser(ctx, kkpUser.Spec.Email)
+		return transient, nil
 	})
 	if err != nil {
-		return fmt.Errorf("waiting for grafana user: %w", err)
+		return nil, fmt.Errorf("waiting for grafana user: %w", err)
+	}
+
+	if user.IsGrafanaAdmin != true || user.OrgID != org.ID {
+		return nil, fmt.Errorf("user expected to be Grafana Admin and have orgID %d", org.ID)
 	}
 
 	log.Info("Verifying Grafana org user's role...")
-	orgUser, err := mla.GetGrafanaOrgUser(ctx, grafanaClient, org.ID, user.ID)
+	orgUser, err := grafanaClient.GetOrgUser(ctx, org.ID, user.ID)
 	if err != nil {
-		return fmt.Errorf("failed to get grafana org user: %w", err)
+		return nil, fmt.Errorf("failed to get grafana org user: %w", err)
 	}
 
 	if orgUser.Role != string(grafanasdk.ROLE_EDITOR) {
-		return fmt.Errorf("orgUser %v expected to have Editor role, but has %v", orgUser, orgUser.Role)
+		return nil, fmt.Errorf("orgUser %v expected to have Editor role, but has %v", orgUser, orgUser.Role)
 	}
 
 	log.Info("Grafana user successfully verified.")
 
-	return nil
+	return &kkpUser, nil
 }
 
-func verifyLogRuleGroup(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) error {
+func verifyLogsRuleGroup(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, cortexClient cortex.Client, cluster *kubermaticv1.Cluster) error {
 	log.Info("Creating logs RuleGroup...")
 
 	lokiRule := `
@@ -269,37 +269,23 @@ rules:
 `
 	expectedData, err := createRuleGroup(ctx, client, cluster, []byte(lokiRule), kubermaticv1.RuleGroupTypeLogs)
 	if err != nil {
-		return fmt.Errorf("unable to create rule group: %w", err)
+		return fmt.Errorf("failed to create rule group: %w", err)
 	}
 
-	logRuleGroupURL := fmt.Sprintf("%s%s%s", "http://localhost:3003", mla.LogRuleGroupConfigEndpoint, "/default")
-	httpClient := &http.Client{Timeout: 15 * time.Second}
-
-	err = wait.Poll(ctx, 1*time.Second, 5*time.Minute, func() (error, error) {
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", logRuleGroupURL, "test-rule"), nil)
+	err = wait.PollLog(ctx, log, 3*time.Second, 3*time.Minute, func() (error, error) {
+		ruleGroup, err := cortexClient.GetRuleGroupConfiguration(ctx, cluster.Name, kubermaticv1.RuleGroupTypeLogs, "test-rule")
 		if err != nil {
-			return fmt.Errorf("unable to create request: %v", err), nil
-		}
-		req.Header.Add(mla.RuleGroupTenantHeaderName, cluster.Name)
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("unable to get rule group: %w", err), nil
-		}
-		defer resp.Body.Close()
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("expected HTTP 200 OK, got HTTP %s", resp.Status), nil
+			return fmt.Errorf("failed to get rule group: %w", err), nil
 		}
 
 		config := map[string]interface{}{}
-		decoder := yaml.NewDecoder(resp.Body)
+		decoder := yaml.NewDecoder(bytes.NewReader(ruleGroup))
 		if err := decoder.Decode(&config); err != nil {
-			return fmt.Errorf("unable to decode response body: %w", err), nil
+			return fmt.Errorf("failed to decode rule group: %w", err), nil
 		}
 
 		if !reflect.DeepEqual(config, expectedData) {
-			return errors.New("response does not match the expected rule group"), nil
+			return errors.New("Cortex rule group does not match the expected rule group"), nil
 		}
 
 		return nil, nil
@@ -313,43 +299,29 @@ rules:
 	return nil
 }
 
-func verifyMetricsRuleGroup(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) error {
+func verifyMetricsRuleGroup(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, cortexClient cortex.Client, cluster *kubermaticv1.Cluster) error {
 	log.Info("Creating metrics RuleGroup...")
 
 	testRuleGroup := generator.GenerateTestRuleGroupData("test-metric-rule")
 	expectedData, err := createRuleGroup(ctx, client, cluster, testRuleGroup, kubermaticv1.RuleGroupTypeMetrics)
 	if err != nil {
-		return fmt.Errorf("unable to create rule group: %w", err)
+		return fmt.Errorf("failed to create rule group: %w", err)
 	}
 
-	metricRuleGroupURL := fmt.Sprintf("%s%s%s", "http://localhost:3002", mla.MetricsRuleGroupConfigEndpoint, "/default")
-	httpClient := &http.Client{Timeout: 15 * time.Second}
-
-	err = wait.Poll(ctx, 1*time.Second, 5*time.Minute, func() (error, error) {
-		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", metricRuleGroupURL, "test-metric-rule"), nil)
+	err = wait.Poll(ctx, 3*time.Second, 3*time.Minute, func() (error, error) {
+		ruleGroup, err := cortexClient.GetRuleGroupConfiguration(ctx, cluster.Name, kubermaticv1.RuleGroupTypeMetrics, "test-metric-rule")
 		if err != nil {
-			return fmt.Errorf("unable to create request: %v", err), nil
-		}
-		req.Header.Add(mla.RuleGroupTenantHeaderName, cluster.Name)
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("unable to get rule group: %w", err), nil
+			return fmt.Errorf("failed to get rule group: %w", err), nil
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("expected HTTP 200 OK, got HTTP %s", resp.Status), nil
-		}
-
-		defer resp.Body.Close()
 		config := map[string]interface{}{}
-		decoder := yaml.NewDecoder(resp.Body)
+		decoder := yaml.NewDecoder(bytes.NewReader(ruleGroup))
 		if err := decoder.Decode(&config); err != nil {
-			return fmt.Errorf("unable to decode response body: %w", err), nil
+			return fmt.Errorf("failed to decode rule group: %w", err), nil
 		}
 
 		if !reflect.DeepEqual(config, expectedData) {
-			return errors.New("response does not match the expected rule group"), nil
+			return errors.New("Cortex rule group does not match the expected rule group"), nil
 		}
 
 		return nil, nil
@@ -363,62 +335,47 @@ func verifyMetricsRuleGroup(ctx context.Context, log *zap.SugaredLogger, client 
 	return nil
 }
 
-func verifyAlertmanager(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) error {
+func verifyAlertmanager(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, cortexClient cortex.Client, cluster *kubermaticv1.Cluster) error {
 	log.Info("Verifying Alertmanager...")
+
 	if err := updateAlertmanager(ctx, client, cluster, []byte(testAlertmanagerConfig)); err != nil {
-		return fmt.Errorf("unable to update alertmanager config: %w", err)
+		return fmt.Errorf("failed to update alertmanager config: %w", err)
 	}
 
-	if !utils.WaitFor(1*time.Second, 1*time.Minute, func() bool {
+	err := wait.PollLog(ctx, log, 3*time.Second, 3*time.Minute, func() (transient error, terminal error) {
 		if err := client.Get(ctx, types.NamespacedName{Name: cluster.Name}, cluster); err != nil {
-			return false
+			return err, nil
 		}
-		return *cluster.Status.ExtendedHealth.AlertmanagerConfig == kubermaticv1.HealthStatusUp
-	}) {
-		return fmt.Errorf("has alertmanager status: %v", *cluster.Status.ExtendedHealth.AlertmanagerConfig)
+
+		if *cluster.Status.ExtendedHealth.AlertmanagerConfig != kubermaticv1.HealthStatusUp {
+			return fmt.Errorf("alertmanager config is %v", *cluster.Status.ExtendedHealth.AlertmanagerConfig), nil
+		}
+
+		return nil, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for alertmanager: %w", err)
 	}
 
-	alertmanagerURL := "http://localhost:3001" + mla.AlertmanagerConfigEndpoint
 	expectedConfig := map[string]interface{}{}
 	if err := yaml.Unmarshal([]byte(testAlertmanagerConfig), &expectedConfig); err != nil {
-		return fmt.Errorf("unable to unmarshal expected config: %w", err)
+		return fmt.Errorf("failed to unmarshal expected config: %w", err)
 	}
 
-	httpClient := &http.Client{Timeout: 15 * time.Second}
-
-	err := wait.Poll(ctx, 1*time.Second, 5*time.Minute, func() (error, error) {
-		req, err := http.NewRequest(http.MethodGet, alertmanagerURL, nil)
+	err = wait.PollLog(ctx, log, 3*time.Second, 3*time.Minute, func() (error, error) {
+		ruleGroup, err := cortexClient.GetAlertmanagerConfiguration(ctx, cluster.Name)
 		if err != nil {
-			return fmt.Errorf("unable to create request to get alertmanager config: %w", err), nil
-		}
-		req.Header.Add(mla.AlertmanagerTenantHeaderName, cluster.Name)
-
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return fmt.Errorf("unable to get alertmanager config: %w", err), nil
-		}
-		defer resp.Body.Close()
-
-		// https://cortexmetrics.io/docs/api/#get-alertmanager-configuration
-		if resp.StatusCode == http.StatusNotFound {
-			return errors.New("alertmanager config not found"), nil
-		}
-		if resp.StatusCode != http.StatusOK {
-			body, err := io.ReadAll(resp.Body)
-			if err != nil {
-				return fmt.Errorf("unable to read alertmanager config: %w", err), nil
-			}
-			return fmt.Errorf("status code: %d, response body: %s", resp.StatusCode, string(body)), nil
+			return fmt.Errorf("failed to get rule group: %w", err), nil
 		}
 
 		config := map[string]interface{}{}
-		decoder := yaml.NewDecoder(resp.Body)
+		decoder := yaml.NewDecoder(bytes.NewReader(ruleGroup))
 		if err := decoder.Decode(&config); err != nil {
-			return fmt.Errorf("unable to decode response body: %w", err), nil
+			return fmt.Errorf("failed to decode rule group: %w", err), nil
 		}
 
 		if !reflect.DeepEqual(config, expectedConfig) {
-			return errors.New("response does not match the expected rule group"), nil
+			return errors.New("Alertmanager rule group does not match the expected rule group"), nil
 		}
 
 		return nil, nil
@@ -458,7 +415,7 @@ func updateAlertmanager(ctx context.Context, client ctrlruntimeclient.Client, cl
 	return client.Update(ctx, secret)
 }
 
-func verifyRateLimits(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, project *kubermaticv1.Project, cluster *kubermaticv1.Cluster) error {
+func verifyRateLimits(ctx context.Context, log *zap.SugaredLogger, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
 	log.Info("Setting rate limits...")
 
 	rateLimits := kubermaticv1.MonitoringRateLimitSettings{
@@ -469,25 +426,26 @@ func verifyRateLimits(ctx context.Context, log *zap.SugaredLogger, client ctrlru
 		MaxSamplesPerQuery: 5,
 		MaxSeriesPerQuery:  6,
 	}
-	if err := createMonitoringMLARateLimits(ctx, client, cluster, project, rateLimits); err != nil {
-		return fmt.Errorf("unable to set monitoring rate limits: %w", err)
+	if err := createMonitoringMLARateLimits(ctx, client, cluster, rateLimits); err != nil {
+		return fmt.Errorf("failed to set monitoring rate limits: %w", err)
 	}
 
-	err := wait.Poll(ctx, 1*time.Second, 5*time.Minute, func() (error, error) {
+	err := wait.PollLog(ctx, log, 3*time.Second, 3*time.Minute, func() (error, error) {
 		mlaAdminSetting := &kubermaticv1.MLAAdminSetting{}
 		if err := client.Get(ctx, types.NamespacedName{Namespace: cluster.Status.NamespaceName, Name: resources.MLAAdminSettingsName}, mlaAdminSetting); ctrlruntimeclient.IgnoreNotFound(err) != nil {
-			return fmt.Errorf("can't get cluster mlaadminsetting: %w", err), nil
+			return fmt.Errorf("failed to get cluster mlaadminsetting: %w", err), nil
 		}
 
 		configMap := &corev1.ConfigMap{}
-		if err := client.Get(ctx, types.NamespacedName{Namespace: "mla", Name: mla.RuntimeConfigMap}, configMap); err != nil {
-			return fmt.Errorf("unable to get configMap: %w", err), nil
+		if err := client.Get(ctx, types.NamespacedName{Namespace: "mla", Name: mlacontroller.RuntimeConfigMap}, configMap); err != nil {
+			return fmt.Errorf("failed to get configMap: %w", err), nil
 		}
-		actualOverrides := &mla.Overrides{}
-		decoder := yaml.NewDecoder(strings.NewReader(configMap.Data[mla.RuntimeConfigFileName]))
+
+		actualOverrides := &mlacontroller.Overrides{}
+		decoder := yaml.NewDecoder(strings.NewReader(configMap.Data[mlacontroller.RuntimeConfigFileName]))
 		decoder.KnownFields(true)
 		if err := decoder.Decode(actualOverrides); err != nil {
-			return fmt.Errorf("unable to unmarshal rate limit config map"), nil
+			return fmt.Errorf("failed to unmarshal rate limit config map"), nil
 		}
 
 		actualRateLimits, ok := actualOverrides.Overrides[cluster.Name]
@@ -528,7 +486,7 @@ func verifyRateLimits(ctx context.Context, log *zap.SugaredLogger, client ctrlru
 	return nil
 }
 
-func createMonitoringMLARateLimits(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, project *kubermaticv1.Project, rateLimits kubermaticv1.MonitoringRateLimitSettings) error {
+func createMonitoringMLARateLimits(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, rateLimits kubermaticv1.MonitoringRateLimitSettings) error {
 	mlaAdminSetting := &kubermaticv1.MLAAdminSetting{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      resources.MLAAdminSettingsName,
@@ -544,8 +502,8 @@ func createMonitoringMLARateLimits(ctx context.Context, client ctrlruntimeclient
 }
 
 func setMLAIntegration(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, enabled bool) error {
-	if err := toggleMLAInSeed(ctx, client, enabled); err != nil {
-		return fmt.Errorf("failed to update seed: %w", err)
+	if err := toggleMLAInConfiguration(ctx, client, enabled); err != nil {
+		return fmt.Errorf("failed to toggle MLA integration to %v: %w", enabled, err)
 	}
 
 	oldCluster := cluster.DeepCopy()
@@ -557,47 +515,22 @@ func setMLAIntegration(ctx context.Context, client ctrlruntimeclient.Client, clu
 	return client.Patch(ctx, cluster, ctrlruntimeclient.MergeFrom(oldCluster))
 }
 
-func getGrafanaClient(ctx context.Context, client ctrlruntimeclient.Client) (*grafanasdk.Client, error) {
-	grafanaSecret := "mla/grafana"
-
-	split := strings.Split(grafanaSecret, "/")
-	if n := len(split); n != 2 {
-		return nil, fmt.Errorf("splitting value of %q didn't yield two but %d results", grafanaSecret, n)
-	}
-
-	secret := corev1.Secret{}
-	if err := client.Get(ctx, types.NamespacedName{Name: split[1], Namespace: split[0]}, &secret); err != nil {
-		return nil, fmt.Errorf("failed to get Grafana Secret: %w", err)
-	}
-
-	adminName, ok := secret.Data[mla.GrafanaUserKey]
-	if !ok {
-		return nil, fmt.Errorf("Grafana Secret %q does not contain %s key", grafanaSecret, mla.GrafanaUserKey)
-	}
-	adminPass, ok := secret.Data[mla.GrafanaPasswordKey]
-	if !ok {
-		return nil, fmt.Errorf("Grafana Secret %q does not contain %s key", grafanaSecret, mla.GrafanaPasswordKey)
-	}
-
-	grafanaAuth := fmt.Sprintf("%s:%s", adminName, adminPass)
-	httpClient := &http.Client{Timeout: 15 * time.Second}
-	grafanaURL := "http://localhost:3000"
-
-	return grafanasdk.NewClient(grafanaURL, grafanaAuth, httpClient)
-}
-
-func toggleMLAInSeed(ctx context.Context, client ctrlruntimeclient.Client, enable bool) error {
-	seed, _, err := jig.Seed(ctx, client, credentials.KKPDatacenter)
+func toggleMLAInConfiguration(ctx context.Context, client ctrlruntimeclient.Client, enable bool) error {
+	config, err := kubernetes.GetRawKubermaticConfiguration(ctx, client, jig.KubermaticNamespace())
 	if err != nil {
-		return fmt.Errorf("failed to get seed: %w", err)
+		return fmt.Errorf("failed to get KubermaticConfiguration: %w", err)
 	}
 
-	seed.Spec.MLA = &kubermaticv1.SeedMLASettings{
-		UserClusterMLAEnabled: enable,
+	if config.Spec.UserCluster == nil {
+		config.Spec.UserCluster = &kubermaticv1.KubermaticUserClusterConfiguration{}
 	}
 
-	if err := client.Update(ctx, seed); err != nil {
-		return fmt.Errorf("failed to update seed: %w", err)
+	config.Spec.UserCluster.MLA = &kubermaticv1.KubermaticUserClusterMLAConfiguration{
+		Enabled: enable,
+	}
+
+	if err := client.Update(ctx, config); err != nil {
+		return fmt.Errorf("failed to update KubermaticConfiguration: %w", err)
 	}
 
 	return nil
@@ -606,7 +539,7 @@ func toggleMLAInSeed(ctx context.Context, client ctrlruntimeclient.Client, enabl
 func createRuleGroup(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, data []byte, kind kubermaticv1.RuleGroupType) (map[string]interface{}, error) {
 	expected := map[string]interface{}{}
 	if err := yaml.Unmarshal(data, &expected); err != nil {
-		return nil, fmt.Errorf("unable to unmarshal expected rule group: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal expected rule group: %w", err)
 	}
 
 	ruleGroup := &kubermaticv1.RuleGroup{


### PR DESCRIPTION
**What this PR does / why we need it**:
Our MLA stack was recently refactored to work with a single Grafana org, as KKP 3 CE does not have the concept of projects anymore.

This PR now adjusts the e2e tests accordingly, which I skipped when refactoring the controllers. In addition, this PR also improves a couple of other things:

* it includes the fix of #12182
* it improves logging dramatically, outputting an INFO log message for all actions it takes (creating users, adding dashboards, ...)
* changes the tests to use BYO instead of AWS, as we seemingly do not need to deploy anything into the usercluster itself
* uses `protokol` to store all logs from the `mla` namespace
* fixes user permission handling (got lost in the giant refactoring)
* lots of smaller improvements

**What type of PR is this?**
/kind cleanup
/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
