### PR TITLE
Fix multi arch builds

### DIFF
--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -14,7 +14,7 @@
 
 FROM docker.io/golang:1.20.5 as builder
 
-# import the GOPROXY variable from Buildah via an arg and then use
+# import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on
 ARG GOPROXY=
 ARG GOCACHE=

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -14,7 +14,7 @@
 
 FROM docker.io/golang:1.20.5 as builder
 
-# import the GOPROXY variable from Buildah via an arg and then use
+# import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on
 ARG GOPROXY=
 ARG GOCACHE=

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -14,7 +14,7 @@
 
 FROM docker.io/golang:1.20.5 as builder
 
-# import the GOPROXY variable from Buildah via an arg and then use
+# import the GOPROXY variable via an arg and then use
 # that arg to define the environment variable later on
 ARG GOPROXY=
 ARG GOCACHE=

--- a/hack/ci/push-images.sh
+++ b/hack/ci/push-images.sh
@@ -40,13 +40,10 @@ elif [[ "$GIT_BRANCH" =~ release/v[0-9]+.* ]]; then
   TAGS="$TAGS $RELEASE_LATEST"
 fi
 
-apt install time -y
-
 if [ -z "${NO_DOCKER_IMAGES:-}" ]; then
   echodate "Logging into Quay"
   start_docker_daemon_ci
   retry 5 docker login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
-  retry 5 buildah login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
   echodate "Successfully logged into Quay"
 fi
 
@@ -98,7 +95,7 @@ if [ -z "${NO_DOCKER_IMAGES:-}" ]; then
 
   set -f # prevent globbing, do word splitting
   # shellcheck disable=SC2086
-  retry 5 ./hack/release-docker-images.sh $TAGS
+  retry 1 ./hack/release-docker-images.sh $TAGS
   echodate "Successfully finished building and pushing quay images"
   unset TEST_NAME
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR replaces our use of Buildah with Docker's buildx.

Since the update to Go 1.20.5, our postsubmit jobs failed to compile KKP:

* https://public-prow.loodse.com/view/gs/prow-dev-public-data/logs/post-kubermatic-push-ee-images-2.23/1671050850820165632

We traced this back to the Go update, as Go 1.20.3 worked just fine.

Ultimately it turns out that our Buildah version (1.19, i.e. aaaaancient) was simply not compatible anymore, but new Buildah releases (1.30 is current at the time of this PR) would work.

However, new Buildah releases are not in the apt repositories from the `golang` image we're using. We _could_ try to add Debian sid's repository, but then Buildah (1.28) is not installable anymore because of dependency issues. Likewise installing Buildah by just downloading a binary seems to be futile.

So in order to use a newer Buildah release, we would have to use the upstream `quay.io/buildah/buildah:1.30.0` image. This however goes against our CI concept, where we use one god image that has all the tools included. It would feel just weird to use that god image everywhere, but for the most important piece (actual releases) we rely on an otherwise never used image.

Additionally, if we went with dedicated build jobs that use the Buildah image, we suddenly could not compile KKP anymore, as the Buildah image of course does not contain Go. So all Dockerfiles in KKP would need to be redesigned to make use of multi stage builds and build the binaries inside containers.

However, as we already install Docker 23.0 into our build image, we can make use of its buildx builder, which is capable of producing multi architecture images just fine. And it does not require us to use a dedicated container image just for the release job.

There are 2 minor downsides:

1. buildx does not support mounting volumes into the containers during build, so we cannot inject our gocache anymore. However in the future we could make use of what I would call "manual build stage" approach to save a bit on compile time.
2. `docker buildx build --load` is not supported and if one does not `--load` or `--push` an image immediately, it cannot be tagged and pushed later. So our old "build all images first, then push them all" approach doesn't work anymore, as all the multi-arch images have to be pushed immediately. This can also be improved with a "manual build stage" approach.

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Use buildx instead of Buildah to create multi-architecture KKP container images.
```

**Documentation**:
```documentation
NONE
```
