### PR TITLE
bump Karma to 0.114

### DIFF
--- a/charts/monitoring/karma/Chart.yaml
+++ b/charts/monitoring/karma/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: karma
 version: v9.9.9-dev
-appVersion: v0.103
+appVersion: v0.114
 description: Dashboard for Prometheus Alertmanager
 keywords:
   - kubermatic

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -51,7 +51,7 @@ karma:
   images:
     karma:
       repository: docker.io/lmierzwa/karma
-      tag: v0.103
+      tag: v0.114
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a bunch of bugfixes and removed support for Alertmanagers prior to 0.22.0 (KKP is on 0.24, 0.22 is from May 24, 2021).

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Karma to 0.114
```

**Documentation**:
```documentation
NONE
```
