### PR TITLE
Replace irate with rate for node cpu usage graphs

### DIFF
--- a/charts/mla/grafana/files/kkp-kubernetes-nodes-overview.json
+++ b/charts/mla/grafana/files/kkp-kubernetes-nodes-overview.json
@@ -51,7 +51,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg by (node_name) (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ node_name }}",
@@ -162,7 +162,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"

--- a/charts/mla/grafana/files/kkp-kubernetes-nodes.json
+++ b/charts/mla/grafana/files/kkp-kubernetes-nodes.json
@@ -161,7 +161,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
+          "expr": "sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "core {{ cpu }}",
@@ -253,7 +253,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+          "expr": "avg(sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 10,
           "legendFormat": "average",
@@ -364,7 +364,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "avg (sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+          "expr": "avg (sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"

--- a/charts/mla/grafana/test/config.yaml.out
+++ b/charts/mla/grafana/test/config.yaml.out
@@ -165,7 +165,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (node_name) (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ node_name }}",
@@ -276,7 +276,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"
@@ -1254,7 +1254,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
+              "expr": "sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "core {{ cpu }}",
@@ -1346,7 +1346,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+              "expr": "avg(sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 10,
               "legendFormat": "average",
@@ -1457,7 +1457,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg (sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+              "expr": "avg (sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"

--- a/charts/mla/grafana/test/default.yaml.out
+++ b/charts/mla/grafana/test/default.yaml.out
@@ -165,7 +165,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg by (node_name) (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ node_name }}",
@@ -276,7 +276,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"
@@ -1254,7 +1254,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
+              "expr": "sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "core {{ cpu }}",
@@ -1346,7 +1346,7 @@ data:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+              "expr": "avg(sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 10,
               "legendFormat": "average",
@@ -1457,7 +1457,7 @@ data:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg (sum by (cpu) (irate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+              "expr": "avg (sum by (cpu) (rate(node_cpu_seconds_total{job=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"

--- a/charts/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/nodes-overview.json
@@ -94,7 +94,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (node_name) (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ node_name }}",
@@ -177,7 +177,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg (100 - (irate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"

--- a/charts/monitoring/grafana/dashboards/kubernetes/nodes.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/nodes.json
@@ -258,7 +258,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
+          "expr": "sum by (cpu) (rate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[5m]) * 100)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "core {{ cpu }}",
@@ -356,7 +356,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg(sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+          "expr": "avg(sum by (cpu) (rate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 10,
           "legendFormat": "average",
@@ -439,7 +439,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg (sum by (cpu) (irate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
+          "expr": "avg (sum by (cpu) (rate(node_cpu_seconds_total{app=\"node-exporter\", mode!=\"idle\", node_name=\"$node\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"


### PR DESCRIPTION
**What this PR does / why we need it**:
This replaces `irate` with `rate` in node CPU usage graphs as it has been discovered that `irate` can generate negative values for this graph.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Replace `irate` with `rate` for node cpu usage graphs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
