### PR TITLE
Bump Alertmanager to 0.25.0

### DIFF
--- a/charts/monitoring/alertmanager/Chart.yaml
+++ b/charts/monitoring/alertmanager/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: alertmanager
 version: v9.9.9-dev
-appVersion: v0.24.0
+appVersion: v0.25.0
 description: Alertmanager for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -15,7 +15,7 @@
 alertmanager:
   image:
     repository: quay.io/prometheus/alertmanager
-    tag: v0.24.0
+    tag: v0.25.0
     pullPolicy: IfNotPresent
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload


### PR DESCRIPTION
**What this PR does / why we need it**:
A few telegram and Discord updates, nothing too special: https://github.com/prometheus/alertmanager/releases/tag/v0.25.0

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Alertmanager to 0.25.0
```

**Documentation**:
```documentation
NONE
```
