### PR TITLE
Improve error messages in rbac-controller's project sync

### DIFF
--- a/pkg/controller/master-controller-manager/rbac/sync_project.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_project.go
@@ -126,7 +126,7 @@ func (c *projectController) ensureClusterRBACRoleForResources(ctx context.Contex
 			} else {
 				err := ensureClusterRBACRoleForResource(ctx, c.log, c.client, groupPrefix, rmapping.Resource.Resource, gvk.Kind)
 				if err != nil {
-					return fmt.Errorf("failed to ensure ClusterRole for resource on master: %d", err)
+					return fmt.Errorf("failed to ensure ClusterRole for resource on master: %w", err)
 				}
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
We recently ran into #12186, but from the logged error it was hard to determine the actual problem. This PR adds more context to errors emitted by the rbac-controller, which hopefully helps in the future.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
