### PR TITLE
Fix VCD CSI credentials secret for Kubernetes v1.24

### DIFF
--- a/addons/csi/vmware-cloud-director/vcloud-basic-auth.yaml
+++ b/addons/csi/vmware-cloud-director/vcloud-basic-auth.yaml
@@ -23,8 +23,11 @@ metadata:
   name: vcloud-basic-auth
   namespace: kube-system
 data:
+{{ if .Credentials.VMwareCloudDirector.Username }}
   username: {{ .Credentials.VMwareCloudDirector.Username | b64enc }}
   password: {{ .Credentials.VMwareCloudDirector.Password | b64enc }}
+{{ end }}
+{{ if .Credentials.VMwareCloudDirector.APIToken }}
   refreshToken: {{ .Credentials.VMwareCloudDirector.APIToken | b64enc }}
-
+{{ end }}
 {{ end }}

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -819,6 +819,7 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "VCD_PASSWORD", ValueFrom: refTo(VMwareCloudDirectorPassword)})
 		vars = append(vars, corev1.EnvVar{Name: "VCD_ORG", ValueFrom: refTo(VMwareCloudDirectorOrganization)})
 		vars = append(vars, corev1.EnvVar{Name: "VCD_VDC", ValueFrom: refTo(VMwareCloudDirectorVDC)})
+		vars = append(vars, corev1.EnvVar{Name: "VCD_API_TOKEN", ValueFrom: refTo(VMwareCloudDirectorAPIToken)})
 
 		if dc.Spec.VMwareCloudDirector.AllowInsecure {
 			vars = append(vars, corev1.EnvVar{Name: "VCD_ALLOW_UNVERIFIED_SSL", Value: "true"})


### PR DESCRIPTION
**What this PR does / why we need it**:
With Kubectl on v1.24, secret creation for VMware Cloud Director CSI driver is failing when the refresh token is empty.

```
error validating \“/tmp/cluster-w4n8fflbvq-csi.yaml\“: error validating data: unknown object type \“nil\” in Secret.data.refreshToken; if you choose to ignore these errors, turn validation off with --validate=false\n”}]}
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
