### PR TITLE
bump konnectivity proxy-agent to 0.0.37 / 0.1.2

### DIFF
--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -313,7 +313,7 @@ func getImagesFromReconcilers(log logrus.FieldLogger, templateData *resources.Te
 	}
 
 	if templateData.IsKonnectivityEnabled() {
-		deploymentReconcilers = append(deploymentReconcilers, konnectivity.DeploymentReconciler("dummy", 0, kubermaticv1.DefaultKonnectivityKeepaliveTime, registry.GetImageRewriterFunc(templateData.OverwriteRegistry)))
+		deploymentReconcilers = append(deploymentReconcilers, konnectivity.DeploymentReconciler(templateData.Cluster().Spec.Version, "dummy", 0, kubermaticv1.DefaultKonnectivityKeepaliveTime, registry.GetImageRewriterFunc(templateData.OverwriteRegistry)))
 	}
 
 	cronjobReconcilers := kubernetescontroller.GetCronJobReconcilers(templateData)


### PR DESCRIPTION
**What this PR does / why we need it**:
This performs a minor dependency bump and prepares the code for 1.27 (#12230): Starting with 1.27, it is advised to use 0.1.x versions.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update konnectivity proxy-agent/server to 0.0.37 for user clusters using Kubernetes up until 1.26
Update konnectivity proxy-agent/server to 0.1.2 for user clusters using Kubernetes 1.27+
```

**Documentation**:
```documentation
NONE
```
