### PR TITLE
remove auto-update rule for 1.23->1.24

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -582,17 +582,15 @@ spec:
     updates:
       - # Automatic controls whether this update is executed automatically
         # for the control plane of all matching user clusters.
-        automatic: true
+        automatic: false
         # Automatic controls whether this update is executed automatically
         # for the worker nodes of all matching user clusters.
         automaticNodeUpdate: false
         # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-        from: 1.23.*
+        from: 1.24.*
         # To is the version to which an update is allowed.
         # Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
         # Can be a wildcard otherwise, e.g. "1.20.*".
-        to: 1.24.10
-      - from: 1.24.*
         to: 1.24.*
       - automatic: true
         from: '>= 1.24.0, < 1.24.8'

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -582,17 +582,15 @@ spec:
     updates:
       - # Automatic controls whether this update is executed automatically
         # for the control plane of all matching user clusters.
-        automatic: true
+        automatic: false
         # Automatic controls whether this update is executed automatically
         # for the worker nodes of all matching user clusters.
         automaticNodeUpdate: false
         # From is the version from which an update is allowed. Wildcards are allowed, e.g. "1.18.*".
-        from: 1.23.*
+        from: 1.24.*
         # To is the version to which an update is allowed.
         # Must be a valid version if `automatic` is set to true, e.g. "1.20.13".
         # Can be a wildcard otherwise, e.g. "1.20.*".
-        to: 1.24.10
-      - from: 1.24.*
         to: 1.24.*
       - automatic: true
         from: '>= 1.24.0, < 1.24.8'

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -244,13 +244,6 @@ var (
 			newSemver("v1.26.4"),
 		},
 		Updates: []kubermaticv1.Update{
-			// ======= 1.23 =======
-			{
-				// Auto-upgrade unsupported clusters.
-				From:      "1.23.*",
-				To:        "1.24.10",
-				Automatic: pointer.Bool(true),
-			},
 			// ======= 1.24 =======
 			{
 				// Allow to change to any patch version


### PR DESCRIPTION
**What this PR does / why we need it**:
Normally when a Kubernetes release goes EOL, KKP adds an auto-upgrade rule. This is so that KKP setups with then, with the next KKP release, auto-update all clusters. In the KKP release after that, we can then finally remove all the code related to the EOL Kubernetes release.

The gap between 1.23 and 1.24 is a bit out of sync with KKP's release schedule and so we have _two_ KKP releases that have the same minimum Kubernetes support: 1.23.

* KKP 2.22 made 1.24 the minimum version and has the upgrade rule for 1.23->1.24.
* KKP 2.23 still keeps 1.24 as the minimum version, but also removes the upgrade rule.

Removing the upgrade rule will make the KKP installer refuse to install the new KKP release (v2.23.x) if there are still 1.23 userclusters remaining. This is so that in KKP 2.23 we can already remove Kubernetes 1.23 code, which is supposedly making featue gate handling in #12230 easier.

In normal release cycles, removing the upgrade rule by itself isn't necessary, as we just remove the entire version support (i.e. instead of removing the 1.23->1.24 rule, we remove 1.24 entirely and have just a 1.24->1.25 left). But since the release cycle overlaps a bit and KKP 2.23 goes out in June and Kubernetes 1.24 goes EOL in July... we chose this method.

This PR is purposefully small and does not try to remove other remnants of 1.23 support, as this will be done cleanly in the "Remove 1.24" PR coming in July.

**What type of PR is this?**
/kind deprecation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Remove auto-upgrade rule for userclusters from 1.23 to 1.24. All userclusters must be migrated to Kubernetes 1.24 before updating to KKP 2.23.
```

**Documentation**:
```documentation
NONE
```
