### PR TITLE
Bump AWS CCM/CSI

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -55,7 +55,7 @@ aws-ebs-csi-driver:
 	mkdir -p csi/aws-ebs
 	cat csi/aws-ebs/_header.txt > $(OUTPUT_FILE)
 	helm --namespace kube-system template aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
-	  --version 2.17.1 \
+	  --version 2.18.0 \
 	  --set 'controller.k8sTagClusterId=\{{ .Cluster.Name }}' \
 	  --set 'node.securityContext.seccompProfile.type=RuntimeDefault' \
 	  --set 'controller.securityContext.seccompProfile.type=RuntimeDefault' \

--- a/addons/csi/aws-ebs/driver.yaml
+++ b/addons/csi/aws-ebs/driver.yaml
@@ -27,8 +27,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -48,8 +48,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 ---
@@ -62,8 +62,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 ---
@@ -75,8 +75,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -104,8 +104,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -121,8 +121,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -165,8 +165,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -202,8 +202,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 rules:
@@ -235,8 +235,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -256,8 +256,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -277,8 +277,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -298,8 +298,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -319,8 +319,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 subjects:
@@ -342,8 +342,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -362,8 +362,8 @@ spec:
         app: ebs-csi-node
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.17.1
-        app.kubernetes.io/version: "1.16.1"
+        helm.sh/chart: aws-ebs-csi-driver-2.18.0
+        app.kubernetes.io/version: "1.18.0"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -391,7 +391,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ebs-plugin
-          image: {{ Image "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1" }}
+          image: {{ Image "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.18.0" }}
           imagePullPolicy: IfNotPresent
           args:
             - node
@@ -437,7 +437,7 @@ spec:
             privileged: true
             readOnlyRootFilesystem: true
         - name: node-driver-registrar
-          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.7.0-eks-1-25-latest" }}
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar:v2.7.0-eks-1-26-7" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -449,11 +449,21 @@ spec:
             - name: DRIVER_REG_SOCK_PATH
               value: /var/lib/kubelet/plugins/ebs.csi.aws.com/csi.sock
           envFrom:
+          livenessProbe:
+            exec:
+              command:
+                - /csi-node-driver-registrar
+                - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+                - --mode=kubelet-registration-probe
+            initialDelaySeconds: 30
+            timeoutSeconds: 15
           volumeMounts:
             - name: plugin-dir
               mountPath: /csi
             - name: registration-dir
               mountPath: /registration
+            - name: probe-dir
+              mountPath: /var/lib/kubelet/plugins/ebs.csi.aws.com/
           resources:
             limits:
               cpu: 100m
@@ -465,7 +475,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest" }}
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-26-7" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -500,6 +510,8 @@ spec:
           hostPath:
             path: /dev
             type: Directory
+        - name: probe-dir
+          emptyDir: {}
 ---
 # Source: aws-ebs-csi-driver/templates/controller.yaml
 # Controller Service
@@ -511,8 +523,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:
@@ -532,8 +544,8 @@ spec:
         app: ebs-csi-controller
         app.kubernetes.io/name: aws-ebs-csi-driver
         app.kubernetes.io/instance: aws-ebs-csi-driver
-        helm.sh/chart: aws-ebs-csi-driver-2.17.1
-        app.kubernetes.io/version: "1.16.1"
+        helm.sh/chart: aws-ebs-csi-driver-2.18.0
+        app.kubernetes.io/version: "1.18.0"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
     spec:
@@ -577,7 +589,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: ebs-plugin
-          image: {{ Image "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.16.1" }}
+          image: {{ Image "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver:v1.18.0" }}
           imagePullPolicy: IfNotPresent
           args:
             - controller
@@ -645,7 +657,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-provisioner
-          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.4.0-eks-1-25-latest" }}
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner:v3.4.1-eks-1-26-7" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -672,7 +684,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-attacher
-          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.1.0-eks-1-25-latest" }}
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-attacher:v4.2.0-eks-1-26-7" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -696,7 +708,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: csi-resizer
-          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.7.0-eks-1-25-latest" }}
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/external-resizer:v1.7.0-eks-1-26-7" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -720,7 +732,7 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
         - name: liveness-probe
-          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-25-latest" }}
+          image: {{ Image "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe:v2.9.0-eks-1-26-7" }}
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=/csi/csi.sock
@@ -750,8 +762,8 @@ metadata:
   labels:
     app.kubernetes.io/name: aws-ebs-csi-driver
     app.kubernetes.io/instance: aws-ebs-csi-driver
-    helm.sh/chart: aws-ebs-csi-driver-2.17.1
-    app.kubernetes.io/version: "1.16.1"
+    helm.sh/chart: aws-ebs-csi-driver-2.18.0
+    app.kubernetes.io/version: "1.18.0"
     app.kubernetes.io/component: csi-driver
     app.kubernetes.io/managed-by: Helm
 spec:

--- a/pkg/resources/cloudcontroller/aws.go
+++ b/pkg/resources/cloudcontroller/aws.go
@@ -148,9 +148,9 @@ func getAWSCCMVersion(version semver.Semver) string {
 	case v125:
 		return "v1.25.3"
 	case v126:
-		fallthrough
+		return "v1.26.1"
 	//	By default return latest version
 	default:
-		return "v1.26.0"
+		return "v1.27.1"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -48,7 +48,7 @@ spec:
             secretKeyRef:
               key: secretAccessKey
               name: cloud-credentials
-        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.0
+        image: registry.k8s.io/provider-aws/cloud-controller-manager:v1.26.1
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the AWS CCM/CSI to their latest versions.

* https://github.com/kubernetes/cloud-provider-aws/releases
* https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/CHANGELOG.md

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update AWS EBS CSI to 1.18.0.
Update AWS CCM to 1.26.1 / 1.27.1.
```

**Documentation**:
```documentation
NONE
```
