### PR TITLE
Recover from Grafana data loss

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller_test.go
@@ -117,6 +117,11 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 			hasFinalizer: true,
 			requests: []request{
 				{
+					name:     "get org by id",
+					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+				},
+				{
 					name:     "set dashboard",
 					request:  httptest.NewRequest(http.MethodPost, "/api/dashboards/db", strings.NewReader(string(boardData))),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "dashboard set"}`)), StatusCode: http.StatusOK},
@@ -195,6 +200,11 @@ func TestDashboardGrafanaReconcile(t *testing.T) {
 			},
 			hasFinalizer: false,
 			requests: []request{
+				{
+					name:     "get org by id",
+					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+				},
 				{
 					name:     "delete dashboard",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/dashboards/uid/"+"unique", nil),

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
@@ -19,8 +19,6 @@ package mla
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -32,7 +30,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -122,10 +119,7 @@ func (r *orgGrafanaReconciler) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 	}
 
-	org := grafanasdk.Org{
-		Name: getOrgNameForProject(project),
-	}
-	orgID, err := r.orgGrafanaController.ensureOrganization(ctx, log, project, org, GrafanaOrgAnnotationKey, grafanaClient)
+	orgID, err := r.orgGrafanaController.ensureOrganization(ctx, log, grafanaClient, project)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to ensure Grafana Organization: %w", err)
 	}
@@ -180,67 +174,138 @@ func (r *orgGrafanaController) CleanUp(ctx context.Context) error {
 func (r *orgGrafanaController) handleDeletion(ctx context.Context, project *kubermaticv1.Project, grafanaClient *grafanasdk.Client) error {
 	oldProject := project.DeepCopy()
 	update := false
-	orgID, ok := project.GetAnnotations()[GrafanaOrgAnnotationKey]
+
+	orgID, ok := getOrgIDForProject(project)
 	if ok {
 		update = true
 		delete(project.Annotations, GrafanaOrgAnnotationKey)
-		id, err := strconv.ParseUint(orgID, 10, 32)
-		if err != nil {
-			return err
-		}
+
 		if grafanaClient != nil {
-			_, err = grafanaClient.DeleteOrg(ctx, uint(id))
-			if err != nil {
+			if _, err := grafanaClient.DeleteOrg(ctx, orgID); err != nil {
 				return err
 			}
 		}
 	}
+
 	if kubernetes.HasFinalizer(project, mlaFinalizer) {
 		update = true
 		kubernetes.RemoveFinalizer(project, mlaFinalizer)
 	}
+
 	if update {
 		if err := r.Patch(ctx, project, ctrlruntimeclient.MergeFrom(oldProject)); err != nil {
 			return fmt.Errorf("failed to update Project: %w", err)
 		}
 	}
+
 	return nil
 }
 
-func (r *orgGrafanaController) createGrafanaOrg(ctx context.Context, expected grafanasdk.Org, grafanaClient *grafanasdk.Client) (grafanasdk.Org, error) {
-	status, err := grafanaClient.CreateOrg(ctx, expected)
-	if err != nil {
-		return expected, fmt.Errorf("unable to add organization: %w (status: %s, message: %s)",
-			err, pointer.StringDeref(status.Status, "no status"), pointer.StringDeref(status.Message, "no message"))
-	}
-	if status.OrgID == nil {
-		// possibly organization already exists
-		org, err := grafanaClient.GetOrgByOrgName(ctx, expected.Name)
-		if err != nil {
-			return org, fmt.Errorf("unable to get organization by name %+v %w", expected, err)
-		}
-		return org, nil
-	}
-	expected.ID = *status.OrgID
+func (r *orgGrafanaController) ensureOrganization(ctx context.Context, log *zap.SugaredLogger, grafanaClient *grafanasdk.Client, project *kubermaticv1.Project) (uint, error) {
+	desiredOrgName := getOrgNameForProject(project)
 
+	adoptOrCreateOrg := func() (uint, error) {
+		org, err := r.createGrafanaOrg(ctx, grafanaClient, desiredOrgName)
+		if err != nil {
+			return 0, fmt.Errorf("unable to create Grafana org: %w", err)
+		}
+
+		if err := r.setOrgAnnotation(ctx, project, org.ID); err != nil {
+			// Leave the org in Grafana and during the next reconciliation createGrafanaOrg() will
+			// adopt it and then we can try again to set the annotation.
+			return 0, fmt.Errorf("failed to update Project's org annotation: %w", err)
+		}
+
+		return org.ID, nil
+	}
+
+	// If the project has no org attached yet, try to create a new one;
+	// org names in Grafana are *unique* and createGrafanaOrg() will try
+	// to adopt an existing org if possible.
+	orgID, ok := getOrgIDForProject(project)
+	if !ok {
+		return adoptOrCreateOrg()
+	}
+
+	// We have an org ID, which might be stale. Fetch the associated org.
+	org, err := grafanaClient.GetOrgById(ctx, orgID)
+	if err != nil {
+		return adoptOrCreateOrg()
+	}
+
+	// Now we know that we point to an org and that org exists; however
+	// in case of catastrophic storage failure, it's possible that the Grafana
+	// PVC was removed and all annotations suddenly point to non-existing orgs.
+	// Once this controller begins to reconcile and fix the first (random)
+	// project, it will most likely create a new org with an ID that *another*
+	// project was already using previously. Now 2 projects would point to the
+	// same org.
+	// To prevent this, all we can do is rely on the org name, which will always
+	// be suffixed with the unchanging (!) project name (not the human readable
+	// name, which can easily change at any time).
+	if !orgNameMatchesProject(project, org.Name) {
+		return adoptOrCreateOrg()
+	}
+
+	// Lastly, check if the org name is still using the correct human readable
+	// project name; if not, update the organization.
+	if org.Name != desiredOrgName {
+		org.Name = desiredOrgName
+
+		if _, err := grafanaClient.UpdateOrg(ctx, org, orgID); err != nil {
+			return 0, fmt.Errorf("unable to update organization: %w", err)
+		}
+	}
+
+	// All good!
+	return orgID, nil
+}
+
+func (r *orgGrafanaController) createGrafanaOrg(ctx context.Context, grafanaClient *grafanasdk.Client, orgName string) (*grafanasdk.Org, error) {
+	org := grafanasdk.Org{
+		Name: orgName,
+	}
+
+	// Note that Grafana org names are unique, but a DuplicateName error is *not* returned as an error here.
+	status, err := grafanaClient.CreateOrg(ctx, org)
+	if err != nil {
+		return nil, fmt.Errorf("unable to add organization: %w", err)
+	}
+
+	// possibly organization already exists
+	if status.OrgID == nil {
+		org, err := grafanaClient.GetOrgByOrgName(ctx, orgName)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get organization by name: %w", err)
+		}
+
+		return &org, nil
+	}
+
+	org.ID = *status.OrgID
+
+	// initially assign users; updating these relations is done by the user-grafana-controller.
 	userList := &kubermaticv1.UserList{}
 	if err := r.List(ctx, userList); err != nil {
-		return expected, err
+		return nil, fmt.Errorf("failed to list KKP users: %w", err)
 	}
+
 	for _, user := range userList.Items {
 		if !user.Spec.IsAdmin {
 			continue
 		}
+
 		grafanaUser, err := grafanaClient.LookupUser(ctx, user.Spec.Email)
 		if err != nil {
-			return expected, err
+			return nil, fmt.Errorf("failed to lookup Grafana user %q: %w", user.Spec.Email, err)
 		}
-		if err := addUserToOrg(ctx, grafanaClient, expected, &grafanaUser, grafanasdk.ROLE_EDITOR); err != nil {
-			return expected, err
+
+		if err := addUserToOrg(ctx, grafanaClient, org, &grafanaUser, grafanasdk.ROLE_EDITOR); err != nil {
+			return nil, err
 		}
 	}
 
-	return expected, nil
+	return &org, nil
 }
 
 func (r *orgGrafanaController) ensureDashboards(ctx context.Context, log *zap.SugaredLogger, orgID uint, grafanaClient *grafanasdk.Client) error {
@@ -259,69 +324,22 @@ func (r *orgGrafanaController) ensureDashboards(ctx context.Context, log *zap.Su
 	return nil
 }
 
-func (r *orgGrafanaController) ensureOrganization(ctx context.Context, log *zap.SugaredLogger, project *kubermaticv1.Project, expected grafanasdk.Org, annotationKey string, grafanaClient *grafanasdk.Client) (uint, error) {
-	orgID, ok := project.GetAnnotations()[annotationKey]
-	if !ok {
-		org, err := r.createGrafanaOrg(ctx, expected, grafanaClient)
-		if err != nil {
-			return 0, fmt.Errorf("unable to create grafana org: %w", err)
-		}
-		if err := r.setAnnotation(ctx, project, annotationKey, strconv.FormatUint(uint64(org.ID), 10)); err != nil {
-			// revert org creation, if deletion failed, we can't do much about it
-			// if we failed at this moment and the project would be renamed quickly, that organization will be orphaned and we will never remove it.
-			if status, err := grafanaClient.DeleteOrg(ctx, org.ID); err != nil {
-				log.Debugf("unable to delete organization: %w (status: %s, message: %s)",
-					err, pointer.StringDeref(status.Status, "no status"), pointer.StringDeref(status.Message, "no message"))
-			}
-			return 0, err
-		}
-		return org.ID, nil
-	}
-	id, err := strconv.ParseUint(orgID, 10, 32)
-	if err != nil {
-		return 0, err
-	}
-
-	org, err := grafanaClient.GetOrgById(ctx, uint(id))
-	if err != nil {
-		// possibly not found
-		org, err := r.createGrafanaOrg(ctx, expected, grafanaClient)
-		if err != nil {
-			return 0, fmt.Errorf("unable to create grafana org: %w", err)
-		}
-		if err := r.setAnnotation(ctx, project, annotationKey, strconv.FormatUint(uint64(org.ID), 10)); err != nil {
-			// revert org creation, if deletion failed, we can't do much about it
-			if status, err := grafanaClient.DeleteOrg(ctx, org.ID); err != nil {
-				log.Debugf("unable to delete organization: %w (status: %s, message: %s)",
-					err, pointer.StringDeref(status.Status, "no status"), pointer.StringDeref(status.Message, "no message"))
-			}
-			return 0, err
-		}
-		return org.ID, nil
-	}
-	expected.ID = uint(id)
-	if !reflect.DeepEqual(org, expected) {
-		if status, err := grafanaClient.UpdateOrg(ctx, expected, uint(id)); err != nil {
-			return 0, fmt.Errorf("unable to update organization: %w (status: %s, message: %s)",
-				err, pointer.StringDeref(status.Status, "no status"), pointer.StringDeref(status.Message, "no message"))
-		}
-	}
-	return org.ID, nil
-}
-
-func (r *orgGrafanaController) setAnnotation(ctx context.Context, project *kubermaticv1.Project, key, value string) error {
+func (r *orgGrafanaController) setOrgAnnotation(ctx context.Context, project *kubermaticv1.Project, orgID uint) error {
 	annotations := project.GetAnnotations()
 	if annotations == nil {
 		annotations = map[string]string{}
 	}
-	annotations[key] = value
+
+	annotations[GrafanaOrgAnnotationKey] = fmt.Sprintf("%d", orgID)
 	project.SetAnnotations(annotations)
-	if err := r.Update(ctx, project); err != nil {
-		return fmt.Errorf("updating Project: %w", err)
-	}
-	return nil
+
+	return r.Update(ctx, project)
 }
 
 func getOrgNameForProject(project *kubermaticv1.Project) string {
 	return fmt.Sprintf("%s-%s", project.Spec.Name, project.Name)
+}
+
+func orgNameMatchesProject(project *kubermaticv1.Project, orgName string) bool {
+	return strings.HasSuffix(orgName, fmt.Sprintf("-%s", project.Name))
 }

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller_test.go
@@ -238,12 +238,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			hasFinalizer: true,
 		},
 		{
-			name:        "update org for project",
+			name:        "update org name for project",
 			requestName: "create",
 			objects: []ctrlruntimeclient.Object{&kubermaticv1.Project{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        "create",
-					Annotations: map[string]string{GrafanaOrgAnnotationKey: "1"},
+					Annotations: map[string]string{GrafanaOrgAnnotationKey: "2"},
 				},
 				Spec: kubermaticv1.ProjectSpec{
 					Name: "projectName",
@@ -252,12 +252,12 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 			requests: []request{
 				{
 					name:     "get org by id",
-					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName-oldname","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/2", nil),
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"oldName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "update",
-					request:  httptest.NewRequest(http.MethodPut, "/api/orgs/1", strings.NewReader(`{"id":1,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
+					request:  httptest.NewRequest(http.MethodPut, "/api/orgs/2", strings.NewReader(`{"id":2,"name":"projectName-create","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)),
 					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"message": "name already taken"}`)), StatusCode: http.StatusOK},
 				},
 			},
@@ -333,7 +333,7 @@ func TestOrgGrafanaReconcile(t *testing.T) {
 func buildTestServer(t *testing.T, requests ...request) (http.Handler, func() bool) {
 	var counter int64 = -1
 	assertExpectation := func() bool {
-		return assert.Equal(t, len(requests), int(counter+1))
+		return assert.Equal(t, len(requests), int(counter+1), "number of requests does not match expected number of requests")
 	}
 	r := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c := atomic.AddInt64(&counter, 1)

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller_test.go
@@ -140,7 +140,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
@@ -210,7 +210,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
@@ -230,7 +230,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
@@ -303,7 +303,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				}, {
 					name:     "delete org user",
 					request:  httptest.NewRequest(http.MethodDelete, "/api/orgs/1/users/1", nil),
@@ -312,7 +312,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/2", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2-project2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
@@ -332,7 +332,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",
@@ -347,7 +347,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org 2 by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/2", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":2,"name":"projectName2-project2","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
@@ -437,7 +437,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "delete org user",
@@ -457,7 +457,7 @@ func TestUserGrafanaReconcile(t *testing.T) {
 				{
 					name:     "get org by id",
 					request:  httptest.NewRequest(http.MethodGet, "/api/orgs/1", nil),
-					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
+					response: &http.Response{Body: io.NopCloser(strings.NewReader(`{"id":1,"name":"projectName1-project1","address":{"address1":"","address2":"","city":"","zipCode":"","state":"","country":""}}`)), StatusCode: http.StatusOK},
 				},
 				{
 					name:     "get org users",


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR slightly improves the Grafana org reconciliation loop. It adds another check for the org's name to clumsily detect a drift (most likely caused by a lost storage volume). If the org name does not have the correct suffix, it's assumed that the link between project<->org is invalid and a new org is created instead.

**Which issue(s) this PR fixes**:
Fixes #12127

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The MLA stack is now able to recover from a lost Grafana volume, properly recreating organizations for KKP projects.
```

**Documentation**:
```documentation
NONE
```
