### PR TITLE
Update oauth2-proxy to 7.4.0

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: iap
 version: v9.9.9-dev
-appVersion: v7.3.0
+appVersion: v7.4.0
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
   - kubermatic

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,7 +15,7 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.3.0
+    tag: v7.4.0
     pullPolicy: IfNotPresent
 
   # list of image pull secret references, e.g.


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.4.0 brings primarily

* New Azure groups support for Azure OAuth2 v2.0
* Option to configure API routes - paths that will not redirect to login when unauthenticated
* CSRF and session cookies now have different timeouts

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update IAP (oauth2-proxy) to 7.4.0
```

**Documentation**:
```documentation
NONE
```
