### PR TITLE
update to kube-state-metrics 2.8.2

### DIFF
--- a/addons/kube-state-metrics/deployment.yaml
+++ b/addons/kube-state-metrics/deployment.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.1
+    app.kubernetes.io/version: 2.8.2
   name: kube-state-metrics
   namespace: kube-system
 spec:
@@ -34,7 +34,7 @@ spec:
       labels:
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.8.1
+        app.kubernetes.io/version: 2.8.2
     spec:
       containers:
         - args:
@@ -42,7 +42,7 @@ spec:
             - --port=8081
             - --telemetry-host=127.0.0.1
             - --telemetry-port=8082
-          image: '{{ Image "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.1" }}'
+          image: '{{ Image "registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2" }}'
           name: kube-state-metrics
           resources:
             limits:

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -49,7 +49,7 @@ var (
 
 const (
 	name    = "kube-state-metrics"
-	version = "v2.5.0"
+	version = "v2.8.2"
 )
 
 // DeploymentReconciler returns the function to create and update the kube-state-metrics deployment.

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics.yaml
@@ -37,7 +37,7 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.5.0
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
         name: kube-state-metrics
         ports:
         - containerPort: 8080


### PR DESCRIPTION
**What this PR does / why we need it**:
It's high time we update kube-state-metrics again. The only breaking changes was deprecating the `kube_verticalpodautoscaler_` metrics in 2.7, which does not affect us.

Ref: https://github.com/kubernetes/kube-state-metrics/blob/main/CHANGELOG.md

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update kube-state-metrics to 2.8.2
```

**Documentation**:
```documentation
NONE
```
