### PR TITLE
Allow to specific RHEL subscription details in conformance-tester

### DIFF
--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -463,7 +463,7 @@ func (r *TestRunner) executeTests(
 	// Packet is slower at provisioning the instances, presumably because those are actual
 	// physical hosts.
 	if cluster.Spec.Cloud.Packet != nil {
-		overallTimeout += 5 * time.Minute
+		overallTimeout += 45 * time.Minute
 	}
 
 	var timeoutRemaining time.Duration
@@ -584,9 +584,13 @@ func (r *TestRunner) testCluster(
 		log.Errorf("Failed to verify that user cluster RBAC controller work: %v", err)
 	}
 
+	// Metrics availability can take forever so for these tests we need
+	// to try for longer than normal.
+	maxMetrixAttempts := 15
+
 	// Do prometheus metrics available test
 	if err := util.JUnitWrapper("[KKP] Test prometheus metrics availability", report, func() error {
-		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
+		return util.RetryN(5*time.Second, maxMetrixAttempts, func(attempt int) error {
 			return tests.TestUserClusterMetrics(ctx, log, r.opts, cluster, r.opts.SeedClusterClient)
 		})
 	}); err != nil {
@@ -595,7 +599,7 @@ func (r *TestRunner) testCluster(
 
 	// Do pod and node metrics availability test
 	if err := util.JUnitWrapper("[KKP] Test pod and node metrics availability", report, func() error {
-		return util.RetryN(5*time.Second, maxTestAttempts, func(attempt int) error {
+		return util.RetryN(5*time.Second, maxMetrixAttempts, func(attempt int) error {
 			return tests.TestUserClusterPodAndNodeMetrics(ctx, log, r.opts, cluster, userClusterClient)
 		})
 	}); err != nil {

--- a/cmd/conformance-tester/pkg/scenarios/alibaba.go
+++ b/cmd/conformance-tester/pkg/scenarios/alibaba.go
@@ -51,7 +51,7 @@ func (s *alibabaScenario) MachineDeployments(_ context.Context, replicas int, se
 		WithVSwitchID("vsw-gw8g8mn4ohmj483hsylmn").
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, replicas, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, replicas, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/anexia.go
+++ b/cmd/conformance-tester/pkg/scenarios/anexia.go
@@ -71,7 +71,7 @@ func (s *anexiaScenario) MachineDeployments(_ context.Context, num int, secrets 
 		WithVlanID(secrets.Anexia.VlanID).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -109,7 +109,7 @@ func (s *awsScenario) MachineDeployments(ctx context.Context, num int, secrets t
 			WithSpotInstanceMaxPrice("0.5").
 			Build()
 
-		md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+		md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/conformance-tester/pkg/scenarios/azure.go
+++ b/cmd/conformance-tester/pkg/scenarios/azure.go
@@ -55,7 +55,7 @@ func (s *azureScenario) MachineDeployments(_ context.Context, num int, secrets t
 		WithVMSize(azureVMSize).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/digitalocean.go
+++ b/cmd/conformance-tester/pkg/scenarios/digitalocean.go
@@ -73,7 +73,7 @@ func (s *digitaloceanScenario) MachineDeployments(_ context.Context, num int, se
 		WithSize(dropletSize).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/google.go
+++ b/cmd/conformance-tester/pkg/scenarios/google.go
@@ -67,7 +67,7 @@ func (s *googleScenario) MachineDeployments(_ context.Context, num int, secrets 
 		WithPreemptible(false).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/hetzner.go
+++ b/cmd/conformance-tester/pkg/scenarios/hetzner.go
@@ -73,7 +73,7 @@ func (s *hetznerScenario) MachineDeployments(_ context.Context, num int, secrets
 		WithServerType(hetznerServerType).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -73,7 +73,7 @@ func (s *kubevirtScenario) MachineDeployments(_ context.Context, num int, secret
 		WithPrimaryDiskStorageClassName(kubevirtStorageClassName).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/nutanix.go
+++ b/cmd/conformance-tester/pkg/scenarios/nutanix.go
@@ -65,7 +65,7 @@ func (s *nutanixScenario) MachineDeployments(_ context.Context, num int, secrets
 		WithDiskSize(nutanixDiskSize).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/openstack.go
+++ b/cmd/conformance-tester/pkg/scenarios/openstack.go
@@ -62,7 +62,7 @@ func (s *openStackScenario) MachineDeployments(_ context.Context, num int, secre
 		WithInstanceReadyCheckTimeout(openStackInstanceReadyCheckTimeout).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/packet.go
+++ b/cmd/conformance-tester/pkg/scenarios/packet.go
@@ -75,7 +75,7 @@ func (s *packetScenario) MachineDeployments(_ context.Context, num int, secrets 
 		WithInstanceType(packetInstanceType).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -85,7 +85,7 @@ func (s *vmwareCloudDirectorScenario) MachineDeployments(_ context.Context, num 
 		WithIPAllocationMode(vmwareCloudDirectorIPAllocationMode).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/scenarios/vsphere.go
+++ b/cmd/conformance-tester/pkg/scenarios/vsphere.go
@@ -66,7 +66,7 @@ func (s *vSphereScenario) MachineDeployments(_ context.Context, num int, secrets
 		WithDiskSizeGB(10).
 		Build()
 
-	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys)
+	md, err := s.createMachineDeployment(cluster, num, cloudProviderSpec, sshPubKeys, secrets)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/conformance-tester/pkg/types/secrets.go
+++ b/cmd/conformance-tester/pkg/types/secrets.go
@@ -107,6 +107,11 @@ type Secrets struct {
 		VDC           string
 		OVDCNetwork   string
 	}
+	RHEL struct {
+		SubscriptionUser     string
+		SubscriptionPassword string
+		OfflineToken         string
+	}
 }
 
 var (
@@ -167,6 +172,9 @@ func (s *Secrets) AddFlags() {
 	flag.StringVar(&s.VMwareCloudDirector.VDC, "vmware-cloud-director-vdc", "", "VMware Cloud Director: Organizational VDC")
 	flag.StringVar(&s.VMwareCloudDirector.OVDCNetwork, "vmware-cloud-director-ovdc-network", "", "VMware Cloud Director: Organizational VDC network name")
 	flag.StringVar(&s.VMwareCloudDirector.KKPDatacenter, "vmware-cloud-director-kkp-datacenter", "", "VMware Cloud Director: KKP datacenter to use")
+	flag.StringVar(&s.RHEL.SubscriptionUser, "rhel-subscription-user", "", "RedHat Enterprise subscription user")
+	flag.StringVar(&s.RHEL.SubscriptionPassword, "rhel-subscription-password", "", "RedHat Enterprise subscription password")
+	flag.StringVar(&s.RHEL.OfflineToken, "rhel-offline-token", "", "RedHat Enterprise offlien token")
 }
 
 func (s *Secrets) ParseFlags() error {

--- a/pkg/machine/operatingsystem/builders.go
+++ b/pkg/machine/operatingsystem/builders.go
@@ -116,6 +116,14 @@ func (b *RHELSpecBuilder) WithDistUpgradeOnBoot(enable bool) *RHELSpecBuilder {
 	return b
 }
 
+func (b *RHELSpecBuilder) SetSubscriptionDetails(username, password, offlineToken string) *RHELSpecBuilder {
+	b.RHELSubscriptionManagerUser = username
+	b.RHELSubscriptionManagerPassword = password
+	b.RHSMOfflineToken = offlineToken
+	b.AttachSubscription = username != "" && password != ""
+	return b
+}
+
 func (b *RHELSpecBuilder) WithPatch(patch func(*RHELSpecBuilder)) *RHELSpecBuilder {
 	patch(b)
 	return b


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds CLI flags to specify the RHEL subscription details in the conformance-tester. These details are then placed into the generated MachineSpecs.

Code like this must have existed for previous releases, but was never merged into the mainline of KKP. The script I was using to run the mass-conformance-tests before new KKP minor releases already had a 

```
  EXTRA_FLAGS+=(
    -rhel-subscription-user "$rhelSubscriptionUser"
    -rhel-subscription-password "$rhelSubscriptionPassword"
    -rhel-offline-token "$rhelOfflineToken"
  )
```

block, yet no matter how hard to grepped and searched and git logged, these flags never existed in KKP. They must have only been in my local working copy and then I must have removed the branch by accident at some point.

This PR brings the code back, thereby fixing #12352 and #12354.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
