### PR TITLE
Use root disk size while calculating resource quota for Openstack

### DIFF
--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -412,6 +412,15 @@ func getOpenstackResourceRequirements(ctx context.Context, userClient ctrlruntim
 		return nil, fmt.Errorf("failed to get the value of openstack \"flavorSize\" field: %w", err)
 	}
 
+	if rawConfig.RootDiskSizeGB != nil {
+		// Setting custom disk size
+		storageReq, err := resource.ParseQuantity(fmt.Sprintf("%dG", *rawConfig.RootDiskSizeGB))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse machine storage request to quantity: %w", err)
+		}
+		flavor.Storage = &storageReq
+	}
+
 	return NewResourceDetailsFromCapacity(flavor)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If user sets custom disk size for Openstack machines, it's ignored in resource quota calculation and default flavour's storage is used instead. This makes the calculation wrong and allows for allocating unlimited storage for Openstack machines.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix storage calculation for Openstack resource quota when custom disk size is provided.
```

**Documentation**:
```documentation
NONE
```
