### PR TITLE
force canal update at k8s 1.25

### DIFF
--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -22,7 +22,6 @@ import (
 	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/cni"
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -114,21 +113,6 @@ func MutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, config *kubermat
 	}
 
 	if newCluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal {
-		// This part handles CNI upgrade from unsupported CNI version to the default Canal version.
-		// This upgrade is necessary for k8s versions >= 1.22, where v1beta1 CRDs used in old Canal version (v3.8)
-		// are not supported anymore.
-		if newCluster.Spec.CNIPlugin.Version == cni.CanalCNILastUnspecifiedVersion {
-			upgradeConstraint, err := semverlib.NewConstraint(">= 1.22")
-			if err != nil {
-				return field.InternalError(nil, fmt.Errorf("parsing CNI upgrade constraint failed: %w", err))
-			}
-			if curVersion.String() != "" && upgradeConstraint.Check(curVersion.Semver()) {
-				newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
-					Type:    kubermaticv1.CNIPluginTypeCanal,
-					Version: cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal),
-				}
-			}
-		}
 
 		// This part handles Canal version upgrade for clusters with Kubernetes version 1.26 and higher,
 		// where the minimal Canal version is v3.23.

--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -140,11 +140,11 @@ func MutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, config *kubermat
 		if err != nil {
 			return field.InternalError(nil, fmt.Errorf("semver constraint parsing failed: %w", err))
 		}
-		equalOrHigherThan126, err := semverlib.NewConstraint(">= 1.26")
+		equalOrHigherThan125, err := semverlib.NewConstraint(">= 1.25")
 		if err != nil {
 			return field.InternalError(nil, fmt.Errorf("semver constraint parsing failed: %w", err))
 		}
-		if lowerThan323.Check(cniVersion) && curVersion.String() != "" && equalOrHigherThan126.Check(curVersion.Semver()) {
+		if lowerThan323.Check(cniVersion) && newCluster.Spec.Version.String() != "" && equalOrHigherThan125.Check(newCluster.Spec.Version.Semver()) {
 			newCluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{
 				Type:    kubermaticv1.CNIPluginTypeCanal,
 				Version: "v3.23",

--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -108,12 +108,11 @@ func MutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, config *kubermat
 	// just because spec.Version might say 1.23 doesn't say that the cluster is already on 1.23,
 	// so for all feature toggles and migrations we should base this on the actual, current apiserver
 	curVersion := newCluster.Status.Versions.ControlPlane
-	if curVersion == "" {
+	if curVersion.String() == "" {
 		curVersion = newCluster.Spec.Version
 	}
 
 	if newCluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal {
-
 		// This part handles Canal version upgrade for clusters with Kubernetes version 1.25 and higher,
 		// where the minimal Canal version is v3.23. We need to check the target cluster version here to ensure,
 		// the upgrade happens at the same time.

--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -114,8 +114,9 @@ func MutateUpdate(oldCluster, newCluster *kubermaticv1.Cluster, config *kubermat
 
 	if newCluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCanal {
 
-		// This part handles Canal version upgrade for clusters with Kubernetes version 1.26 and higher,
-		// where the minimal Canal version is v3.23.
+		// This part handles Canal version upgrade for clusters with Kubernetes version 1.25 and higher,
+		// where the minimal Canal version is v3.23. We need to check the target cluster version here to ensure,
+		// the upgrade happens at the same time.
 		cniVersion, err := semverlib.NewVersion(newCluster.Spec.CNIPlugin.Version)
 		if err != nil {
 			return field.Invalid(field.NewPath("spec", "cniPlugin", "version"), newCluster.Spec.CNIPlugin.Version, err.Error())

--- a/pkg/webhook/cluster/mutation/mutator_test.go
+++ b/pkg/webhook/cluster/mutation/mutator_test.go
@@ -580,10 +580,10 @@ func TestMutator(t *testing.T) {
 			),
 		},
 		{
-			name: "CNI plugin version bump to v3.23 on k8s version upgrade to 1.26",
+			name: "CNI plugin version bump to v3.23 on k8s version upgrade to 1.25",
 			oldCluster: rawClusterGen{
 				Name:    "foo",
-				Version: *semver.NewSemverOrDie("1.25"),
+				Version: *semver.NewSemverOrDie("1.24"),
 				CloudSpec: kubermaticv1.CloudSpec{
 					ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 					DatacenterName: "openstack-dc",
@@ -608,7 +608,7 @@ func TestMutator(t *testing.T) {
 			}.Do(),
 			newCluster: rawClusterGen{
 				Name:    "foo",
-				Version: *semver.NewSemverOrDie("1.26"),
+				Version: *semver.NewSemverOrDie("1.25"),
 				CloudSpec: kubermaticv1.CloudSpec{
 					ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
 					DatacenterName: "openstack-dc",

--- a/pkg/webhook/cluster/mutation/mutator_test.go
+++ b/pkg/webhook/cluster/mutation/mutator_test.go
@@ -520,66 +520,6 @@ func TestMutator(t *testing.T) {
 			),
 		},
 		{
-			name: "Unsupported CNI plugin version bump on k8s version upgrade",
-			oldCluster: rawClusterGen{
-				Name:    "foo",
-				Version: *semver.NewSemverOrDie("1.23"),
-				CloudSpec: kubermaticv1.CloudSpec{
-					ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
-					DatacenterName: "openstack-dc",
-					Openstack:      &kubermaticv1.OpenstackCloudSpec{},
-				},
-				ExternalCloudProvider: true,
-				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
-					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
-					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
-					DNSDomain:                "example.local",
-					ProxyMode:                resources.IPTablesProxyMode,
-					NodeLocalDNSCacheEnabled: pointer.Bool(true),
-				},
-				CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
-					Type:    kubermaticv1.CNIPluginTypeCanal,
-					Version: cni.CanalCNILastUnspecifiedVersion,
-				},
-				Features: map[string]bool{
-					kubermaticv1.ApiserverNetworkPolicy:    true,
-					kubermaticv1.KubeSystemNetworkPolicies: true,
-				},
-			}.Do(),
-			newCluster: rawClusterGen{
-				Name:    "foo",
-				Version: *semver.NewSemverOrDie("1.24"),
-				CloudSpec: kubermaticv1.CloudSpec{
-					ProviderName:   string(kubermaticv1.OpenstackCloudProvider),
-					DatacenterName: "openstack-dc",
-					Openstack:      &kubermaticv1.OpenstackCloudSpec{},
-				},
-				ExternalCloudProvider: true,
-				NetworkConfig: kubermaticv1.ClusterNetworkingConfig{
-					IPFamily:                 kubermaticv1.IPFamilyIPv4,
-					Pods:                     kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.241.0.0/16"}},
-					Services:                 kubermaticv1.NetworkRanges{CIDRBlocks: []string{"10.240.32.0/20"}},
-					NodeCIDRMaskSizeIPv4:     pointer.Int32(24),
-					DNSDomain:                "example.local",
-					ProxyMode:                resources.IPTablesProxyMode,
-					NodeLocalDNSCacheEnabled: pointer.Bool(true),
-				},
-				CNIPluginSpec: &kubermaticv1.CNIPluginSettings{
-					Type:    kubermaticv1.CNIPluginTypeCanal,
-					Version: cni.CanalCNILastUnspecifiedVersion,
-				},
-				Features: map[string]bool{
-					kubermaticv1.ApiserverNetworkPolicy:    true,
-					kubermaticv1.KubeSystemNetworkPolicies: true,
-				},
-			}.Do(),
-			wantAllowed: true,
-			wantPatches: append(
-				defaultPatches,
-				jsonpatch.NewOperation("replace", "/spec/cniPlugin/version", cni.GetDefaultCNIPluginVersion(kubermaticv1.CNIPluginTypeCanal)),
-			),
-		},
-		{
 			name: "CNI plugin version bump to v3.23 on k8s version upgrade to 1.25",
 			oldCluster: rawClusterGen{
 				Name:    "foo",


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to force update canal one release earlier because of the deprecation of the PDB.

In Addition we check the spec.Version instead the control plane version to ensure the cni upgrade happens at the same time.

Removes code that force updates canal for k8s version 1.22 and higher. At this time this should have happened already. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

/kind bug

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Force update canal below 3.22 on k8s version 1.25 and above.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
