### PR TITLE
Compile oidc auth plugin into kubermatic-installer

### DIFF
--- a/cmd/kubermatic-installer/main.go
+++ b/cmd/kubermatic-installer/main.go
@@ -27,6 +27,8 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/log"
 	kubermaticversion "k8c.io/kubermatic/v2/pkg/version/kubermatic"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 )
 
 type Options struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Similar to https://github.com/xrstf/stalk/pull/1, this adds OIDC support for `kubermatic-installer`. That will allow to run KKP installations on OIDC-enabled Kubernetes clusters (e.g. KKP's own user clusters on our dev environment or KubeOne clusters configured accordingly). 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for `oidc` authentication in kubeconfigs passed to `kubermatic-installer`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
