### PR TITLE
update blackbox-exporter to 0.23.0

### DIFF
--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: blackbox-exporter
 version: v9.9.9-dev
-appVersion: v0.21.1
+appVersion: v0.23.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:
   - kubermatic

--- a/charts/monitoring/blackbox-exporter/values.yaml
+++ b/charts/monitoring/blackbox-exporter/values.yaml
@@ -15,7 +15,7 @@
 blackboxExporter:
   image:
     repository: quay.io/prometheus/blackbox-exporter
-    tag: v0.21.1
+    tag: v0.23.0
     pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:


### PR DESCRIPTION
**What this PR does / why we need it**:
[0.23.0](https://github.com/prometheus/blackbox_exporter/releases/tag/v0.23.0) fixes a CVE, but apart from that, nothing special to note here.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update blackbox-exporter to 0.23.0
```

**Documentation**:
```documentation
NONE
```
