### PR TITLE
Propagate datastore cluster for vSphere to cloud-config

### DIFF
--- a/pkg/resources/cloudconfig/cloudconfig.go
+++ b/pkg/resources/cloudconfig/cloudconfig.go
@@ -244,10 +244,10 @@ func GetVSphereCloudConfig(
 	datastore := dc.Spec.VSphere.DefaultDatastore
 	// if a datastore is provided at cluster level override the default
 	// datastore provided at datacenter level.
-	// Note that in case a DatastoreCluster is provided at cluster level we
-	// still use DefaultDatastore specified at datacenter level.
 	if cluster.Spec.Cloud.VSphere.Datastore != "" {
 		datastore = cluster.Spec.Cloud.VSphere.Datastore
+	} else if cluster.Spec.Cloud.VSphere.DatastoreCluster != "" {
+		datastore = cluster.Spec.Cloud.VSphere.DatastoreCluster
 	}
 
 	// Originally, we have been setting cluster-id to the vSphere Compute Cluster name


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, for vSphere, we have a safe guard around `DatastoreCluster` that prevents it's value from being propagated to the cloud-config. This is incorrect and users can't create clusters with storage placement being done via the datastore cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vSphere: Fix a bug where datastore cluster value was not being propagated to the CSI driver
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
