### PR TITLE
Use vSphere infraManagement user creds if defined

### DIFF
--- a/pkg/resources/credentials.go
+++ b/pkg/resources/credentials.go
@@ -660,6 +660,16 @@ func GetVSphereCredentials(data CredentialsData) (VSphereCredentials, error) {
 			return VSphereCredentials{}, err
 		}
 	}
+	if username == "" {
+		if spec.Username != "" {
+			username = spec.Username
+		} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
+			username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereUsername)
+			if err != nil {
+				return VSphereCredentials{}, err
+			}
+		}
+	}
 
 	if spec.InfraManagementUser.Password != "" {
 		password = spec.InfraManagementUser.Password
@@ -669,22 +679,14 @@ func GetVSphereCredentials(data CredentialsData) (VSphereCredentials, error) {
 			return VSphereCredentials{}, err
 		}
 	}
-
-	if username == "" && spec.Username != "" {
-		username = spec.Username
-	} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		username, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VsphereUsername)
-		if err != nil {
-			return VSphereCredentials{}, err
-		}
-	}
-
-	if password == "" && spec.Password != "" {
-		password = spec.Password
-	} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
-		password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VspherePassword)
-		if err != nil {
-			return VSphereCredentials{}, err
+	if password == "" {
+		if spec.Password != "" {
+			password = spec.Password
+		} else if spec.CredentialsReference != nil && spec.CredentialsReference.Name != "" {
+			password, err = data.GetGlobalSecretKeySelectorValue(spec.CredentialsReference, VspherePassword)
+			if err != nil {
+				return VSphereCredentials{}, err
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
* During reconciling a Cluster object, its credentials are wiped and moved to the credentialsReference-secret.
* With username and password not set on the cluster obj, username and password were read again from the credentialsReference-secret, no matter if infraManagementUser credentials were stored there as well, essentially overwriting them. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes cases where, when using dedicated infra- and ccm-credentials, infra-credentials were always overwritten by ccm-credentials.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
