### PR TITLE
Add support for creating snapshots from `etcd-launcher` 

### DIFF
--- a/cmd/etcd-launcher/cmd_defrag.go
+++ b/cmd/etcd-launcher/cmd_defrag.go
@@ -45,6 +45,15 @@ func DefragCommand(log *zap.SugaredLogger) *cobra.Command {
 		},
 	}
 
+	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+		if err := c.Usage(); err != nil {
+			return err
+		}
+
+		// ensure we exit with code 1 later on
+		return err
+	})
+
 	return cmd
 }
 

--- a/cmd/etcd-launcher/cmd_is_running.go
+++ b/cmd/etcd-launcher/cmd_is_running.go
@@ -54,6 +54,15 @@ func IsRunningCommand(logger *zap.SugaredLogger) *cobra.Command {
 		},
 	}
 
+	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+		if err := c.Usage(); err != nil {
+			return err
+		}
+
+		// ensure we exit with code 1 later on
+		return err
+	})
+
 	cmd.PersistentFlags().StringVar(&opt.testKey, "key", "kubermatic/quorum-check", "key to write into etcd for testing its availability")
 	cmd.PersistentFlags().StringVar(&opt.testValue, "value", "something", "value to write into etcd for testing its availability")
 	cmd.PersistentFlags().DurationVar(&opt.interval, "interval", opt.interval, "interval as a Go duration between attempts to write to etcd")

--- a/cmd/etcd-launcher/cmd_run.go
+++ b/cmd/etcd-launcher/cmd_run.go
@@ -73,6 +73,15 @@ func RunCommand(logger *zap.SugaredLogger) *cobra.Command {
 		},
 	}
 
+	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+		if err := c.Usage(); err != nil {
+			return err
+		}
+
+		// ensure we exit with code 1 later on
+		return err
+	})
+
 	cmd.PersistentFlags().StringVar(&opt.podName, "pod-name", "", "name of this etcd pod")
 	cmd.PersistentFlags().StringVar(&opt.podIP, "pod-ip", "", "IP address of this etcd pod")
 	cmd.PersistentFlags().StringVar(&opt.token, "token", "", "etcd database token")

--- a/cmd/etcd-launcher/cmd_snapshot.go
+++ b/cmd/etcd-launcher/cmd_snapshot.go
@@ -48,6 +48,15 @@ func SnapshotCommand(log *zap.SugaredLogger) *cobra.Command {
 		},
 	}
 
+	cmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
+		if err := c.Usage(); err != nil {
+			return err
+		}
+
+		// ensure we exit with code 1 later on
+		return err
+	})
+
 	cmd.PersistentFlags().StringVar(&opt.file, "file", "/backup/snapshot.db", "file to save database snapshot to")
 
 	return cmd

--- a/cmd/etcd-launcher/cmd_snapshot.go
+++ b/cmd/etcd-launcher/cmd_snapshot.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"go.etcd.io/etcd/etcdutl/v3/snapshot"
+	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/cmd/etcd-launcher/pkg/etcd"
+)
+
+type snapshotOptions struct {
+	options
+
+	file string
+}
+
+func SnapshotCommand(log *zap.SugaredLogger) *cobra.Command {
+	opt := snapshotOptions{}
+
+	cmd := &cobra.Command{
+		Use:          "snapshot",
+		Short:        "Create etcd database snapshot and save it to file",
+		RunE:         SnapshotFunc(log, &opt),
+		SilenceUsage: true,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			opts.CopyInto(&opt.options)
+
+			return nil
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&opt.file, "file", "/backup/snapshot.db", "file to save database snapshot to")
+
+	return cmd
+}
+
+func SnapshotFunc(log *zap.SugaredLogger, opt *snapshotOptions) cobraFuncE {
+	return handleErrors(log, func(cmd *cobra.Command, args []string) error {
+		ctx := cmd.Context()
+		log := log.With("cluster", opt.cluster)
+
+		e := &etcd.Cluster{
+			Cluster:           opt.cluster,
+			EtcdctlAPIVersion: opt.etcdctlAPIVersion,
+
+			CaCertFile:     opt.etcdCAFile,
+			ClientCertFile: opt.etcdCertFile,
+			ClientKeyFile:  opt.etcdKeyFile,
+		}
+
+		if _, err := e.Init(ctx); err != nil {
+			return fmt.Errorf("failed to initialize etcd cluster configuration: %w", err)
+		}
+
+		if err := e.SetClusterSize(ctx); err != nil {
+			return fmt.Errorf("failed to set expected cluster size: %w", err)
+		}
+
+		configs, err := e.GetEtcdEndpointConfigs(ctx, log)
+		if err != nil {
+			return fmt.Errorf("failed to get etcd cluster clients: %w", err)
+		}
+
+		for _, config := range configs {
+			if len(config.Endpoints) != 1 {
+				log.Warnw("unexpected number of endpoints, skipping this configuration", "endpoints", strings.Join(config.Endpoints, ","))
+				continue
+			}
+
+			snapv3 := snapshot.NewV3(log.Desugar())
+			err := snapv3.Save(ctx, config, opt.file)
+
+			if err == nil {
+				log.Infow("saved snapshot from endpoint", "endpoint", strings.Join(config.Endpoints, ","), "file", opt.file)
+				return nil
+			}
+
+			log.Errorw("failed to save snapshot from endpoint, trying next endpoint", "endpoint", strings.Join(config.Endpoints, ","), zap.Error(err))
+		}
+
+		return fmt.Errorf("exhausted all endpoints, no snapshot was successful")
+	})
+}

--- a/cmd/etcd-launcher/main.go
+++ b/cmd/etcd-launcher/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	// cobra does not make any distinction between "error that happened because of bad flags"
 	// and "error that happens because of something going bad inside the RunE function", and
-	// so would always show the Usage, no matter what error occurred. Tow ork around this, we
+	// so would always show the Usage, no matter what error occurred. To work around this, we
 	// set SilenceUsages on all commands and manually print the error using the FlagErrorFunc.
 	rootCmd.SetFlagErrorFunc(func(c *cobra.Command, err error) error {
 		if err := c.Usage(); err != nil {
@@ -105,6 +105,7 @@ func addCommands(cmd *cobra.Command, logger *zap.SugaredLogger, versions kuberma
 		RunCommand(logger),
 		IsRunningCommand(logger),
 		DefragCommand(logger),
+		SnapshotCommand(logger),
 	)
 }
 

--- a/cmd/etcd-launcher/pkg/etcd/cluster.go
+++ b/cmd/etcd-launcher/pkg/etcd/cluster.go
@@ -18,6 +18,7 @@ package etcd
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -412,27 +413,37 @@ func (e *Cluster) GetEtcdClient(ctx context.Context, log *zap.SugaredLogger) (*c
 	return e.getClientWithEndpoints(ctx, log, endpoints)
 }
 
+// GetEtcdEndpointClients returns a slice of client configs with each config pointing to exactly one of the automatically discovered etcd endpoints.
+func (e *Cluster) GetEtcdEndpointConfigs(ctx context.Context, log *zap.SugaredLogger) ([]client.Config, error) {
+	configs := []client.Config{}
+	endpoints := clientEndpoints(e.clusterSize, e.namespace)
+
+	tlsConfig, err := getTLSConfig(e)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set up TLS client config: %w", err)
+	}
+
+	for _, endpoint := range endpoints {
+		configs = append(configs, getConfig([]string{endpoint}, tlsConfig))
+	}
+
+	return configs, nil
+}
+
 func (e *Cluster) getLocalClient(ctx context.Context, log *zap.SugaredLogger) (*client.Client, error) {
 	return e.getClientWithEndpoints(ctx, log, []string{e.endpoint()})
 }
 
 func (e *Cluster) getClientWithEndpoints(ctx context.Context, log *zap.SugaredLogger, eps []string) (*client.Client, error) {
-	var err error
-	tlsInfo := transport.TLSInfo{
-		CertFile:       e.ClientCertFile,
-		KeyFile:        e.ClientKeyFile,
-		TrustedCAFile:  e.CaCertFile,
-		ClientCertAuth: true,
-	}
 
-	tlsConfig, err := tlsInfo.ClientConfig()
+	tlsConfig, err := getTLSConfig(e)
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate client TLS config: %w", err)
+		return nil, fmt.Errorf("failed to set up TLS client config: %w", err)
 	}
 
 	var etcdClient *client.Client
 
-	if err = wait.PollImmediateLog(ctx, log.With("endpoints", strings.Join(eps, ",")), 5*time.Second, 60*time.Second, func() (error, error) {
+	if err := wait.PollImmediateLog(ctx, log.With("endpoints", strings.Join(eps, ",")), 5*time.Second, 60*time.Second, func() (error, error) {
 		cli, err := client.New(client.Config{
 			Endpoints:   eps,
 			DialTimeout: 2 * time.Second,
@@ -450,6 +461,25 @@ func (e *Cluster) getClientWithEndpoints(ctx context.Context, log *zap.SugaredLo
 	}
 
 	return etcdClient, nil
+}
+
+func getConfig(endpoints []string, tlsConfig *tls.Config) client.Config {
+	return client.Config{
+		Endpoints:   endpoints,
+		DialTimeout: 2 * time.Second,
+		TLS:         tlsConfig,
+	}
+}
+
+func getTLSConfig(e *Cluster) (*tls.Config, error) {
+	tlsInfo := transport.TLSInfo{
+		CertFile:       e.ClientCertFile,
+		KeyFile:        e.ClientKeyFile,
+		TrustedCAFile:  e.CaCertFile,
+		ClientCertAuth: true,
+	}
+
+	return tlsInfo.ClientConfig()
 }
 
 func (e *Cluster) listMembers(ctx context.Context, log *zap.SugaredLogger) ([]*etcdserverpb.Member, error) {

--- a/cmd/etcd-launcher/pkg/etcd/cluster.go
+++ b/cmd/etcd-launcher/pkg/etcd/cluster.go
@@ -414,7 +414,7 @@ func (e *Cluster) GetEtcdClient(ctx context.Context, log *zap.SugaredLogger) (*c
 }
 
 // GetEtcdEndpointClients returns a slice of client configs with each config pointing to exactly one of the automatically discovered etcd endpoints.
-func (e *Cluster) GetEtcdEndpointConfigs(ctx context.Context, log *zap.SugaredLogger) ([]client.Config, error) {
+func (e *Cluster) GetEtcdEndpointConfigs(ctx context.Context) ([]client.Config, error) {
 	configs := []client.Config{}
 	endpoints := clientEndpoints(e.clusterSize, e.namespace)
 

--- a/cmd/etcd-launcher/pkg/etcd/cluster.go
+++ b/cmd/etcd-launcher/pkg/etcd/cluster.go
@@ -435,7 +435,6 @@ func (e *Cluster) getLocalClient(ctx context.Context, log *zap.SugaredLogger) (*
 }
 
 func (e *Cluster) getClientWithEndpoints(ctx context.Context, log *zap.SugaredLogger, eps []string) (*client.Client, error) {
-
 	tlsConfig, err := getTLSConfig(e)
 	if err != nil {
 		return nil, fmt.Errorf("failed to set up TLS client config: %w", err)

--- a/cmd/seed-controller-manager/controllers.go
+++ b/cmd/seed-controller-manager/controllers.go
@@ -186,11 +186,14 @@ func createEtcdBackupController(ctrlCtx *controllerContext) error {
 		ctrlCtx.log,
 		ctrlCtx.runOptions.workerCount,
 		ctrlCtx.runOptions.workerName,
-		ctrlCtx.runOptions.backupContainerImage,
+
 		ctrlCtx.versions,
 		ctrlCtx.runOptions.caBundle,
 		ctrlCtx.seedGetter,
 		ctrlCtx.configGetter,
+
+		ctrlCtx.runOptions.etcdLauncherImage,
+		ctrlCtx.runOptions.overwriteRegistry,
 	)
 }
 

--- a/hack/ci/run-etcd-launcher-tests.sh
+++ b/hack/ci/run-etcd-launcher-tests.sh
@@ -49,6 +49,7 @@ source hack/ci/setup-kind-cluster.sh
 # gather the logs of all things in the Kubermatic / cluster namespace
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kubermatic" --namespace kubermatic > /dev/null 2>&1 &
 protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/usercluster" --namespace 'cluster-*' > /dev/null 2>&1 &
+protokol --kubeconfig "$KUBECONFIG" --flat --output "$ARTIFACTS/logs/kube-system" --namespace 'kube-system' > /dev/null 2>&1 &
 
 source hack/ci/setup-kubermatic-backups-in-kind.sh
 

--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -27,9 +27,9 @@ import (
 	"go.uber.org/zap"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/etcdbackup"
 	"k8c.io/kubermatic/v2/pkg/provider"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
+	etcdbackup "k8c.io/kubermatic/v2/pkg/resources/etcd/backup"
 	"k8c.io/kubermatic/v2/pkg/util/s3"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/controller/master-controller-manager/rbac/mapper.go
+++ b/pkg/controller/master-controller-manager/rbac/mapper.go
@@ -217,8 +217,8 @@ func generateClusterRBACRoleBindingForResource(resourceName, groupName string) *
 	return binding
 }
 
-// generateClusterRBACRoleBindingForResourceWithServiceAccount creates a ClusterRoleBinding with a ServiceAccount as a subject, instead of a group.
-func generateClusterRBACRoleBindingForResourceWithServiceAccount(resourceName, kind, groupName, sa, namespace string, oRef metav1.OwnerReference) *rbacv1.ClusterRoleBinding {
+// generateEtcdRBACRoleBindingForResourceWithServiceAccount creates a ClusterRoleBinding with etcd-launcher ServiceAccounts as a subject.
+func generateEtcdRBACRoleBindingForResourceWithServiceAccount(resourceName, kind, groupName, clusterName, sa, namespace string, oRef metav1.OwnerReference) *rbacv1.ClusterRoleBinding {
 	binding := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            generateRBACRoleNameForNamedResourceWithServiceAccount(kind, resourceName, sa),
@@ -230,6 +230,12 @@ func generateClusterRBACRoleBindingForResourceWithServiceAccount(resourceName, k
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      sa,
 				Namespace: namespace,
+			},
+			{
+				APIGroup:  "",
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      fmt.Sprintf("%s-%s", sa, clusterName),
+				Namespace: metav1.NamespaceSystem,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{
@@ -480,8 +486,8 @@ func generateRBACRoleForClusterNamespaceResourceAndServiceAccount(cluster *kuber
 	return role, nil
 }
 
-// generateRBACRoleBindingForClusterNamespaceResourceAndServiceAccount generates per-cluster RoleBinding for the given cluster and service account in the cluster namespace.
-func generateRBACRoleBindingForClusterNamespaceResourceAndServiceAccount(cluster *kubermaticv1.Cluster, serviceAccountName, kind string) *rbacv1.RoleBinding {
+// generateRBACRoleBindingForEtcdLauncherServiceAccount generates per-cluster RoleBinding for the given cluster and service account in the cluster namespace.
+func generateRBACRoleBindingForEtcdLauncherServiceAccount(cluster *kubermaticv1.Cluster, serviceAccountName, kind string) *rbacv1.RoleBinding {
 	binding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      generateRBACRoleNameForClusterNamespaceResourceAndServiceAccount(kind, serviceAccountName),
@@ -493,6 +499,12 @@ func generateRBACRoleBindingForClusterNamespaceResourceAndServiceAccount(cluster
 				Kind:      rbacv1.ServiceAccountKind,
 				Name:      serviceAccountName,
 				Namespace: cluster.Status.NamespaceName,
+			},
+			{
+				APIGroup:  "",
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      fmt.Sprintf("%s-%s", serviceAccountName, cluster.Name),
+				Namespace: metav1.NamespaceSystem,
 			},
 		},
 		RoleRef: rbacv1.RoleRef{

--- a/pkg/controller/master-controller-manager/rbac/sync_resource.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource.go
@@ -614,7 +614,7 @@ func (c *resourcesController) ensureRBACRoleForEtcdLauncher(ctx context.Context,
 }
 
 func (c *resourcesController) ensureRBACRoleBindingForEtcdLauncher(ctx context.Context, cluster *kubermaticv1.Cluster, kindName string) error {
-	generatedRoleBinding := generateRBACRoleBindingForClusterNamespaceResourceAndServiceAccount(
+	generatedRoleBinding := generateRBACRoleBindingForEtcdLauncherServiceAccount(
 		cluster,
 		EtcdLauncherServiceAccountName,
 		kindName,
@@ -698,10 +698,11 @@ func shouldSkipRBACRoleForClusterNamespaceNamedResource(projectName string, clus
 
 // ensureClusterRBACRoleBindingForEtcdLauncher ensures the ClusterRoleBinding required to allow the etcd launcher to get Clusters on the Seed.
 func (c *resourcesController) ensureClusterRBACRoleBindingForEtcdLauncher(ctx context.Context, resourceName, resourceKind, namespace, projectName string, cluster *kubermaticv1.Cluster) error {
-	generatedRoleBinding := generateClusterRBACRoleBindingForResourceWithServiceAccount(
+	generatedRoleBinding := generateEtcdRBACRoleBindingForResourceWithServiceAccount(
 		resourceName,
 		resourceKind,
 		GenerateActualGroupNameFor(projectName, ViewerGroupNamePrefix),
+		cluster.Name,
 		EtcdLauncherServiceAccountName,
 		namespace,
 		metav1.OwnerReference{

--- a/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
+++ b/pkg/controller/master-controller-manager/rbac/sync_resource_test.go
@@ -274,6 +274,11 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 							Kind:      "ServiceAccount",
 							Name:      "etcd-launcher",
 						},
+						{
+							Namespace: "kube-system",
+							Kind:      "ServiceAccount",
+							Name:      "etcd-launcher-abcd",
+						},
 					},
 					RoleRef: rbacv1.RoleRef{
 						APIGroup: rbacv1.GroupName,
@@ -300,6 +305,11 @@ func TestSyncProjectResourcesClusterWide(t *testing.T) {
 							Namespace: "cluster-abcd",
 							Kind:      "ServiceAccount",
 							Name:      "etcd-launcher",
+						},
+						{
+							Namespace: "kube-system",
+							Kind:      "ServiceAccount",
+							Name:      "etcd-launcher-abcd",
 						},
 					},
 					RoleRef: rbacv1.RoleRef{

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -869,11 +869,6 @@ func getJobConditionIfTrue(job *batchv1.Job, condType batchv1.JobConditionType) 
 }
 
 func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed, config *kubermaticv1.KubermaticConfiguration, backupConfig *kubermaticv1.EtcdBackupConfig) (*resources.TemplateData, error) {
-	datacenter, found := seed.Spec.Datacenters[cluster.Spec.Cloud.DatacenterName]
-	if !found {
-		return nil, fmt.Errorf("failed to get datacenter %s", cluster.Spec.Cloud.DatacenterName)
-	}
-
 	destination := seed.GetEtcdBackupDestination(backupConfig.Spec.Destination)
 	if destination == nil {
 		return nil, fmt.Errorf("cannot find backup destination %q", backupConfig.Spec.Destination)
@@ -896,7 +891,6 @@ func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kuberm
 		WithContext(ctx).
 		WithClient(r).
 		WithCluster(cluster).
-		WithDatacenter(&datacenter).
 		WithSeed(seed.DeepCopy()).
 		WithKubermaticConfiguration(config.DeepCopy()).
 		WithVersions(r.versions).

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -19,9 +19,6 @@ package etcdbackup
 import (
 	"context"
 	"fmt"
-	"net/url"
-	"strconv"
-	"strings"
 	"time"
 
 	cron "github.com/robfig/cron/v3"
@@ -36,7 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
-	"k8c.io/kubermatic/v2/pkg/resources/etcd"
+	etcdbackup "k8c.io/kubermatic/v2/pkg/resources/etcd/backup"
 	utilerrors "k8c.io/kubermatic/v2/pkg/util/errors"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -51,7 +48,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/clock"
-	utilpointer "k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -63,42 +59,10 @@ import (
 const (
 	// ControllerName name of etcd backup controller.
 	ControllerName = "kkp-etcd-backup-controller"
-
 	// DeleteAllBackupsFinalizer indicates that the backups still need to be deleted in the backend.
 	DeleteAllBackupsFinalizer = "kubermatic.k8c.io/delete-all-backups"
-
-	// BackupConfigNameLabelKey is the label key which should be used to name the BackupConfig a job belongs to.
-	BackupConfigNameLabelKey = "backupConfig"
 	// DefaultBackupContainerImage holds the default Image used for creating the etcd backups.
 	DefaultBackupContainerImage = "gcr.io/etcd-development/etcd"
-	// SharedVolumeName is the name of the `emptyDir` volume the initContainer
-	// will write the backup to.
-	SharedVolumeName = "etcd-backup"
-	// backupJobLabel defines the label we use on all backup jobs.
-	backupJobLabel = "kubermatic-etcd-backup"
-	// clusterEnvVarKey defines the environment variable key for the cluster name.
-	clusterEnvVarKey = "CLUSTER"
-	// backupToCreateEnvVarKey defines the environment variable key for the name of the backup to create.
-	backupToCreateEnvVarKey = "BACKUP_TO_CREATE"
-	// backupToDeleteEnvVarKey defines the environment variable key for the name of the backup to delete.
-	backupToDeleteEnvVarKey = "BACKUP_TO_DELETE"
-	// backupScheduleEnvVarKey defines the environment variable key for the backup schedule.
-	backupScheduleEnvVarKey = "BACKUP_SCHEDULE"
-	// backupKeepCountEnvVarKey defines the environment variable key for the number of backups to keep.
-	backupKeepCountEnvVarKey = "BACKUP_KEEP_COUNT"
-	// backupConfigEnvVarKey defines the environment variable key for the name of the backup configuration resource.
-	backupConfigEnvVarKey = "BACKUP_CONFIG"
-	// AccessKeyIdEnvVarKey defines the environment variable key for the backup credentials access key id.
-	AccessKeyIdEnvVarKey = "ACCESS_KEY_ID"
-	// SecretAccessKeyEnvVarKey defines the environment variable key for the backup credentials secret access key.
-	SecretAccessKeyEnvVarKey = "SECRET_ACCESS_KEY"
-	// bucketNameEnvVarKey defines the environment variable key for the backup bucket name.
-	bucketNameEnvVarKey = "BUCKET_NAME"
-	// backupEndpointEnvVarKey defines the environment variable key for the backup endpoint.
-	backupEndpointEnvVarKey = "ENDPOINT"
-	// backupInsecureEnvVarKey defines the environment variable key for a boolean that tells whether the
-	// configured endpoint uses HTTPS ("false") or HTTP ("true").
-	backupInsecureEnvVarKey = "INSECURE"
 
 	// requeueAfter time after starting a job
 	// should be the time after which a started job will usually have completed.
@@ -121,16 +85,17 @@ type Reconciler struct {
 	log        *zap.SugaredLogger
 	scheme     *runtime.Scheme
 	workerName string
-	// backupContainerImage holds the image used for creating the etcd backup
-	// It must be configurable to cover offline use cases
-	backupContainerImage string
-	clock                clock.WithTickerAndDelayedExecution
-	randStringGenerator  func() string
-	caBundle             resources.CABundle
-	recorder             record.EventRecorder
-	versions             kubermatic.Versions
-	seedGetter           provider.SeedGetter
-	configGetter         provider.KubermaticConfigurationGetter
+
+	clock               clock.WithTickerAndDelayedExecution
+	randStringGenerator func() string
+	caBundle            resources.CABundle
+	recorder            record.EventRecorder
+	versions            kubermatic.Versions
+	seedGetter          provider.SeedGetter
+	configGetter        provider.KubermaticConfigurationGetter
+
+	overwriteRegistry string
+	etcdLauncherImage string
 }
 
 // Add creates a new Backup controller that is responsible for
@@ -140,34 +105,36 @@ func Add(
 	log *zap.SugaredLogger,
 	numWorkers int,
 	workerName string,
-	backupContainerImage string,
+
 	versions kubermatic.Versions,
 	caBundle resources.CABundle,
 	seedGetter provider.SeedGetter,
 	configGetter provider.KubermaticConfigurationGetter,
+
+	etcdLauncherImage string,
+	overwriteRegistry string,
 ) error {
 	log = log.Named(ControllerName)
 	client := mgr.GetClient()
 
-	if backupContainerImage == "" {
-		backupContainerImage = DefaultBackupContainerImage
-	}
-
 	reconciler := &Reconciler{
-		Client:               client,
-		log:                  log,
-		scheme:               mgr.GetScheme(),
-		workerName:           workerName,
-		backupContainerImage: backupContainerImage,
-		recorder:             mgr.GetEventRecorderFor(ControllerName),
-		versions:             versions,
-		clock:                &clock.RealClock{},
-		caBundle:             caBundle,
+		Client:     client,
+		log:        log,
+		scheme:     mgr.GetScheme(),
+		workerName: workerName,
+		recorder:   mgr.GetEventRecorderFor(ControllerName),
+
+		versions: versions,
+		clock:    &clock.RealClock{},
+		caBundle: caBundle,
 		randStringGenerator: func() string {
 			return rand.String(10)
 		},
 		seedGetter:   seedGetter,
 		configGetter: configGetter,
+
+		etcdLauncherImage: etcdLauncherImage,
+		overwriteRegistry: overwriteRegistry,
 	}
 
 	ctrlOptions := controller.Options{
@@ -276,12 +243,10 @@ func (r *Reconciler) reconcile(
 	seed *kubermaticv1.Seed,
 	config *kubermaticv1.KubermaticConfiguration,
 ) (*reconcile.Result, error) {
-	destination := seed.GetEtcdBackupDestination(backupConfig.Spec.Destination)
-	if destination == nil {
-		return nil, fmt.Errorf("cannot find backup destination %q", backupConfig.Spec.Destination)
-	}
-	if destination.Credentials == nil {
-		return nil, fmt.Errorf("credentials not set for backup destination %q", backupConfig.Spec.Destination)
+
+	data, err := r.getClusterTemplateData(ctx, cluster, seed, config, backupConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get template data: %w", err)
 	}
 
 	if err := r.ensureSecrets(ctx, cluster); err != nil {
@@ -290,16 +255,6 @@ func (r *Reconciler) reconcile(
 
 	if err := r.ensureConfigMaps(ctx, cluster); err != nil {
 		return nil, fmt.Errorf("failed to create backup configmaps: %w", err)
-	}
-
-	backupStoreContainer, err := getBackupStoreContainer(config, seed)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create backup store container: %w", err)
-	}
-
-	backupDeleteContainer, err := getBackupDeleteContainer(config, seed)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create backup delete container: %w", err)
 	}
 
 	var nextReconcile, totalReconcile *reconcile.Result
@@ -311,19 +266,19 @@ func (r *Reconciler) reconcile(
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
-	if nextReconcile, err = r.startPendingBackupJobs(ctx, backupConfig, cluster, destination, backupStoreContainer); err != nil {
+	if nextReconcile, err = r.startPendingBackupJobs(ctx, data, backupConfig); err != nil {
 		return errorReconcile, fmt.Errorf("failed to start pending and update running backups: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
-	if nextReconcile, err = r.startPendingBackupDeleteJobs(ctx, backupConfig, cluster, destination, backupDeleteContainer); err != nil {
+	if nextReconcile, err = r.startPendingBackupDeleteJobs(ctx, data, backupConfig); err != nil {
 		return errorReconcile, fmt.Errorf("failed to start pending backup delete jobs: %w", err)
 	}
 
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
-	if nextReconcile, err = r.updateRunningBackupDeleteJobs(ctx, backupConfig, cluster, destination, backupDeleteContainer); err != nil {
+	if nextReconcile, err = r.updateRunningBackupDeleteJobs(ctx, data, backupConfig); err != nil {
 		return errorReconcile, fmt.Errorf("failed to update running backup delete jobs: %w", err)
 	}
 
@@ -342,24 +297,6 @@ func (r *Reconciler) reconcile(
 	totalReconcile = minReconcile(totalReconcile, nextReconcile)
 
 	return totalReconcile, nil
-}
-
-func getBackupStoreContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) (*corev1.Container, error) {
-	// a customized container is configured
-	if cfg.Spec.SeedController.BackupStoreContainer != "" {
-		return kuberneteshelper.ContainerFromString(cfg.Spec.SeedController.BackupStoreContainer)
-	}
-
-	return kuberneteshelper.ContainerFromString(defaulting.DefaultNewBackupStoreContainer)
-}
-
-func getBackupDeleteContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) (*corev1.Container, error) {
-	// a customized container is configured
-	if cfg.Spec.SeedController.BackupDeleteContainer != "" {
-		return kuberneteshelper.ContainerFromString(cfg.Spec.SeedController.BackupDeleteContainer)
-	}
-
-	return kuberneteshelper.ContainerFromString(defaulting.DefaultNewBackupDeleteContainer)
 }
 
 func minReconcile(reconciles ...*reconcile.Result) *reconcile.Result {
@@ -532,8 +469,7 @@ func (r *Reconciler) setBackupConfigCondition(backupConfig *kubermaticv1.EtcdBac
 
 // create any backup jobs that can be created, i.e. that don't exist yet while their scheduled time has arrived
 // also update status of backups whose jobs have completed.
-func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster,
-	destination *kubermaticv1.BackupDestination, storeContainer *corev1.Container) (*reconcile.Result, error) {
+func (r *Reconciler) startPendingBackupJobs(ctx context.Context, data *resources.TemplateData, backupConfig *kubermaticv1.EtcdBackupConfig) (*reconcile.Result, error) {
 	var returnReconcile *reconcile.Result
 
 	for i := range backupConfig.Status.CurrentBackups {
@@ -565,7 +501,7 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 					}
 				}
 			} else if backup.BackupPhase == "" && r.clock.Now().Sub(backup.ScheduledTime.Time) >= 0 && backupConfig.DeletionTimestamp == nil {
-				job := r.backupJob(backupConfig, cluster, backup, destination, storeContainer)
+				job := etcdbackup.BackupJob(data, backupConfig, backup)
 				if err := r.Create(ctx, job); ctrlruntimeclient.IgnoreAlreadyExists(err) != nil {
 					return nil, fmt.Errorf("error creating job for backup %s: %w", backup.BackupName, err)
 				}
@@ -592,8 +528,7 @@ func (r *Reconciler) startPendingBackupJobs(ctx context.Context, backupConfig *k
 }
 
 // create any backup delete jobs that can be created, i.e. for all completed backups older than the last backupConfig.GetKeptBackupsCount() ones.
-func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster,
-	destination *kubermaticv1.BackupDestination, deleteContainer *corev1.Container) (*reconcile.Result, error) {
+func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, data *resources.TemplateData, backupConfig *kubermaticv1.EtcdBackupConfig) (*reconcile.Result, error) {
 	// one-shot backups are not deleted until their backupConfig is deleted
 	if backupConfig.Spec.Schedule == "" && backupConfig.DeletionTimestamp == nil {
 		return nil, nil
@@ -626,7 +561,7 @@ func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupCon
 	modified := false
 	for _, backup := range backupsToDelete {
 		if runningDeleteJobsCount < maxSimultaneousDeleteJobsPerConfig {
-			if err := r.createBackupDeleteJob(ctx, backupConfig, cluster, backup, destination, deleteContainer); err != nil {
+			if err := r.createBackupDeleteJob(ctx, data, backupConfig, backup); err != nil {
 				return nil, err
 			}
 			runningDeleteJobsCount++
@@ -645,10 +580,9 @@ func (r *Reconciler) startPendingBackupDeleteJobs(ctx context.Context, backupCon
 	return nil, nil
 }
 
-func (r *Reconciler) createBackupDeleteJob(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backup *kubermaticv1.BackupStatus,
-	destination *kubermaticv1.BackupDestination, deleteContainer *corev1.Container) error {
-	if deleteContainer != nil {
-		job := r.backupDeleteJob(backupConfig, cluster, backup, destination, deleteContainer)
+func (r *Reconciler) createBackupDeleteJob(ctx context.Context, data *resources.TemplateData, backupConfig *kubermaticv1.EtcdBackupConfig, backup *kubermaticv1.BackupStatus) error {
+	if data.EtcdBackupDeleteContainer() != nil {
+		job := etcdbackup.BackupDeleteJob(data, backupConfig, backup)
 		if err := r.Create(ctx, job); ctrlruntimeclient.IgnoreAlreadyExists(err) != nil {
 			return fmt.Errorf("error creating delete job for backup %s: %w", backup.BackupName, err)
 		}
@@ -662,8 +596,7 @@ func (r *Reconciler) createBackupDeleteJob(ctx context.Context, backupConfig *ku
 }
 
 // update status of all delete jobs that have completed and are still marked as running.
-func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster,
-	destination *kubermaticv1.BackupDestination, deleteContainer *corev1.Container) (*reconcile.Result, error) {
+func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, data *resources.TemplateData, backupConfig *kubermaticv1.EtcdBackupConfig) (*reconcile.Result, error) {
 	var returnReconcile *reconcile.Result
 
 	oldBackupConfig := backupConfig.DeepCopy()
@@ -713,7 +646,7 @@ func (r *Reconciler) updateRunningBackupDeleteJobs(ctx context.Context, backupCo
 
 	for _, deleteJobToRestart := range deleteJobsToRestart {
 		if runningDeleteJobsCount < maxSimultaneousDeleteJobsPerConfig {
-			if err := r.createBackupDeleteJob(ctx, backupConfig, cluster, deleteJobToRestart.backup, destination, deleteContainer); err != nil {
+			if err := r.createBackupDeleteJob(ctx, data, backupConfig, deleteJobToRestart.backup); err != nil {
 				return nil, err
 			}
 			deleteJobToRestart.backup.DeleteMessage = deleteJobToRestart.deleteMessage
@@ -855,316 +788,8 @@ func (r *Reconciler) handleFinalization(ctx context.Context, backupConfig *kuber
 	return nil, err
 }
 
-func isInsecureURL(u string) bool {
-	parsed, err := url.Parse(u)
-	if err != nil {
-		return false
-	}
-
-	// a hostname like "foo.com:9000" is parsed as {scheme: "foo.com", host: ""},
-	// so we must make sure to not mis-interpret "http:9000" ({scheme: "http", host: ""}) as
-	// an HTTP url
-
-	return strings.ToLower(parsed.Scheme) == "http" && parsed.Host != ""
-}
-
-func (r *Reconciler) backupJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus,
-	destination *kubermaticv1.BackupDestination, storeContainer *corev1.Container) *batchv1.Job {
-	storeContainer = storeContainer.DeepCopy()
-
-	// If destination is set, we need to set the credentials and backup bucket details to match the destination
-	if destination != nil {
-		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, destination))
-		storeContainer.Env = setEnvVar(storeContainer.Env, genSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, destination))
-		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
-			Name:  bucketNameEnvVarKey,
-			Value: destination.BucketName,
-		})
-		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
-			Name:  backupEndpointEnvVarKey,
-			Value: destination.Endpoint,
-		})
-
-		insecure := "false"
-		if isInsecureURL(destination.Endpoint) {
-			insecure = "true"
-		}
-
-		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
-			Name:  backupInsecureEnvVarKey,
-			Value: insecure,
-		})
-	}
-
-	storeContainer.Env = append(
-		storeContainer.Env,
-		corev1.EnvVar{
-			Name:  clusterEnvVarKey,
-			Value: cluster.Name,
-		},
-		corev1.EnvVar{
-			Name:  backupToCreateEnvVarKey,
-			Value: backupStatus.BackupName,
-		},
-		corev1.EnvVar{
-			Name:  backupScheduleEnvVarKey,
-			Value: backupConfig.Spec.Schedule,
-		},
-		corev1.EnvVar{
-			Name:  backupKeepCountEnvVarKey,
-			Value: strconv.Itoa(backupConfig.GetKeptBackupsCount()),
-		},
-		corev1.EnvVar{
-			Name:  backupConfigEnvVarKey,
-			Value: backupConfig.Name,
-		})
-
-	storeContainer.VolumeMounts = append(storeContainer.VolumeMounts, corev1.VolumeMount{
-		Name:      "ca-bundle",
-		MountPath: "/etc/ca-bundle/",
-		ReadOnly:  true,
-	})
-
-	job := r.jobBase(backupConfig, cluster, backupStatus.JobName)
-
-	job.Spec.Template.Spec.Containers = []corev1.Container{*storeContainer}
-
-	endpoints := etcd.GetClientEndpoints(cluster.Status.NamespaceName)
-	image := r.backupContainerImage
-	if !strings.Contains(image, ":") {
-		image = image + ":" + etcd.ImageTag(cluster)
-	}
-	job.Spec.Template.Spec.InitContainers = []corev1.Container{
-		{
-			Name:  "backup-creator",
-			Image: image,
-			Env: []corev1.EnvVar{
-				{
-					Name:  "ETCDCTL_API",
-					Value: "3",
-				},
-				{
-					Name:  "ETCDCTL_DIAL_TIMEOUT",
-					Value: "3s",
-				},
-				{
-					Name:  "ETCDCTL_CACERT",
-					Value: "/etc/etcd/client/ca.crt",
-				},
-				{
-					Name:  "ETCDCTL_CERT",
-					Value: "/etc/etcd/client/backup-etcd-client.crt",
-				},
-				{
-					Name:  "ETCDCTL_KEY",
-					Value: "/etc/etcd/client/backup-etcd-client.key",
-				},
-			},
-			Command: snapshotCommand(endpoints),
-			VolumeMounts: []corev1.VolumeMount{
-				{
-					Name:      SharedVolumeName,
-					MountPath: "/backup",
-				},
-				{
-					Name:      r.getEtcdSecretName(cluster),
-					MountPath: "/etc/etcd/client",
-				},
-				{
-					Name:      "ca-bundle",
-					MountPath: "/etc/ca-bundle/",
-					ReadOnly:  true,
-				},
-			},
-		},
-	}
-
-	job.Spec.Template.Spec.Volumes = []corev1.Volume{
-		{
-			Name: SharedVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				EmptyDir: &corev1.EmptyDirVolumeSource{},
-			},
-		},
-		{
-			Name: r.getEtcdSecretName(cluster),
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: r.getEtcdSecretName(cluster),
-				},
-			},
-		},
-		{
-			Name: "ca-bundle",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: caBundleConfigMapName(cluster),
-					},
-				},
-			},
-		},
-	}
-
-	return job
-}
-
-func setEnvVar(envVars []corev1.EnvVar, newEnvVar corev1.EnvVar) []corev1.EnvVar {
-	for i, envVar := range envVars {
-		if strings.EqualFold(envVar.Name, newEnvVar.Name) {
-			envVars[i] = newEnvVar
-			return envVars
-		}
-	}
-	envVars = append(envVars, newEnvVar)
-	return envVars
-}
-
-func genSecretEnvVar(name, key string, destination *kubermaticv1.BackupDestination) corev1.EnvVar {
-	return corev1.EnvVar{
-		Name: name,
-		ValueFrom: &corev1.EnvVarSource{
-			SecretKeyRef: &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: destination.Credentials.Name},
-				Key:                  key,
-			},
-		},
-	}
-}
-
-func (r *Reconciler) backupDeleteJob(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, backupStatus *kubermaticv1.BackupStatus,
-	destination *kubermaticv1.BackupDestination, deleteContainer *corev1.Container) *batchv1.Job {
-	deleteContainer = deleteContainer.DeepCopy()
-
-	// If destination is set, we need to set the credentials and backup bucket details to match the destination
-	if destination != nil {
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, destination))
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, genSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, destination))
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
-			Name:  bucketNameEnvVarKey,
-			Value: destination.BucketName,
-		})
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
-			Name:  backupEndpointEnvVarKey,
-			Value: destination.Endpoint,
-		})
-
-		insecure := "false"
-		if isInsecureURL(destination.Endpoint) {
-			insecure = "true"
-		}
-
-		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
-			Name:  backupInsecureEnvVarKey,
-			Value: insecure,
-		})
-	}
-
-	deleteContainer.Env = append(
-		deleteContainer.Env,
-		corev1.EnvVar{
-			Name:  clusterEnvVarKey,
-			Value: cluster.Name,
-		},
-		corev1.EnvVar{
-			Name:  backupToDeleteEnvVarKey,
-			Value: backupStatus.BackupName,
-		},
-		corev1.EnvVar{
-			Name:  backupScheduleEnvVarKey,
-			Value: backupConfig.Spec.Schedule,
-		},
-		corev1.EnvVar{
-			Name:  backupKeepCountEnvVarKey,
-			Value: strconv.Itoa(backupConfig.GetKeptBackupsCount()),
-		},
-		corev1.EnvVar{
-			Name:  backupConfigEnvVarKey,
-			Value: backupConfig.Name,
-		})
-
-	deleteContainer.VolumeMounts = append(deleteContainer.VolumeMounts, corev1.VolumeMount{
-		Name:      "ca-bundle",
-		MountPath: "/etc/ca-bundle/",
-		ReadOnly:  true,
-	})
-
-	job := r.jobBase(backupConfig, cluster, backupStatus.DeleteJobName)
-	job.Spec.Template.Spec.Containers = []corev1.Container{*deleteContainer}
-	job.Spec.ActiveDeadlineSeconds = resources.Int64(4 * 60)
-	job.Spec.Template.Spec.Volumes = []corev1.Volume{
-		{
-			Name: "ca-bundle",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: caBundleConfigMapName(cluster),
-					},
-				},
-			},
-		},
-	}
-	return job
-}
-
-func (r *Reconciler) jobBase(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, jobName string) *batchv1.Job {
-	return &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      jobName,
-			Namespace: metav1.NamespaceSystem,
-			Labels: map[string]string{
-				resources.AppLabelKey:    backupJobLabel,
-				BackupConfigNameLabelKey: backupConfig.Name,
-			},
-			OwnerReferences: []metav1.OwnerReference{
-				resources.GetClusterRef(cluster),
-			},
-		},
-		Spec: batchv1.JobSpec{
-			BackoffLimit:          utilpointer.Int32(3),
-			Completions:           utilpointer.Int32(1),
-			Parallelism:           utilpointer.Int32(1),
-			ActiveDeadlineSeconds: resources.Int64(2 * 60),
-			Template: corev1.PodTemplateSpec{
-				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyOnFailure,
-				},
-			},
-		},
-	}
-}
-
-func snapshotCommand(etcdEndpoints []string) []string {
-	cmd := []string{
-		"/bin/sh",
-		"-c",
-	}
-	script := &strings.Builder{}
-	// Accordings to its godoc, this always returns a nil error
-	_, _ = script.WriteString(
-		`backupOrReportFailure() {
-  echo "Creating backup"
-  if ! eval $@; then
-    echo "Backup creation failed"
-    return 1
-  fi
-  echo "Successfully created backup, exiting"
-  exit 0
-}`)
-	for _, endpoint := range etcdEndpoints {
-		_, _ = script.WriteString(fmt.Sprintf("\nbackupOrReportFailure etcdctl --endpoints %s snapshot save /backup/snapshot.db", endpoint))
-	}
-	_, _ = script.WriteString("\necho \"Unable to create backup\"\nexit 1")
-	cmd = append(cmd, script.String())
-	return cmd
-}
-
-func (r *Reconciler) getEtcdSecretName(cluster *kubermaticv1.Cluster) string {
-	return fmt.Sprintf("cluster-%s-etcd-client-certificate", cluster.Name)
-}
-
 func (r *Reconciler) ensureSecrets(ctx context.Context, cluster *kubermaticv1.Cluster) error {
-	secretName := r.getEtcdSecretName(cluster)
+	secretName := etcdbackup.GetEtcdBackupSecretName(cluster)
 
 	getCA := func() (*triple.KeyPair, error) {
 		return resources.GetClusterRootCA(ctx, cluster.Status.NamespaceName, r.Client)
@@ -1241,4 +866,62 @@ func getJobConditionIfTrue(job *batchv1.Job, condType batchv1.JobConditionType) 
 		}
 	}
 	return nil
+}
+
+func (r *Reconciler) getClusterTemplateData(ctx context.Context, cluster *kubermaticv1.Cluster, seed *kubermaticv1.Seed, config *kubermaticv1.KubermaticConfiguration, backupConfig *kubermaticv1.EtcdBackupConfig) (*resources.TemplateData, error) {
+	datacenter, found := seed.Spec.Datacenters[cluster.Spec.Cloud.DatacenterName]
+	if !found {
+		return nil, fmt.Errorf("failed to get datacenter %s", cluster.Spec.Cloud.DatacenterName)
+	}
+
+	destination := seed.GetEtcdBackupDestination(backupConfig.Spec.Destination)
+	if destination == nil {
+		return nil, fmt.Errorf("cannot find backup destination %q", backupConfig.Spec.Destination)
+	}
+	if destination.Credentials == nil {
+		return nil, fmt.Errorf("credentials not set for backup destination %q", backupConfig.Spec.Destination)
+	}
+
+	storeContainer, err := getBackupStoreContainer(config, seed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get etcd backup store container: %w", err)
+	}
+
+	deleteContainer, err := getBackupDeleteContainer(config, seed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get etcd backup delete container: %w", err)
+	}
+
+	return resources.NewTemplateDataBuilder().
+		WithContext(ctx).
+		WithClient(r).
+		WithCluster(cluster).
+		WithDatacenter(&datacenter).
+		WithSeed(seed.DeepCopy()).
+		WithKubermaticConfiguration(config.DeepCopy()).
+		WithVersions(r.versions).
+		WithOverwriteRegistry(r.overwriteRegistry).
+		WithEtcdLauncherImage(r.etcdLauncherImage).
+		WithEtcdBackupStoreContainer(storeContainer).
+		WithEtcdBackupDeleteContainer(deleteContainer).
+		WithEtcdBackupDestination(destination).
+		Build(), nil
+}
+
+func getBackupDeleteContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) (*corev1.Container, error) {
+	// a customized container is configured
+	if cfg.Spec.SeedController.BackupDeleteContainer != "" {
+		return kuberneteshelper.ContainerFromString(cfg.Spec.SeedController.BackupDeleteContainer)
+	}
+
+	return kuberneteshelper.ContainerFromString(defaulting.DefaultNewBackupDeleteContainer)
+}
+
+func getBackupStoreContainer(cfg *kubermaticv1.KubermaticConfiguration, seed *kubermaticv1.Seed) (*corev1.Container, error) {
+	// a customized container is configured
+	if cfg.Spec.SeedController.BackupStoreContainer != "" {
+		return kuberneteshelper.ContainerFromString(cfg.Spec.SeedController.BackupStoreContainer)
+	}
+
+	return kuberneteshelper.ContainerFromString(defaulting.DefaultNewBackupStoreContainer)
 }

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -243,7 +243,6 @@ func (r *Reconciler) reconcile(
 	seed *kubermaticv1.Seed,
 	config *kubermaticv1.KubermaticConfiguration,
 ) (*reconcile.Result, error) {
-
 	data, err := r.getClusterTemplateData(ctx, cluster, seed, config, backupConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get template data: %w", err)

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package etcdbackup
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"net/url"
@@ -34,18 +33,17 @@ import (
 	"k8c.io/kubermatic/v2/pkg/provider"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
-	//"k8c.io/kubermatic/v2/pkg/resources/certificates"
+	"k8c.io/kubermatic/v2/pkg/resources/certificates"
 	etcdbackup "k8c.io/kubermatic/v2/pkg/resources/etcd/backup"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/test/generator"
-	"k8c.io/kubermatic/v2/pkg/util/yaml"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	//"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	clocktesting "k8s.io/utils/clock/testing"
@@ -55,15 +53,6 @@ import (
 )
 
 type jobFunc func(data *resources.TemplateData) []batchv1.Job
-
-func encodeContainerAsYAML(t *testing.T, c *corev1.Container) string {
-	var buf bytes.Buffer
-	if err := yaml.Encode(c, &buf); err != nil {
-		t.Fatalf("failed to encode container as YAML: %v", err)
-	}
-
-	return buf.String()
-}
 
 func genTestCluster() *kubermaticv1.Cluster {
 	version := *semver.NewSemverOrDie("1.16.3")
@@ -1660,7 +1649,6 @@ func constRandStringGenerator(str string) func() string {
 	}
 }
 
-/*
 func TestMultipleBackupDestination(t *testing.T) {
 	testCases := []struct {
 		name               string
@@ -1697,7 +1685,7 @@ func TestMultipleBackupDestination(t *testing.T) {
 				return c
 			}(),
 			expectedJobEnvVars: []corev1.EnvVar{},
-			expectedErr:        fmt.Sprintf("credentials not set for backup destination %q", "no-credentials"),
+			expectedErr:        fmt.Sprintf("failed to get template data: credentials not set for backup destination %q", "no-credentials"),
 		},
 		{
 			name: "backup should fail destination is missing",
@@ -1707,7 +1695,7 @@ func TestMultipleBackupDestination(t *testing.T) {
 				return c
 			}(),
 			expectedJobEnvVars: []corev1.EnvVar{},
-			expectedErr:        fmt.Sprintf("cannot find backup destination %q", "missing"),
+			expectedErr:        fmt.Sprintf("failed to get template data: cannot find backup destination %q", "missing"),
 		},
 	}
 
@@ -1731,6 +1719,8 @@ func TestMultipleBackupDestination(t *testing.T) {
 				},
 				randStringGenerator: constRandStringGenerator("bob"),
 				configGetter:        getConfigGetter(t),
+
+				etcdLauncherImage: defaulting.DefaultEtcdLauncherImage,
 			}
 
 			ctx := context.Background()
@@ -1765,7 +1755,6 @@ func TestMultipleBackupDestination(t *testing.T) {
 		})
 	}
 }
-*/
 
 func addSeedDestinations(seed *kubermaticv1.Seed) {
 	seed.Spec.EtcdBackupRestore = &kubermaticv1.EtcdBackupRestore{

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -543,6 +543,14 @@ func (r *Reconciler) ensureServiceAccounts(ctx context.Context, c *kubermaticv1.
 		return fmt.Errorf("failed to ensure ServiceAccounts: %w", err)
 	}
 
+	namedKubeSystemServiceAccountReconcilerFactorys := []reconciling.NamedServiceAccountReconcilerFactory{
+		etcd.KubeSystemServiceAccountReconciler(c),
+	}
+
+	if err := reconciling.ReconcileServiceAccounts(ctx, namedKubeSystemServiceAccountReconcilerFactorys, metav1.NamespaceSystem, r.Client); err != nil {
+		return fmt.Errorf("failed to ensure ServiceAccounts in %s namespace: %w", metav1.NamespaceSystem, err)
+	}
+
 	return nil
 }
 

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -75,7 +75,6 @@ type TemplateData struct {
 	oidcIssuerURL                    string
 	oidcIssuerClientID               string
 	kubermaticImage                  string
-	etcdLauncherImage                string
 	dnatControllerImage              string
 	networkIntfMgrImage              string
 	machineControllerImageTag        string
@@ -90,6 +89,11 @@ type TemplateData struct {
 	isKonnectivityEnabled bool
 
 	tunnelingAgentIP string
+
+	etcdLauncherImage         string
+	etcdBackupStoreContainer  *corev1.Container
+	etcdBackupDeleteContainer *corev1.Container
+	etcdBackupDestination     *kubermaticv1.BackupDestination
 }
 
 type TemplateDataBuilder struct {
@@ -185,6 +189,21 @@ func (td *TemplateDataBuilder) WithEtcdLauncherImage(image string) *TemplateData
 	return td
 }
 
+func (td *TemplateDataBuilder) WithEtcdBackupStoreContainer(container *corev1.Container) *TemplateDataBuilder {
+	td.data.etcdBackupStoreContainer = container
+	return td
+}
+
+func (td *TemplateDataBuilder) WithEtcdBackupDeleteContainer(container *corev1.Container) *TemplateDataBuilder {
+	td.data.etcdBackupDeleteContainer = container
+	return td
+}
+
+func (td *TemplateDataBuilder) WithEtcdBackupDestination(destination *kubermaticv1.BackupDestination) *TemplateDataBuilder {
+	td.data.etcdBackupDestination = destination
+	return td
+}
+
 func (td *TemplateDataBuilder) WithDnatControllerImage(image string) *TemplateDataBuilder {
 	td.data.dnatControllerImage = image
 	return td
@@ -272,6 +291,18 @@ func (d *TemplateData) EtcdDiskSize() resource.Quantity {
 
 func (d *TemplateData) EtcdLauncherImage() string {
 	return registry.Must(d.RewriteImage(d.etcdLauncherImage))
+}
+
+func (d *TemplateData) EtcdBackupStoreContainer() *corev1.Container {
+	return d.etcdBackupStoreContainer
+}
+
+func (d *TemplateData) EtcdBackupDeleteContainer() *corev1.Container {
+	return d.etcdBackupDeleteContainer
+}
+
+func (d *TemplateData) EtcdBackupDestination() *kubermaticv1.BackupDestination {
+	return d.etcdBackupDestination
 }
 
 func (d *TemplateData) EtcdLauncherTag() string {

--- a/pkg/resources/etcd/backup/jobs.go
+++ b/pkg/resources/etcd/backup/jobs.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+const (
+	// BackupConfigNameLabelKey is the label key which should be used to name the BackupConfig a job belongs to.
+	BackupConfigNameLabelKey = "backupConfig"
+	// SharedVolumeName is the name of the `emptyDir` volume the initContainer
+	// will write the backup to.
+	SharedVolumeName = "etcd-backup"
+	// clusterEnvVarKey defines the environment variable key for the cluster name.
+	AccessKeyIdEnvVarKey = "ACCESS_KEY_ID"
+	// SecretAccessKeyEnvVarKey defines the environment variable key for the backup credentials secret access key.
+	SecretAccessKeyEnvVarKey = "SECRET_ACCESS_KEY"
+	// bucketNameEnvVarKey defines the environment variable key for the backup bucket name.
+
+	// BackupJobLabel defines the label we use on all backup jobs.
+	BackupJobLabel   = "kubermatic-etcd-backup"
+	clusterEnvVarKey = "CLUSTER"
+	// BackupToCreateEnvVarKey defines the environment variable key for the name of the backup to create.
+	BackupToCreateEnvVarKey = "BACKUP_TO_CREATE"
+	// BackupToDeleteEnvVarKey defines the environment variable key for the name of the backup to delete.
+	BackupToDeleteEnvVarKey = "BACKUP_TO_DELETE"
+	// BackupScheduleEnvVarKey defines the environment variable key for the backup schedule.
+	BackupScheduleEnvVarKey = "BACKUP_SCHEDULE"
+	// BackupKeepCountEnvVarKey defines the environment variable key for the number of backups to keep.
+	BackupKeepCountEnvVarKey = "BACKUP_KEEP_COUNT"
+	// backupConfigEnvVarKey defines the environment variable key for the name of the backup configuration resource.
+	BackupConfigEnvVarKey = "BACKUP_CONFIG"
+	// AccessKeyIdEnvVarKey defines the environment variable key for the backup credentials access key id.
+	BucketNameEnvVarKey = "BUCKET_NAME"
+	// BackupEndpointEnvVarKey defines the environment variable key for the backup endpoint.
+	BackupEndpointEnvVarKey = "ENDPOINT"
+	// BackupInsecureEnvVarKey defines the environment variable key for a boolean that tells whether the
+	// configured endpoint uses HTTPS ("false") or HTTP ("true").
+	BackupInsecureEnvVarKey = "INSECURE"
+)
+
+type etcdBackupData interface {
+	Cluster() *kubermaticv1.Cluster
+	EtcdBackupDestination() *kubermaticv1.BackupDestination
+	EtcdBackupStoreContainer() *corev1.Container
+	EtcdBackupDeleteContainer() *corev1.Container
+	EtcdLauncherImage() string
+	EtcdLauncherTag() string
+	GetClusterRef() metav1.OwnerReference
+}
+
+func BackupJob(data etcdBackupData, config *kubermaticv1.EtcdBackupConfig, status *kubermaticv1.BackupStatus) *batchv1.Job {
+	storeContainer := data.EtcdBackupStoreContainer().DeepCopy()
+
+	// If destination is set, we need to set the credentials and backup bucket details to match the destination
+	if data.EtcdBackupDestination() != nil {
+		storeContainer.Env = setEnvVar(storeContainer.Env, GenSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, data.EtcdBackupDestination()))
+		storeContainer.Env = setEnvVar(storeContainer.Env, GenSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, data.EtcdBackupDestination()))
+		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
+			Name:  BucketNameEnvVarKey,
+			Value: data.EtcdBackupDestination().BucketName,
+		})
+		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
+			Name:  BackupEndpointEnvVarKey,
+			Value: data.EtcdBackupDestination().Endpoint,
+		})
+
+		insecure := "false"
+		if isInsecureURL(data.EtcdBackupDestination().Endpoint) {
+			insecure = "true"
+		}
+
+		storeContainer.Env = setEnvVar(storeContainer.Env, corev1.EnvVar{
+			Name:  BackupInsecureEnvVarKey,
+			Value: insecure,
+		})
+	}
+
+	storeContainer.Env = append(
+		storeContainer.Env,
+		corev1.EnvVar{
+			Name:  clusterEnvVarKey,
+			Value: data.Cluster().Name,
+		},
+		corev1.EnvVar{
+			Name:  BackupToCreateEnvVarKey,
+			Value: status.BackupName,
+		},
+		corev1.EnvVar{
+			Name:  BackupScheduleEnvVarKey,
+			Value: config.Spec.Schedule,
+		},
+		corev1.EnvVar{
+			Name:  BackupKeepCountEnvVarKey,
+			Value: strconv.Itoa(config.GetKeptBackupsCount()),
+		},
+		corev1.EnvVar{
+			Name:  BackupConfigEnvVarKey,
+			Value: config.Name,
+		})
+
+	storeContainer.VolumeMounts = append(storeContainer.VolumeMounts, corev1.VolumeMount{
+		Name:      "ca-bundle",
+		MountPath: "/etc/ca-bundle/",
+		ReadOnly:  true,
+	})
+
+	job := jobBase(config, data.Cluster(), status.JobName)
+
+	job.Spec.Template.Spec.ServiceAccountName = fmt.Sprintf("%s-%s", rbac.EtcdLauncherServiceAccountName, data.Cluster().Name)
+	job.Spec.Template.Spec.Containers = []corev1.Container{*storeContainer}
+	job.Spec.Template.Spec.InitContainers = []corev1.Container{
+		{
+			Name:    "backup-creator",
+			Image:   fmt.Sprintf("%s:%s", data.EtcdLauncherImage(), data.EtcdLauncherTag()),
+			Command: snapshotCommand(data.Cluster()),
+			VolumeMounts: []corev1.VolumeMount{
+				{
+					Name:      SharedVolumeName,
+					MountPath: "/backup",
+				},
+				{
+					Name:      GetEtcdBackupSecretName(data.Cluster()),
+					MountPath: "/etc/etcd/pki/client",
+				},
+				{
+					Name:      "ca-bundle",
+					MountPath: "/etc/ca-bundle/",
+					ReadOnly:  true,
+				},
+			},
+		},
+	}
+
+	job.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: SharedVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: GetEtcdBackupSecretName(data.Cluster()),
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: GetEtcdBackupSecretName(data.Cluster()),
+				},
+			},
+		},
+		{
+			Name: "ca-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: caBundleConfigMapName(data.Cluster()),
+					},
+				},
+			},
+		},
+	}
+
+	return job
+}
+
+func snapshotCommand(cluster *kubermaticv1.Cluster) []string {
+	return []string{
+		"/etcd-launcher",
+		"snapshot",
+		"--etcd-ca-file=/etc/etcd/pki/client/ca.crt",
+		"--etcd-client-cert-file=/etc/etcd/pki/client/backup-etcd-client.crt",
+		"--etcd-client-key-file=/etc/etcd/pki/client/backup-etcd-client.key",
+		fmt.Sprintf("--cluster=%s", cluster.Name),
+		"--file=/backup/snapshot.db",
+	}
+}
+
+func setEnvVar(envVars []corev1.EnvVar, newEnvVar corev1.EnvVar) []corev1.EnvVar {
+	for i, envVar := range envVars {
+		if strings.EqualFold(envVar.Name, newEnvVar.Name) {
+			envVars[i] = newEnvVar
+			return envVars
+		}
+	}
+	envVars = append(envVars, newEnvVar)
+	return envVars
+}
+
+func BackupDeleteJob(data etcdBackupData, config *kubermaticv1.EtcdBackupConfig, status *kubermaticv1.BackupStatus) *batchv1.Job {
+	deleteContainer := data.EtcdBackupDeleteContainer().DeepCopy()
+
+	// If destination is set, we need to set the credentials and backup bucket details to match the destination
+	if data.EtcdBackupDestination() != nil {
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, GenSecretEnvVar(AccessKeyIdEnvVarKey, AccessKeyIdEnvVarKey, data.EtcdBackupDestination()))
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, GenSecretEnvVar(SecretAccessKeyEnvVarKey, SecretAccessKeyEnvVarKey, data.EtcdBackupDestination()))
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
+			Name:  BucketNameEnvVarKey,
+			Value: data.EtcdBackupDestination().BucketName,
+		})
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
+			Name:  BackupEndpointEnvVarKey,
+			Value: data.EtcdBackupDestination().Endpoint,
+		})
+
+		insecure := "false"
+		if isInsecureURL(data.EtcdBackupDestination().Endpoint) {
+			insecure = "true"
+		}
+
+		deleteContainer.Env = setEnvVar(deleteContainer.Env, corev1.EnvVar{
+			Name:  BackupInsecureEnvVarKey,
+			Value: insecure,
+		})
+	}
+
+	deleteContainer.Env = append(
+		deleteContainer.Env,
+		corev1.EnvVar{
+			Name:  clusterEnvVarKey,
+			Value: data.Cluster().Name,
+		},
+		corev1.EnvVar{
+			Name:  BackupToDeleteEnvVarKey,
+			Value: status.BackupName,
+		},
+		corev1.EnvVar{
+			Name:  BackupScheduleEnvVarKey,
+			Value: config.Spec.Schedule,
+		},
+		corev1.EnvVar{
+			Name:  BackupKeepCountEnvVarKey,
+			Value: strconv.Itoa(config.GetKeptBackupsCount()),
+		},
+		corev1.EnvVar{
+			Name:  BackupConfigEnvVarKey,
+			Value: config.Name,
+		})
+
+	deleteContainer.VolumeMounts = append(deleteContainer.VolumeMounts, corev1.VolumeMount{
+		Name:      "ca-bundle",
+		MountPath: "/etc/ca-bundle/",
+		ReadOnly:  true,
+	})
+
+	job := jobBase(config, data.Cluster(), status.DeleteJobName)
+	job.Spec.Template.Spec.Containers = []corev1.Container{*deleteContainer}
+	job.Spec.ActiveDeadlineSeconds = resources.Int64(4 * 60)
+	job.Spec.Template.Spec.Volumes = []corev1.Volume{
+		{
+			Name: "ca-bundle",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: caBundleConfigMapName(data.Cluster()),
+					},
+				},
+			},
+		},
+	}
+	return job
+}
+
+func jobBase(backupConfig *kubermaticv1.EtcdBackupConfig, cluster *kubermaticv1.Cluster, jobName string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: metav1.NamespaceSystem,
+			Labels: map[string]string{
+				resources.AppLabelKey:    BackupJobLabel,
+				BackupConfigNameLabelKey: backupConfig.Name,
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				resources.GetClusterRef(cluster),
+			},
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit:          utilpointer.Int32(3),
+			Completions:           utilpointer.Int32(1),
+			Parallelism:           utilpointer.Int32(1),
+			ActiveDeadlineSeconds: resources.Int64(2 * 60),
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyOnFailure,
+				},
+			},
+		},
+	}
+}

--- a/pkg/resources/etcd/backup/utils.go
+++ b/pkg/resources/etcd/backup/utils.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func GenSecretEnvVar(name, key string, destination *kubermaticv1.BackupDestination) corev1.EnvVar {
+	return corev1.EnvVar{
+		Name: name,
+		ValueFrom: &corev1.EnvVarSource{
+			SecretKeyRef: &corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: destination.Credentials.Name},
+				Key:                  key,
+			},
+		},
+	}
+}
+
+func GetEtcdBackupSecretName(cluster *kubermaticv1.Cluster) string {
+	return fmt.Sprintf("cluster-%s-etcd-client-certificate", cluster.Name)
+}
+
+func caBundleConfigMapName(cluster *kubermaticv1.Cluster) string {
+	return fmt.Sprintf("cluster-%s-ca-bundle", cluster.Name)
+}
+
+func isInsecureURL(u string) bool {
+	parsed, err := url.Parse(u)
+	if err != nil {
+		return false
+	}
+
+	// a hostname like "foo.com:9000" is parsed as {scheme: "foo.com", host: ""},
+	// so we must make sure to not mis-interpret "http:9000" ({scheme: "http", host: ""}) as
+	// an HTTP url
+
+	return strings.ToLower(parsed.Scheme) == "http" && parsed.Host != ""
+}

--- a/pkg/resources/etcd/serviceaccount.go
+++ b/pkg/resources/etcd/serviceaccount.go
@@ -17,6 +17,9 @@ limitations under the License.
 package etcd
 
 import (
+	"fmt"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/master-controller-manager/rbac"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -27,5 +30,13 @@ import (
 func ServiceAccountReconciler() (string, reconciling.ServiceAccountReconciler) {
 	return rbac.EtcdLauncherServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
 		return sa, nil
+	}
+}
+
+func KubeSystemServiceAccountReconciler(cluster *kubermaticv1.Cluster) reconciling.NamedServiceAccountReconcilerFactory {
+	return func() (string, reconciling.ServiceAccountReconciler) {
+		return fmt.Sprintf("%s-%s", rbac.EtcdLauncherServiceAccountName, cluster.Name), func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			return sa, nil
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds another command to `etcd-launcher` called `snapshot` which will be used as part of the backup routine. We need to do this because future etcd images have lost their shells (switching to distroless), so the init container used for etcd backups can no longer use it.

I had to rebuild parts of the etcdbackup controller to use templating data, as the controller was previously all over the place and I had to e.g. get the etcd-launcher image logic into the job generation.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Switch backup containers to use `etcd-launcher snapshot` for creating etcd database snapshots
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
