### PR TITLE
fix possible npe if vsphere cloud spec is nil

### DIFF
--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -122,6 +122,10 @@ func (v *VSphere) InitializeCloudProvider(ctx context.Context, cluster *kubermat
 
 // DefaultCloudSpec adds defaults to the cloud spec.
 func (v *VSphere) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec) error {
+	if spec.Cloud.VSphere == nil {
+		return errors.New("no vSphere cloud spec found")
+	}
+
 	if spec.Cloud.VSphere.Tags == nil {
 		if v.dc.DefaultTagCategoryID != "" {
 			spec.Cloud.VSphere.Tags = &kubermaticv1.VSphereTag{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a possible npe if the vsphere cloud spec is nil.

```
2023/06/19 13:20:10 http: panic serving 172.27.0.5:59280: runtime error: invalid memory address or nil pointer dereference
goroutine 476943 [running]:
net/http.(*conn).serve.func1()
	net/http/server.go:1854 +0xbf
panic({0x3a36640, 0x69e6450})
	runtime/panic.go:890 +0x263
k8c.io/kubermatic/v2/pkg/provider/cloud/vsphere.(*VSphere).DefaultCloudSpec(0x3ab8020?, {0xc000c9cab0?, 0x3f3f040?}, 0xc00001b800?)
	k8c.io/kubermatic/v2/pkg/provider/cloud/vsphere/provider.go:125 +0x1f
k8c.io/kubermatic/v2/pkg/defaulting.DefaultClusterSpec({0x48caf40, 0xc000109040}, 0xc000c9c908, 0x0?, 0xc000ca4f00?, 0xc000cd2300?, {0x48cd680, 0xc000a3e9a0})
	k8c.io/kubermatic/v2/pkg/defaulting/cluster.go:78 +0x43d
k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation.(*Mutator).Mutate(0xc0007c8a28, {0x48caf40, 0xc000109040}, 0x0, 0xc000c9c800)
	k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation/mutator.go:78 +0x134
k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation.(*AdmissionHandler).Handle(_, {_, _}, {{{0xc000aec480, 0x24}, {{0xc0013d1578, 0x11}, {0xc000ae8c80, 0x2}, {0xc000ae8c82, ...}}, ...}})
	k8c.io/kubermatic/v2/pkg/webhook/cluster/mutation/handler.go:103 +0x525
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).Handle(_, {_, _}, {{{0xc000aec480, 0x24}, {{0xc0013d1578, 0x11}, {0xc000ae8c80, 0x2}, {0xc000ae8c82, ...}}, ...}})
	sigs.k8s.io/controller-runtime@v0.14.6/pkg/webhook/admission/webhook.go:169 +0xfd
sigs.k8s.io/controller-runtime/pkg/webhook/admission.(*Webhook).ServeHTTP(0xc000b3a980, {0x7f906705daa8?, 0xc000109090}, 0xc000eb5200)
	sigs.k8s.io/controller-runtime@v0.14.6/pkg/webhook/admission/http.go:98 +0xed2
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerInFlight.func1({0x7f906705daa8, 0xc000109090}, 0x48c9d00?)
	github.com/prometheus/client_golang@v1.15.0/prometheus/promhttp/instrument_server.go:40 +0xd4
net/http.HandlerFunc.ServeHTTP(0x48c9d20?, {0x7f906705daa8?, 0xc000109090?}, 0xc0007c9828?)
	net/http/server.go:2122 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1({0x48c9d20?, 0xc000cdb880?}, 0xc000eb5200)
	github.com/prometheus/client_golang@v1.15.0/prometheus/promhttp/instrument_server.go:127 +0xc5
net/http.HandlerFunc.ServeHTTP(0x72fdc5?, {0x48c9d20?, 0xc000cdb880?}, 0x40dc2a?)
	net/http/server.go:2122 +0x2f
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2({0x48c9d20, 0xc000cdb880}, 0xc000eb5200)
	github.com/prometheus/client_golang@v1.15.0/prometheus/promhttp/instrument_server.go:89 +0xc7
net/http.HandlerFunc.ServeHTTP(0xc000cdb880?, {0x48c9d20?, 0xc000cdb880?}, 0x418b761?)
	net/http/server.go:2122 +0x2f
net/http.(*ServeMux).ServeHTTP(0xc0006746ea?, {0x48c9d20, 0xc000cdb880}, 0xc000eb5200)
	net/http/server.go:2500 +0x149
net/http.serverHandler.ServeHTTP({0x48b9de0?}, {0x48c9d20, 0xc000cdb880}, 0xc000eb5200)
	net/http/server.go:2936 +0x316
net/http.(*conn).serve(0xc00012bb00, {0x48cafe8, 0xc00097cb70})
	net/http/server.go:1995 +0x612
created by net/http.(*Server).Serve
	net/http/server.go:3089 +0x5ed
```


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

/kind bug

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
