### PR TITLE
bump cluster-autoscaler addon

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -17,13 +17,13 @@
 {{ $version = "v1.23.1"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.0"}}
+{{ $version = "v1.24.1"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.0"}}
+{{ $version = "v1.25.1"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.1"}}
+{{ $version = "v1.26.2"}}
 {{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the used patch releases for each of the supported Kubernetes releases. See https://github.com/kubernetes/autoscaler/tags

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update cluster-autoscaler to 1.24.1 / 1.25.1 / 1.26.2
```

**Documentation**:
```documentation
NONE
```
