### PR TITLE
[release/v2.21] fix usercluster manager oom (#12090)

### DIFF
--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -26,6 +26,8 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"go.uber.org/zap"
@@ -39,7 +41,10 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 	"helm.sh/helm/v3/pkg/repo"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // secretStorageDriver is the name of the secret storage driver.
@@ -203,6 +208,31 @@ func (h HelmClient) DownloadChart(url string, chartName string, version string, 
 // Otherwise it upgrades the chart.
 // charLoc is the path to the chart archive (e.g. /tmp/foo/apache-1.0.0.tgz) or folder containing the chart (e.g. /tmp/mychart/apache).
 func (h HelmClient) InstallOrUpgrade(chartLoc string, releaseName string, values map[string]interface{}, auth AuthSettings) (*release.Release, error) {
+	// To know if we have to do an install or an upgrade, we have to fetch the last version of the helm release. We do
+	// that with the following command:
+	//              h.actionConfig.Releases.Last(releaseName)
+	// Unfortunately, this command load all the versions and returns the last one. By default, the history is limited to
+	// 256 versions. In the case of a big chart like Cilium, loading all history consume several hundred of RAM, leading
+	// to OOM kill. cf https://github.com/kubermatic/kubermatic/issues/12078
+	//
+	// To fix that, we have limited the history. So when we upgrade a chart, Helm automatically cleans the history.
+	// However, for that to happen, an upgrade must happen, which may not be possible if the history is already too
+	// big. The Controller is OOM killed when it tries to figure out if it has to do an install or an upgrade. So we manually purge
+	// the history.
+	// This manual purged will not be need in KPP 2.23
+	restConfig, err := h.restClientGetter.ToRESTConfig()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get restConfig to create k8s client: %w", err)
+	}
+	k8sClient, err := ctrlruntimeclient.New(restConfig, ctrlruntimeclient.Options{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create k8s client: %w", err)
+	}
+
+	if err := purgeOldReleases(h.ctx, h.logger, k8sClient, h.targetNamespace, releaseName); err != nil {
+		return nil, fmt.Errorf("failed to purge history of helm release '%s': %w", releaseName, err)
+	}
+
 	if _, err := h.actionConfig.Releases.Last(releaseName); err != nil {
 		return h.Install(chartLoc, releaseName, values, auth)
 	}
@@ -238,6 +268,9 @@ func (h HelmClient) Upgrade(chartLoc string, releaseName string, values map[stri
 
 	upgradeClient := action.NewUpgrade(h.actionConfig)
 	upgradeClient.Namespace = h.targetNamespace
+
+	// restrict history to avoid OOM kill
+	upgradeClient.MaxHistory = 1
 
 	rel, err := upgradeClient.RunWithContext(h.ctx, releaseName, chartToUpgrade, values)
 	if err != nil {
@@ -361,6 +394,51 @@ func (h HelmClient) ensureRepository(url string, auth AuthSettings) (string, err
 		return repoName, repoFile.WriteFile(h.settings.RepositoryConfig, 0644)
 	}
 	return repoName, nil
+}
+
+// purgeOldReleases will purge the helm release history to keep only the 3 most recent releases.
+// Helm releases are stored in secrets (because we use the secret driver) labeled with name=<the name of the release>, version=<the version of the release> and owner=helm.
+func purgeOldReleases(ctx context.Context, logger *zap.SugaredLogger, k8sClient ctrlruntimeclient.Client, namespace string, releaseName string) error {
+	// List secret storging helm releaseinformation but get only metadata to avoid OOM kill.
+	var secrets metav1.PartialObjectMetadataList
+	secrets.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("SecretList"))
+	if err := k8sClient.List(ctx, &secrets, &ctrlruntimeclient.ListOptions{Namespace: namespace}, &ctrlruntimeclient.MatchingLabels{"name": releaseName, "owner": "helm"}); err != nil {
+		return fmt.Errorf("failed to list secrets: %w", err)
+	}
+
+	// Sort releases in decreasing order.
+	var sortError error
+	sort.Slice(secrets.Items, func(i, j int) bool {
+		secretI := secrets.Items[i]
+		versionI, err := strconv.Atoi(secretI.Labels["version"])
+		if err != nil { // should not be possible
+			sortError = fmt.Errorf("failed to get version for secret %s/%s: %w", secretI.Namespace, secretI.Name, err)
+		}
+		secretJ := secrets.Items[j]
+		versionJ, err := strconv.Atoi(secretJ.Labels["version"])
+		if err != nil {
+			sortError = fmt.Errorf("failed to get version for secret %s/%s: %w", secretJ.Namespace, secretJ.Name, err)
+		}
+
+		return versionI > versionJ
+	})
+
+	if sortError != nil {
+		return fmt.Errorf("failed to sort secrets: %w", sortError)
+	}
+
+	// Keep the 3 most recent releases.
+	// We keep 3 because if atomic is true and upgrade fails, we have the following history:
+	//              version 1 // the previous installed version
+	//              version 2 // the upgrade that fails.
+	//              version 3 // the version generated by the rollback (atomic=true)
+	for i := 3; i < len(secrets.Items); i++ {
+		if err := k8sClient.Delete(ctx, &secrets.Items[i]); err != nil {
+			return fmt.Errorf("failed to delete secret %s/%s (release version %s): %w", secrets.Items[i].Namespace, secrets.Items[i].Name, secrets.Items[i].Labels["version"], err)
+		}
+		logger.Debugw("helm release purged", "namespace", secrets.Items[i].Namespace, "secret-name", secrets.Items[i].Name, "name", secrets.Items[i].Labels["name"], "version", secrets.Items[i].Labels["version"])
+	}
+	return nil
 }
 
 // computeRepoName computes the name of the repository from url.

--- a/pkg/applications/test/kubernetes.go
+++ b/pkg/applications/test/kubernetes.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// AssertContainsExactly failed the test if the actual slice does not contain exactly the element of the expected slice.
+func AssertContainsExactly[T comparable](t *testing.T, prefixMsg string, actual []T, expected []T) {
+	t.Helper()
+
+	missing := map[T]struct{}{}
+	notExpected := map[T]struct{}{}
+	for _, val := range expected {
+		missing[val] = struct{}{}
+	}
+
+	for _, val := range actual {
+		notExpected[val] = struct{}{}
+	}
+
+	for _, val := range actual {
+		if _, found := missing[val]; found {
+			delete(missing, val)
+			delete(notExpected, val)
+		}
+	}
+	if len(missing) != 0 || len(notExpected) != 0 {
+		t.Fatalf("%s. expect %+v, to contains only %+v.\nMissing elements %+v\nUnexpected elements %+v", prefixMsg, actual, expected, keys(missing), keys(notExpected))
+	}
+}
+
+// keys return the keys of the map.
+func keys[T comparable](dict map[T]struct{}) []T {
+	var res []T
+	for k := range dict {
+		res = append(res, k)
+	}
+	return res
+}
+
+// ReleaseStorageInfo holds information about the secret storing the Helm release information.
+type ReleaseStorageInfo struct {
+	// Name of the secret containing release information.
+	Name string
+
+	// Version of the release.
+	Version string
+}
+
+// MapToReleaseStorageInfo maps the secrets containing the Helm release information to a smaller struct only containing the Name of the secret and the release version.
+func MapToReleaseStorageInfo(secrets []corev1.Secret) []ReleaseStorageInfo {
+	res := []ReleaseStorageInfo{}
+	for _, secret := range secrets {
+		res = append(res, ReleaseStorageInfo{
+			Name:    secret.Name,
+			Version: secret.Labels["version"],
+		})
+	}
+	return res
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #12089 with a "manual" purge of helm history releases to overcome OOM kill.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Applications: fix OOM on usercluster-controller by limiting the history of helm releases. This fix is critical if user-cluster is using Cilium >= 1.13.0 as CNI. From this version, Cilium is deployed using System Applications.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
