### PR TITLE
Add monitoing and dashboard for envoy-agent and nodeport-proxy

### DIFF
--- a/charts/monitoring/grafana/dashboards/kubermatic/nodeport-proxy.json
+++ b/charts/monitoring/grafana/dashboards/kubermatic/nodeport-proxy.json
@@ -1,0 +1,1450 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Envoy proxy monitoring Dashboard with cluster and service level templates. ",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 11021,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 23,
+      "panels": [],
+      "title": "Envoy",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "max": 3,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 1
+              },
+              {
+                "color": "#299c46",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 1
+      },
+      "id": 9,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(envoy_server_live{app_kubernetes_io_name=\"nodeport-proxy-envoy\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Live servers",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 5,
+        "y": 1
+      },
+      "id": 12,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "avg(envoy_server_uptime{app_kubernetes_io_name=\"nodeport-proxy-envoy\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg uptime per node",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 9,
+        "y": 1
+      },
+      "id": 11,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "SUM(envoy_server_memory_allocated{app_kubernetes_io_name=\"nodeport-proxy-envoy\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Allocated Memory",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 14,
+        "y": 1
+      },
+      "id": 13,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "SUM(envoy_server_memory_heap_size{app_kubernetes_io_name=\"nodeport-proxy-envoy\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Heap Size",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 18,
+        "y": 1
+      },
+      "id": 19,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "(sum(envoy_cluster_membership_healthy{envoy_cluster_name=~\".*$cluster.*\"})  - sum(envoy_cluster_membership_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\",envoy_cluster_name=~\".*$cluster.*\"}))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Unhealthy Clusters",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "text": "NOT WELL"
+                },
+                "1": {
+                  "text": "OK"
+                }
+              },
+              "type": "value"
+            },
+            {
+              "options": {
+                "match": "null",
+                "result": {
+                  "text": "N/A"
+                }
+              },
+              "type": "special"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#d44a3a",
+                "value": null
+              },
+              {
+                "color": "rgba(237, 129, 40, 0.89)",
+                "value": 0
+              },
+              {
+                "color": "#299c46",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 21,
+        "y": 1
+      },
+      "id": 20,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.1",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "(sum(envoy_cluster_membership_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\",envoy_cluster_name=~\".*$cluster.*\"})-sum(envoy_cluster_membership_healthy{app_kubernetes_io_name=\"nodeport-proxy-envoy\",envoy_cluster_name=~\".*$cluster.*\"})) == bool 0",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cluster State",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(envoy_cluster_upstream_cx_active{app_kubernetes_io_name=\"nodeport-proxy-envoy\",envoy_cluster_name=~\"cluster-$cluster.*\"}) by (envoy_cluster_name)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{envoy_cluster_name}} ({{service}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Total active connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(envoy_cluster_upstream_rq_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\",envoy_cluster_name=~\"cluster-$cluster.*\"}[1m])) by (envoy_cluster_name)",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{envoy_cluster_name}} ({{service}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Total requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(envoy_cluster_upstream_cx_rx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-$cluster.*\"}[1m])) by (envoy_cluster_name)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} ({{service}}) - in",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(envoy_cluster_upstream_cx_tx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-$cluster.*\"}[1m])) by (envoy_cluster_name)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} ({{service}}) - out",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Upstream Network Traffic",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(envoy_cluster_membership_healthy{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-.*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "healthy",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(envoy_cluster_membership_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-.*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "total",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Downstream members",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 21,
+      "panels": [],
+      "title": "Tunneling",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-$cluster.*\"}[1m])) by (le, envoy_cluster_name))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} 99%",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.9, sum(rate(envoy_cluster_upstream_rq_time_bucket{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-$cluster.*\"}[1m])) by (le, envoy_cluster_name))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} 90%",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(envoy_cluster_upstream_rq_time_bucket{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-$cluster.*\"}[1m])) by (le, envoy_cluster_name))",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} 50% ",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Upstream Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(envoy_http_downstream_rq_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Downstream Total active requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "description": "",
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 28
+      },
+      "hiddenSeries": false,
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(envoy_http_downstream_cx_active{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Downstream Active Connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 28
+      },
+      "hiddenSeries": false,
+      "id": 17,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(envoy_http_downstream_cx_rx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{service}} - in",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "sum(irate(envoy_http_downstream_cx_tx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{service}} - out",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Downstream Network Traffic",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "definition": "label_values(kubermatic_cluster_info,name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Cluster",
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": {
+          "query": "label_values(kubermatic_cluster_info,name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "Nodeport Proxy",
+  "uid": "8WkEOMnANKE7PW5hhpVv",
+  "version": 1,
+  "weekStart": ""
+}

--- a/charts/monitoring/grafana/dashboards/kubermatic/nodeport-proxy.json
+++ b/charts/monitoring/grafana/dashboards/kubermatic/nodeport-proxy.json
@@ -830,7 +830,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": {
-        "type": "prometheus",
         "uid": "$datasource"
       },
       "fieldConfig": {
@@ -846,125 +845,6 @@
         "w": 12,
         "x": 12,
         "y": 13
-      },
-      "hiddenSeries": false,
-      "id": 7,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "9.5.1",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "expr": "sum(envoy_cluster_membership_healthy{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-.*\"})",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "healthy",
-          "range": true,
-          "refId": "A"
-        },
-        {
-          "datasource": {
-            "uid": "$datasource"
-          },
-          "editorMode": "code",
-          "expr": "sum(envoy_cluster_membership_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-.*\"})",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "total",
-          "range": true,
-          "refId": "B"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Downstream members",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        },
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false
-      }
-    },
-    {
-      "collapsed": false,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 21,
-      "panels": [],
-      "title": "Tunneling",
-      "type": "row"
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 21
       },
       "hiddenSeries": false,
       "id": 10,
@@ -1002,12 +882,10 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "editorMode": "code",
           "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-$cluster.*\"}[1m])) by (le, envoy_cluster_name))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{envoy_cluster_name}} 99%",
-          "range": true,
           "refId": "A"
         },
         {
@@ -1063,98 +941,432 @@
       }
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": {
-        "type": "prometheus",
-        "uid": "$datasource"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "links": []
-        },
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
+      "collapsed": true,
       "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 21
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
       },
-      "hiddenSeries": false,
-      "id": 6,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "9.5.1",
-      "pointradius": 5,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
+      "id": 21,
+      "panels": [
         {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
           "datasource": {
+            "type": "prometheus",
             "uid": "$datasource"
           },
-          "editorMode": "code",
-          "expr": "sum(irate(envoy_http_downstream_rq_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
-          "format": "time_series",
-          "intervalFactor": 2,
-          "legendFormat": "{{service}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeRegions": [],
-      "title": "Downstream Total active requests",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "mode": "time",
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 53
+          },
+          "hiddenSeries": false,
+          "id": 5,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.5.1",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(envoy_http_downstream_cx_active{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Downstream Active Connections",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         },
         {
-          "format": "short",
-          "logBase": 1,
-          "show": true
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 53
+          },
+          "hiddenSeries": false,
+          "id": 6,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.5.1",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(irate(envoy_http_downstream_rq_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{service}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Downstream Total active requests",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 60
+          },
+          "hiddenSeries": false,
+          "id": 7,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.5.1",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(envoy_cluster_membership_healthy{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-.*\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "healthy",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(envoy_cluster_membership_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_cluster_name=~\"cluster-.*\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "total",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Downstream members",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "type": "prometheus",
+            "uid": "$datasource"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 60
+          },
+          "hiddenSeries": false,
+          "id": 17,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "9.5.1",
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(irate(envoy_http_downstream_cx_rx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{service}} - in",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "editorMode": "code",
+              "expr": "sum(irate(envoy_http_downstream_cx_tx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+              "format": "time_series",
+              "intervalFactor": 1,
+              "legendFormat": "{{service}} - out",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Downstream Network Traffic",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
         }
       ],
-      "yaxis": {
-        "align": false
-      }
+      "title": "Tunneling",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "id": 24,
+      "panels": [],
+      "title": "Envoy Agent",
+      "type": "row"
     },
     {
       "aliasColors": {},
@@ -1165,7 +1377,6 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1178,10 +1389,10 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 22
       },
       "hiddenSeries": false,
-      "id": 5,
+      "id": 25,
       "legend": {
         "avg": false,
         "current": false,
@@ -1213,17 +1424,17 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(envoy_http_downstream_cx_active{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"})",
+          "expr": "job:envoy_cluster_upstream_cx_active:sum{cluster=~\"$cluster\"}",
           "format": "time_series",
           "intervalFactor": 2,
-          "legendFormat": "{{service}}",
+          "legendFormat": "{{envoy_cluster_name}} ({{service}})",
           "range": true,
           "refId": "A"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Downstream Active Connections",
+      "title": "Total active connections",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1272,10 +1483,10 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 22
       },
       "hiddenSeries": false,
-      "id": 17,
+      "id": 26,
       "legend": {
         "avg": false,
         "current": false,
@@ -1307,10 +1518,104 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(irate(envoy_http_downstream_cx_rx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+          "expr": "job:envoy_cluster_upstream_rq_total:irate1msum{cluster=~\"$cluster\"}",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{envoy_cluster_name}} ({{service}})",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Total requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 29
+      },
+      "hiddenSeries": false,
+      "id": 27,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "job:envoy_cluster_upstream_cx_rx_bytes_total:irate1msum{cluster=~\"$cluster\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{service}} - in",
+          "legendFormat": "{{envoy_cluster_name}} ({{service}}) - in",
           "range": true,
           "refId": "A"
         },
@@ -1319,17 +1624,17 @@
             "uid": "$datasource"
           },
           "editorMode": "code",
-          "expr": "sum(irate(envoy_http_downstream_cx_tx_bytes_total{app_kubernetes_io_name=\"nodeport-proxy-envoy\", envoy_http_conn_manager_prefix=\"ingress_http\"}[1m]))",
+          "expr": "job:envoy_cluster_upstream_cx_tx_bytes_total:irate1msum{cluster=~\"$cluster\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "{{service}} - out",
+          "legendFormat": "{{envoy_cluster_name}} ({{service}}) - out",
           "range": true,
           "refId": "B"
         }
       ],
       "thresholds": [],
       "timeRegions": [],
-      "title": "Downstream Network Traffic",
+      "title": "Upstream Network Traffic",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1344,6 +1649,129 @@
       "yaxes": [
         {
           "format": "decbytes",
+          "logBase": 1,
+          "show": true
+        },
+        {
+          "format": "short",
+          "logBase": 1,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 29
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideZero": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "9.5.1",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, job:envoy_cluster_upstream_rq_time_bucket:rate1msum{cluster=~\"$cluster\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} 99%",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.9, job:envoy_cluster_upstream_rq_time_bucket:rate1msum{cluster=~\"$cluster\"})",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} 90%",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.5, job:envoy_cluster_upstream_rq_time_bucket:rate1msum{cluster=~\"$cluster\"})",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{envoy_cluster_name}} 50% ",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeRegions": [],
+      "title": "Upstream Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
           "logBase": 1,
           "show": true
         },
@@ -1384,9 +1812,9 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": false,
-          "text": "All",
-          "value": "$__all"
+          "selected": true,
+          "text": "isphll5sfh",
+          "value": "isphll5sfh"
         },
         "datasource": {
           "uid": "$datasource"
@@ -1414,7 +1842,7 @@
     ]
   },
   "time": {
-    "from": "now-12h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -1444,7 +1872,7 @@
   },
   "timezone": "",
   "title": "Nodeport Proxy",
-  "uid": "8WkEOMnANKE7PW5hhpVv",
+  "uid": "8WkEONmBNKE9PW5hhpVv",
   "version": 1,
   "weekStart": ""
 }

--- a/charts/monitoring/grafana/dashboards/kubermatic/nodeport-proxy.json
+++ b/charts/monitoring/grafana/dashboards/kubermatic/nodeport-proxy.json
@@ -1,25 +1,13 @@
 {
   "annotations": {
-    "list": [
-      {
-        "builtIn": 1,
-        "datasource": {
-          "type": "datasource",
-          "uid": "grafana"
-        },
-        "enable": true,
-        "hide": true,
-        "iconColor": "rgba(0, 211, 255, 1)",
-        "name": "Annotations & Alerts",
-        "type": "dashboard"
-      }
-    ]
+    "list": []
   },
   "description": "Envoy proxy monitoring Dashboard with cluster and service level templates. ",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "gnetId": 11021,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
+  "hideControls": false,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -41,6 +29,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -117,7 +106,9 @@
           "refId": "A"
         }
       ],
+      "timeRegions": [],
       "title": "Live servers",
+      "transparent": true,
       "type": "gauge"
     },
     {
@@ -125,6 +116,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -196,7 +188,9 @@
           "refId": "A"
         }
       ],
+      "timeRegions": [],
       "title": "Avg uptime per node",
+      "transparent": true,
       "type": "stat"
     },
     {
@@ -204,6 +198,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -275,7 +270,9 @@
           "refId": "A"
         }
       ],
+      "timeRegions": [],
       "title": "Allocated Memory",
+      "transparent": true,
       "type": "stat"
     },
     {
@@ -283,6 +280,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -354,7 +352,9 @@
           "refId": "A"
         }
       ],
+      "timeRegions": [],
       "title": "Heap Size",
+      "transparent": true,
       "type": "stat"
     },
     {
@@ -362,6 +362,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -433,7 +434,9 @@
           "refId": "A"
         }
       ],
+      "timeRegions": [],
       "title": "Unhealthy Clusters",
+      "transparent": true,
       "type": "stat"
     },
     {
@@ -441,6 +444,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -527,7 +531,9 @@
           "refId": "A"
         }
       ],
+      "timeRegions": [],
       "title": "Cluster State",
+      "transparent": true,
       "type": "stat"
     },
     {
@@ -539,6 +545,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -602,6 +609,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -633,6 +641,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -696,6 +705,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -727,6 +737,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -802,6 +813,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -832,6 +844,7 @@
       "datasource": {
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -918,6 +931,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -1377,6 +1391,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1440,6 +1455,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -1471,6 +1487,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1534,6 +1551,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -1565,6 +1583,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1640,6 +1659,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -1671,6 +1691,7 @@
         "type": "prometheus",
         "uid": "$datasource"
       },
+      "editable": true,
       "fieldConfig": {
         "defaults": {
           "links": []
@@ -1763,6 +1784,7 @@
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": true,
       "type": "graph",
       "xaxis": {
         "mode": "time",
@@ -1793,11 +1815,7 @@
   "templating": {
     "list": [
       {
-        "current": {
-          "selected": false,
-          "text": "prometheus",
-          "value": "prometheus"
-        },
+        "current": {},
         "hide": 0,
         "includeAll": false,
         "multi": false,
@@ -1811,11 +1829,7 @@
       },
       {
         "allValue": ".*",
-        "current": {
-          "selected": true,
-          "text": "isphll5sfh",
-          "value": "isphll5sfh"
-        },
+        "current": {},
         "datasource": {
           "uid": "$datasource"
         },
@@ -1830,7 +1844,7 @@
           "query": "label_values(kubermatic_cluster_info,name)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
@@ -1842,7 +1856,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
+	envoyagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -185,6 +186,9 @@ func main() {
 	}
 	if runOp.dnsClusterIP == "" {
 		log.Fatal("-dns-cluster-ip must be set")
+	}
+	if runOp.kasSecurePort == int(envoyagent.StatsPort) {
+		log.Fatalf("-kas-secure-port \"%d\" is reserved and must not be used", runOp.kasSecurePort)
 	}
 	clusterURL, err := url.Parse(runOp.clusterURL)
 	if err != nil {

--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
-	envoyagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -44,6 +43,7 @@ import (
 	ownerbindingcreator "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/owner-binding-creator"
 	rbacusercluster "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/rbac"
 	usercluster "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources"
+	envoyagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent"
 	machinecontrollerresources "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/machine-controller"
 	roleclonercontroller "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/role-cloner-controller"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -43,7 +43,7 @@ static_resources:
 	  socket_address:
 		protocol: TCP
 		address: 0.0.0.0
-		port_value: {{.statsPort}}
+		port_value: {{.StatsPort}}
 	filter_chains:
 	- filters:
 	  - name: envoy.filters.network.http_connection_manager
@@ -115,7 +115,7 @@ static_resources:
 `
 
 type Config struct {
-	statsPort uint32
+	StatsPort uint32
 	AdminPort uint32
 	ProxyHost string
 	ProxyPort uint32
@@ -138,7 +138,7 @@ func ConfigMapReconciler(cfg Config) reconciling.NamedConfigMapReconcilerFactory
 					return nil, fmt.Errorf("listener port \"%d\" is reserved and must not be used", listener.BindPort)
 				}
 			}
-			cfg.statsPort = StatsPort
+			cfg.StatsPort = StatsPort
 
 			if cm.Data == nil {
 				cm.Data = map[string]string{}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package envoyagent
 
 import (
+	"fmt"
 	"strings"
 	"text/template"
 
@@ -26,6 +27,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const StatsPort uint32 = 8002
+
 var envoyConfigTemplate = `admin:
   access_log_path: /dev/stdout
   address:
@@ -34,7 +37,33 @@ var envoyConfigTemplate = `admin:
       address: 127.0.0.1
       port_value: {{.AdminPort}}
 static_resources:
-  listeners: {{if not .Listeners -}}[]{{- end}}
+  listeners:
+  - name: service_stats
+	address:
+	  socket_address:
+		protocol: TCP
+		address: 0.0.0.0
+		port_value: {{.statsPort}}
+	filter_chains:
+	- filters:
+	  - name: envoy.filters.network.http_connection_manager
+		typed_config:
+		  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+		  stat_prefix: service_stats
+		  route_config:
+			name: local_route
+			virtual_hosts:
+			- name: stats_backend
+			  domains: ["*"]
+			  routes:
+			  - match:
+				  prefix: "/stats"
+				route:
+				  cluster: service_stats
+		  http_filters:
+		  - name: envoy.filters.http.router
+			"typed_config":
+			  "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
 {{- range $i, $l := .Listeners}}
   - name: listener_{{$i}}
     address:
@@ -71,9 +100,22 @@ static_resources:
                     socket_address:
                       address: {{.ProxyHost}}
                       port_value: {{.ProxyPort}}
+	- name: service_stats
+	  connect_timeout: 0.1s
+	  type: STATIC
+	  load_assignment:
+		cluster_name: service_stats
+		endpoints:
+		- lb_endpoints:
+			- endpoint:
+				address:
+				  socket_address:
+					address: 127.0.0.1
+                    port_value: {{.AdminPort}}
 `
 
 type Config struct {
+	statsPort uint32
 	AdminPort uint32
 	ProxyHost string
 	ProxyPort uint32
@@ -90,6 +132,14 @@ type Listener struct {
 func ConfigMapReconciler(cfg Config) reconciling.NamedConfigMapReconcilerFactory {
 	return func() (string, reconciling.ConfigMapReconciler) {
 		return resources.EnvoyAgentConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			// ensure StatsPort is not used by any listener
+			for _, listener := range cfg.Listeners {
+				if listener.BindPort == StatsPort {
+					return nil, fmt.Errorf("listener port \"%d\" is reserved and must not be used", listener.BindPort)
+				}
+			}
+			cfg.statsPort = StatsPort
+
 			if cm.Data == nil {
 				cm.Data = map[string]string{}
 			}

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/configmap.go
@@ -39,31 +39,31 @@ var envoyConfigTemplate = `admin:
 static_resources:
   listeners:
   - name: service_stats
-	address:
-	  socket_address:
-		protocol: TCP
-		address: 0.0.0.0
-		port_value: {{.StatsPort}}
-	filter_chains:
-	- filters:
-	  - name: envoy.filters.network.http_connection_manager
-		typed_config:
-		  "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-		  stat_prefix: service_stats
-		  route_config:
-			name: local_route
-			virtual_hosts:
-			- name: stats_backend
-			  domains: ["*"]
-			  routes:
-			  - match:
-				  prefix: "/stats"
-				route:
-				  cluster: service_stats
-		  http_filters:
-		  - name: envoy.filters.http.router
-			"typed_config":
-			  "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+    address:
+      socket_address:
+        protocol: TCP
+        address: 0.0.0.0
+        port_value: {{.StatsPort}}
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: service_stats
+          route_config:
+            name: local_route
+            virtual_hosts:
+            - name: stats_backend
+              domains: ["*"]
+              routes:
+              - match:
+                  prefix: "/stats"
+                route:
+                  cluster: service_stats
+          http_filters:
+          - name: envoy.filters.http.router
+            "typed_config":
+              "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
 {{- range $i, $l := .Listeners}}
   - name: listener_{{$i}}
     address:
@@ -100,17 +100,17 @@ static_resources:
                     socket_address:
                       address: {{.ProxyHost}}
                       port_value: {{.ProxyPort}}
-	- name: service_stats
-	  connect_timeout: 0.1s
-	  type: STATIC
-	  load_assignment:
-		cluster_name: service_stats
-		endpoints:
-		- lb_endpoints:
-			- endpoint:
-				address:
-				  socket_address:
-					address: 127.0.0.1
+    - name: service_stats
+      connect_timeout: 0.1s
+      type: STATIC
+      load_assignment:
+        cluster_name: service_stats
+        endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
                     port_value: {{.AdminPort}}
 `
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -19,6 +19,7 @@ package envoyagent
 import (
 	"fmt"
 	"net"
+	"strconv"
 
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -71,7 +72,12 @@ func DaemonSetReconciler(agentIP net.IP, versions kubermatic.Versions, configHas
 
 				// Used to force the restart of the envoy-agent to re-read its configuration
 				// from the configMap when it changes. Necessary to support switching to/from Konnectivity.
-				Annotations: map[string]string{"checksum/config": configHash},
+				Annotations: map[string]string{
+					"checksum/config":            configHash,
+					"prometheus.io/scrape":       "true",
+					"prometheus.io/port":         strconv.Itoa(int(StatsPort)),
+					"prometheus.io/metrics_path": "/stats/prometheus",
+				},
 			}
 
 			initContainers, err := getInitContainers(agentIP, versions, imageRewriter)

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -73,10 +73,10 @@ func DaemonSetReconciler(agentIP net.IP, versions kubermatic.Versions, configHas
 				// Used to force the restart of the envoy-agent to re-read its configuration
 				// from the configMap when it changes. Necessary to support switching to/from Konnectivity.
 				Annotations: map[string]string{
-					"checksum/config":            configHash,
-					"prometheus.io/scrape":       "true",
-					"prometheus.io/port":         strconv.Itoa(int(StatsPort)),
-					"prometheus.io/metrics_path": "/stats/prometheus",
+					"checksum/config":      configHash,
+					"prometheus.io/scrape": "true",
+					"prometheus.io/port":   strconv.Itoa(int(StatsPort)),
+					"prometheus.io/path":   "/stats/prometheus",
 				},
 			}
 

--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -41,6 +41,33 @@ groups:
     labels:
       kubermatic: federate
 
+- name: kubermatic.envoy-agent
+  rules:
+  - record: job:envoy_cluster_upstream_cx_active:sum
+	expr: sum(envoy_cluster_upstream_cx_active)
+	labels:
+	  kubermatic: federate
+
+  - record: job:envoy_cluster_upstream_rq_total:irate1msum
+	expr: sum(irate(envoy_cluster_upstream_rq_total[1m])) by (envoy_cluster_name)
+	labels:
+	  kubermatic: federate
+
+  - record: job:envoy_cluster_upstream_cx_rx_bytes_total:irate1msum
+	expr: sum(irate(envoy_cluster_upstream_cx_rx_bytes_total[1m])) by (envoy_cluster_name)
+	labels:
+	  kubermatic: federate
+  
+  - record: job:envoy_cluster_upstream_cx_tx_bytes_total:irate1msum
+	expr: sum(irate(envoy_cluster_upstream_cx_tx_bytes_total[1m])) by (envoy_cluster_name)
+	labels:
+	  kubermatic: federate
+  
+  - record: job:envoy_cluster_upstream_rq_time_bucket:rate1msum
+	expr: sum(rate(envoy_cluster_upstream_rq_time_bucket[1m])) by (le, envoy_cluster_name)
+	labels:
+	  kubermatic: federate
+
 - name: kubermatic.etcd
   rules:
   - alert: EtcdInsufficientMembers

--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -44,29 +44,29 @@ groups:
 - name: kubermatic.envoy-agent
   rules:
   - record: job:envoy_cluster_upstream_cx_active:sum
-	expr: sum(envoy_cluster_upstream_cx_active)
-	labels:
-	  kubermatic: federate
+    expr: sum(envoy_cluster_upstream_cx_active)
+    labels:
+      kubermatic: federate
 
   - record: job:envoy_cluster_upstream_rq_total:irate1msum
-	expr: sum(irate(envoy_cluster_upstream_rq_total[1m])) by (envoy_cluster_name)
-	labels:
-	  kubermatic: federate
+    expr: sum(irate(envoy_cluster_upstream_rq_total[1m])) by (envoy_cluster_name)
+    labels:
+      kubermatic: federate
 
   - record: job:envoy_cluster_upstream_cx_rx_bytes_total:irate1msum
-	expr: sum(irate(envoy_cluster_upstream_cx_rx_bytes_total[1m])) by (envoy_cluster_name)
-	labels:
-	  kubermatic: federate
+    expr: sum(irate(envoy_cluster_upstream_cx_rx_bytes_total[1m])) by (envoy_cluster_name)
+    labels:
+      kubermatic: federate
   
   - record: job:envoy_cluster_upstream_cx_tx_bytes_total:irate1msum
-	expr: sum(irate(envoy_cluster_upstream_cx_tx_bytes_total[1m])) by (envoy_cluster_name)
-	labels:
-	  kubermatic: federate
+    expr: sum(irate(envoy_cluster_upstream_cx_tx_bytes_total[1m])) by (envoy_cluster_name)
+    labels:
+      kubermatic: federate
   
   - record: job:envoy_cluster_upstream_rq_time_bucket:rate1msum
-	expr: sum(rate(envoy_cluster_upstream_rq_time_bucket[1m])) by (le, envoy_cluster_name)
-	labels:
-	  kubermatic: federate
+    expr: sum(rate(envoy_cluster_upstream_rq_time_bucket[1m])) by (le, envoy_cluster_name)
+    labels:
+      kubermatic: federate
 
 - name: kubermatic.etcd
   rules:

--- a/pkg/resources/prometheus/configmap-rules.go
+++ b/pkg/resources/prometheus/configmap-rules.go
@@ -41,33 +41,6 @@ groups:
     labels:
       kubermatic: federate
 
-- name: kubermatic.envoy-agent
-  rules:
-  - record: job:envoy_cluster_upstream_cx_active:sum
-    expr: sum(envoy_cluster_upstream_cx_active)
-    labels:
-      kubermatic: federate
-
-  - record: job:envoy_cluster_upstream_rq_total:irate1msum
-    expr: sum(irate(envoy_cluster_upstream_rq_total[1m])) by (envoy_cluster_name)
-    labels:
-      kubermatic: federate
-
-  - record: job:envoy_cluster_upstream_cx_rx_bytes_total:irate1msum
-    expr: sum(irate(envoy_cluster_upstream_cx_rx_bytes_total[1m])) by (envoy_cluster_name)
-    labels:
-      kubermatic: federate
-  
-  - record: job:envoy_cluster_upstream_cx_tx_bytes_total:irate1msum
-    expr: sum(irate(envoy_cluster_upstream_cx_tx_bytes_total[1m])) by (envoy_cluster_name)
-    labels:
-      kubermatic: federate
-  
-  - record: job:envoy_cluster_upstream_rq_time_bucket:rate1msum
-    expr: sum(rate(envoy_cluster_upstream_rq_time_bucket[1m])) by (le, envoy_cluster_name)
-    labels:
-      kubermatic: federate
-
 - name: kubermatic.etcd
   rules:
   - alert: EtcdInsufficientMembers
@@ -444,4 +417,33 @@ const prometheusRuleDNSResolverDownAlert = `
     for: 15m
     labels:
       severity: warning
+`
+
+const prometheusRuleEnvoyAgentFederation = `
+- name: kubermatic.envoy
+  rules:
+  - record: job:envoy_cluster_upstream_cx_active:sum
+    expr: sum(envoy_cluster_upstream_cx_active)
+    labels:
+      kubermatic: federate
+
+  - record: job:envoy_cluster_upstream_rq_total:irate1msum
+    expr: sum(irate(envoy_cluster_upstream_rq_total[1m])) by (envoy_cluster_name)
+    labels:
+      kubermatic: federate
+
+  - record: job:envoy_cluster_upstream_cx_rx_bytes_total:irate1msum
+    expr: sum(irate(envoy_cluster_upstream_cx_rx_bytes_total[1m])) by (envoy_cluster_name)
+    labels:
+      kubermatic: federate
+
+  - record: job:envoy_cluster_upstream_cx_tx_bytes_total:irate1msum
+    expr: sum(irate(envoy_cluster_upstream_cx_tx_bytes_total[1m])) by (envoy_cluster_name)
+    labels:
+      kubermatic: federate
+
+  - record: job:envoy_cluster_upstream_rq_time_bucket:rate1msum
+    expr: sum(rate(envoy_cluster_upstream_rq_time_bucket[1m])) by (le, envoy_cluster_name)
+    labels:
+      kubermatic: federate
 `

--- a/pkg/resources/prometheus/configmap.go
+++ b/pkg/resources/prometheus/configmap.go
@@ -409,6 +409,43 @@ scrape_configs:
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics/resource
 
+# scrape envoy-agent
+- job_name: 'envoy-agent'
+  scheme: http
+  tls_config:
+{{ .ApiserverTLSConfig | indent 4 }}
+  kubernetes_sd_configs:
+  - role: pod
+    api_server: 'https://{{ .APIServerHost }}'
+    tls_config:
+{{ .ApiserverTLSConfig | indent 6 }}
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_label_app]
+	regex: "envoy-agent"
+	action: keep
+  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+	action: keep
+	regex: true
+  - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+	action: replace
+	target_label: __metrics_path__
+	regex: (.+)
+  - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+	action: replace
+	regex: ([^:]+)(?::\d+)?;(\d+)
+	replacement: $1:$2
+	target_label: __address__
+  - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
+	action: replace
+	target_label: job
+	separator: ''
+  - source_labels: [__meta_kubernetes_namespace]
+	action: replace
+	target_label: namespace
+  - source_labels: [__meta_kubernetes_pod_name]
+	action: replace
+	target_label: pod
+
 {{- end }}
 
 {{- with .CustomScrapingConfigs }}

--- a/pkg/resources/prometheus/configmap.go
+++ b/pkg/resources/prometheus/configmap.go
@@ -147,6 +147,10 @@ func ConfigMapReconciler(data *resources.TemplateData) reconciling.NamedConfigMa
 				if !data.IsKonnectivityEnabled() {
 					cm.Data["rules.yaml"] += prometheusRuleDNSResolverDownAlert
 				}
+
+				if cluster.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyTunneling {
+					cm.Data["rules.yaml"] += prometheusRuleEnvoyAgentFederation
+				}
 			}
 
 			if customRules == "" {
@@ -409,6 +413,7 @@ scrape_configs:
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}/proxy/metrics/resource
 
+{{ if eq .TemplateData.Cluster.Spec.ExposeStrategy "Tunneling" -}}
 # scrape envoy-agent
 - job_name: 'envoy-agent'
   scheme: http
@@ -447,7 +452,7 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: pod
-
+{{ end }}
 {{- end }}
 
 {{- with .CustomScrapingConfigs }}

--- a/pkg/resources/prometheus/configmap.go
+++ b/pkg/resources/prometheus/configmap.go
@@ -414,11 +414,13 @@ scrape_configs:
   scheme: http
   tls_config:
 {{ .ApiserverTLSConfig | indent 4 }}
+
   kubernetes_sd_configs:
   - role: pod
     api_server: 'https://{{ .APIServerHost }}'
     tls_config:
 {{ .ApiserverTLSConfig | indent 6 }}
+
   relabel_configs:
   - source_labels: [__meta_kubernetes_pod_label_app]
 	regex: "envoy-agent"

--- a/pkg/resources/prometheus/configmap.go
+++ b/pkg/resources/prometheus/configmap.go
@@ -423,30 +423,30 @@ scrape_configs:
 
   relabel_configs:
   - source_labels: [__meta_kubernetes_pod_label_app]
-	regex: "envoy-agent"
-	action: keep
+    regex: "envoy-agent"
+    action: keep
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
-	action: keep
-	regex: true
+    action: keep
+    regex: true
   - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
-	action: replace
-	target_label: __metrics_path__
-	regex: (.+)
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
   - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
-	action: replace
-	regex: ([^:]+)(?::\d+)?;(\d+)
-	replacement: $1:$2
-	target_label: __address__
+    action: replace
+    regex: ([^:]+)(?::\d+)?;(\d+)
+    replacement: $1:$2
+    target_label: __address__
   - source_labels: [__meta_kubernetes_pod_label_role, __meta_kubernetes_pod_label_app]
-	action: replace
-	target_label: job
-	separator: ''
+    action: replace
+    target_label: job
+    separator: ''
   - source_labels: [__meta_kubernetes_namespace]
-	action: replace
-	target_label: namespace
+    action: replace
+    target_label: namespace
   - source_labels: [__meta_kubernetes_pod_name]
-	action: replace
-	target_label: pod
+    action: replace
+    target_label: pod
 
 {{- end }}
 

--- a/pkg/resources/prometheus/configmap.go
+++ b/pkg/resources/prometheus/configmap.go
@@ -452,10 +452,9 @@ scrape_configs:
   - source_labels: [__meta_kubernetes_pod_name]
     action: replace
     target_label: pod
-{{ end }}
 {{- end }}
-
-{{- with .CustomScrapingConfigs }}
+{{- end }}
+{{- with .CustomScrapingConfigs -}}
 #######################################################################
 # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.24.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.25.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.26.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.26.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.24.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.25.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.26.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.26.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.24.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.25.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.26.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.27.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.24.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.25.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.26.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.26.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-gcp-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.24.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-gcp-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.25.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-gcp-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.26.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-gcp-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.27.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.24.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.25.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.26.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.26.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.24.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.25.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.26.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.26.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.26.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.26.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus.yaml
@@ -249,6 +249,7 @@ data:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/resource
+
     #######################################################################
     # custom scraping configurations
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adding monitoring for envoy-agent together with federation to Seed MLA Prometheus.

Adding Grafana Dashboard Nodeport Proxy for Metrics regarding envoy nodeport proxy and envoy-agent.

Most metrics are available with `Tunneling` expose strategy. For instance the envoy-agent is only deployed with Tunneling.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #7124 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add monitoring and dashboard for envoy-agent and nodeport-proxy
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
