### PR TITLE
WIP - Make tunneling default expose strategy

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -69,10 +69,10 @@ spec:
     kind: ""
     # Name is the name of resource being referenced
     name: ca-bundle
-  # ExposeStrategy is the strategy to expose the cluster with.
-  # Note: The `seed_dns_overwrite` setting of a Seed's datacenter doesn't have any effect
+  # ExposeStrategy is the strategy to expose the cluster with, default is Tunneling.
+  # Note: The `seedDNSOverwrite` setting of a Seed's datacenter doesn't have any effect
   # if this is set to LoadBalancerStrategy.
-  exposeStrategy: NodePort
+  exposeStrategy: Tunneling
   # FeatureGates are used to optionally enable certain features.
   featureGates:
     EtcdLauncher: true

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -69,10 +69,10 @@ spec:
     kind: ""
     # Name is the name of resource being referenced
     name: ca-bundle
-  # ExposeStrategy is the strategy to expose the cluster with.
-  # Note: The `seed_dns_overwrite` setting of a Seed's datacenter doesn't have any effect
+  # ExposeStrategy is the strategy to expose the cluster with, default is Tunneling.
+  # Note: The `seedDNSOverwrite` setting of a Seed's datacenter doesn't have any effect
   # if this is set to LoadBalancerStrategy.
-  exposeStrategy: NodePort
+  exposeStrategy: Tunneling
   # FeatureGates are used to optionally enable certain features.
   featureGates:
     EtcdLauncher: true

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -426,7 +426,7 @@ spec:
   # if this is set, the new backup/restore controllers are enabled for this Seed.
   etcdBackupRestore: null
   # Optional: ExposeStrategy explicitly sets the expose strategy for this seed cluster, if not set, the default provided by the master is used.
-  exposeStrategy: NodePort
+  exposeStrategy: Tunneling
   # A reference to the Kubeconfig of this cluster. The Kubeconfig must
   # have cluster-admin privileges. This field is mandatory for every
   # seed, even if there are no datacenters defined yet.

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -426,7 +426,7 @@ spec:
   # if this is set, the new backup/restore controllers are enabled for this Seed.
   etcdBackupRestore: null
   # Optional: ExposeStrategy explicitly sets the expose strategy for this seed cluster, if not set, the default provided by the master is used.
-  exposeStrategy: NodePort
+  exposeStrategy: Tunneling
   # A reference to the Kubeconfig of this cluster. The Kubeconfig must
   # have cluster-admin privileges. This field is mandatory for every
   # seed, even if there are no datacenters defined yet.

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -99,8 +99,8 @@ type KubermaticConfigurationSpec struct {
 	Webhook KubermaticWebhookConfiguration `json:"webhook,omitempty"`
 	// UserCluster configures various aspects of the user-created clusters.
 	UserCluster KubermaticUserClusterConfiguration `json:"userCluster,omitempty"`
-	// ExposeStrategy is the strategy to expose the cluster with.
-	// Note: The `seed_dns_overwrite` setting of a Seed's datacenter doesn't have any effect
+	// ExposeStrategy is the strategy to expose the cluster with, default is Tunneling.
+	// Note: The `seedDNSOverwrite` setting of a Seed's datacenter doesn't have any effect
 	// if this is set to LoadBalancerStrategy.
 	ExposeStrategy ExposeStrategy `json:"exposeStrategy,omitempty"`
 	// Ingress contains settings for making the API and UI accessible remotely.

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -53,7 +53,7 @@ const (
 	DefaultWebhookReplicas                        = 1
 	DefaultControllerManagerReplicas              = 1
 	DefaultSchedulerReplicas                      = 1
-	DefaultExposeStrategy                         = kubermaticv1.ExposeStrategyNodePort
+	DefaultExposeStrategy                         = kubermaticv1.ExposeStrategyTunneling
 	DefaultVPARecommenderDockerRepository         = "registry.k8s.io/autoscaling/vpa-recommender"
 	DefaultVPAUpdaterDockerRepository             = "registry.k8s.io/autoscaling/vpa-updater"
 	DefaultVPAAdmissionControllerDockerRepository = "registry.k8s.io/autoscaling/vpa-admission-controller"


### PR DESCRIPTION
**What this PR does / why we need it**:

With the [GA of Tunneling](https://github.com/kubermatic/kubermatic/commit/e9719f577d65ab903cff506d5a9c70b5e8726d36) we want to use it as out default expose strategy.

In comparison to NodePort our current default expose strategy it offers are more unified and centralized endpoint where user clusters connect to. Only requiring port 6443 and 8088 via a load balancer service.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Tunneling is now the default expose strategy.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
