### PR TITLE
Increase metrics server write timeout

### DIFF
--- a/pkg/metrics/server/server.go
+++ b/pkg/metrics/server/server.go
@@ -77,7 +77,7 @@ func (m *MetricsServer) Start(ctx context.Context) error {
 		Addr:         m.listenAddress,
 		Handler:      mux,
 		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		WriteTimeout: 2 * time.Minute,
 	}
 
 	return fmt.Errorf("metrics server stopped: %w", s.ListenAndServe())


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the metrics server write timeout to mitigate issues with slower S3 (backup) endpoints.

**Which issue(s) this PR fixes**:
Slack: https://kubermatic-community.slack.com/archives/C0PGCH99P/p1682600106229819

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
With the default Prometheus scrape interval of 1 min, our proposed write timeout of 2 min might be a little high as a default. Maybe making this value configurable might be another solution. What is your opinion on this?

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Metrics server write timeout increased.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
