### PR TITLE
installer: disable network policies in local kubevirt seed

### DIFF
--- a/cmd/kubermatic-installer/local_kind_resources.go
+++ b/cmd/kubermatic-installer/local_kind_resources.go
@@ -171,7 +171,8 @@ var kindLocalSeed = kubermaticv1.Seed{
 				Location: "Hamburg", // TODO: some clever heuristic or geolocation service?
 				Spec: kubermaticv1.DatacenterSpec{
 					Kubevirt: &kubermaticv1.DatacenterSpecKubevirt{
-						DNSPolicy: "ClusterFirst",
+						EnableDefaultNetworkPolicies: ptr(false),
+						DNSPolicy:                    "ClusterFirst",
 						Images: kubermaticv1.KubeVirtImageSources{
 							HTTP: &kubermaticv1.KubeVirtHTTPSource{
 								OperatingSystems: map[providerconfig.OperatingSystem]kubermaticv1.OSVersions{


### PR DESCRIPTION
**What this PR does / why we need it**:
Somewhere between https://github.com/kubermatic/kubermatic/releases/tag/v2.23.0-beta.2 and https://github.com/kubermatic/kubermatic/releases/tag/v2.23.0-beta.1 the `kubermatic-installer local kind` command got broken (possibly when https://github.com/kubermatic/kubermatic/pull/12329 was introduced).
```
kubermatic                 kubermatic-seed-controller-manager-68bc64897f-h2r5x     0/1     CrashLoopBackOff   2 (21s ago)   26m
```
```
panic: runtime error: invalid memory address or nil pointer dereference

goroutine 1026 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        sigs.k8s.io/controller-runtime@v0.14.6/pkg/internal/controller/controller.go:119 +0x1fa
k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt.reconcileClusterIsolationNetworkPolicy({0x4cb8578, 0xc00156d2c0}, 0xc0023a6000, 0x12?, {0x4cceb90, 0xc000c08540})
        k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt/network_policy.go:167 +0x60
...
```
The reason is that the `kubermatic-installer local` command doesn't set any DNS nameservers which is fine for the scope of the interest of local KKP installation

https://github.com/kubermatic/kubermatic/blob/9b6e6341cb8641ea9cdcc3e9533e4e0a2157a545/pkg/provider/cloud/kubevirt/network_policy.go#L167

Easy remediation is to disable default network policies
```
$ k patch -n kubermatic seed kubermatic --type=merge --patch='{"spec":{"datacenters":{"kubevirt":{"spec":{"kubevirt":{"enableDefaultNetworkPolicies":false}}}}}}'
```
For the local environment, network policies are not critical so I would like to propose disabling them by default for now.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
n/a

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
