### PR TITLE
Add kubermatic_seed_* Prometheus metrics on the master cluster

### DIFF
--- a/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/kubermatic-master-kubermatic.yaml
@@ -51,3 +51,12 @@ groups:
         labels:
           severity: critical
           service: kubermatic-master
+      - alert: KubermaticSeedNotHealthy
+        annotations:
+          message: The Seed cluster {{ $labels.seed_name }} cannot be reached or reconciled properly.
+          runbook_url: https://docs.kubermatic.com/kubermatic/main/cheat-sheets/alerting-runbook/#alert-kubermaticseednothealthy
+        expr: kubermatic_seed_info{phase!="Healthy"}
+        for: 5m
+        labels:
+          severity: warning
+          service: kubermatic-master

--- a/charts/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
+++ b/charts/monitoring/prometheus/rules/src/kubermatic-master/kubermatic.yaml
@@ -63,3 +63,18 @@ groups:
           steps:
             - Check the Prometheus Service Discovery page to find out why the target is unreachable.
             - Ensure that the master-controller-manager pod's logs and that it is not crashlooping.
+
+      - alert: KubermaticSeedNotHealthy
+        annotations:
+          message: The Seed cluster {{ $labels.seed_name }} cannot be reached or reconciled properly.
+          runbook_url: https://docs.kubermatic.com/kubermatic/main/cheat-sheets/alerting-runbook/#alert-kubermaticseednothealthy
+        expr: kubermatic_seed_info{phase!="Healthy"}
+        for: 5m
+        labels:
+          severity: warning
+          service: kubermatic-master
+        runbook:
+          steps:
+            - Check the conditions on the Seed object to learn more about the issues.
+            - Check the kubermatic-operator logs for additional information.
+            - Ensure that a valid kubeconfig Secret exists for the Seed.

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -200,6 +200,9 @@ func main() {
 	log.Debug("Starting projects collector")
 	collectors.MustRegisterProjectCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
 
+	log.Debug("Starting seeds collector")
+	collectors.MustRegisterSeedCollector(prometheus.DefaultRegisterer, ctrlCtx.mgr.GetAPIReader())
+
 	if err := createAllControllers(ctrlCtx); err != nil {
 		log.Fatalw("could not create all controllers", zap.Error(err))
 	}

--- a/pkg/collectors/seed.go
+++ b/pkg/collectors/seed.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	corev1 "k8s.io/api/core/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	seedPrefix = "kubermatic_seed_"
+)
+
+// SeedCollector exports metrics for seed resources.
+type SeedCollector struct {
+	client ctrlruntimeclient.Reader
+
+	seedInfo      *prometheus.Desc
+	seedClusters  *prometheus.Desc
+	seedCondition *prometheus.Desc
+}
+
+// MustRegisterSeedCollector registers the seed collector at the given prometheus registry.
+func MustRegisterSeedCollector(registry prometheus.Registerer, client ctrlruntimeclient.Reader) {
+	cc := &SeedCollector{
+		client: client,
+		seedInfo: prometheus.NewDesc(
+			seedPrefix+"info",
+			"Additional seed information",
+			[]string{
+				"seed_name",
+				"country",
+				"location",
+				"phase",
+				"kubermatic_version",
+				"kubernetes_version",
+			},
+			nil,
+		),
+		seedClusters: prometheus.NewDesc(
+			seedPrefix+"clusters",
+			"Number of user clusters per seed cluster",
+			[]string{"seed_name"},
+			nil,
+		),
+		seedCondition: prometheus.NewDesc(
+			seedPrefix+"condition",
+			"Binary metric that describes one of the Seed conditions",
+			[]string{
+				"seed_name",
+				"condition",
+				"reason",
+			},
+			nil,
+		),
+	}
+
+	registry.MustRegister(cc)
+}
+
+// Describe returns the metrics descriptors.
+func (cc SeedCollector) Describe(ch chan<- *prometheus.Desc) {
+	prometheus.DescribeByCollect(cc, ch)
+}
+
+// Collect gets called by prometheus to collect the metrics.
+func (cc SeedCollector) Collect(ch chan<- prometheus.Metric) {
+	seeds := &kubermaticv1.SeedList{}
+	if err := cc.client.List(context.Background(), seeds); err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list seeds in SeedCollector: %w", err))
+		return
+	}
+
+	kubernetesLabelSet := sets.New[string]()
+	for _, seed := range seeds.Items {
+		kubernetesLabelSet = kubernetesLabelSet.Union(sets.KeySet(seed.Labels))
+	}
+
+	kubernetesLabels := caseInsensitiveSort(sets.List(kubernetesLabelSet))
+
+	prometheusLabels := convertToPrometheusLabels(kubernetesLabels)
+	labelsGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: seedPrefix + "labels",
+		Help: "Kubernetes labels on Seed resources",
+	}, append([]string{"seed_name"}, prometheusLabels...))
+
+	for _, seed := range seeds.Items {
+		cc.collectSeed(ch, &seed, kubernetesLabels, labelsGauge)
+	}
+}
+
+func (cc *SeedCollector) collectSeed(ch chan<- prometheus.Metric, seed *kubermaticv1.Seed, kubernetesLabels []string, labelsGaugeVec *prometheus.GaugeVec) {
+	ch <- prometheus.MustNewConstMetric(
+		cc.seedInfo,
+		prometheus.GaugeValue,
+		1,
+		seed.Name,
+		seed.Spec.Country,
+		seed.Spec.Location,
+		string(seed.Status.Phase),
+		seed.Status.Versions.Kubermatic,
+		seed.Status.Versions.Cluster,
+	)
+
+	ch <- prometheus.MustNewConstMetric(
+		cc.seedClusters,
+		prometheus.GaugeValue,
+		float64(seed.Status.Clusters),
+		seed.Name,
+	)
+
+	for condName, cond := range seed.Status.Conditions {
+		value := 0
+		if cond.Status == corev1.ConditionTrue {
+			value = 1
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			cc.seedCondition,
+			prometheus.GaugeValue,
+			float64(value),
+			seed.Name,
+			string(condName),
+			cond.Reason,
+		)
+	}
+
+	// assemble the labels for this seed, in the order given by kubernetesLabels, but
+	// taking special care of label key conflicts
+	seedLabels := []string{seed.Name}
+	usedLabels := sets.New[string]()
+	for _, key := range kubernetesLabels {
+		prometheusLabel := convertToPrometheusLabel(key)
+		if !usedLabels.Has(prometheusLabel) {
+			seedLabels = append(seedLabels, seed.Labels[key])
+			usedLabels.Insert(prometheusLabel)
+		}
+	}
+
+	labelsGaugeVec.WithLabelValues(seedLabels...).Collect(ch)
+}

--- a/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
+++ b/pkg/controller/master-controller-manager/seed-status-controller/reconciler.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	// SeedKubeconfigUnavailableReason is the reason for the SeedConditionKubeconfigValid
-	// in case the kubeconfig does not exist and not client can be constructed.
+	// in case the kubeconfig does not exist and no client can be constructed.
 	SeedKubeconfigUnavailableReason = "KubeconfigUnavailable"
 	// SeedKubeconfigUnavailableReason is the reason for the SeedConditionKubeconfigValid
 	// in case the seed cluster was not yet prepared by the admin to be a seed (i.e. a


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds additional Prometheus metrics to the master-ctrl-mgr. These new metrics are as follows (if one were to look into an e2e test scenario):

```
# HELP kubermatic_seed_clusters Number of user clusters per seed cluster
# TYPE kubermatic_seed_clusters gauge
kubermatic_seed_clusters{seed_name="kubermatic"} 1

# HELP kubermatic_seed_condition Binary metric that describes one of the Seed conditions
# TYPE kubermatic_seed_condition gauge
kubermatic_seed_condition{condition="ClusterInitialized",reason="CRDsUpdated",seed_name="kubermatic"} 1
kubermatic_seed_condition{condition="KubeconfigValid",reason="KubeconfigValid",seed_name="kubermatic"} 1
kubermatic_seed_condition{condition="ResourcesReconciled",reason="ReconcilingSuccess",seed_name="kubermatic"} 1

# HELP kubermatic_seed_info Additional seed information
# TYPE kubermatic_seed_info gauge
kubermatic_seed_info{country="Germany",kubermatic_version="v2.22.0-101-g962824a52",kubernetes_version="v1.25.3",location="Hamburg",phase="Healthy",seed_name="kubermatic"} 1

# HELP kubermatic_seed_labels Kubernetes labels on Seed resources
# TYPE kubermatic_seed_labels gauge
kubermatic_seed_labels{label_hello="world",seed_name="kubermatic"} 0
```

The main purpose for these is to provide alerts to the KKP admin if a seed becomes unreachable. Do note that the alert is not firing immediately, as we do not toggle a condition on a seed object every time connectivity failed (fearing that this condition might flip and flop back and forth quickly in some setups). That's why the alert is not "seed is unreachable", as there is no condition (yet?) to express this.

**Which issue(s) this PR fixes**:
Fixes #12192

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `kubermatic_seed_info` metric containing Seed metadata like version, location or phase.
Add `kubermatic_seed_clusters` metric containing the number of user clusters per Seed.
Add `kubermatic_seed_condition` metric describing the conditions for each Seed.
Add `kubermatic_seed_labels` metric containing the Kubernetes labels on Seed resources.
Add `KubermaticSeedNotHealthy` alert if a Seed is not healthy.
```

**Documentation**:
```documentation
NONE
```
