### PR TITLE
[release/v2.22] Align versions of monitoring addons and charts

### DIFF
--- a/addons/kube-state-metrics/deployment.yaml
+++ b/addons/kube-state-metrics/deployment.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.1.1
+    app.kubernetes.io/version: 2.5.0
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -34,7 +34,7 @@ spec:
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.1.1
+        app.kubernetes.io/version: 2.5.0
     spec:
       containers:
         - args:
@@ -42,7 +42,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: '{{ Image "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.1.1" }}'
+          image: '{{ Image "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0" }}'
           name: kube-state-metrics
           resources:
             limits:
@@ -58,7 +58,7 @@ spec:
             - --secure-listen-address=:8443
             - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
             - --upstream=http://127.0.0.1:8081/
-          image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.11.0" }}'
+          image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.13.1" }}'
           name: kube-rbac-proxy
           ports:
             - containerPort: 8443

--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     app.kubernetes.io/name: node-exporter
-    app.kubernetes.io/version: v1.2.2
+    app.kubernetes.io/version: v1.4.0
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -37,71 +37,71 @@ spec:
       hostPID: true
       serviceAccountName: node-exporter
       containers:
-      - name: node-exporter
-        image: '{{ Image "quay.io/prometheus/node-exporter:v1.2.2" }}'
-        args:
-        - '--path.procfs=/host/proc'
-        - '--path.sysfs=/host/sys'
-        - '--path.rootfs=/host/root'
-        - '--web.listen-address=127.0.0.1:9100'
-        resources:
-          requests:
-            cpu: 10m
-            memory: 24Mi
-          limits:
-            cpu: 25m
-            memory: 48Mi
-        volumeMounts:
-        - name: proc
-          readOnly:  true
-          mountPath: /host/proc
-        - name: sys
-          readOnly: true
-          mountPath: /host/sys
-        - name: root
-          readOnly: true
-          mountPath: /host/root
-          mountPropagation: HostToContainer
+        - name: node-exporter
+          image: '{{ Image "quay.io/prometheus/node-exporter:v1.4.0" }}'
+          args:
+            - "--path.procfs=/host/proc"
+            - "--path.sysfs=/host/sys"
+            - "--path.rootfs=/host/root"
+            - "--web.listen-address=127.0.0.1:9100"
+          resources:
+            requests:
+              cpu: 10m
+              memory: 24Mi
+            limits:
+              cpu: 25m
+              memory: 48Mi
+          volumeMounts:
+            - name: proc
+              readOnly: true
+              mountPath: /host/proc
+            - name: sys
+              readOnly: true
+              mountPath: /host/sys
+            - name: root
+              readOnly: true
+              mountPath: /host/root
+              mountPropagation: HostToContainer
 
-      - name: kube-rbac-proxy
-        image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.11.0" }}'
-        args:
-        - '--logtostderr'
-        - '--secure-listen-address=$(IP):9100'
-        - '--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256'
-        - '--upstream=http://127.0.0.1:9100/'
-        env:
-        - name: IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
-        ports:
-        - containerPort: 9100
-          hostPort: 9100
-          name: https
-        resources:
-          requests:
-            cpu: 10m
-            memory: 24Mi
-          limits:
-            cpu: 20m
-            memory: 48Mi
+        - name: kube-rbac-proxy
+          image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.13.1" }}'
+          args:
+            - "--logtostderr"
+            - "--secure-listen-address=$(IP):9100"
+            - "--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
+            - "--upstream=http://127.0.0.1:9100/"
+          env:
+            - name: IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          ports:
+            - containerPort: 9100
+              hostPort: 9100
+              name: https
+          resources:
+            requests:
+              cpu: 10m
+              memory: 24Mi
+            limits:
+              cpu: 20m
+              memory: 48Mi
 
       tolerations:
-      - effect: NoExecute
-        operator: Exists
-      - effect: NoSchedule
-        operator: Exists
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists
       volumes:
-      - name: proc
-        hostPath:
-          path: /proc
-      - name: sys
-        hostPath:
-          path: /sys
-      - name: root
-        hostPath:
-          path: /
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump kube-state-metrics and node-exporter to the same versions as provided with KKP charts.

* bumps kube-state-metrics to v2.5.0
* bumps node-exporter to v1.4.0

(the `main` branch is already updated past that)
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Identified in #12126 

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
addons: kube-state-metrics updated to v2.5.0
addons: node-exporter updated to v1.4.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
