### PR TITLE
Allow antiAffinity values to be merged when needed

### DIFF
--- a/pkg/resources/antiaffinity.go
+++ b/pkg/resources/antiaffinity.go
@@ -35,11 +35,8 @@ func FailureDomainZoneAntiAffinity(app string, antiAffinityType kubermaticv1.Ant
 }
 
 func MergeAffinities(a *corev1.Affinity, b *corev1.Affinity) *corev1.Affinity {
-	mergedAffinity := &corev1.Affinity{
-		PodAntiAffinity: &corev1.PodAntiAffinity{},
-	}
 	if a == nil && b == nil {
-		return mergedAffinity
+		return a
 	}
 	if a == nil {
 		return b
@@ -47,15 +44,15 @@ func MergeAffinities(a *corev1.Affinity, b *corev1.Affinity) *corev1.Affinity {
 	if b == nil {
 		return a
 	}
-	mergedAffinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+	a.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
 		a.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution,
 		b.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution...,
 	)
-	mergedAffinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
+	a.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = append(
 		a.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution,
 		b.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution...,
 	)
-	return mergedAffinity
+	return a
 }
 
 func antiAffinity(app string, antiAffinity kubermaticv1.AntiAffinityType, topologyKey string) *corev1.Affinity {

--- a/pkg/resources/antiaffinity.go
+++ b/pkg/resources/antiaffinity.go
@@ -62,14 +62,14 @@ func antiAffinity(app string, antiAffinity kubermaticv1.AntiAffinityType, topolo
 	if antiAffinity == kubermaticv1.AntiAffinityTypeRequired {
 		return &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: podAffinityTerm(app, TopologyKeyZone),
+				RequiredDuringSchedulingIgnoredDuringExecution: podAffinityTerm(app, topologyKey),
 			},
 		}
 	}
 
 	return &corev1.Affinity{
 		PodAntiAffinity: &corev1.PodAntiAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm(app, TopologyKeyZone),
+			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm(app, topologyKey),
 		},
 	}
 }

--- a/pkg/resources/antiaffinity_test.go
+++ b/pkg/resources/antiaffinity_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resources
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMerge(t *testing.T) {
+	a := &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution:  podAffinityTerm("app", "zone"),
+			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm("app", "zone"),
+		},
+	}
+	b := &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution:  podAffinityTerm("app", "zone"),
+			PreferredDuringSchedulingIgnoredDuringExecution: weightedPodAffinityTerm("app", "zone"),
+		},
+	}
+	c := MergeAffinities(a, b)
+
+	if len(c.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution) != 2 {
+		t.Errorf("Merge failed, expected length of PreferredDuringSchedulingIgnoredDuringExecution to be 2, got %d", len(a.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution))
+	}
+	if len(c.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution) != 2 {
+		t.Errorf("Merge failed, expected length of RequiredDuringSchedulingIgnoredDuringExecution to be 2, got %d", len(a.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	}
+}

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -314,7 +314,7 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 			if data.SupportsFailureDomainZoneAntiAffinity() {
 				zoneAntiAffinityType := data.Cluster().Spec.ComponentsOverride.Etcd.ZoneAntiAffinity
 				failureDomainZoneAntiAffinity := resources.FailureDomainZoneAntiAffinity(resources.EtcdStatefulSetName, zoneAntiAffinityType)
-				set.Spec.Template.Spec.Affinity = resources.MergeAffinities(failureDomainZoneAntiAffinity, set.Spec.Template.Spec.Affinity)
+				set.Spec.Template.Spec.Affinity = resources.MergeAffinities(set.Spec.Template.Spec.Affinity, failureDomainZoneAntiAffinity)
 			}
 
 			set.Spec.Template.Spec.Volumes = volumes

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -308,12 +308,13 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			antiAffinityType := data.Cluster().Spec.ComponentsOverride.Etcd.HostAntiAffinity
-			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName, antiAffinityType)
+			hostAntiAffinityType := data.Cluster().Spec.ComponentsOverride.Etcd.HostAntiAffinity
+			set.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(resources.EtcdStatefulSetName, hostAntiAffinityType)
+
 			if data.SupportsFailureDomainZoneAntiAffinity() {
-				antiAffinities := set.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-				antiAffinities = append(antiAffinities, resources.FailureDomainZoneAntiAffinity(resources.EtcdStatefulSetName))
-				set.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = antiAffinities
+				zoneAntiAffinityType := data.Cluster().Spec.ComponentsOverride.Etcd.ZoneAntiAffinity
+				failureDomainZoneAntiAffinity := resources.FailureDomainZoneAntiAffinity(resources.EtcdStatefulSetName, zoneAntiAffinityType)
+				set.Spec.Template.Spec.Affinity = resources.MergeAffinities(failureDomainZoneAntiAffinity, set.Spec.Template.Spec.Affinity)
 			}
 
 			set.Spec.Template.Spec.Volumes = volumes

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -308,9 +308,8 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 
 			d.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(envoyAppLabelValue, kubermaticv1.AntiAffinityTypePreferred)
 			if data.SupportsFailureDomainZoneAntiAffinity() {
-				antiAffinities := d.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
-				antiAffinities = append(antiAffinities, resources.FailureDomainZoneAntiAffinity(envoyAppLabelValue))
-				d.Spec.Template.Spec.Affinity.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution = antiAffinities
+				failureDomainZoneAntiAffinity := resources.FailureDomainZoneAntiAffinity(envoyAppLabelValue, kubermaticv1.AntiAffinityTypePreferred)
+				d.Spec.Template.Spec.Affinity = resources.MergeAffinities(d.Spec.Template.Spec.Affinity, failureDomainZoneAntiAffinity)
 			}
 
 			d.Spec.Template.Spec.Volumes = []corev1.Volume{{


### PR DESCRIPTION
**What this PR does / why we need it**:
Testing ticket https://github.com/kubermatic/kubermatic/issues/12326 failed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12326 

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
* I consolidated the code around affinity-values. During that I streamlined the `weight` to 100 (nodeport had it at 10), so I don't need to add an extra param for it: https://github.com/kubermatic/kubermatic/compare/main...hc2p:kubermatic:fix-etcd-antiaffinity?expand=1#diff-bf528870f432c8fca7d7b9e4bde6ea3cd469e0cc02ccde6b2b542f04bcbd088cL206

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
