### PR TITLE
Add available OS properties to kubermatic settings

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -36,6 +38,9 @@ type KubermaticSetting struct {
 
 	Spec SettingSpec `json:"spec,omitempty"`
 }
+
+// allowedOperatingSystems defines a map of operating systems that can be used for the machines.
+type allowedOperatingSystems map[providerconfig.OperatingSystem]bool
 
 type SettingSpec struct {
 	// CustomLinks are additional links that can be shown the dashboard's footer.
@@ -90,6 +95,9 @@ type SettingSpec struct {
 
 	// MachineDeploymentVMResourceQuota is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
 	MachineDeploymentVMResourceQuota *MachineFlavorFilter `json:"machineDeploymentVMResourceQuota,omitempty"`
+
+	// AllowedOperatingSystems shows if the operating system is allowed to be use in the machinedeployment.
+	AllowedOperatingSystems allowedOperatingSystems `json:"allowedOperatingSystems,omitempty"`
 
 	// DefaultProjectResourceQuota allows to configure a default project resource quota which
 	// will be set for all projects that do not have a custom quota already set. EE-version only.

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -6121,6 +6121,13 @@ func (in *SettingSpec) DeepCopyInto(out *SettingSpec) {
 		*out = new(MachineFlavorFilter)
 		**out = **in
 	}
+	if in.AllowedOperatingSystems != nil {
+		in, out := &in.AllowedOperatingSystems, &out.AllowedOperatingSystems
+		*out = make(allowedOperatingSystems, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.DefaultProjectResourceQuota != nil {
 		in, out := &in.DefaultProjectResourceQuota, &out.DefaultProjectResourceQuota
 		*out = new(DefaultProjectResourceQuota)

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -35,6 +35,11 @@ spec:
               type: object
             spec:
               properties:
+                allowedOperatingSystems:
+                  additionalProperties:
+                    type: boolean
+                  description: AllowedOperatingSystems shows if the operating system is allowed to be use in the machinedeployment.
+                  type: object
                 cleanupOptions:
                   description: CleanupOptions control what happens when a cluster is deleted via the dashboard.
                   properties:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a new option to the Admin settings to control the availability of an operating system in the machine deployment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
ref  #https://github.com/kubermatic/dashboard/issues/4105

**What type of PR is this?**
/kind feature

```release-note
NONE
```

```documentation
NONE
```
