### PR TITLE
Fix Azure CCM 

### DIFF
--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -94,7 +94,7 @@ func azureDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDe
 					LivenessProbe: &corev1.Probe{
 						ProbeHandler: corev1.ProbeHandler{
 							HTTPGet: &corev1.HTTPGetAction{
-								Scheme: corev1.URISchemeHTTP,
+								Scheme: corev1.URISchemeHTTPS,
 								Path:   "/healthz",
 								Port:   intstr.FromInt(10258),
 							},

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10258
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10258
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10258
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -44,7 +44,7 @@ spec:
           httpGet:
             path: /healthz
             port: 10258
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 20
           periodSeconds: 10
           successThreshold: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
In #11969 I updated the CCM and since more recent versions of the Azure CCM do not have a `--port` flag anymore, I removed it and changed the liveness probe to use the `--secure-port`. But forgot to change to HTTPS, which makes the pod now crashloop accidentally.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
