### PR TITLE
Make etcd anti-affinity configurable via component override

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -364,11 +364,29 @@ spec:
       tolerations: null
     # Etcd configures the etcd ring used to store Kubernetes data.
     etcd:
+      # ClusterSize is the number of replicas created for etcd. This should be an
+      # odd number to guarantee consensus, e.g. 3, 5 or 7.
       clusterSize: 3
+      # DiskSize is the volume size used when creating persistent storage from
+      # the configured StorageClass. This is inherited from KubermaticConfiguration
+      # if not set. Defaults to 5Gi.
       diskSize: 5Gi
+      # HostAntiAffinity allows to enforce a certain type of host anti-affinity on etcd
+      # pods. Options are "preferred" (default) and "required". Please note that
+      # enforcing anti-affinity via "required" can mean that pods are never scheduled.
+      hostAntiAffinity: ""
+      # Resources allows to override the resource requirements for etcd Pods.
       resources: null
+      # StorageClass is the Kubernetes StorageClass used for persistent storage
+      # which stores the etcd WAL and other data persisted across restarts. Defaults to
+      # `kubermatic-fast` (the global default).
       storageClass: ""
+      # Tolerations allows to override the scheduling tolerations for etcd Pods.
       tolerations: null
+      # ZoneAntiAffinity allows to enforce a certain type of availability zone anti-affinity on etcd
+      # pods. Options are "preferred" (default) and "required". Please note that
+      # enforcing anti-affinity via "required" can mean that pods are never scheduled.
+      zoneAntiAffinity: ""
     # KonnectivityProxy configures konnectivity-server and konnectivity-agent components.
     konnectivityProxy:
       # KeepaliveTime represents a duration of time to check if the transport is still alive.

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -364,11 +364,29 @@ spec:
       tolerations: null
     # Etcd configures the etcd ring used to store Kubernetes data.
     etcd:
+      # ClusterSize is the number of replicas created for etcd. This should be an
+      # odd number to guarantee consensus, e.g. 3, 5 or 7.
       clusterSize: 3
+      # DiskSize is the volume size used when creating persistent storage from
+      # the configured StorageClass. This is inherited from KubermaticConfiguration
+      # if not set. Defaults to 5Gi.
       diskSize: 5Gi
+      # HostAntiAffinity allows to enforce a certain type of host anti-affinity on etcd
+      # pods. Options are "preferred" (default) and "required". Please note that
+      # enforcing anti-affinity via "required" can mean that pods are never scheduled.
+      hostAntiAffinity: ""
+      # Resources allows to override the resource requirements for etcd Pods.
       resources: null
+      # StorageClass is the Kubernetes StorageClass used for persistent storage
+      # which stores the etcd WAL and other data persisted across restarts. Defaults to
+      # `kubermatic-fast` (the global default).
       storageClass: ""
+      # Tolerations allows to override the scheduling tolerations for etcd Pods.
       tolerations: null
+      # ZoneAntiAffinity allows to enforce a certain type of availability zone anti-affinity on etcd
+      # pods. Options are "preferred" (default) and "required". Please note that
+      # enforcing anti-affinity via "required" can mean that pods are never scheduled.
+      zoneAntiAffinity: ""
     # KonnectivityProxy configures konnectivity-server and konnectivity-agent components.
     konnectivityProxy:
       # KeepaliveTime represents a duration of time to check if the transport is still alive.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -693,6 +693,17 @@ type ApplicationSettings struct {
 	CacheSize *resource.Quantity `json:"cacheSize,omitempty"`
 }
 
+// +kubebuilder:validation:Enum="";preferred;required
+
+// AntiAffinityType is the type of anti-affinity that should be used. Can be "preferred"
+// or "required".
+type AntiAffinityType string
+
+const (
+	AntiAffinityTypePreferred = "preferred"
+	AntiAffinityTypeRequired  = "required"
+)
+
 type ComponentSettings struct {
 	// Apiserver configures kube-apiserver settings.
 	Apiserver APIServerSettings `json:"apiserver"`
@@ -746,11 +757,29 @@ type StatefulSetSettings struct {
 }
 
 type EtcdStatefulSetSettings struct {
-	ClusterSize  *int32                       `json:"clusterSize,omitempty"`
-	StorageClass string                       `json:"storageClass,omitempty"`
-	DiskSize     *resource.Quantity           `json:"diskSize,omitempty"`
-	Resources    *corev1.ResourceRequirements `json:"resources,omitempty"`
-	Tolerations  []corev1.Toleration          `json:"tolerations,omitempty"`
+	// ClusterSize is the number of replicas created for etcd. This should be an
+	// odd number to guarantee consensus, e.g. 3, 5 or 7.
+	ClusterSize *int32 `json:"clusterSize,omitempty"`
+	// StorageClass is the Kubernetes StorageClass used for persistent storage
+	// which stores the etcd WAL and other data persisted across restarts. Defaults to
+	// `kubermatic-fast` (the global default).
+	StorageClass string `json:"storageClass,omitempty"`
+	// DiskSize is the volume size used when creating persistent storage from
+	// the configured StorageClass. This is inherited from KubermaticConfiguration
+	// if not set. Defaults to 5Gi.
+	DiskSize *resource.Quantity `json:"diskSize,omitempty"`
+	// Resources allows to override the resource requirements for etcd Pods.
+	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
+	// Tolerations allows to override the scheduling tolerations for etcd Pods.
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	// HostAntiAffinity allows to enforce a certain type of host anti-affinity on etcd
+	// pods. Options are "preferred" (default) and "required". Please note that
+	// enforcing anti-affinity via "required" can mean that pods are never scheduled.
+	HostAntiAffinity AntiAffinityType `json:"hostAntiAffinity,omitempty"`
+	// ZoneAntiAffinity allows to enforce a certain type of availability zone anti-affinity on etcd
+	// pods. Options are "preferred" (default) and "required". Please note that
+	// enforcing anti-affinity via "required" can mean that pods are never scheduled.
+	ZoneAntiAffinity AntiAffinityType `json:"zoneAntiAffinity,omitempty"`
 }
 
 type LeaderElectionSettings struct {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1243,16 +1243,25 @@ spec:
                       description: Etcd configures the etcd ring used to store Kubernetes data.
                       properties:
                         clusterSize:
+                          description: ClusterSize is the number of replicas created for etcd. This should be an odd number to guarantee consensus, e.g. 3, 5 or 7.
                           format: int32
                           type: integer
                         diskSize:
                           anyOf:
                             - type: integer
                             - type: string
+                          description: DiskSize is the volume size used when creating persistent storage from the configured StorageClass. This is inherited from KubermaticConfiguration if not set. Defaults to 5Gi.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        hostAntiAffinity:
+                          description: HostAntiAffinity allows to enforce a certain type of host anti-affinity on etcd pods. Options are "preferred" (default) and "required". Please note that enforcing anti-affinity via "required" can mean that pods are never scheduled.
+                          enum:
+                            - ""
+                            - preferred
+                            - required
+                          type: string
                         resources:
-                          description: ResourceRequirements describes the compute resource requirements.
+                          description: Resources allows to override the resource requirements for etcd Pods.
                           properties:
                             claims:
                               description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
@@ -1289,8 +1298,10 @@ spec:
                               type: object
                           type: object
                         storageClass:
+                          description: StorageClass is the Kubernetes StorageClass used for persistent storage which stores the etcd WAL and other data persisted across restarts. Defaults to `kubermatic-fast` (the global default).
                           type: string
                         tolerations:
+                          description: Tolerations allows to override the scheduling tolerations for etcd Pods.
                           items:
                             description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                             properties:
@@ -1312,6 +1323,13 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        zoneAntiAffinity:
+                          description: ZoneAntiAffinity allows to enforce a certain type of availability zone anti-affinity on etcd pods. Options are "preferred" (default) and "required". Please note that enforcing anti-affinity via "required" can mean that pods are never scheduled.
+                          enum:
+                            - ""
+                            - preferred
+                            - required
+                          type: string
                       type: object
                     konnectivityProxy:
                       description: KonnectivityProxy configures konnectivity-server and konnectivity-agent components.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1238,16 +1238,25 @@ spec:
                       description: Etcd configures the etcd ring used to store Kubernetes data.
                       properties:
                         clusterSize:
+                          description: ClusterSize is the number of replicas created for etcd. This should be an odd number to guarantee consensus, e.g. 3, 5 or 7.
                           format: int32
                           type: integer
                         diskSize:
                           anyOf:
                             - type: integer
                             - type: string
+                          description: DiskSize is the volume size used when creating persistent storage from the configured StorageClass. This is inherited from KubermaticConfiguration if not set. Defaults to 5Gi.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        hostAntiAffinity:
+                          description: HostAntiAffinity allows to enforce a certain type of host anti-affinity on etcd pods. Options are "preferred" (default) and "required". Please note that enforcing anti-affinity via "required" can mean that pods are never scheduled.
+                          enum:
+                            - ""
+                            - preferred
+                            - required
+                          type: string
                         resources:
-                          description: ResourceRequirements describes the compute resource requirements.
+                          description: Resources allows to override the resource requirements for etcd Pods.
                           properties:
                             claims:
                               description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
@@ -1284,8 +1293,10 @@ spec:
                               type: object
                           type: object
                         storageClass:
+                          description: StorageClass is the Kubernetes StorageClass used for persistent storage which stores the etcd WAL and other data persisted across restarts. Defaults to `kubermatic-fast` (the global default).
                           type: string
                         tolerations:
+                          description: Tolerations allows to override the scheduling tolerations for etcd Pods.
                           items:
                             description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                             properties:
@@ -1307,6 +1318,13 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        zoneAntiAffinity:
+                          description: ZoneAntiAffinity allows to enforce a certain type of availability zone anti-affinity on etcd pods. Options are "preferred" (default) and "required". Please note that enforcing anti-affinity via "required" can mean that pods are never scheduled.
+                          enum:
+                            - ""
+                            - preferred
+                            - required
+                          type: string
                       type: object
                     konnectivityProxy:
                       description: KonnectivityProxy configures konnectivity-server and konnectivity-agent components.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -933,16 +933,25 @@ spec:
                       description: Etcd configures the etcd ring used to store Kubernetes data.
                       properties:
                         clusterSize:
+                          description: ClusterSize is the number of replicas created for etcd. This should be an odd number to guarantee consensus, e.g. 3, 5 or 7.
                           format: int32
                           type: integer
                         diskSize:
                           anyOf:
                             - type: integer
                             - type: string
+                          description: DiskSize is the volume size used when creating persistent storage from the configured StorageClass. This is inherited from KubermaticConfiguration if not set. Defaults to 5Gi.
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
+                        hostAntiAffinity:
+                          description: HostAntiAffinity allows to enforce a certain type of host anti-affinity on etcd pods. Options are "preferred" (default) and "required". Please note that enforcing anti-affinity via "required" can mean that pods are never scheduled.
+                          enum:
+                            - ""
+                            - preferred
+                            - required
+                          type: string
                         resources:
-                          description: ResourceRequirements describes the compute resource requirements.
+                          description: Resources allows to override the resource requirements for etcd Pods.
                           properties:
                             claims:
                               description: "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container. \n This is an alpha field and requires enabling the DynamicResourceAllocation feature gate. \n This field is immutable."
@@ -979,8 +988,10 @@ spec:
                               type: object
                           type: object
                         storageClass:
+                          description: StorageClass is the Kubernetes StorageClass used for persistent storage which stores the etcd WAL and other data persisted across restarts. Defaults to `kubermatic-fast` (the global default).
                           type: string
                         tolerations:
+                          description: Tolerations allows to override the scheduling tolerations for etcd Pods.
                           items:
                             description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                             properties:
@@ -1002,6 +1013,13 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        zoneAntiAffinity:
+                          description: ZoneAntiAffinity allows to enforce a certain type of availability zone anti-affinity on etcd pods. Options are "preferred" (default) and "required". Please note that enforcing anti-affinity via "required" can mean that pods are never scheduled.
+                          enum:
+                            - ""
+                            - preferred
+                            - required
+                          type: string
                       type: object
                     konnectivityProxy:
                       description: KonnectivityProxy configures konnectivity-server and konnectivity-agent components.

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -260,7 +260,7 @@ func DeploymentReconciler(data *resources.TemplateData, enableOIDCAuthentication
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
 			return dep, nil
 		}

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -196,7 +196,7 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -171,7 +171,7 @@ func DeploymentReconciler(data deploymentReconcilerData) reconciling.NamedDeploy
 
 			dep.Spec.Template.Spec.Volumes = volumes
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.DNSResolverDeploymentName)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.DNSResolverDeploymentName, kubermaticv1.AntiAffinityTypePreferred)
 
 			return dep, nil
 		}

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -308,7 +308,8 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName)
+			antiAffinityType := data.Cluster().Spec.ComponentsOverride.Etcd.HostAntiAffinity
+			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName, antiAffinityType)
 			if data.SupportsFailureDomainZoneAntiAffinity() {
 				antiAffinities := set.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 				antiAffinities = append(antiAffinities, resources.FailureDomainZoneAntiAffinity(resources.EtcdStatefulSetName))

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -100,7 +100,7 @@ func DeploymentReconciler(data kubernetesDashboardData) reconciling.NamedDeploym
 			if err != nil {
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -198,7 +198,7 @@ func DeploymentReconciler(data metricsServerData) reconciling.NamedDeploymentRec
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -306,7 +306,7 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			d.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(envoyAppLabelValue)
+			d.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(envoyAppLabelValue, kubermaticv1.AntiAffinityTypePreferred)
 			if data.SupportsFailureDomainZoneAntiAffinity() {
 				antiAffinities := d.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
 				antiAffinities = append(antiAffinities, resources.FailureDomainZoneAntiAffinity(envoyAppLabelValue))

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	semverlib "github.com/Masterminds/semver/v3"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -186,7 +187,7 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name)
+			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
 			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds two new fields to the etcd component override to provide soft (default) or hard anti-affinity. This will allow users to enforce host and zone anti-affinity at the expense of potentially not seeing pods being scheduled, but that is a tradeoff that people need to judge by themselves.



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12169

**What type of PR is this?**
/kind feature
/kind api-change

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add component override settings for etcd that allow configuring the type of anti-affinity
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
