### PR TITLE
[release/v2.21] Upgrade Anexia CCM to v1.5.4

### DIFF
--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -68,7 +68,7 @@ func anexiaDeploymentCreator(data *resources.TemplateData) reconciling.NamedDepl
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:1.5.3",
+					Image: data.ImageRegistry(resources.RegistryAnexia) + "/anexia/anx-cloud-controller-manager:1.5.4",
 					Command: []string{
 						"/app/ccm",
 						"--cloud-provider=anexia",


### PR DESCRIPTION
This is a manual backport for `v2.21` based on #12212 

```release-note
Update Anexia CCM (cloud-controller-manager) to version 1.5.4
```
