### PR TITLE
[release/v2.22] alter canal cni auto update

### DIFF
--- a/pkg/webhook/cluster/mutation/mutator.go
+++ b/pkg/webhook/cluster/mutation/mutator.go
@@ -193,24 +193,24 @@ func (m *Mutator) mutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, con
 			}
 		}
 
-		// This part handles Canal version upgrade for clusters with Kubernetes version 1.23 and higher,
-		// where the minimal Canal version is v3.22.
+		// This part handles Canal version upgrade for clusters with Kubernetes version 1.26 and higher,
+		// where the minimal Canal version is v3.23.
 		cniVersion, err := semverlib.NewVersion(newCluster.Spec.CNIPlugin.Version)
 		if err != nil {
 			return field.Invalid(field.NewPath("spec", "cniPlugin", "version"), newCluster.Spec.CNIPlugin.Version, err.Error())
 		}
-		lowerThan322, err := semverlib.NewConstraint("< 3.22")
+		lowerThan322, err := semverlib.NewConstraint("< 3.23")
 		if err != nil {
 			return field.InternalError(nil, fmt.Errorf("semver constraint parsing failed: %w", err))
 		}
-		equalOrHigherThan123, err := semverlib.NewConstraint(">= 1.23")
+		equalOrHigherThan123, err := semverlib.NewConstraint(">= 1.26")
 		if err != nil {
 			return field.InternalError(nil, fmt.Errorf("semver constraint parsing failed: %w", err))
 		}
 		if lowerThan322.Check(cniVersion) && curVersion.String() != "" && equalOrHigherThan123.Check(curVersion.Semver()) {
 			newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
 				Type:    kubermaticv1.CNIPluginTypeCanal,
-				Version: "v3.22",
+				Version: "v3.23",
 			}
 		}
 	}

--- a/pkg/webhook/cluster/mutation/mutator.go
+++ b/pkg/webhook/cluster/mutation/mutator.go
@@ -199,15 +199,15 @@ func (m *Mutator) mutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, con
 		if err != nil {
 			return field.Invalid(field.NewPath("spec", "cniPlugin", "version"), newCluster.Spec.CNIPlugin.Version, err.Error())
 		}
-		lowerThan322, err := semverlib.NewConstraint("< 3.23")
+		lowerThan323, err := semverlib.NewConstraint("< 3.23")
 		if err != nil {
 			return field.InternalError(nil, fmt.Errorf("semver constraint parsing failed: %w", err))
 		}
-		equalOrHigherThan123, err := semverlib.NewConstraint(">= 1.26")
+		equalOrHigherThan126, err := semverlib.NewConstraint(">= 1.26")
 		if err != nil {
 			return field.InternalError(nil, fmt.Errorf("semver constraint parsing failed: %w", err))
 		}
-		if lowerThan322.Check(cniVersion) && curVersion.String() != "" && equalOrHigherThan123.Check(curVersion.Semver()) {
+		if lowerThan323.Check(cniVersion) && curVersion.String() != "" && equalOrHigherThan126.Check(curVersion.Semver()) {
 			newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
 				Type:    kubermaticv1.CNIPluginTypeCanal,
 				Version: "v3.23",

--- a/pkg/webhook/cluster/mutation/mutator_test.go
+++ b/pkg/webhook/cluster/mutation/mutator_test.go
@@ -580,10 +580,10 @@ func TestMutator(t *testing.T) {
 			),
 		},
 		{
-			name: "CNI plugin version bump to v3.22 on k8s version upgrade to 1.23",
+			name: "CNI plugin version bump to v3.23 on k8s version upgrade to 1.26",
 			oldCluster: rawClusterGen{
 				Name:    "foo",
-				Version: *semver.NewSemverOrDie("1.22"),
+				Version: *semver.NewSemverOrDie("1.25"),
 				CloudSpec: kubermaticv1.CloudSpec{
 					ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 					DatacenterName: "openstack-dc",
@@ -599,7 +599,7 @@ func TestMutator(t *testing.T) {
 				},
 				CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
 					Type:    kubermaticv1.CNIPluginTypeCanal,
-					Version: "v3.21",
+					Version: "v3.22",
 				},
 				Features: map[string]bool{
 					kubermaticv1.ApiserverNetworkPolicy:    true,
@@ -608,7 +608,7 @@ func TestMutator(t *testing.T) {
 			}.Do(),
 			newCluster: rawClusterGen{
 				Name:    "foo",
-				Version: *semver.NewSemverOrDie("1.23"),
+				Version: *semver.NewSemverOrDie("1.26"),
 				CloudSpec: kubermaticv1.CloudSpec{
 					ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 					DatacenterName: "openstack-dc",
@@ -626,7 +626,7 @@ func TestMutator(t *testing.T) {
 				},
 				CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
 					Type:    kubermaticv1.CNIPluginTypeCanal,
-					Version: "v3.21",
+					Version: "v3.22",
 				},
 				Features: map[string]bool{
 					kubermaticv1.ApiserverNetworkPolicy:    true,
@@ -636,7 +636,7 @@ func TestMutator(t *testing.T) {
 			wantAllowed: true,
 			wantPatches: append(
 				defaultPatches,
-				jsonpatch.NewOperation("replace", "/spec/cniPlugin/version", "v3.22"),
+				jsonpatch.NewOperation("replace", "/spec/cniPlugin/version", "v3.23"),
 			),
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

Alters the existing canal auto update rule to enforce a working canal version (greater v3.22) on k8s 1.26 or higher. 


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12327
Backport of: https://github.com/kubermatic/kubermatic/pull/12347

**What type of PR is this?**


/kind chore
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Force update for canal below 3.22 on k8s version 1.26 and above.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
