### PR TITLE
Bump Azure CCM/CSI

### DIFF
--- a/addons/azure-cloud-node-manager/cloud-node-manager.yaml
+++ b/addons/azure-cloud-node-manager/cloud-node-manager.yaml
@@ -12,22 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Source: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/v1.26.5/examples/out-of-tree/cloud-node-manager.yaml
+# Source: https://github.com/kubernetes-sigs/cloud-provider-azure/blob/v1.26.8/examples/out-of-tree/cloud-node-manager.yaml
 #
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
-{{ $version = "v1.23.28"}}
+{{ $version = "v1.23.30" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.15"}}
+{{ $version = "v1.24.18" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.9"}}
+{{ $version = "v1.25.12" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.5"}}
+{{ $version = "v1.26.8" }}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 apiVersion: v1

--- a/addons/csi/azure-disk/csi-azuredisk-controller.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-controller.yaml
@@ -23,7 +23,7 @@
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
-{{ $version := "1.27.0" }}
+{{ $version := "1.27.1" }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/addons/csi/azure-disk/csi-azuredisk-driver.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-driver.yaml
@@ -17,7 +17,7 @@
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
-{{ $version := "1.27.0" }}
+{{ $version := "1.27.1" }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/addons/csi/azure-disk/csi-azuredisk-node.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-node.yaml
@@ -22,7 +22,7 @@
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
-{{ $version := "1.27.0" }}
+{{ $version := "1.27.1" }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/addons/csi/azure-file/csi-azurefile-controller.yaml
+++ b/addons/csi/azure-file/csi-azurefile-controller.yaml
@@ -21,7 +21,7 @@
 # - add security context
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
-{{ $version := "1.26.1" }}
+{{ $version := "1.27.0" }}
 
 ---
 apiVersion: apps/v1

--- a/addons/csi/azure-file/csi-azurefile-driver.yaml
+++ b/addons/csi/azure-file/csi-azurefile-driver.yaml
@@ -15,7 +15,7 @@
 # Source: https://github.com/kubernetes-sigs/azurefile-csi-driver/raw/v1.26.1/deploy/v1.26.1/csi-azurefile-driver.yaml
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
-{{ $version := "1.26.1" }}
+{{ $version := "1.27.0" }}
 ---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver

--- a/addons/csi/azure-file/csi-azurefile-node.yaml
+++ b/addons/csi/azure-file/csi-azurefile-node.yaml
@@ -21,7 +21,7 @@
 # - add seccomp profile
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
-{{ $version := "1.26.1" }}
+{{ $version := "1.27.0" }}
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -126,15 +126,15 @@ func getAzureVersion(version semver.Semver) (string, error) {
 	// reminder: do not forget to update addons/azure-cloud-node-manager as well!
 	switch version.MajorMinor() {
 	case v123:
-		return "1.23.28", nil
+		return "1.23.30", nil
 	case v124:
-		return "1.24.15", nil
+		return "1.24.18", nil
 	case v125:
-		return "1.25.9", nil
+		return "1.25.12", nil
 	case v126:
-		fallthrough
+		return "1.26.8", nil
 	default:
-		return "1.26.5", nil
+		return "1.27.1", nil
 	}
 }
 

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.24.15
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.24.18
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.25.9
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.25.12
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.26.5
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.26.8
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the used patch releases for each of the supported Kubernetes releases. See https://github.com/kubernetes-sigs/cloud-provider-azure/releases

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Azure Cloud Node Manager to 1.24.18 / 1.25.12 / 1.26.8
Update Azure Disk CSI to 1.27.1
Update Azure File CSI to 1.27.0
Update Azure CCM to 1.24.18 / 1.25.12 / 1.26.8 / 1.27.1
```

**Documentation**:
```documentation
NONE
```
