### PR TITLE
[release/v2.21] set metering output prefix to seed name

### DIFF
--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -40,14 +40,15 @@ import (
 )
 
 // cronJobCreator returns the func to create/update the metering report cronjob.
-func cronJobCreator(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.WithOverwriteFunc, namespace string) reconciling.NamedCronJobCreatorGetter {
+func cronJobCreator(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.WithOverwriteFunc, seed *kubermaticv1.Seed) reconciling.NamedCronJobCreatorGetter {
 	return func() (string, reconciling.CronJobCreator) {
 		return reportName, func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
 			var args []string
 			args = append(args, fmt.Sprintf("--ca-bundle=%s", "/opt/ca-bundle/ca-bundle.pem"))
-			args = append(args, fmt.Sprintf("--prometheus-api=http://%s.%s.svc", prometheus.Name, namespace))
+			args = append(args, fmt.Sprintf("--prometheus-api=http://%s.%s.svc", prometheus.Name, seed.Namespace))
 			args = append(args, fmt.Sprintf("--last-number-of-days=%d", mrc.Interval))
 			args = append(args, fmt.Sprintf("--output-dir=%s", reportName))
+			args = append(args, fmt.Sprintf("--output-prefix=%s", seed.Name))
 			args = append(args, mrc.Types...)
 
 			if job.Labels == nil {

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -103,7 +103,7 @@ func reconcileMeteringReportConfigurations(ctx context.Context, client ctrlrunti
 	var cronJobs []reconciling.NamedCronJobCreatorGetter
 
 	for reportName, reportConf := range seed.Spec.Metering.ReportConfigurations {
-		cronJobs = append(cronJobs, cronJobCreator(reportName, reportConf, caBundle.Name, overwriter, seed.Namespace))
+		cronJobs = append(cronJobs, cronJobCreator(reportName, reportConf, caBundle.Name, overwriter, seed))
 
 		if reportConf.Retention != nil {
 			config.Rules = append(config.Rules, lifecycle.Rule{


### PR DESCRIPTION
This is a manual cherry-pick of #12221

/assign WeirdMachine

```release-note
Fix a bug that lead to metering reports overwriting each other when used with multiple seeds. Report names now include the Seed name as a Prefix.
```