### PR TITLE
Bump Dex to 2.36.0

### DIFF
--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: oauth
 version: v9.9.9-dev
-appVersion: v2.35.3
+appVersion: v2.36.0
 description: Dex
 keywords:
   - kubermatic

--- a/charts/oauth/test/default.yaml.out
+++ b/charts/oauth/test/default.yaml.out
@@ -248,7 +248,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: ghcr.io/dexidp/dex:v2.35.3
+      - image: ghcr.io/dexidp/dex:v2.36.0
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         env: 

--- a/charts/oauth/test/image-pull-secret.yaml.out
+++ b/charts/oauth/test/image-pull-secret.yaml.out
@@ -250,7 +250,7 @@ spec:
       imagePullSecrets:
         - name: quay-io-pull-secret
       containers:
-      - image: ghcr.io/dexidp/dex:v2.35.3
+      - image: ghcr.io/dexidp/dex:v2.36.0
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         env: 

--- a/charts/oauth/test/values.example.ce.yaml.out
+++ b/charts/oauth/test/values.example.ce.yaml.out
@@ -272,7 +272,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: ghcr.io/dexidp/dex:v2.35.3
+      - image: ghcr.io/dexidp/dex:v2.36.0
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         env: 

--- a/charts/oauth/test/values.example.ee.yaml.out
+++ b/charts/oauth/test/values.example.ee.yaml.out
@@ -272,7 +272,7 @@ spec:
     spec:
       serviceAccountName: dex
       containers:
-      - image: ghcr.io/dexidp/dex:v2.35.3
+      - image: ghcr.io/dexidp/dex:v2.36.0
         name: dex
         command: ["/usr/local/bin/dex", "serve", "/etc/dex/cfg/config.yaml"]
         env: 

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -15,7 +15,7 @@
 dex:
   image:
     repository: "ghcr.io/dexidp/dex"
-    tag: "v2.35.3"
+    tag: "v2.36.0"
   # list of image pull secret references, e.g.
   # imagePullSecrets:
   #   - name: gchr-io-pull-secret


### PR DESCRIPTION
**What this PR does / why we need it**:
Release contains a handful of nice fixes: https://github.com/dexidp/dex/releases/tag/v2.36.0

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Dex to 2.36.0
```

**Documentation**:
```documentation
NONE
```
