### PR TITLE
Add Kubernetes 1.24.15, 1.25.11, 1.26.6 and 1.27.3

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -511,7 +511,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.26.4
+    default: v1.26.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -618,14 +618,17 @@ spec:
       - v1.24.9
       - v1.24.10
       - v1.24.13
+      - v1.24.15
       - v1.25.2
       - v1.25.4
       - v1.25.5
       - v1.25.6
       - v1.25.9
+      - v1.25.11
       - v1.26.1
       - v1.26.4
-      - v1.27.1
+      - v1.26.6
+      - v1.27.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -511,7 +511,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.26.4
+    default: v1.26.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -618,14 +618,17 @@ spec:
       - v1.24.9
       - v1.24.10
       - v1.24.13
+      - v1.24.15
       - v1.25.2
       - v1.25.4
       - v1.25.5
       - v1.25.6
       - v1.25.9
+      - v1.25.11
       - v1.26.1
       - v1.26.4
-      - v1.27.1
+      - v1.26.6
+      - v1.27.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -217,7 +217,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.26.4"),
+		Default: semver.NewSemverOrDie("v1.26.6"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -233,17 +233,20 @@ var (
 			newSemver("v1.24.9"),
 			newSemver("v1.24.10"),
 			newSemver("v1.24.13"),
+			newSemver("v1.24.15"),
 			// Kubernetes 1.25
 			newSemver("v1.25.2"),
 			newSemver("v1.25.4"),
 			newSemver("v1.25.5"),
 			newSemver("v1.25.6"),
 			newSemver("v1.25.9"),
+			newSemver("v1.25.11"),
 			// Kubernetes 1.26
 			newSemver("v1.26.1"),
 			newSemver("v1.26.4"),
+			newSemver("v1.26.6"),
 			// Kubernetes 1.27
-			newSemver("v1.27.1"),
+			newSemver("v1.27.3"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.24 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Kubernetes patch releases made available in June 2023. They fix three CVEs:

- CVE-2023-2431: Bypass of seccomp profile enforcement
- CVE-2023-2727: Bypassing policies imposed by the ImagePolicyWebhook admission plugin
- CVE-2023-2728: Bypassing enforce mountable secrets policy imposed by the ServiceAccount admission plugin

By default, users would need to use specific, somewhat obscure features in Kubernetes to be affected by those CVEs (e.g. the `localhost` seccomp profile type or the `kubernetes.io/enforce-mountable-secrets` annotation. Therefore we don't enforce auto-upgrades, but we make those releases available to ship all available security fixes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Part of https://github.com/kubermatic/release/issues/16

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Add support for Kubernetes 1.24.15, 1.25.11, 1.26.6 and 1.27.3 (fixing CVE-2023-2431, CVE-2023-2727 and CVE-2023-2728)
* Set default Kubernetes version to 1.26.6
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
