### PR TITLE
Simplify anti-affinity rules for pods

### DIFF
--- a/pkg/resources/antiaffinity.go
+++ b/pkg/resources/antiaffinity.go
@@ -22,37 +22,20 @@ import (
 )
 
 // HostnameAntiAffinity returns a simple Affinity rule to prevent* scheduling of same kind pods on the same node.
-// It contains 2 AntiAffinity terms:
-// High priority: We don't schedule multiple pods of this app & cluster on a single node
-// Low priority: We don't schedule multiple pods of this app on a single node - regardless of the cluster.
-// This prevents that we schedule all API server pods on a single node
 // *if scheduling is not possible with this rule, it will be ignored.
-func HostnameAntiAffinity(app, clusterName string) *corev1.Affinity {
+func HostnameAntiAffinity(app string) *corev1.Affinity {
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: hostnameAntiAffinity(app, clusterName),
+			PreferredDuringSchedulingIgnoredDuringExecution: hostnameAntiAffinity(app),
 		},
 	}
 }
 
-func hostnameAntiAffinity(app, clusterName string) []corev1.WeightedPodAffinityTerm {
+func hostnameAntiAffinity(app string) []corev1.WeightedPodAffinityTerm {
 	return []corev1.WeightedPodAffinityTerm{
-		// Avoid that we schedule multiple same-kind pods of a cluster on a single node
+		// Avoid that we schedule multiple same-kind pods within the same namespace on a single node.
 		{
 			Weight: 100,
-			PodAffinityTerm: corev1.PodAffinityTerm{
-				LabelSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						AppLabelKey:     app,
-						ClusterLabelKey: clusterName,
-					},
-				},
-				TopologyKey: TopologyKeyHostname,
-			},
-		},
-		// Avoid that we schedule multiple same-kind pods on a single node
-		{
-			Weight: 10,
 			PodAffinityTerm: corev1.PodAffinityTerm{
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -260,7 +260,7 @@ func DeploymentReconciler(data *resources.TemplateData, enableOIDCAuthentication
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
 
 			return dep, nil
 		}

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -196,7 +196,7 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -169,7 +169,7 @@ func DeploymentReconciler(data deploymentReconcilerData) reconciling.NamedDeploy
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.DNSResolverDeploymentName, data.Cluster().Name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.DNSResolverDeploymentName)
 
 			return dep, nil
 		}

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -308,7 +308,7 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName, data.Cluster().Name)
+			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName)
 			if data.SupportsFailureDomainZoneAntiAffinity() {
 				antiAffinities := set.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 				antiAffinities = append(antiAffinities, resources.FailureDomainZoneAntiAffinity(resources.EtcdStatefulSetName))

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -100,7 +100,7 @@ func DeploymentReconciler(data kubernetesDashboardData) reconciling.NamedDeploym
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -198,7 +198,7 @@ func DeploymentReconciler(data metricsServerData) reconciling.NamedDeploymentRec
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -305,7 +305,7 @@ func DeploymentEnvoyReconciler(data nodePortProxyData) reconciling.NamedDeployme
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			d.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(envoyAppLabelValue, data.Cluster().Name)
+			d.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(envoyAppLabelValue)
 			if data.SupportsFailureDomainZoneAntiAffinity() {
 				antiAffinities := d.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 				antiAffinities = append(antiAffinities, resources.FailureDomainZoneAntiAffinity(envoyAppLabelValue))

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -186,7 +186,7 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, data.Cluster().Name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-controller-manager.yaml
@@ -38,15 +38,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-controller-manager.yaml
@@ -38,15 +38,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-controller-manager.yaml
@@ -38,15 +38,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver-externalCloudProvider.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-apiserver.yaml
@@ -45,15 +45,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: apiserver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: apiserver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - --client

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager.yaml
@@ -37,15 +37,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: controller-manager
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: controller-manager
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-dns-resolver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-dns-resolver-externalCloudProvider.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-dns-resolver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-dns-resolver.yaml
@@ -33,15 +33,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: dns-resolver
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: dns-resolver
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -conf

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard.yaml
@@ -27,15 +27,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: kubernetes-dashboard
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: kubernetes-dashboard
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server.yaml
@@ -30,15 +30,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: metrics-server
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: metrics-server
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
@@ -25,15 +25,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: nodeport-proxy-envoy
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /envoy-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler-externalCloudProvider.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler.yaml
@@ -35,15 +35,8 @@ spec:
               labelSelector:
                 matchLabels:
                   app: scheduler
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: scheduler
-              topologyKey: kubernetes.io/hostname
-            weight: 10
       containers:
       - args:
         - -endpoint

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd-externalCloudProvider.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-etcd.yaml
@@ -30,15 +30,14 @@ spec:
               labelSelector:
                 matchLabels:
                   app: etcd
-                  cluster: de-test-01
               topologyKey: kubernetes.io/hostname
             weight: 100
           - podAffinityTerm:
               labelSelector:
                 matchLabels:
                   app: etcd
-              topologyKey: kubernetes.io/hostname
-            weight: 10
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
       - command:
         - /bin/sh

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -747,6 +747,7 @@ func TestLoadFiles(t *testing.T) {
 						WithDnatControllerImage("quay.io/kubermatic/kubeletdnat-controller").
 						WithNetworkIntfMgrImage("quay.io/kubermatic/network-interface-manager").
 						WithVersions(kubermaticVersions).
+						WithFailureDomainZoneAntiaffinity(true).
 						Build()
 
 					generateAndVerifyResources(t, data, tc, markFixtureUsed)


### PR DESCRIPTION
**What this PR does / why we need it**:
In #12197, I thought that we were missing anti-affinity rules due to the existing rules for `kubernetes.io/hostname` anti-affinity on various pods. However, as per [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity), anti-affinity rules by default only consider `Pods` within the same namespace:

> If omitted or empty, namespaces defaults to the namespace of the Pod where the affinity/anti-affinity definition appears.

Thus, it is not necessary to have two anti-affinity rules (one for pods of the same type belonging to a specific cluster and one for all pods of the same type) as that second rule will only apply to the same pods already targeted before. Since pod inter-affinity is expensive, it is better to simplify this rule. Will hopefully also prevent people from having the same misunderstanding in the future.

From the page linked above:

>  Inter-pod affinity and anti-affinity require substantial amount of processing which can slow down scheduling in large clusters significantly. We do not recommend using them in clusters larger than several hundred nodes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Anti-affinity rules for control plane components have been simplified to optimise scheduler performance while yielding the same results
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
