### PR TITLE
fix always true if statement in kubevirt network policies

### DIFF
--- a/pkg/provider/cloud/kubevirt/network_policy.go
+++ b/pkg/provider/cloud/kubevirt/network_policy.go
@@ -40,7 +40,7 @@ func clusterIsolationNetworkPolicyReconciler(clusterIp string, nameservers []str
 
 	// This address might only be set after the control plane has initialized.
 	var apiServerRule networkingv1.NetworkPolicyEgressRule
-	if apiServerCIDR != "" {
+	if clusterIp != "" {
 		apiServerRule = networkingv1.NetworkPolicyEgressRule{
 			To: []networkingv1.NetworkPolicyPeer{
 				{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix my stupid mistake that checks for a condition that is always true 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

/kind bug

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
