### PR TITLE
bump metrics-server to 0.6.3

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -52,7 +52,7 @@ const (
 	servingCertMountFolder = "/etc/serving-cert"
 
 	imageName = "metrics-server/metrics-server"
-	imageTag  = "v0.6.1"
+	imageTag  = "v0.6.3"
 )
 
 // TLSServingCertSecretReconciler returns a function to manage the TLS serving cert for the metrics server.


### PR DESCRIPTION
**What this PR does / why we need it**:
This new version brings mostly just bumped dependencies, no actual changes.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update metrics-server to 0.6.3
```

**Documentation**:
```documentation
NONE
```
