### PR TITLE
Bump envoy-agent to 1.26.1

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -497,7 +497,7 @@ spec:
     # Envoy configures the Envoy application itself.
     envoy:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: docker.io/envoyproxy/envoy-alpine
+      dockerRepository: docker.io/envoyproxy/envoy-distroless
       loadBalancerService:
         # Annotations are used to further tweak the LoadBalancer integration with the
         # cloud provider.

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -497,7 +497,7 @@ spec:
     # Envoy configures the Envoy application itself.
     envoy:
       # DockerRepository is the repository containing the component's image.
-      dockerRepository: docker.io/envoyproxy/envoy-alpine
+      dockerRepository: docker.io/envoyproxy/envoy-distroless
       loadBalancerService:
         # Annotations are used to further tweak the LoadBalancer integration with the
         # cloud provider.

--- a/hack/run-nodeport-proxy-e2e-test-in-kind.sh
+++ b/hack/run-nodeport-proxy-e2e-test-in-kind.sh
@@ -58,6 +58,12 @@ time kind create cluster --name "${KIND_CLUSTER_NAME}"
 # load nodeport-proxy image
 time kind load docker-image "${DOCKER_REPO}/nodeport-proxy:${TAG}" --name "$KIND_CLUSTER_NAME"
 
+# gather the logs of all Envoys
+if [ -n "${ARTIFACTS:-}" ]; then
+  protokol --kubeconfig "${HOME}/.kube/config" --output "$ARTIFACTS/logs" --namespace 'np-proxy-test-*' > /dev/null 2>&1 &
+  protokol --kubeconfig "${HOME}/.kube/config" --output "$ARTIFACTS/logs" --namespace 'nodeport-proxy-*' > /dev/null 2>&1 &
+fi
+
 # run tests
 go_test nodeport_proxy_e2e -tags e2e -v -race ./pkg/test/e2e/nodeport-proxy \
   -kubeconfig "${HOME}/.kube/config" \

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
@@ -26,6 +26,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -324,7 +325,7 @@ func TestCloudControllerManagerDeployment(t *testing.T) {
 			if err := fc.Create(ctx, tc.kcmDeploymentConfig.Create(td)); err != nil {
 				t.Fatalf("error occurred while creating KCM deployment: %v", err)
 			}
-			creators := GetDeploymentReconcilers(td, false)
+			creators := GetDeploymentReconcilers(td, false, kubermatic.NewFakeVersions())
 			var ccmDeploymentFound bool
 			for _, c := range creators {
 				name, _ := c()

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -57,7 +57,7 @@ const (
 	DefaultVPARecommenderDockerRepository         = "registry.k8s.io/autoscaling/vpa-recommender"
 	DefaultVPAUpdaterDockerRepository             = "registry.k8s.io/autoscaling/vpa-updater"
 	DefaultVPAAdmissionControllerDockerRepository = "registry.k8s.io/autoscaling/vpa-admission-controller"
-	DefaultEnvoyDockerRepository                  = "docker.io/envoyproxy/envoy-alpine"
+	DefaultEnvoyDockerRepository                  = "docker.io/envoyproxy/envoy-distroless"
 	DefaultUserClusterScrapeAnnotationPrefix      = "monitoring.kubermatic.io"
 	DefaultMaximumParallelReconciles              = 10
 	DefaultS3Endpoint                             = "s3.amazonaws.com"

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -292,7 +292,7 @@ func getImagesFromReconcilers(log logrus.FieldLogger, templateData *resources.Te
 	statefulsetReconcilers := kubernetescontroller.GetStatefulSetReconcilers(templateData, false, false)
 	statefulsetReconcilers = append(statefulsetReconcilers, monitoring.GetStatefulSetReconcilers(templateData)...)
 
-	deploymentReconcilers := kubernetescontroller.GetDeploymentReconcilers(templateData, false)
+	deploymentReconcilers := kubernetescontroller.GetDeploymentReconcilers(templateData, false, kubermaticVersions)
 	deploymentReconcilers = append(deploymentReconcilers, monitoring.GetDeploymentReconcilers(templateData)...)
 	deploymentReconcilers = append(deploymentReconcilers, masteroperator.APIDeploymentReconciler(config, "", kubermaticVersions))
 	deploymentReconcilers = append(deploymentReconcilers, masteroperator.MasterControllerManagerDeploymentReconciler(config, "", kubermaticVersions))

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -23,6 +23,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -197,7 +198,7 @@ func RoleBindingReconciler() (string, reconciling.RoleBindingReconciler) {
 	}
 }
 
-func DeploymentEnvoyReconciler(data nodePortProxyData) reconciling.NamedDeploymentReconcilerFactory {
+func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versions) reconciling.NamedDeploymentReconcilerFactory {
 	volumeMountNameEnvoyConfig := "envoy-config"
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.NodePortProxyEnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
@@ -253,7 +254,7 @@ func DeploymentEnvoyReconciler(data nodePortProxyData) reconciling.NamedDeployme
 				},
 			}, {
 				Name:  resources.NodePortProxyEnvoyContainerName,
-				Image: registry.Must(data.RewriteImage("envoyproxy/envoy-alpine:v1.16.0")),
+				Image: registry.Must(data.RewriteImage(fmt.Sprintf("envoyproxy/envoy-alpine:%s", versions.Envoy))),
 				Command: []string{
 					"/usr/local/bin/envoy",
 					"-c",

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -254,7 +254,7 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 				},
 			}, {
 				Name:  resources.NodePortProxyEnvoyContainerName,
-				Image: registry.Must(data.RewriteImage(fmt.Sprintf("envoyproxy/envoy-alpine:%s", versions.Envoy))),
+				Image: registry.Must(data.RewriteImage(fmt.Sprintf("envoyproxy/envoy-distroless:%s", versions.Envoy))),
 				Command: []string{
 					"/usr/local/bin/envoy",
 					"-c",

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.16.0
+        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-nodeport-proxy-envoy.yaml
@@ -73,7 +73,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: docker.io/envoyproxy/envoy-alpine:v1.17.1
+        image: docker.io/envoyproxy/envoy-distroless:v1.17.1
         lifecycle:
           preStop:
             exec:

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -750,7 +750,7 @@ func TestLoadFiles(t *testing.T) {
 						WithFailureDomainZoneAntiaffinity(true).
 						Build()
 
-					generateAndVerifyResources(t, data, tc, markFixtureUsed)
+					generateAndVerifyResources(t, data, tc, markFixtureUsed, kubermaticVersions)
 				})
 			}
 		}
@@ -761,11 +761,11 @@ func TestLoadFiles(t *testing.T) {
 	}
 }
 
-func generateAndVerifyResources(t *testing.T, data *resources.TemplateData, tc testCase, fixtureDone func(string)) {
+func generateAndVerifyResources(t *testing.T, data *resources.TemplateData, tc testCase, fixtureDone func(string), versions kubermatic.Versions) {
 	cluster := data.Cluster()
 
 	var deploymentReconcilers []reconciling.NamedDeploymentReconcilerFactory
-	deploymentReconcilers = append(deploymentReconcilers, kubernetescontroller.GetDeploymentReconcilers(data, true)...)
+	deploymentReconcilers = append(deploymentReconcilers, kubernetescontroller.GetDeploymentReconcilers(data, true, versions)...)
 	deploymentReconcilers = append(deploymentReconcilers, monitoringcontroller.GetDeploymentReconcilers(data)...)
 	for _, create := range deploymentReconcilers {
 		name, creator := create()

--- a/pkg/version/kubermatic/versions.go
+++ b/pkg/version/kubermatic/versions.go
@@ -61,7 +61,7 @@ func NewDefaultVersions() Versions {
 		Kubermatic:        kubermaticDockerTag,
 		UI:                uiDockerTag,
 		VPA:               "0.11.0",
-		Envoy:             "v1.17.1",
+		Envoy:             "v1.26.1",
 		KubermaticEdition: edition.KubermaticEdition,
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is an attempt to bring our Envoy dependency into the 21st century.

* `envoy-alpine` is no more, was replaced with `envoy-distroless`
* do not be confused by the updated fixtures using 1.17: this is purely because we use static fake versions for these deployments; in real life scenarios we deploy v1.26.1 now.
* PR adds some additional typing infos (see https://github.com/envoyproxy/envoy/issues/26118)

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Envoy to 1.26.1
```

**Documentation**:
```documentation
NONE
```
