### PR TITLE
Add aws k8s >=1.27 in-tree cloud provider incompatibility

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -556,6 +556,14 @@ spec:
         version: < 1.24.0
       - condition: inTreeProvider
         operation: CREATE
+        provider: aws
+        version: '>= 1.27.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: aws
+        version: '>= 1.27.0'
+      - condition: inTreeProvider
+        operation: CREATE
         provider: openstack
         version: '>= 1.26.0'
       - condition: inTreeProvider

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -556,6 +556,14 @@ spec:
         version: < 1.24.0
       - condition: inTreeProvider
         operation: CREATE
+        provider: aws
+        version: '>= 1.27.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: aws
+        version: '>= 1.27.0'
+      - condition: inTreeProvider
+        operation: CREATE
         provider: openstack
         version: '>= 1.26.0'
       - condition: inTreeProvider

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -330,6 +330,21 @@ var (
 				Condition: kubermaticv1.ExternalCloudProviderCondition,
 				Operation: kubermaticv1.UpdateOperation,
 			},
+			// In-tree cloud provider for AWS is not supported starting with Kubernetes 1.27.
+			// This can be removed once we drop support for Kubernetes 1.27 (note: not for 1.26, because
+			// at that point we still might have clusters that needs to be upgraded from 1.26 to 1.27).
+			{
+				Provider:  string(kubermaticv1.AWSCloudProvider),
+				Version:   ">= 1.27.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.CreateOperation,
+			},
+			{
+				Provider:  string(kubermaticv1.AWSCloudProvider),
+				Version:   ">= 1.27.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.UpdateOperation,
+			},
 			// In-tree cloud provider for OpenStack is not supported starting with Kubernetes 1.26.
 			// This can be removed once we drop support for Kubernetes 1.26 (note: not for 1.25, because
 			// at that point we still might have clusters that needs to be upgraded from 1.25 to 1.26).


### PR DESCRIPTION
**What this PR does / why we need it**:

Restrict create/update of  aws clusters with k8s >= 1.27 and in-tree provider.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

/kind bug

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Do not allow Kubernetes >= 1.27 with in-tree CCM on AWS.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1487
```
