### PR TITLE
Use eu-west-1 for AWS E2E tests

### DIFF
--- a/cmd/conformance-tester/README.md
+++ b/cmd/conformance-tester/README.md
@@ -64,7 +64,7 @@ secretAccessKey="$(kubectl get presets qa -o json | jq '.spec.aws.secretAccessKe
 _build/conformance-tester \
   -aws-access-key-id "$accessKey" \
   -aws-secret-access-key "$secretAccessKey" \
-  -aws-kkp-datacenter "aws-eu-central-1a" \
+  -aws-kkp-datacenter "aws-eu-west-1a" \
   -providers "aws" \
   -distributions "${DISTRIBUTIONS:-}" \
   -releases "${RELEASES:-}" \

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	awsInstanceType = "t2.medium"
+	awsInstanceType = "t3.small"
 	awsVolumeType   = "gp2"
 	awsVolumeSize   = 100
 )

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	awsInstanceType = "t3.small"
+	awsInstanceType = "t2.medium"
 	awsVolumeType   = "gp2"
 	awsVolumeSize   = 100
 )

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -51,7 +51,7 @@ if [[ $provider == "anexia" ]]; then
 elif [[ $provider == "aws" ]]; then
   EXTRA_ARGS="-aws-access-key-id=${AWS_E2E_TESTS_KEY_ID}
     -aws-secret-access-key=${AWS_E2E_TESTS_SECRET}
-    -aws-kkp-datacenter=aws-eu-central-1a"
+    -aws-kkp-datacenter=aws-eu-west-1a"
 elif [[ $provider == "packet" ]]; then
   maxDuration=90
   EXTRA_ARGS="-packet-api-key=${PACKET_API_KEY}

--- a/hack/ci/run-dualstack-e2e-test.sh
+++ b/hack/ci/run-dualstack-e2e-test.sh
@@ -98,7 +98,7 @@ go_test dualstack_e2e -race -timeout 90m -tags "dualstack,$KUBERMATIC_EDITION" -
   -provider "${PROVIDER:-}" \
   -os "${OSNAMES:-all}" \
   -alibaba-kkp-datacenter alibaba-eu-central-1a \
-  -aws-kkp-datacenter aws-eu-central-1a \
+  -aws-kkp-datacenter aws-eu-west-1a \
   -azure-kkp-datacenter azure-westeurope \
   -digitalocean-kkp-datacenter do-fra1 \
   -equinix-kkp-datacenter packet-am \

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -59,18 +59,18 @@ spec:
       spec:
         anexia:
           locationID: "__ANEXIA_LOCATION_ID__"
-    aws-eu-central-1a:
+    aws-eu-west-1a:
       location: EU (Frankfurt)
       country: DE
       spec:
         aws:
-          region: eu-central-1
-    aws-eu-central-1b:
+          region: eu-west-1
+    aws-eu-west-1b:
       location: EU (Frankfurt)
       country: DE
       spec:
         aws:
-          region: eu-central-1
+          region: eu-west-1
     hetzner-hel1:
       location: Helsinki 1 DC 6
       country: DE

--- a/hack/run-ccm-migration-e2e-test-in-kind.sh
+++ b/hack/run-ccm-migration-e2e-test-in-kind.sh
@@ -82,7 +82,7 @@ azure)
   EXTRA_ARGS="-azure-kkp-datacenter=azure-westeurope"
   ;;
 aws)
-  EXTRA_ARGS="-aws-kkp-datacenter=aws-eu-central-1a"
+  EXTRA_ARGS="-aws-kkp-datacenter=aws-eu-west-1a"
   ;;
 esac
 

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -79,7 +79,7 @@ aws)
   AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)}"
   extraArgs="-aws-access-key-id=$AWS_ACCESS_KEY_ID
     -aws-secret-access-key=$AWS_SECRET_ACCESS_KEY
-    -aws-kkp-datacenter=aws-eu-central-1a"
+    -aws-kkp-datacenter=aws-eu-west-1a"
   ;;
 
 azure)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR changes AWS E2E tests to use eu-west-1 (Ireland) instead of eu-central-1 (Frankfurt). Starting yesterday, instances are not coming up in eu-central-1a and eu-central-1c (most of times). There are no errors in machine-controller logs and there are no events in Machines/MachineDeployments, but after some investigation, we found out that disabling spot instances fixes the issue.

To avoid disabling spot instances (because that would increase our cloud spending quite a bit), @xrstf proposed switching to another region and I decided to go with eu-west-1 because we use it in some other places as well.

**What type of PR is this?**

/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```