### PR TITLE
Add option to restrict project deletion to admin

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -63,9 +63,11 @@ type SettingSpec struct {
 
 	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig"` //nolint:tagliatelle
 	// UserProjectsLimit is the maximum number of projects a user can create.
-	UserProjectsLimit           int64 `json:"userProjectsLimit"`
-	RestrictProjectCreation     bool  `json:"restrictProjectCreation"`
-	EnableExternalClusterImport bool  `json:"enableExternalClusterImport"`
+	UserProjectsLimit       int64 `json:"userProjectsLimit"`
+	RestrictProjectCreation bool  `json:"restrictProjectCreation"`
+	RestrictProjectDeletion bool  `json:"restrictProjectDeletion"`
+
+	EnableExternalClusterImport bool `json:"enableExternalClusterImport"`
 
 	// CleanupOptions control what happens when a cluster is deleted via the dashboard.
 	// +optional

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -210,6 +210,8 @@ spec:
                   type: object
                 restrictProjectCreation:
                   type: boolean
+                restrictProjectDeletion:
+                  type: boolean
                 userProjectsLimit:
                   description: UserProjectsLimit is the maximum number of projects a user can create.
                   format: int64
@@ -226,6 +228,7 @@ spec:
                 - mlaAlertmanagerPrefix
                 - mlaGrafanaPrefix
                 - restrictProjectCreation
+                - restrictProjectDeletion
                 - userProjectsLimit
               type: object
           type: object


### PR DESCRIPTION
**What this PR does / why we need it**:
add new option for admin panel in the limits page to restrict project deletion to admin
**Which issue(s) this PR fixes**:
https://github.com/kubermatic/kubermatic/issues/11945

**What type of PR is this?**
/kind feature

```release-note
Add option to restrict project deletion to admin
```

```documentation
NONE
```
