### PR TITLE
use bookworm-based build image

### DIFF
--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -155,7 +155,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -578,7 +578,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -616,7 +616,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -289,7 +289,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -114,7 +114,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -156,7 +156,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: "ce"
@@ -200,7 +200,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -69,7 +69,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-8
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+        - image: quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-7
+FROM quay.io/kubermatic/build:go-1.20-node-18-kind-0.18-8
 LABEL maintainer="support@kubermatic.com"
 
 # envtest binaries are not available for all k8s patch releases, so beware when updating

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-7 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-8 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-7 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-8 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-7 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.20-node-18-8 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since docker library decided to randomly sneakingly switch go 1.20.5 from bullseye to bookworm, it wasn't clear anymore what the previous build image was even based on. _We_ thought bookworm, but nope, bullseye.

To fix this we released a new revision of the build image and this PR adjusts the references.

**What type of PR is this?**
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
