### PR TITLE
Use serializable etcd health endpoint

### DIFF
--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -248,7 +248,7 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Path:   "/health",
+								Path:   "/health?exclude=NOSPACE&serializable=true",
 								Port:   intstr.FromInt(2378),
 								Scheme: corev1.URISchemeHTTP,
 							},

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -259,6 +259,22 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 						SuccessThreshold:    1,
 						TimeoutSeconds:      10,
 					},
+					// timing info calculated based on
+					// https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/staticpod/utils.go#L254-L265
+					StartupProbe: &corev1.Probe{
+						ProbeHandler: corev1.ProbeHandler{
+							HTTPGet: &corev1.HTTPGetAction{
+								Path:   "/health?serializable=false",
+								Port:   intstr.FromInt(2378),
+								Scheme: corev1.URISchemeHTTP,
+							},
+						},
+						InitialDelaySeconds: 10,
+						FailureThreshold:    16,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						TimeoutSeconds:      15,
+					},
 					VolumeMounts: []corev1.VolumeMount{
 						{
 							Name:      "data",

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
@@ -138,6 +138,16 @@ spec:
           requests:
             cpu: 50m
             memory: 256Mi
+        startupProbe:
+          failureThreshold: 16
+          httpGet:
+            path: /health?serializable=false
+            port: 2378
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         volumeMounts:
         - mountPath: /var/run/etcd
           name: data

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
@@ -103,7 +103,7 @@ spec:
         livenessProbe:
           failureThreshold: 3
           httpGet:
-            path: /health
+            path: /health?exclude=NOSPACE&serializable=true
             port: 2378
             scheme: HTTP
           initialDelaySeconds: 5


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/kubernetes/kubernetes/pull/110744 for more information:

> As per the etcd maintainers' recommendation - startup probes shouldn't be serialized, while the liveness probes should be.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use serializable etcd liveness probes and add a startup probe, as per upstream recommendations.
```

**Documentation**:
```documentation
NONE
```
