### PR TITLE
fix Blackbox exporter scraping

### DIFF
--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -72,7 +72,7 @@ prometheus:
     # Enable Blackbox Exporter scraping rules, this requires to deploy blackbox exporter in the cluster.
     blackBoxExporter:
       enabled: false
-      #url: blackbox-exporter:9115
+      url: blackbox-exporter:9115
     # Enable if minio is running with tls in the same cluster
     minio:
       tls:


### PR DESCRIPTION
**What this PR does / why we need it**:
In our [documentation](https://docs.kubermatic.com/kubermatic/v2.22/tutorials-howtos/monitoring-logging-alerting/master-seed/installation/) we stated that blackbox exporter:

> prometheus.blackboxExporter.enabled is used to enable integration between Prometheus and Blackbox Exporter, used for monitoring of API endpoints of user clusters created on the seed. prometheus.blackboxExporter.url should be adjusted accordingly (default value would be blackbox-exporter:9115)

the default value is not set cause the `url` is commented out.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix default url configuration of Blacbox exporter
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
