### PR TITLE
nginx-ingress-controller: set memory limits to 1Gi

### DIFF
--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -480,7 +480,7 @@ spec:
           resources: 
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1Gi
             requests:
               cpu: 50m
               memory: 128Mi

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -480,7 +480,7 @@ spec:
           resources: 
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1Gi
             requests:
               cpu: 50m
               memory: 128Mi

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -480,7 +480,7 @@ spec:
           resources: 
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1Gi
             requests:
               cpu: 50m
               memory: 128Mi

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -29,7 +29,7 @@ nginx:
         memory: 128Mi
       limits:
         cpu: 500m
-        memory: 512Mi
+        memory: 1Gi
     nodeSelector: {}
     affinity:
       nodeAffinity:


### PR DESCRIPTION
**What this PR does / why we need it**:
As discovered during testing: https://github.com/kubermatic/kubermatic/issues/12340#issuecomment-1604016505, the nginx-ingress-controller can become quite memory hungry during the local KKP installation. This PR would like to propose setting the memory limit from the default 512Mi to 1Gi.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
n/a

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
nginx-ingress-controller: set default memory limit to 1Gi
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
