### PR TITLE
Improve pod anti-affinity for etcd and kube-apiserver to spread across zones

### DIFF
--- a/pkg/resources/antiaffinity.go
+++ b/pkg/resources/antiaffinity.go
@@ -79,3 +79,35 @@ func FailureDomainZoneAntiAffinity(app string) corev1.WeightedPodAffinityTerm {
 		},
 	}
 }
+
+// ClusterFailureDomainZoneAntiAffinity ensures that same-kind pods for a specific user cluster are spread across different availability zones.
+func ClusterFailureDomainZoneAntiAffinity(app, clusterName string) []corev1.WeightedPodAffinityTerm {
+	return []corev1.WeightedPodAffinityTerm{
+		// Avoid that we schedule multiple same-kind pods of a cluster on a single zone
+		{
+			Weight: 100,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						AppLabelKey:     app,
+						ClusterLabelKey: clusterName,
+					},
+				},
+				TopologyKey: TopologyKeyZone,
+			},
+		},
+		// Avoid that we schedule multiple same-kind pods on a single zone
+
+		{
+			Weight: 10,
+			PodAffinityTerm: corev1.PodAffinityTerm{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						AppLabelKey: app,
+					},
+				},
+				TopologyKey: TopologyKeyZone,
+			},
+		},
+	}
+}

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -261,6 +261,11 @@ func DeploymentReconciler(data *resources.TemplateData, enableOIDCAuthentication
 			}
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+			if data.SupportsFailureDomainZoneAntiAffinity() {
+				antiAffinities := dep.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+				antiAffinities = append(antiAffinities, resources.ClusterFailureDomainZoneAntiAffinity(name, data.Cluster().Name)...)
+				dep.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = antiAffinities
+			}
 
 			return dep, nil
 		}

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -311,7 +311,7 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName, data.Cluster().Name)
 			if data.SupportsFailureDomainZoneAntiAffinity() {
 				antiAffinities := set.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-				antiAffinities = append(antiAffinities, resources.FailureDomainZoneAntiAffinity(resources.EtcdStatefulSetName))
+				antiAffinities = append(antiAffinities, resources.ClusterFailureDomainZoneAntiAffinity(resources.EtcdStatefulSetName, data.Cluster().Name)...)
 				set.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = antiAffinities
 			}
 

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver-externalCloudProvider.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver.yaml
@@ -54,6 +54,19 @@ spec:
                   app: apiserver
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: apiserver
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
@@ -34,6 +34,12 @@ spec:
                   app: nodeport-proxy-envoy
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: nodeport-proxy-envoy
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
@@ -39,6 +39,19 @@ spec:
                   app: etcd
               topologyKey: kubernetes.io/hostname
             weight: 10
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+                  cluster: de-test-01
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: etcd
+              topologyKey: topology.kubernetes.io/zone
+            weight: 10
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -747,6 +747,7 @@ func TestLoadFiles(t *testing.T) {
 						WithDnatControllerImage("quay.io/kubermatic/kubeletdnat-controller").
 						WithNetworkIntfMgrImage("quay.io/kubermatic/network-interface-manager").
 						WithVersions(kubermaticVersions).
+						WithFailureDomainZoneAntiaffinity(true).
 						Build()
 
 					generateAndVerifyResources(t, data, tc, markFixtureUsed)


### PR DESCRIPTION
**What this PR does / why we need it**:
If an environment supports zones, we put a general pod anti-affinity on the `etcd` StatefulSet to spread as much as possible across zones. However, we don't really care about _all_ etcds spreading across zones, we mostly care about etcds _of the same cluster_ to not be co-located in the same zone.

This PR makes the pod anti-affinity more explicit about that, lowering the weight of the "no two etcds (no matter which user cluster) should run in the same zone" anti-affinity and adding "no two etcds of the same user cluster should in the same zone" as new anti-affinity.

In addition, this PR also adds zone-aware anti-affinity to kube-apiserver. It seems like a good idea to spread those across multiple zones as well.

With all that being said, it's important to recognise that all of those pod anti-affinities are **soft**, _prefered_ during scheduling. So while this should improve scheduling, there is no guarantee that pods will not end up on the same zone if no nodes are available.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12171

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
If zone topology is available, user cluster etcds and kube-apiservers now have a *soft* pod anti-affinity that tries to ensure replicas of a specific user cluster are not co-located in the same zone
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
