### PR TITLE
update Minio to RELEASE.2023-05-04T21-44-30Z, change to quay.io

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: minio
 version: v9.9.9-dev
-appVersion: RELEASE.2022-06-25T15-50-16Z
+appVersion: RELEASE.2023-05-04T21-44-30Z
 description: minio
 keywords:
   - kubermatic

--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -148,7 +148,7 @@ spec:
         - name: quay-io-pull-secret
       containers:
       - name: minio
-        image: 'docker.io/minio/minio:RELEASE.2022-06-25T15-50-16Z'
+        image: 'quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z'
         args:
         - server
         - /storage
@@ -179,7 +179,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.1.0'
+        image: 'quay.io/kubermatic/util:2.3.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'docker.io/minio/minio:RELEASE.2022-06-25T15-50-16Z'
+        image: 'quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z'
         args:
         - server
         - /storage
@@ -178,7 +178,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.1.0'
+        image: 'quay.io/kubermatic/util:2.3.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'docker.io/minio/minio:RELEASE.2022-06-25T15-50-16Z'
+        image: 'quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z'
         args:
         - server
         - /storage
@@ -178,7 +178,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.1.0'
+        image: 'quay.io/kubermatic/util:2.3.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -20,8 +20,8 @@ minio:
   imagePullSecrets: []
 
   image:
-    repository: docker.io/minio/minio
-    tag: RELEASE.2022-06-25T15-50-16Z
+    repository: quay.io/minio/minio
+    tag: RELEASE.2023-05-04T21-44-30Z
   storeSize: 100Gi
 
   # The is required to enable the BackupRestore controller so it can backup
@@ -57,7 +57,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.1.0
+      tag: 2.3.0
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that


### PR DESCRIPTION
**What this PR does / why we need it**:
This performs a long overdue bumping of Minio. We can also move away from docker.io for this one, as sometime in 2021 Minio changed from docker.io to quay.io: https://github.com/minio/minio/search?q=quay&type=commits

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update etcd-backup Minio to RELEASE.2023-05-04T21-44-30Z, change to quay.io/minio/minio
```

**Documentation**:
```documentation
NONE
```
