### PR TITLE
inject seedManager cache into `Cluster` watch source for `usersshkey-synchronizer`

### DIFF
--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -104,7 +104,7 @@ func Add(
 		}
 
 		clusterSource := &source.Kind{Type: &kubermaticv1.Cluster{}}
-		if err := clusterSource.InjectCache(mgr.GetCache()); err != nil {
+		if err := clusterSource.InjectCache(seedManager.GetCache()); err != nil {
 			return fmt.Errorf("failed to inject cache into clusterSource for seed %s: %w", seedName, err)
 		}
 		if err := c.Watch(


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm not _entirely_ sure this is the way to go, but I'm trying to address [this part of the standalone master issues](https://github.com/kubermatic/kubermatic/issues/12186#issuecomment-1545574262). Looking at the code and logic here, I _think_ this controller was meant to inject the seed client caches, not the master cache.

At least from my reading, I don't see a reason for trying to watch `Clusters` on the master so you can sync user SSH keys.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not try to watch `Cluster` resources on the master in `usersshkey-synchronizer` and use Seeds as correct source instead
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
