### PR TITLE
[release/v2.22] OSM Migration: Remove redundant Webhooks from seed

### DIFF
--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -684,6 +684,18 @@ func (r *Reconciler) migrationForOSM(ctx context.Context, client ctrlruntimeclie
 
 	// We aggregate errors to ensure that we don't early exist and try to migrate as much as possible.
 	var errs []error
+
+	// Remove webhooks for OSM
+	err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, "kubermatic-operating-system-configs")
+	if err != nil {
+		errs = append(errs, fmt.Errorf("Unable to delete Validating Admission Webhook kubermatic-operating-system-configs: %w", err))
+	}
+	err = common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, "kubermatic-operating-system-profiles")
+	if err != nil {
+		errs = append(errs, fmt.Errorf("Unable to delete Validating Admission Webhook kubermatic-operating-system-profiles: %w", err))
+	}
+
+	// Check if OSM CRD exists
 	ospCRDExists, err := osmmigration.IsOperatingSystemProfileInstalled(ctx, client)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("Unable to check for OperatingSystemProfile CRD: %w", err))


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/kubermatic/kubermatic/pull/11720, we implemented migration for OSM to move OSP and OSC from seed to user clusters. This included the CRDs thus making use of the webhooks `kubermatic-operating-system-configs` and `kubermatic-operating-system-profiles` redundant in the seed cluster.

Unfortunately, we removed the code to manage those webhooks but never actually took care of cleanup for those resources. Hence after migration, those resources still exist and can block the removal of OSPs from the seed cluster.

```go
Warning  ReconcilingError  17m (x2 over 18h)   kkp-seed-operator  Failed to convert OSPs to Custom OSPs: failed to remove OSP finalizer: failed to remove finalizers [kubermatic.k8c.io/cleanup-kubermatic-operating-system-profiles] from OperatingSystemProfile kubermatic/offline-ubuntu: Internal error occurred: failed calling webhook "operatingsystemprofiles.operatingsystemmanager.k8c.io": failed to call webhook: the server could not find the requested resource
``` 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12309

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix a bug where redundant webhooks for OSM were not being removed from the seed cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
