### PR TITLE
openstack: don't override input for floating IP for default MD from Cluster

### DIFF
--- a/pkg/machine/provider/openstack.go
+++ b/pkg/machine/provider/openstack.go
@@ -118,10 +118,6 @@ func CompleteOpenstackProviderSpec(config *openstack.RawConfig, cluster *kuberma
 	}
 
 	if cluster != nil {
-		if config.FloatingIPPool.Value == "" {
-			config.FloatingIPPool.Value = cluster.Spec.Cloud.Openstack.FloatingIPPool
-		}
-
 		if config.Network.Value == "" {
 			config.Network.Value = cluster.Spec.Cloud.Openstack.Network
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
reported externally:
> Hello,
I just noticed that when I create a new cluster in KKP 2.22.2 with the OpenStack provider `Allocate Floating IP` is active in the initial MD even when it was not active during cluster creation.

This actually happens only for the default MD, when a user requests additional MDs for the same cluster, KKP correctly respects the settings in UI/API payload. I came to the conclusion this is due to the fact that the initial MD goes through defaulting (this is not executed for any additional MDs created after the initial MD).
https://github.com/kubermatic/kubermatic/blob/712e8890abe2e55015f94c911286e17a67362abe/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller.go#L205
https://github.com/kubermatic/kubermatic/blob/712e8890abe2e55015f94c911286e17a67362abe/pkg/machine/provider/openstack.go#L121-L123

In the defaulting, it inherits floating IP from the `Cluster` resource. However, when user un-selects the `Allocate Floating IP` field, seed-controller defaults the field to the first external network returned by OpenStack API.
https://github.com/kubermatic/kubermatic/blob/8015ddf4fc9d56e8ebd66cd2e3c97b879149e0d7/pkg/provider/cloud/openstack/provider.go#L284-L292
https://github.com/kubermatic/kubermatic/blob/8015ddf4fc9d56e8ebd66cd2e3c97b879149e0d7/pkg/provider/cloud/openstack/helper.go#L114-L127
This value in the `Cluster` resource is later used to connect networks and routers.

In this PR, I would like to propose a fix to not override user input for FloatingIP configuration for the initial MD from `Cluster` resource.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
n/a

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
bugfix: don't override floating IP settings from user input for OpenStack initial MD
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
