### PR TITLE
Gather logs in expose-strategy e2e tests with protokol

### DIFF
--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -156,6 +156,13 @@ EOF
 copy_crds_to_chart
 set_crds_version_annotation
 
+# gather logs
+if [ -n "${ARTIFACTS:-}" ] && [ -x "$(command -v protokol)" ]; then
+  # gather the logs of all things in the cluster control plane and in the Kubermatic namespace
+  protokol --kubeconfig "${HOME}/.kube/config" --flat --output "$ARTIFACTS/logs/cluster-control-plane" --namespace 'cluster-*' > /dev/null 2>&1 &
+  protokol --kubeconfig "${HOME}/.kube/config" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
+fi
+
 # install dependencies and Kubermatic Operator into cluster
 ./_build/kubermatic-installer deploy --disable-telemetry \
   --storageclass copy-default \


### PR DESCRIPTION
**What this PR does / why we need it**:
The expose-strategy e2e test doesn't gather logs, so it's hard to look into why it's failing (e.g. in #12302). This PR adds the `protokol` log fetching that we already do for most other e2e jobs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
