### PR TITLE
addons: openstack: SA for CSI snapshot webhook

### DIFF
--- a/addons/csi/openstack/snapshot-webhook.yaml
+++ b/addons/csi/openstack/snapshot-webhook.yaml
@@ -40,6 +40,7 @@ spec:
       labels:
         app: snapshot-validation
     spec:
+      serviceAccountName: snapshot-webhook
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -71,6 +72,34 @@ spec:
     - protocol: TCP
       port: 443 # Change if needed
       targetPort: 443 # Change if the webserver image expects a different port
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-webhook
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-runner
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: snapshot-webhook-role
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-webhook
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: snapshot-webhook-runner
+  apiGroup: rbac.authorization.k8s.io
 
 {{ end }}
 {{ end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Reported by an OpenStack user
> Hello,
in KKP 2.22.2 the snapshot-validation-deployment is falling with:
> 
> k logs -n kube-system   snapshot-validation-deployment-586f59cf98-zt4x2
I0417 06:50:12.832793       1 certwatcher.go:129] Updated current TLS certificate
E0417 06:50:12.832883       1 webhook.go:240] open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory

This is because OpenStack `snapshot-validation-deployment` currently uses `kube-system/default` SA which has `automountServiceAccountToken: false` and after https://github.com/kubermatic/kubermatic/pull/12120, the webhook server needs RBAC to list `VolumeSnapshotClass`.

The following error would appear after SA token automount resolved but RBAC wasn't configured
```
W0426 14:08:07.531573       1 reflector.go:324] github.com/kubernetes-csi/external-snapshotter/client/v6/informers/externalversions/factory.go:117: failed to list *v1.VolumeSnapshotClass: volumesnapshotclasses.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:default" cannot list resource "volumesnapshotclasses" in API group "snapshot.storage.k8s.io" at the cluster scope
E0426 14:08:07.531594       1 reflector.go:138] github.com/kubernetes-csi/external-snapshotter/client/v6/informers/externalversions/factory.go:117: Failed to watch *v1.VolumeSnapshotClass: failed to list *v1.VolumeSnapshotClass: volumesnapshotclasses.snapshot.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:default" cannot list resource "volumesnapshotclasses" in API group "snapshot.storage.k8s.io" at the cluster scope
```

This PR introduces dedicated SA for snapshot webhook that doesn't have `automountServiceAccountToken: false`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
n/a, reported internally

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
addons: openstack: service account for CSI snapshot webhook server
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
