### PR TITLE
update k8s-dns-node-cache to 1.22.20

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -87,7 +87,7 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
-					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.22.13", resources.RegistryK8S))),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.22.20", resources.RegistryK8S))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",


### PR DESCRIPTION
**What this PR does / why we need it**:
https://github.com/kubernetes/dns/compare/1.22.13...1.22.20 brings lots of dependency updates and switches to another base image. Should be a harmless update for us.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update k8s-dns-node-cache to 1.22.20
```

**Documentation**:
```documentation
NONE
```
