### PR TITLE
Update Prometheus to 2.43.1

### DIFF
--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: prometheus
 version: v9.9.9-dev
-appVersion: v2.40.2
+appVersion: v2.43.1
 description: Prometheus Monitoring for Kubernetes
 keywords:
   - kubermatic

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -16,7 +16,7 @@ prometheus:
   replicas: 2
   image:
     repository: quay.io/prometheus/prometheus
-    tag: v2.40.2
+    tag: v2.43.1
     pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/hack/update-prometheus-rules.sh
+++ b/hack/update-prometheus-rules.sh
@@ -23,7 +23,7 @@ containerize ./hack/update-prometheus-rules.sh
 
 promtool=promtool
 if ! [ -x "$(command -v $promtool)" ]; then
-  version=2.41.0
+  version=2.43.1
   url="https://github.com/prometheus/prometheus/releases/download/v$version/prometheus-$version.linux-amd64.tar.gz"
   promtool=/tmp/promtool
 

--- a/hack/verify-prometheus-rules.sh
+++ b/hack/verify-prometheus-rules.sh
@@ -20,7 +20,7 @@ cd $(dirname $0)/..
 source hack/lib.sh
 
 if ! [ -x "$(command -v promtool)" ]; then
-  version=2.41.0
+  version=2.43.1
 
   echodate "Downloading promtool v$version..."
 

--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -147,7 +147,6 @@ func ListUpgrades(ctx context.Context, sa, zone, name string) ([]*apiv1.MasterVe
 	if err != nil {
 		return nil, err
 	}
-	releaseChannel := ""
 
 	req := svc.Projects.Zones.GetServerconfig(project, zone)
 	resp, err := req.Context(ctx).Do()
@@ -157,7 +156,7 @@ func ListUpgrades(ctx context.Context, sa, zone, name string) ([]*apiv1.MasterVe
 	upgradesMap := map[string]bool{}
 
 	if cluster.ReleaseChannel != nil && len(cluster.ReleaseChannel.Channel) > 0 && cluster.ReleaseChannel.Channel != resources.GKEUnspecifiedReleaseChannel {
-		releaseChannel = cluster.ReleaseChannel.Channel
+		releaseChannel := cluster.ReleaseChannel.Channel
 		for _, channel := range resp.Channels {
 			// select versions from the current channel
 			if releaseChannel == channel.Channel {

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.40.2"
+	tag  = "v2.43.1"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.26.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.26.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.26.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.26.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.26.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.26.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.24.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.25.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-prometheus-externalCloudProvider.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.26.0-prometheus.yaml
@@ -34,7 +34,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.40.2
+        image: quay.io/prometheus/prometheus:v2.43.1
         livenessProbe:
           failureThreshold: 10
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This biggest change is the support for new Histograms, which apparently cause an imcompatibility with older WAL data, in [2.42.2](https://github.com/prometheus/prometheus/releases/tag/v2.42.0):

> This release comes with a bunch of feature coverage for native histograms and breaking changes.
>
> If you are trying native histograms already, we recommend you remove the wal directory when upgrading.
Because the old WAL record for native histograms is not backward compatible in v2.42.0, this will lead to some data loss for the latest data.
>
> Additionally, if you scrape "float histograms" or use recording rules on native histograms in v2.42.0 (which writes float histograms), it is a one-way street since older versions do not support float histograms.

As we're not using the new native Histograms yet, this should not be a problem for our usecase.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Prometheus to 2.43.1
```

**Documentation**:
```documentation
NONE
```
