### PR TITLE
Bump Openstack CCM/CSI

### DIFF
--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -16,6 +16,7 @@ presubmits:
   - name: pre-kubermatic-e2e-openstack-ubuntu-1.26
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    run_if_changed: "(addons/csi/openstack/|pkg/provider/cloud/openstack/|pkg/resources/cloudconfig/openstack|pkg/resources/cloudcontroller/openstack.go)"
     labels:
       preset-openstack: "true"
       preset-vault: "true"
@@ -61,6 +62,7 @@ presubmits:
   - name: pre-kubermatic-e2e-openstack-centos-1.26
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    run_if_changed: "(addons/csi/openstack/|pkg/provider/cloud/openstack/|pkg/resources/cloudconfig/openstack|pkg/resources/cloudcontroller/openstack.go)"
     labels:
       preset-openstack: "true"
       preset-vault: "true"

--- a/addons/csi/openstack/controllerplugin-rbac.yaml
+++ b/addons/csi/openstack/controllerplugin-rbac.yaml
@@ -119,9 +119,13 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
+  # Secret permission is optional.
+  # Enable it if your driver needs secret.
+  # For example, `csi.storage.k8s.io/snapshotter-secret-name` is set in VolumeSnapshotClass.
+  # See https://kubernetes-csi.github.io/docs/secrets-and-credentials.html for more details.
+  #  - apiGroups: [""]
+  #    resources: ["secrets"]
+  #    verbs: ["get", "list"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotclasses"]
     verbs: ["get", "list", "watch"]
@@ -156,9 +160,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-resizer-role
 rules:
-  - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
+  # The following rule should be uncommented for plugins that require secrets
+  # for provisioning.
+  # - apiGroups: [""]
+  #   resources: ["secrets"]
+  #   verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "patch"]
@@ -174,6 +180,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
 
 ---
 kind: ClusterRoleBinding

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -23,10 +23,10 @@
 {{ $version = "v1.24.6"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.4"}}
+{{ $version = "v1.25.5"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.1"}}
+{{ $version = "v1.26.2"}}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 ---

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -15,20 +15,20 @@
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 
 {{ if eq .Cluster.CloudProviderName "openstack" }}
-{{ $version := "UNSUPPORTED" }}
+{{ $csiImage := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
-{{ $version = "v1.23.4"}}
+{{ $csiImage = "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.6"}}
+{{ $csiImage = "registry.k8s.io/provider-os/cinder-csi-plugin:v1.24.6"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.5"}}
+{{ $csiImage = "registry.k8s.io/provider-os/cinder-csi-plugin:v1.25.5"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.2"}}
+{{ $csiImage = "registry.k8s.io/provider-os/cinder-csi-plugin:v1.26.2"}}
 {{ end }}
-{{ if not (eq $version "UNSUPPORTED") }}
+{{ if not (eq $csiImage "UNSUPPORTED") }}
 ---
 kind: Deployment
 apiVersion: apps/v1
@@ -120,7 +120,7 @@ spec:
             - mountPath: /var/lib/csi/sockets/pluginproxy/
               name: socket-dir
         - name: cinder-csi-plugin
-          image: '{{ Image (print "k8scloudprovider/cinder-csi-plugin:" $version) }}'
+          image: '{{ Image $csiImage }}'
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -15,20 +15,20 @@
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 
 {{ if eq .Cluster.CloudProviderName "openstack" }}
-{{ $version := "UNSUPPORTED" }}
+{{ $csiImage := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.23" }}
-{{ $version = "v1.23.4"}}
+{{ $csiImage = "docker.io/k8scloudprovider/cinder-csi-plugin:v1.23.4"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.6"}}
+{{ $csiImage = "registry.k8s.io/provider-os/cinder-csi-plugin:v1.24.6"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.5"}}
+{{ $csiImage = "registry.k8s.io/provider-os/cinder-csi-plugin:v1.25.5"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.2"}}
+{{ $csiImage = "registry.k8s.io/provider-os/cinder-csi-plugin:v1.26.2"}}
 {{ end }}
-{{ if not (eq $version "UNSUPPORTED") }}
+{{ if not (eq $csiImage "UNSUPPORTED") }}
 ---
 kind: DaemonSet
 apiVersion: apps/v1
@@ -89,7 +89,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: '{{ Image (print "k8scloudprovider/cinder-csi-plugin:" $version) }}'
+          image: '{{ Image $csiImage }}'
           args:
             - /bin/cinder-csi-plugin
             - "--nodeid=$(NODE_ID)"

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -23,10 +23,10 @@
 {{ $version = "v1.24.6"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.4"}}
+{{ $version = "v1.25.5"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.1"}}
+{{ $version = "v1.26.2"}}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 ---

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -131,9 +131,9 @@ func getOSVersion(version semver.Semver) (string, error) {
 	case v124:
 		return "1.24.6", nil
 	case v125:
-		return "1.25.4", nil
+		return "1.25.5", nil
 	case v126:
-		return "1.26.1", nil
+		return "1.26.2", nil
 	default:
 		return "", fmt.Errorf("%v is not yet supported", version)
 	}

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -76,7 +76,7 @@ func openStackDeploymentReconciler(data *resources.TemplateData) reconciling.Nam
 				return nil, err
 			}
 
-			version, err := getOSVersion(data.Cluster().Status.Versions.ControlPlane)
+			ccmImage, err := getOpenStackCCMImage(data.Cluster().Status.Versions.ControlPlane)
 			if err != nil {
 				return nil, err
 			}
@@ -86,7 +86,7 @@ func openStackDeploymentReconciler(data *resources.TemplateData) reconciling.Nam
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:         ccmContainerName,
-					Image:        registry.Must(data.RewriteImage(resources.RegistryDocker + "/k8scloudprovider/openstack-cloud-controller-manager:v" + version)),
+					Image:        registry.Must(data.RewriteImage(ccmImage)),
 					Command:      []string{"/bin/openstack-cloud-controller-manager"},
 					Args:         getOSFlags(data),
 					Env:          getEnvVars(),
@@ -124,16 +124,16 @@ func getOSFlags(data *resources.TemplateData) []string {
 	return flags
 }
 
-func getOSVersion(version semver.Semver) (string, error) {
+func getOpenStackCCMImage(version semver.Semver) (string, error) {
 	switch version.MajorMinor() {
 	case v123:
-		return "1.23.4", nil
+		return resources.RegistryDocker + "/k8scloudprovider/openstack-cloud-controller-manager:v1.23.4", nil
 	case v124:
-		return "1.24.6", nil
+		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager:v1.24.6", nil
 	case v125:
-		return "1.25.5", nil
+		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager:v1.25.5", nil
 	case v126:
-		return "1.26.2", nil
+		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager:v1.26.2", nil
 	default:
 		return "", fmt.Errorf("%v is not yet supported", version)
 	}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.24.6
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.24.6
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.25.4
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.25.5
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.25.5
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.25.5
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.26.2
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.2
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.26.1
+        image: docker.io/k8scloudprovider/openstack-cloud-controller-manager:v1.26.2
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This bumps the Openstack components by one patch release. It also switches to registry.k8s.io in preparation for Kubernetes 1.27 (#12230), for which the related container images will not be published on docker.io anymore, yet 1.23.x are _only_ on docker.io. :grin: 

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update OpenStack CCM/CSI to 1.25.5 / 1.26.2. For Kubernetes 1.24+ the OpenStack container images are now using `registry.k8s.io` instead of `docker.io`.
```

**Documentation**:
```documentation
NONE
```
