### PR TITLE
bump kube-rbac-proxy to 0.14.1

### DIFF
--- a/addons/node-exporter/daemonset.yaml
+++ b/addons/node-exporter/daemonset.yaml
@@ -64,7 +64,7 @@ spec:
           mountPropagation: HostToContainer
 
       - name: kube-rbac-proxy
-        image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.14.0" }}'
+        image: '{{ Image "quay.io/brancz/kube-rbac-proxy:v0.14.1" }}'
         args:
         - '--secure-listen-address=$(IP):9100'
         - '--upstream=http://127.0.0.1:9100/'

--- a/charts/monitoring/node-exporter/values.yaml
+++ b/charts/monitoring/node-exporter/values.yaml
@@ -31,7 +31,7 @@ nodeExporter:
   rbacProxy:
     image:
       repository: quay.io/brancz/kube-rbac-proxy
-      tag: v0.13.1
+      tag: v0.14.1
     resources:
       requests:
         cpu: 50m


### PR DESCRIPTION
**What this PR does / why we need it**:
No dramatic changes, but still worthwhile to bump: https://github.com/brancz/kube-rbac-proxy/releases

Note that #12225 includes the bump for the ksm addon.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
