### PR TITLE
set metering output prefix to seed name

### DIFF
--- a/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
@@ -35,6 +35,6 @@ func ReconcileMeteringResources(_ context.Context, _ ctrlruntimeclient.Client, _
 }
 
 // CronJobReconciler returns the func to create/update the metering report cronjob. Available only for ee.
-func CronJobReconciler(_ string, _ *kubermaticv1.MeteringReportConfiguration, _ string, _ registry.ImageRewriter, _ string) reconciling.NamedCronJobReconcilerFactory {
+func CronJobReconciler(_ string, _ *kubermaticv1.MeteringReportConfiguration, _ string, _ registry.ImageRewriter, _ *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
 	return nil
 }

--- a/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
@@ -36,6 +36,6 @@ func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Cl
 }
 
 // CronJobReconciler returns the func to create/update the metering report cronjob. Available only for ee.
-func CronJobReconciler(rn string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, r registry.ImageRewriter, ns string) reconciling.NamedCronJobReconcilerFactory {
-	return metering.CronJobReconciler(rn, mrc, caBundleName, r, ns)
+func CronJobReconciler(rn string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, r registry.ImageRewriter, seed *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
+	return metering.CronJobReconciler(rn, mrc, caBundleName, r, seed)
 }

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -40,14 +40,15 @@ import (
 )
 
 // CronJobReconciler returns the func to create/update the metering report cronjob.
-func CronJobReconciler(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.ImageRewriter, namespace string) reconciling.NamedCronJobReconcilerFactory {
+func CronJobReconciler(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.ImageRewriter, seed *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
 	return func() (string, reconciling.CronJobReconciler) {
 		return reportName, func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
 			var args []string
 			args = append(args, fmt.Sprintf("--ca-bundle=%s", "/opt/ca-bundle/ca-bundle.pem"))
-			args = append(args, fmt.Sprintf("--prometheus-api=http://%s.%s.svc", prometheus.Name, namespace))
+			args = append(args, fmt.Sprintf("--prometheus-api=http://%s.%s.svc", prometheus.Name, seed.Namespace))
 			args = append(args, fmt.Sprintf("--last-number-of-days=%d", mrc.Interval))
 			args = append(args, fmt.Sprintf("--output-dir=%s", reportName))
+			args = append(args, fmt.Sprintf("--output-prefix=%s", seed.Name))
 			args = append(args, mrc.Types...)
 
 			if job.Labels == nil {

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -93,7 +93,7 @@ func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlrunti
 	var cronJobs []reconciling.NamedCronJobReconcilerFactory
 
 	for reportName, reportConf := range seed.Spec.Metering.ReportConfigurations {
-		cronJobs = append(cronJobs, CronJobReconciler(reportName, reportConf, caBundle.Name, overwriter, seed.Namespace))
+		cronJobs = append(cronJobs, CronJobReconciler(reportName, reportConf, caBundle.Name, overwriter, seed))
 
 		if reportConf.Retention != nil {
 			config.Rules = append(config.Rules, lifecycle.Rule{

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -317,7 +317,7 @@ func getImagesFromReconcilers(log logrus.FieldLogger, templateData *resources.Te
 	}
 
 	cronjobReconcilers := kubernetescontroller.GetCronJobReconcilers(templateData)
-	if mcjr := metering.CronJobReconciler("reportName", &kubermaticv1.MeteringReportConfiguration{}, "caBundleName", templateData.RewriteImage, mockNamespaceName); mcjr != nil {
+	if mcjr := metering.CronJobReconciler("reportName", &kubermaticv1.MeteringReportConfiguration{}, "caBundleName", templateData.RewriteImage, seed); mcjr != nil {
 		cronjobReconcilers = append(cronjobReconcilers, mcjr)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The generated name for metering reports does not include seed specific information. Therefore report names have the same name and  overwrite each other when generated on different seeds at the same time. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug that lead to metering reports overwriting each other when used with multiple seeds. Report names now include the Seed name as a Prefix.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
