### PR TITLE
WIP - Downgrade Minio to bring back legacy filesystem support

### DIFF
--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: minio
 version: v9.9.9-dev
-appVersion: RELEASE.2023-05-04T21-44-30Z
+appVersion: RELEASE.2022-10-24T18-35-07Z
 description: minio
 keywords:
   - kubermatic

--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -148,7 +148,7 @@ spec:
         - name: quay-io-pull-secret
       containers:
       - name: minio
-        image: 'quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z'
+        image: 'quay.io/minio/minio:RELEASE.2022-10-24T18-35-07Z'
         args:
         - server
         - /storage

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z'
+        image: 'quay.io/minio/minio:RELEASE.2022-10-24T18-35-07Z'
         args:
         - server
         - /storage

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -147,7 +147,7 @@ spec:
     spec:
       containers:
       - name: minio
-        image: 'quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z'
+        image: 'quay.io/minio/minio:RELEASE.2022-10-24T18-35-07Z'
         args:
         - server
         - /storage

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -21,7 +21,9 @@ minio:
 
   image:
     repository: quay.io/minio/minio
-    tag: RELEASE.2023-05-04T21-44-30Z
+    # any release after this removes support for the legacy filesystem driver,
+    # requiring a data migration; see https://github.com/kubermatic/kubermatic/issues/12430
+    tag: RELEASE.2022-10-24T18-35-07Z
   storeSize: 100Gi
 
   # The is required to enable the BackupRestore controller so it can backup


### PR DESCRIPTION
**What this PR does / why we need it**:
This reverts Minio to a version that still supports the older filesystem layout.

**Which issue(s) this PR fixes**:
Related to #12430

**What type of PR is this?**
/kind bug
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Downgrade Minio to RELEASE.2022-10-24T18-35-07Z to restore legacy filesystem support.
```

**Documentation**:
```documentation
NONE
```
