### PR TITLE
Update local-kubevirt chart to v1.0.0-beta.0

### DIFF
--- a/charts/local-kubevirt/Chart.yaml
+++ b/charts/local-kubevirt/Chart.yaml
@@ -14,9 +14,9 @@
 
 apiVersion: v1
 name: kubevirt
-version: v1.0.0-alpha.0
-appVersion: v1.0.0-alpha.0
-description: KubeVirt chart for KKP local installation
+version: v1.0.0-beta.0
+appVersion: v1.0.0-beta.0
+description: KubeVirt chart for KKP local installation 
 keywords:
   - kubermatic
   - kubevirt

--- a/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
+++ b/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
@@ -310,7 +310,7 @@ spec:
                           x-kubernetes-list-type: atomic
                         nodeMediatedDeviceTypes:
                           items:
-                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specifc node that matches the NodeSelector field.
+                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specific node that matches the NodeSelector field.
                             properties:
                               mediatedDeviceTypes:
                                 items:
@@ -350,7 +350,7 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: BandwidthPerMigration limits the amount of network bandwith live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
+                          description: BandwidthPerMigration limits the amount of network bandwidth live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         completionTimeoutPerGiB:
@@ -2033,7 +2033,7 @@ spec:
                           x-kubernetes-list-type: atomic
                         nodeMediatedDeviceTypes:
                           items:
-                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specifc node that matches the NodeSelector field.
+                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specific node that matches the NodeSelector field.
                             properties:
                               mediatedDeviceTypes:
                                 items:
@@ -2073,7 +2073,7 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: BandwidthPerMigration limits the amount of network bandwith live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
+                          description: BandwidthPerMigration limits the amount of network bandwidth live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         completionTimeoutPerGiB:

--- a/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
+++ b/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
@@ -118,6 +118,47 @@ spec:
                               type: object
                           type: object
                       type: object
+                    architectureConfiguration:
+                      properties:
+                        amd64:
+                          properties:
+                            emulatedMachines:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            machineType:
+                              type: string
+                            ovmfPath:
+                              type: string
+                          type: object
+                        arm64:
+                          properties:
+                            emulatedMachines:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            machineType:
+                              type: string
+                            ovmfPath:
+                              type: string
+                          type: object
+                        defaultArchitecture:
+                          type: string
+                        ppc64le:
+                          properties:
+                            emulatedMachines:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            machineType:
+                              type: string
+                            ovmfPath:
+                              type: string
+                          type: object
+                      type: object
                     controllerConfiguration:
                       description: ReloadableComponentConfiguration holds all generic k8s configuration options which can be reloaded by components without requiring a restart.
                       properties:
@@ -269,7 +310,7 @@ spec:
                           x-kubernetes-list-type: atomic
                         nodeMediatedDeviceTypes:
                           items:
-                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specific node that matches the NodeSelector field.
+                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specifc node that matches the NodeSelector field.
                             properties:
                               mediatedDeviceTypes:
                                 items:
@@ -309,7 +350,7 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: BandwidthPerMigration limits the amount of network bandwidth live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
+                          description: BandwidthPerMigration limits the amount of network bandwith live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         completionTimeoutPerGiB:
@@ -1644,6 +1685,8 @@ spec:
                       - type
                     type: object
                   type: array
+                defaultArchitecture:
+                  type: string
                 generations:
                   items:
                     description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
@@ -1706,7 +1749,7 @@ spec:
             - spec
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -1716,6 +1759,8 @@ spec:
         - jsonPath: .status.phase
           name: Phase
           type: string
+      deprecated: true
+      deprecationWarning: kubevirt.io/v1alpha3 is now deprecated and will be removed in a future release.
       name: v1alpha3
       schema:
         openAPIV3Schema:
@@ -1796,6 +1841,47 @@ spec:
                               type: object
                           type: object
                       type: object
+                    architectureConfiguration:
+                      properties:
+                        amd64:
+                          properties:
+                            emulatedMachines:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            machineType:
+                              type: string
+                            ovmfPath:
+                              type: string
+                          type: object
+                        arm64:
+                          properties:
+                            emulatedMachines:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            machineType:
+                              type: string
+                            ovmfPath:
+                              type: string
+                          type: object
+                        defaultArchitecture:
+                          type: string
+                        ppc64le:
+                          properties:
+                            emulatedMachines:
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            machineType:
+                              type: string
+                            ovmfPath:
+                              type: string
+                          type: object
+                      type: object
                     controllerConfiguration:
                       description: ReloadableComponentConfiguration holds all generic k8s configuration options which can be reloaded by components without requiring a restart.
                       properties:
@@ -1947,7 +2033,7 @@ spec:
                           x-kubernetes-list-type: atomic
                         nodeMediatedDeviceTypes:
                           items:
-                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specific node that matches the NodeSelector field.
+                            description: NodeMediatedDeviceTypesConfig holds information about MDEV types to be defined in a specifc node that matches the NodeSelector field.
                             properties:
                               mediatedDeviceTypes:
                                 items:
@@ -1987,7 +2073,7 @@ spec:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: BandwidthPerMigration limits the amount of network bandwidth live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
+                          description: BandwidthPerMigration limits the amount of network bandwith live migrations are allowed to use. The value is in quantity per second. Defaults to 0 (no limit)
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
                         completionTimeoutPerGiB:
@@ -3322,6 +3408,8 @@ spec:
                       - type
                     type: object
                   type: array
+                defaultArchitecture:
+                  type: string
                 generations:
                   items:
                     description: GenerationStatus keeps track of the generation for a given resource so that decisions about forced updates can be made.
@@ -3384,6 +3472,6 @@ spec:
             - spec
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}

--- a/charts/local-kubevirt/templates/deployment-virt-operator.yaml
+++ b/charts/local-kubevirt/templates/deployment-virt-operator.yaml
@@ -56,14 +56,14 @@ spec:
             - virt-operator
           env:
             - name: VIRT_OPERATOR_IMAGE
-              value: quay.io/kubevirt/virt-operator:v1.0.0-alpha.0
+              value: quay.io/kubevirt/virt-operator:v1.0.0-beta.0
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['olm.targetNamespaces']
             - name: KUBEVIRT_VERSION
-              value: v1.0.0-alpha.0
-          image: quay.io/kubevirt/virt-operator:v1.0.0-alpha.0
+              value: v1.0.0-beta.0
+          image: quay.io/kubevirt/virt-operator:v1.0.0-beta.0
           imagePullPolicy: IfNotPresent
           name: virt-operator
           ports:

--- a/charts/local-kubevirt/update.bash
+++ b/charts/local-kubevirt/update.bash
@@ -63,7 +63,7 @@ yq -s '.kind + "-" + .metadata.name + ".yaml"' ./cdi-operator.yaml
 rm ./cdi-operator.yaml
 
 for f in *; do 
-    l=$(echo "$f" | tr '[A-Z]' '[a-z]')
+    l=$(echo "$f" | tr '[A-Z:]' '[a-z-]')
     cat <(boilerplate) "$f" > tmp.yaml
     mv tmp.yaml "$f"
     if [[ "$f" != "$l" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
As mentioned by https://github.com/kubermatic/kubermatic/pull/12330, the name of a chart templates files can't contain `:`. The file names in `local-kubevirt` chart are determined by the resource name and kind, adjusting the filter to swap `:` for `-`.

And also bumping to latest kubevirt released resources.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
followup to a fix from https://github.com/kubermatic/kubermatic/pull/12330

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
local kubevirt chart: update to v1.0.0-beta.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
