### PR TITLE
[release/v2.21] Add Kubernetes 1.24.15

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -553,6 +553,7 @@ spec:
       - v1.24.8
       - v1.24.9
       - v1.24.13
+      - v1.24.15
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -240,6 +240,7 @@ var (
 			newSemver("v1.24.8"),
 			newSemver("v1.24.9"),
 			newSemver("v1.24.13"),
+			newSemver("v1.24.15"),
 		},
 		Updates: []kubermaticv1.Update{
 			{


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of #12374. This PR adds Kubernetes patch releases made available in June 2023. They fix three CVEs:

- CVE-2023-2431: Bypass of seccomp profile enforcement
- CVE-2023-2727: Bypassing policies imposed by the ImagePolicyWebhook admission plugin
- CVE-2023-2728: Bypassing enforce mountable secrets policy imposed by the ServiceAccount admission plugin

By default, users would need to use specific, somewhat obscure features in Kubernetes to be affected by those CVEs (e.g. the `localhost` seccomp profile type or the `kubernetes.io/enforce-mountable-secrets` annotation. Therefore we don't enforce auto-upgrades, but we make those releases available to ship all available security fixes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Part of https://github.com/kubermatic/release/issues/16

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Kubernetes 1.24.15 (fixing CVE-2023-2431, CVE-2023-2727 and CVE-2023-2728)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
