### PR TITLE
VCD: mark apiToken as an optional secret mount

### DIFF
--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -819,7 +819,7 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 		vars = append(vars, corev1.EnvVar{Name: "VCD_PASSWORD", ValueFrom: refTo(VMwareCloudDirectorPassword)})
 		vars = append(vars, corev1.EnvVar{Name: "VCD_ORG", ValueFrom: refTo(VMwareCloudDirectorOrganization)})
 		vars = append(vars, corev1.EnvVar{Name: "VCD_VDC", ValueFrom: refTo(VMwareCloudDirectorVDC)})
-		vars = append(vars, corev1.EnvVar{Name: "VCD_API_TOKEN", ValueFrom: refTo(VMwareCloudDirectorAPIToken)})
+		vars = append(vars, corev1.EnvVar{Name: "VCD_API_TOKEN", ValueFrom: optionalRefTo(VMwareCloudDirectorAPIToken)})
 
 		if dc.Spec.VMwareCloudDirector.AllowInsecure {
 			vars = append(vars, corev1.EnvVar{Name: "VCD_ALLOW_UNVERIFIED_SSL", Value: "true"})


### PR DESCRIPTION
**What this PR does / why we need it**:
We introduced `apiToken` support for VMware Cloud Director with https://github.com/kubermatic/kubermatic/pull/12124. This adds a new key `apiToken` for the `cloud-credentials` secret for the clusters on VCD. For new clusters created after this change was merged, everything works fine. Although for existing clusters that were created before merging this change(read KKP 2.22), this key is missing from the secrets causing its consumers; OSM, MC, and user cluster controller pods to fail.

This PR circumvents it by making this key an optional secret mount for the affected pods. For more details, please go through https://github.com/kubermatic/kubermatic/issues/12401

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12401

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
