### PR TITLE
Create an internal NetworkPolicy for konnectivity+apiserver to communicate with itself

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -56,6 +56,7 @@ import (
 	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -174,6 +175,14 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 		}
 	} else {
 		if err := r.ensureKonnectivitySetupIsRemoved(ctx, data); err != nil {
+			return nil, err
+		}
+	}
+
+	// clean up NetworkPolicy created before konnectivity-server's kubeconfig was changed
+	// to use the internal API server endpoint.
+	if data.IsKonnectivityEnabled() {
+		if err := r.ensureKonnectivityNetworkPolicyIsRemoved(ctx, data); err != nil {
 			return nil, err
 		}
 	}
@@ -612,15 +621,7 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 		defer cancel()
 
 		if data.IsKonnectivityEnabled() {
-			extName := data.Cluster().Status.Address.ExternalName
-
-			// allow egress traffic to all resolved cluster external IPs
-			ipList, err := hostnameToIPList(resolverCtx, extName)
-			if err != nil {
-				return fmt.Errorf("failed to resolve cluster external name %q: %w", extName, err)
-			}
-
-			namedNetworkPolicyReconcilerFactorys = append(namedNetworkPolicyReconcilerFactorys, apiserver.ClusterExternalAddrAllowReconciler(ipList, c.Spec.ExposeStrategy))
+			namedNetworkPolicyReconcilerFactorys = append(namedNetworkPolicyReconcilerFactorys, apiserver.ApiserverInternalAllowReconciler())
 		} else {
 			namedNetworkPolicyReconcilerFactorys = append(namedNetworkPolicyReconcilerFactorys,
 				apiserver.OpenVPNServerAllowReconciler(c),
@@ -865,6 +866,21 @@ func (r *Reconciler) ensureKonnectivitySetupIsRemoved(ctx context.Context, data 
 		if err := r.Client.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure Konnectivity resources are removed/not present: %w", err)
 		}
+	}
+	return nil
+}
+
+// ensureKonnectivityNetworkPolicyIsRemoved removes the NetworkPolicy put in place for
+// konnectivity-server -> external API server endpoint communication.
+func (r *Reconciler) ensureKonnectivityNetworkPolicyIsRemoved(ctx context.Context, data *resources.TemplateData) error {
+	if err := r.Client.Delete(ctx, &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.NetworkPolicyClusterExternalAddrAllow,
+			Namespace: data.Cluster().Status.NamespaceName,
+		},
+	},
+	); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to ensure external konnectivity-server NetworkPolicyy is removed/not present: %w", err)
 	}
 	return nil
 }

--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -21,8 +21,6 @@ import (
 	"net"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
-	"k8c.io/kubermatic/v2/pkg/controller/operator/seed/resources/nodeportproxy"
 	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -288,12 +286,17 @@ func MetricsServerAllowReconciler(c *kubermaticv1.Cluster) reconciling.NamedNetw
 	}
 }
 
-// ClusterExternalAddrAllowReconciler returns a func to create/update the apiserver cluster-external-addr-allow egress policy.
-// This policy is necessary in Konnectivity setup, so that konnectivity-server can connect to the apiserver via
-// the external URL (used as service-account-issuer) to validate konnectivity-agent authentication token.
-func ClusterExternalAddrAllowReconciler(egressIPs []net.IP, exposeStrategy kubermaticv1.ExposeStrategy) reconciling.NamedNetworkPolicyReconcilerFactory {
+// ApiserverInternalAllowReconciler returns a func to create/update the apiserver-internal-allow egress policy.
+// This policy is necessary since konnectivity-server (sidecar to kube-apiserver when konnectivity is enabled) needs
+// to talk to the Kubernetes API to validate tokens coming from konnectivity-agent.
+//
+// This was previously handled with a policy called cluster-external-addr-allow that allowed connection to the
+// the external endpoint, but no reasoning for this design choice could be found in code comments or PR descriptions.
+// Upstream itself uses localhost in an example (see https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/a38752dc9884a1fc1c32652eacb38aed21e4ab25/examples/kubernetes/kubeconfig#L11),
+// so the strong assumption here is that this was never necessary.
+func ApiserverInternalAllowReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
-		return resources.NetworkPolicyClusterExternalAddrAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+		return resources.NetworkPolicyApiserverInternalAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			np.Spec = networkingv1.NetworkPolicySpec{
 				PolicyTypes: []networkingv1.PolicyType{
 					networkingv1.PolicyTypeEgress,
@@ -305,34 +308,17 @@ func ClusterExternalAddrAllowReconciler(egressIPs []net.IP, exposeStrategy kuber
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{
 					{
-						To: ipListToPeers(egressIPs),
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										resources.AppLabelKey: name,
+									},
+								},
+							},
+						},
 					},
 				},
-			}
-
-			// allow egress traffic to the nodeport-proxy as for some CNI + kube-proxy mode
-			// combinations a local path to it may be used to reach the external apiserver address
-			if exposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
-				// allows traffic to the nodeport-proxy running in the user cluster namespace used for the LB expose strategy
-				np.Spec.Egress[0].To = append(np.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: resources.BaseAppLabels(resources.NodePortProxyEnvoyDeploymentName, nil),
-					},
-				})
-			} else {
-				// allows traffic to the nodeport-proxy running in the kubermatic namespace used for other expose strategies
-				np.Spec.Egress[0].To = append(np.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							corev1.LabelMetadataName: resources.KubermaticNamespace,
-						},
-					},
-					PodSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{
-							common.NameLabel: nodeportproxy.EnvoyDeploymentName,
-						},
-					},
-				})
 			}
 
 			return np, nil

--- a/pkg/resources/konnectivity/deletion.go
+++ b/pkg/resources/konnectivity/deletion.go
@@ -57,5 +57,11 @@ func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
 				Namespace: namespace,
 			},
 		},
+		&networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.NetworkPolicyApiserverInternalAllow,
+				Namespace: namespace,
+			},
+		},
 	}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -986,6 +986,7 @@ const (
 	NetworkPolicyMetricsServerAllow                 = "metrics-server-allow"
 	NetworkPolicyClusterExternalAddrAllow           = "cluster-external-addr-allow"
 	NetworkPolicyOIDCIssuerAllow                    = "oidc-issuer-allow"
+	NetworkPolicyApiserverInternalAllow             = "apiserver-internal-allow"
 )
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:
#12344 changed the way konnectivity-server talks to the kube-apiserver - from using the external endpoint to the internal one. This was unfortunately not covered by existing NetworkPolicies, so this PR adds a NetworkPolicy that allows apiserver to apiserver Pod communication (since konnectivity-server is part of that Pod).

I've been trying really hard to figure out _why_ the external endpoint was chosen in the first place and went through the following PRs:

- #9187
- #8730
- #7504

Not one of them explains or discusses why the external endpoint is necessary here. I don't see any reason for this other than this was the initially chosen design and subsequent PRs did not question it but tried to fix the as-is situation.

I was wondering if this could be something related to token validation, but looking at the same file in upstream examples, it even uses localhost there: https://github.com/kubernetes-sigs/apiserver-network-proxy/blob/a38752dc9884a1fc1c32652eacb38aed21e4ab25/examples/kubernetes/kubeconfig#L11

Subsequently, I believe that this PR simplifies things a lot without having impact on functionality.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
An internal NetworkPolicy for apiserver communication is now being created and the previous NetworkPolicy `cluster-external-addr-allow` is cleaned up
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
