### PR TITLE
bump configmap-reload to 0.8.0

### DIFF
--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -19,7 +19,7 @@ alertmanager:
     pullPolicy: IfNotPresent
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload
-    tag: v0.7.1
+    tag: v0.8.0
     pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -33,7 +33,7 @@ prometheus:
 
   configReloaderImage:
     repository: docker.io/jimmidyson/configmap-reload
-    tag: v0.7.1
+    tag: v0.8.0
     pullPolicy: IfNotPresent
 
   # If you install Prometheus using a different Helm release name,


### PR DESCRIPTION
**What this PR does / why we need it**:
Just a few dependency updates: https://github.com/jimmidyson/configmap-reload/compare/v0.7.1...v0.8.0

I opened [a ticket](https://github.com/jimmidyson/configmap-reload/issues/83) to ask for an alternative for docker.io, maybe we're lucky some day. Otherwise we might want to consider mirroring these images, as they change very rarely.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update configmap-reload to 0.8.0
```

**Documentation**:
```documentation
NONE
```
