### PR TITLE
[release/v2.21] Use eu-west-1 for AWS E2E tests

### DIFF
--- a/hack/ci/run-cilium-e2e-test.sh
+++ b/hack/ci/run-cilium-e2e-test.sh
@@ -50,6 +50,6 @@ echodate "Successfully got secrets for dev from Vault"
 echodate "Running Cilium tests..."
 
 go_test cilium_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/cilium \
-  -datacenter aws-eu-central-1a
+  -datacenter aws-eu-west-1a
 
 echodate "Cilium tests done."

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -46,7 +46,7 @@ if [[ $provider == "anexia" ]]; then
 elif [[ $provider == "aws" ]]; then
   EXTRA_ARGS="-aws-access-key-id=${AWS_E2E_TESTS_KEY_ID}
     -aws-secret-access-key=${AWS_E2E_TESTS_SECRET}
-    -aws-kkp-datacenter=aws-eu-central-1a"
+    -aws-kkp-datacenter=aws-eu-west-1a"
 elif [[ $provider == "packet" ]]; then
   maxDuration=90
   EXTRA_ARGS="-packet-api-key=${PACKET_API_KEY}

--- a/hack/ci/run-konnectivity-e2e-test.sh
+++ b/hack/ci/run-konnectivity-e2e-test.sh
@@ -51,6 +51,6 @@ echodate "Successfully got secrets for dev from Vault"
 echodate "Running Konnectivity tests..."
 
 go_test konnectivity_e2e -timeout 1h -tags e2e -v ./pkg/test/e2e/konnectivity \
-  -datacenter aws-eu-central-1a
+  -datacenter aws-eu-west-1a
 
 echodate "Konnectivity tests done."

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -65,8 +65,6 @@ spec:
       spec:
         aws:
           region: eu-west-1
-          images:
-            ubuntu: ami-092f628832a8d22a5 # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523
     hetzner-hel1:
       location: Helsinki 1 DC 6
       country: DE

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -59,12 +59,12 @@ spec:
       spec:
         anexia:
           locationID: "__ANEXIA_LOCATION_ID__"
-    aws-eu-central-1a:
+    aws-eu-west-1a:
       location: EU (Frankfurt)
       country: DE
       spec:
         aws:
-          region: eu-central-1
+          region: eu-west-1
           images:
             ubuntu: ami-092f628832a8d22a5 # ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523
     hetzner-hel1:

--- a/hack/run-conformance-tests.sh
+++ b/hack/run-conformance-tests.sh
@@ -79,7 +79,7 @@ aws)
   AWS_SECRET_ACCESS_KEY="${AWS_SECRET_ACCESS_KEY:-$(vault kv get -field=secretAccessKey dev/e2e-aws-kkp)}"
   extraArgs="-aws-access-key-id=$AWS_ACCESS_KEY_ID
     -aws-secret-access-key=$AWS_SECRET_ACCESS_KEY
-    -aws-kkp-datacenter=aws-eu-central-1a"
+    -aws-kkp-datacenter=aws-eu-west-1a"
   ;;
 
 azure)

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -216,7 +216,7 @@ func (a aws) NodeSpec() models.NodeCloudSpec {
 			IsSpotInstance:                false,
 			SpotInstanceMaxPrice:          "",
 			SpotInstancePersistentRequest: false,
-			SubnetID:                      "subnet-0373d73f016db25c7",
+			SubnetID:                      "subnet-0ef9b1c3a5c398584",
 			VolumeSize:                    pointer.Int64(64),
 			VolumeType:                    pointer.String("standard"),
 		},

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -234,7 +234,7 @@ func (a aws) CloudSpec() models.CloudSpec {
 			RouteTableID:            "",
 			SecretAccessKey:         os.Getenv("AWS_SECRET_ACCESS_KEY"),
 			SecurityGroupID:         "",
-			VPCID:                   "vpc-05dba8c3284fc2836",
+			VPCID:                   "vpc-0b91611f9eac0a67e",
 		},
 	}
 }

--- a/pkg/test/dualstack/cloud_providers.go
+++ b/pkg/test/dualstack/cloud_providers.go
@@ -211,7 +211,7 @@ func (a aws) NodeSpec() models.NodeCloudSpec {
 		Aws: &models.AWSNodeSpec{
 			AMI:                           "",
 			AssignPublicIP:                true,
-			AvailabilityZone:              "eu-central-1b",
+			AvailabilityZone:              "eu-west-1b",
 			InstanceType:                  pointer.String("t3a.small"),
 			IsSpotInstance:                false,
 			SpotInstanceMaxPrice:          "",
@@ -225,7 +225,7 @@ func (a aws) NodeSpec() models.NodeCloudSpec {
 
 func (a aws) CloudSpec() models.CloudSpec {
 	return models.CloudSpec{
-		DatacenterName: "aws-eu-central-1a",
+		DatacenterName: "aws-eu-west-1a",
 		Aws: &models.AWSCloudSpec{
 			AccessKeyID:             os.Getenv("AWS_ACCESS_KEY_ID"),
 			ControlPlaneRoleARN:     "",

--- a/pkg/test/e2e/api/dc_test.go
+++ b/pkg/test/e2e/api/dc_test.go
@@ -403,7 +403,7 @@ func TestListDCForSeed(t *testing.T) {
 		{
 			name:            "list DCs for seed kubermatic",
 			seed:            "kubermatic",
-			expectedDCNames: []string{"alibaba-eu-central-1a", "aws-eu-central-1a", "azure-westeurope", "byo-kubernetes", "do-ams3", "do-fra1", "gcp-westeurope", "hetzner-hel1", "hetzner-nbg1", "kubevirt-europe-west3-c", "packet-am", "syseleven-dbl1", "vsphere-ger"},
+			expectedDCNames: []string{"alibaba-eu-central-1a", "aws-eu-west-1a", "azure-westeurope", "byo-kubernetes", "do-ams3", "do-fra1", "gcp-westeurope", "hetzner-hel1", "hetzner-nbg1", "kubevirt-europe-west3-c", "packet-am", "syseleven-dbl1", "vsphere-ger"},
 		},
 	}
 
@@ -496,7 +496,7 @@ func TestListDC(t *testing.T) {
 	}{
 		{
 			name:            "list DCs",
-			expectedDCNames: []string{"alibaba-eu-central-1a", "aws-eu-central-1a", "azure-westeurope", "byo-kubernetes", "do-ams3", "do-fra1", "gcp-westeurope", "hetzner-hel1", "hetzner-nbg1", "kubevirt-europe-west3-c", "packet-am", "syseleven-dbl1", "vsphere-ger"},
+			expectedDCNames: []string{"alibaba-eu-central-1a", "aws-eu-west-1a", "azure-westeurope", "byo-kubernetes", "do-ams3", "do-fra1", "gcp-westeurope", "hetzner-hel1", "hetzner-nbg1", "kubevirt-europe-west3-c", "packet-am", "syseleven-dbl1", "vsphere-ger"},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #12306 to the release/v2.22 branch

I don't think we even use spot instances on this branch, but let's backport this change for the sake of consistency

**What type of PR is this?**

/kind failing-test

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```