### PR TITLE
[release/v2.22] Set succesful limit for defragger job to 1

### DIFF
--- a/pkg/resources/etcd/cronjob.go
+++ b/pkg/resources/etcd/cronjob.go
@@ -31,6 +31,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 type cronJobReconcilerData interface {
@@ -50,8 +51,7 @@ func CronJobReconciler(data cronJobReconcilerData) reconciling.NamedCronJobRecon
 
 			job.Name = resources.EtcdDefragCronJobName
 			job.Spec.ConcurrencyPolicy = batchv1.ForbidConcurrent
-			var historyLimit int32
-			job.Spec.SuccessfulJobsHistoryLimit = &historyLimit
+			job.Spec.SuccessfulJobsHistoryLimit = pointer.Int32(1)
 			job.Spec.Schedule = "@every 3h"
 			job.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyOnFailure
 			job.Spec.JobTemplate.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}

--- a/pkg/resources/test/fixtures/cronjob-aws-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-aws-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.24.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-aws-1.25.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.25.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-aws-1.25.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.25.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-aws-1.26.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.26.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-aws-1.26.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-aws-1.26.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.24.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-azure-1.25.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.25.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-azure-1.25.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.25.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-azure-1.26.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.26.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-azure-1.26.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-azure-1.26.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.24.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.25.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.25.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-bringyourown-1.26.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-bringyourown-1.26.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.24.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.25.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.25.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.25.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.25.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.26.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.26.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-digitalocean-1.26.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-digitalocean-1.26.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-gcp-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-gcp-1.24.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-gcp-1.25.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-gcp-1.25.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-gcp-1.26.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-gcp-1.26.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.24.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.25.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.25.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.25.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.25.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.26.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.26.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-openstack-1.26.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-openstack-1.26.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.24.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.25.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.25.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.25.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.25.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.26.0-etcd-defragger-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.26.0-etcd-defragger-externalCloudProvider.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}

--- a/pkg/resources/test/fixtures/cronjob-vsphere-1.26.0-etcd-defragger.yaml
+++ b/pkg/resources/test/fixtures/cronjob-vsphere-1.26.0-etcd-defragger.yaml
@@ -55,5 +55,5 @@ spec:
             secret:
               secretName: apiserver-etcd-client-certificate
   schedule: '@every 3h'
-  successfulJobsHistoryLimit: 0
+  successfulJobsHistoryLimit: 1
 status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of https://github.com/kubermatic/kubermatic/pull/12303

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changed `etcd-defragger` CronJob `SuccessfulJobsHistoryLimit` from 0 to 1 to save logs of the most recent successful job.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
