### PR TITLE
switch to egress based network policies for kubervirt provider

### DIFF
--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -84,6 +84,7 @@ elif [[ $provider == "vsphere" ]]; then
     -vsphere-password=${VSPHERE_E2E_PASSWORD}
     -vsphere-kkp-datacenter=vsphere-ger"
 elif [[ $provider == "kubevirt" ]]; then
+  maxDuration=90
   tmpFile="$(mktemp)"
   echo "$KUBEVIRT_E2E_TESTS_KUBECONFIG" > "$tmpFile"
   EXTRA_ARGS="-kubevirt-kubeconfig=$tmpFile

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -154,16 +154,6 @@ spec:
           dnsConfig:
             nameservers:
               - 8.8.8.8
-          customNetworkPolicies:
-            - name: allow-incoming
-              spec:
-                ingress:
-                - from:
-                  - ipBlock:
-                      cidr: 0.0.0.0/0
-                podSelector: {}
-                policyTypes:
-                - Ingress
           infraStorageClasses:
             - isDefaultClass: true
               name: px-csi-db

--- a/pkg/provider/cloud/kubevirt/network_policy.go
+++ b/pkg/provider/cloud/kubevirt/network_policy.go
@@ -85,7 +85,7 @@ func clusterIsolationNetworkPolicyReconciler(clusterIp string, nameservers []str
 							},
 						},
 					},
-					// Allow kubermatic nodeport-proxy ip addresse
+					// Allow kubermatic nodeport-proxy ip address
 					{
 						To: []networkingv1.NetworkPolicyPeer{
 							{

--- a/pkg/provider/cloud/kubevirt/network_policy.go
+++ b/pkg/provider/cloud/kubevirt/network_policy.go
@@ -23,29 +23,123 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/reconciler/pkg/reconciling"
 
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func clusterIsolationNetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
+// clusterIsolationNetworkPolicyReconciler creates a network policy that restrict Egress traffic. By default it allows access to
+// each other pod in the same namespace, Internet, Kubermatic nodeport proxy and DNS servers.
+func clusterIsolationNetworkPolicyReconciler(clusterIp string, nameservers []string) reconciling.NamedNetworkPolicyReconcilerFactory {
+	apiServerCIDR := clusterIp + "/32"
+	dnsPort := intstr.FromInt(53)
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+
+	var dnsRules []networkingv1.NetworkPolicyEgressRule
+	for _, ns := range nameservers {
+		dnsRules = append(dnsRules, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{
+				{
+					IPBlock: &networkingv1.IPBlock{
+						CIDR: ns + "/32",
+					},
+				},
+			},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{
+					Protocol: &tcp,
+					Port:     &dnsPort,
+				},
+				{
+					Protocol: &udp,
+					Port:     &dnsPort,
+				},
+			},
+		})
+	}
+
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		return "cluster-isolation", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PodSelector: metav1.LabelSelector{},
-				Ingress: []networkingv1.NetworkPolicyIngressRule{
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					// Allow access to pod's in same namespace
 					{
-						From: []networkingv1.NetworkPolicyPeer{
+						To: []networkingv1.NetworkPolicyPeer{
 							{
 								PodSelector: &metav1.LabelSelector{},
 							},
 						},
 					},
+					// Allow public ip addresses
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR:   "0.0.0.0/0",
+									Except: []string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16"},
+								},
+							},
+						},
+					},
+					// Allow kubermatic nodeport-proxy ip addresse
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								IPBlock: &networkingv1.IPBlock{
+									CIDR: apiServerCIDR,
+								},
+							},
+						},
+					},
 				},
 				PolicyTypes: []networkingv1.PolicyType{
-					networkingv1.PolicyTypeIngress,
+					networkingv1.PolicyTypeEgress,
 				},
 			}
+
+			// Allow dns servers
+			np.Spec.Egress = append(np.Spec.Egress, dnsRules...)
+			return np, nil
+		}
+	}
+}
+
+// clusterImporterNetworkPolicyReconciler creates a special network policy that allows the importer pod to access
+// the image-repo in the cluster.
+func clusterImporterNetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
+	return func() (string, reconciling.NetworkPolicyReconciler) {
+		return "allow-kubevirt-importer", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"app":             "containerized-data-importer",
+						"cdi.kubevirt.io": "importer",
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					// Allow access to pod in any namespace with specific label
+					{
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app": "image-repo",
+									},
+								},
+							},
+						},
+					},
+				},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+			}
+
 			return np, nil
 		}
 	}
@@ -61,9 +155,10 @@ func customNetworkPolicyReconciler(existing *kubermaticv1.CustomNetworkPolicy) r
 	}
 }
 
-func reconcileClusterIsolationNetworkPolicy(ctx context.Context, cluster *kubermaticv1.Cluster, client ctrlruntimeclient.Client) error {
+func reconcileClusterIsolationNetworkPolicy(ctx context.Context, cluster *kubermaticv1.Cluster, dc *kubermaticv1.DatacenterSpecKubevirt, client ctrlruntimeclient.Client) error {
 	namedNetworkPolicyReconcilerFactorys := []reconciling.NamedNetworkPolicyReconcilerFactory{
-		clusterIsolationNetworkPolicyReconciler(),
+		clusterIsolationNetworkPolicyReconciler(cluster.Status.Address.IP, dc.DNSConfig.Nameservers),
+		clusterImporterNetworkPolicyReconciler(),
 	}
 	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactorys, cluster.Status.NamespaceName, client); err != nil {
 		return fmt.Errorf("failed to ensure Network Policies: %w", err)

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -148,7 +148,7 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 		enableDefaultNetworkPolices = *k.dc.EnableDefaultNetworkPolicies
 	}
 	if enableDefaultNetworkPolices {
-		err = reconcileClusterIsolationNetworkPolicy(ctx, cluster, client)
+		err = reconcileClusterIsolationNetworkPolicy(ctx, cluster, k.dc, client)
 		if err != nil {
 			return cluster, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Introduces Egress based network policies for KubeVirt.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12328

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[action required] Move to Egress based cluster isolation network policies for KubeVirt. Custom Network policies for KubeVirt Datacenter might need adjustment. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
