### PR TITLE
installer: local command usability improvements

### DIFF
--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -53,8 +53,11 @@ import (
 )
 
 const (
-	nip   = "nip.io"
-	sslip = "sslip.io"
+	nip                  = "nip.io"
+	sslip                = "sslip.io"
+	kkpDefaultLogin      = "kubermatic@example.com"
+	kkpDefaultPassword   = "password"
+	localKindTeardownCmd = "kind delete cluster -n kkp-cluster"
 )
 
 var (
@@ -342,7 +345,11 @@ func localKindFunc(logger *logrus.Logger, opt LocalOptions) cobraFuncE {
 		}
 		installKubevirt(logger, dir, helmClient, opt)
 		endpoint := installKubermatic(logger, dir, kubeClient, helmClient, opt)
+		logger.Infoln()
 		logger.Infof("KKP installed successfully, login at http://%v", endpoint)
+		logger.Infof("  Default login:    %v", kkpDefaultLogin)
+		logger.Infof("  Default password: %v\n", kkpDefaultPassword)
+		logger.Infof("You can tear down the environment by %q", localKindTeardownCmd)
 		return nil
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing minor shortcomings discussed in https://github.com/kubermatic/kubermatic/issues/12340
* adding default login credentials for the KKP dashboard
* adding environment teardown instructions
* enhancing the kind version check for semver match

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
example of failed kind version check
```
$ ./kubermatic-installer local kind
FATA[0000] please update your 'kind' 0.16.0, requires at least 0.17.0
```

example of the teardown and login instructions
```
$ ./kubermatic-installer local kind
...
INFO[0357] KKP installed successfully, login at http://10.0.0.12.nip.io
INFO[0357]   Default login:    kubermatic@example.com
INFO[0357]   Default password: password
INFO[0357] You can tear down the environment by "kind delete cluster -n kkp-cluster"
```

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
