### PR TITLE
[release/v2.23] Add Minio compatibility check to the installer (#12477)

### DIFF
--- a/cmd/conformance-tester/main.go
+++ b/cmd/conformance-tester/main.go
@@ -188,7 +188,7 @@ func main() {
 }
 
 func setupKubeClients(ctx context.Context, opts *types.Options) error {
-	_, _, config, err := utils.GetClients()
+	_, config, err := utils.GetClients()
 	if err != nil {
 		return fmt.Errorf("failed to get client config: %w", err)
 	}

--- a/cmd/kubermatic-installer/cmd_deploy.go
+++ b/cmd/kubermatic-installer/cmd_deploy.go
@@ -323,13 +323,14 @@ func DeployFunc(logger *logrus.Logger, versions kubermaticversion.Versions, opt 
 		deployOptions.KubermaticConfiguration = kubermaticConfig
 		deployOptions.HelmValues = helmValues
 		deployOptions.KubeClient = kubeClient
+		deployOptions.RestConfig = ctrlConfig
 		deployOptions.Logger = subLogger
 		deployOptions.SeedsGetter = seedsGetter
 		deployOptions.SeedClientGetter = kubernetesprovider.SeedClientGetterFactory(seedKubeconfigGetter)
 
 		logger.Info("🚦 Validating existing installation…")
 
-		if errs := kubermaticStack.ValidateState(appContext, deployOptions); errs != nil {
+		if errs := kubermaticStack.ValidateState(appContext, deployOptions); len(errs) > 0 {
 			logger.Error("⛔ Cannot proceed with the installation:")
 
 			for _, e := range errs {

--- a/pkg/install/stack/kubermatic-seed/validation.go
+++ b/pkg/install/stack/kubermatic-seed/validation.go
@@ -18,17 +18,120 @@ package kubermaticseed
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/install/stack"
 	"k8c.io/kubermatic/v2/pkg/install/stack/common"
+	"k8c.io/kubermatic/v2/pkg/util/podexec"
 	"k8c.io/kubermatic/v2/pkg/util/yamled"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (m *SeedStack) ValidateState(ctx context.Context, opt stack.DeployOptions) []error {
+	failures := []error{}
+
+	if err := ValidateMinioCompatibility(ctx, opt); err != nil {
+		failures = append(failures, err)
+	}
+
+	return failures
+}
+
+// lastCompatibleMinioRelease is the most recent Minio release that still contains
+// support for the legacy fs driver.
+// See https://github.com/minio/minio/releases/tag/RELEASE.2022-10-29T06-21-33Z
+// changelog and Minio PR 15929 for the removal info in the next release.
+var lastCompatibleMinioRelease = "RELEASE.2022-10-24T18-35-07Z"
+
+// In KKP 2.23, Minio RELEASE.2023-05-04T21-44-30Z i shipped. This version breaks compat
+// with previous versions as the legacy "fs" filesystem driver has been removed.
+// Since Minio RELEASE.2022-06-25T15-50-16Z (KKP 2.21), the default filesystem driver
+// was "xl" already, the new replacement for "fs".
+// This means any Minio [PVC] that was created with KKP 2.21+ is forward-compatible,
+// any PVC originally created with older Minio releases however will not survive the
+// KKP 2.23 upgrade, as a manual migration is required.
+// See https://github.com/kubermatic/kubermatic/issues/12430 for more information.
+// This function will validate Minio's currently used filesystem driver and report
+// an error if upgrading won't be possible.
+func ValidateMinioCompatibility(ctx context.Context, opt stack.DeployOptions) error {
+	// The last Minio release that can still handle "fs" storage is RELEASE.2022-10-24T18-35-07Z;
+	// if the user has configured this or any older version explicitly in their Helm values,
+	// we do not need to perform any further checks and can save a lot of work.
+	minioTag, ok := opt.HelmValues.GetString(yamled.Path{"minio", "image", "tag"})
+	if ok {
+		if !strings.HasPrefix(minioTag, "RELEASE.") {
+			opt.Logger.WithField("tag", minioTag).Warn("Cannot parse customized Minio tag, cannot skip PVC compatibility check")
+		} else if minioTag <= lastCompatibleMinioRelease {
+			return nil // an old release is configured, nothing can go wrong
+		}
+	}
+
+	release, err := opt.HelmClient.GetRelease(MinioNamespace, MinioReleaseName)
+	if err != nil {
+		return fmt.Errorf("failed to check Helm releases: %w", err)
+	}
+
+	// Minio has not been installed (yet?); perfect, the user is free to
+	// install whatever version they wish.
+	if release == nil {
+		return nil
+	}
+
+	// Checking compatibility requires to actually inspect Minio's filesystem;
+	// the current Helm release version won't tell us the original version that
+	// created the storage, and Minio's Admin API does not provide the filesystem
+	// driver name.
+	pods := corev1.PodList{}
+	if err := opt.KubeClient.List(ctx, &pods, &ctrlruntimeclient.ListOptions{
+		Namespace: MinioNamespace,
+		LabelSelector: labels.SelectorFromSet(labels.Set{
+			"app": "minio",
+		}),
+	}); err != nil {
+		return fmt.Errorf("failed to find Minio pod: %w", err)
+	}
+
+	// As the Helm chart provisions a singular PVC, we expect a singular pod. There
+	// is no option in the chart to configure a GCS/S3-backed Minio proxy that might
+	// run multiple replicas.
+	if len(pods.Items) != 1 {
+		return fmt.Errorf("expected exactly 1 Minio Pod, but found %d; cannot exec and check PVC contents", len(pods.Items))
+	}
+
+	minioPod := ctrlruntimeclient.ObjectKeyFromObject(&pods.Items[0])
+
+	// Exec into the pod and look under Minio's hood.
+	command := []string{"cat", "/storage/.minio.sys/format.json"}
+	stdout, _, err := podexec.ExecuteCommand(ctx, opt.RestConfig, minioPod, "minio", command...)
+	if err != nil {
+		return fmt.Errorf("failed to execute command in Minio container: %w", err)
+	}
+
+	// parse Minio's config file
+	type minioFormat struct {
+		Format string `json:"format"`
+	}
+
+	data := minioFormat{}
+	if err := json.Unmarshal([]byte(stdout), &data); err != nil {
+		return fmt.Errorf("failed to decode %q as JSON: %w", stdout, err)
+	}
+
+	// Bad news: This Minio is using the old, legacy fs driver and needs to be migrated manually.
+	if data.Format == "fs" {
+		return errors.New("the Minio storage is using the `fs` filesystem driver, which is incompatible with more recent Minio releases and requires a migration; please refer to https://docs.kubermatic.com/kubermatic/v2.23/installation/upgrading/upgrade-from-2.22-to-2.23/#minio-upgrade for more information")
+	}
+
+	// Good news, the storage is probably using "xl" and so it's future-ready.
 	return nil
 }
 

--- a/pkg/install/stack/types.go
+++ b/pkg/install/stack/types.go
@@ -29,6 +29,7 @@ import (
 
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -36,6 +37,7 @@ type DeployOptions struct {
 	HelmClient                 helm.Client
 	HelmValues                 *yamled.Document
 	KubeClient                 ctrlruntimeclient.Client
+	RestConfig                 *rest.Config
 	StorageClassProvider       string
 	KubermaticConfiguration    *kubermaticv1.KubermaticConfiguration
 	RawKubermaticConfiguration *unstructured.Unstructured

--- a/pkg/test/dualstack/cloud_providers_dualstack_test.go
+++ b/pkg/test/dualstack/cloud_providers_dualstack_test.go
@@ -364,7 +364,7 @@ func TestNewClusters(t *testing.T) {
 
 	parseProviderCredentials(t)
 
-	seedClient, _, _, err := utils.GetClients()
+	seedClient, _, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("Failed to get client for seed cluster: %v", err)
 	}

--- a/pkg/test/e2e/ccm-migration/ccm_migration_test.go
+++ b/pkg/test/e2e/ccm-migration/ccm_migration_test.go
@@ -101,7 +101,7 @@ func TestCCMMigration(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	seedClient, _, _ := e2eutils.GetClientsOrDie()
+	seedClient, _ := e2eutils.GetClientsOrDie()
 	log := log.NewFromOptions(options.logOptions).Sugar().With("provider", options.provider)
 
 	// prepare cluster

--- a/pkg/test/e2e/etcd-launcher/etcd_test.go
+++ b/pkg/test/e2e/etcd-launcher/etcd_test.go
@@ -70,7 +70,7 @@ func TestBackup(t *testing.T) {
 		t.Fatalf("Failed to get credentials: %v", err)
 	}
 
-	client, _, _, err := utils.GetClients()
+	client, _, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestScaling(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewFromOptions(logOptions).Sugar()
 
-	client, _, _, err := utils.GetClients()
+	client, _, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}
@@ -192,7 +192,7 @@ func TestRecovery(t *testing.T) {
 	ctx := context.Background()
 	logger := log.NewFromOptions(logOptions).Sugar()
 
-	client, _, _, err := utils.GetClients()
+	client, _, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -57,7 +57,7 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 		t.Fatalf("Failed to get credentials: %v", err)
 	}
 
-	seedClient, restConfig, seedConfig, err := e2eutils.GetClients()
+	seedClient, seedConfig, err := e2eutils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}
@@ -96,7 +96,6 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 		Log:           logger,
 		Namespace:     cluster.Status.NamespaceName,
 		Client:        seedClient,
-		PodRestClient: restConfig,
 		Config:        seedConfig,
 		CreatePodFunc: newClientPod,
 	}}

--- a/pkg/test/e2e/ipam/ipam_test.go
+++ b/pkg/test/e2e/ipam/ipam_test.go
@@ -62,7 +62,7 @@ func TestIPAM(t *testing.T) {
 		t.Fatalf("failed to get credentials: %v", err)
 	}
 
-	seedClient, _, _, err := utils.GetClients()
+	seedClient, _, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}

--- a/pkg/test/e2e/mla/mla_test.go
+++ b/pkg/test/e2e/mla/mla_test.go
@@ -86,7 +86,7 @@ func TestMLAIntegration(t *testing.T) {
 		t.Fatalf("Failed to get credentials: %v", err)
 	}
 
-	seedClient, _, _, err := utils.GetClients()
+	seedClient, _, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}

--- a/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
+++ b/pkg/test/e2e/nodeport-proxy/nodeport_proxy_test.go
@@ -130,7 +130,7 @@ func TestNodeportProxy(t *testing.T) {
 	ctx := signals.SetupSignalHandler()
 	logger := log.NewFromOptions(logOptions).Sugar()
 
-	k8scli, podRestCli, config, err := e2eutils.GetClients()
+	k8scli, config, err := e2eutils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}
@@ -161,7 +161,6 @@ func TestNodeportProxy(t *testing.T) {
 			Client:        k8scli,
 			Namespace:     npp.Namespace,
 			Config:        config,
-			PodRestClient: podRestCli,
 			CreatePodFunc: newAgnhostPod,
 		},
 	}

--- a/pkg/test/e2e/opa/opa_test.go
+++ b/pkg/test/e2e/opa/opa_test.go
@@ -73,7 +73,7 @@ func TestOPAIntegration(t *testing.T) {
 		t.Fatalf("Failed to get credentials: %v", err)
 	}
 
-	seedClient, _, _, err := utils.GetClients()
+	seedClient, _, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}

--- a/pkg/util/podexec/exec.go
+++ b/pkg/util/podexec/exec.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podexec
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// ExecuteCommand executes the given command in the chosen container of a pod.
+func ExecuteCommand(ctx context.Context, restConfig *rest.Config, pod types.NamespacedName, container string, command ...string) (string, string, error) {
+	gvk, err := apiutil.GVKForObject(&corev1.Pod{}, scheme.Scheme)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to get pod GVK: %w", err)
+	}
+
+	restClient, err := apiutil.RESTClientForGVK(gvk, false, restConfig, scheme.Codecs)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create REST client: %w", err)
+	}
+
+	request := restClient.
+		Post().
+		Resource("pods").
+		Namespace(pod.Namespace).
+		Name(pod.Name).
+		SubResource("exec").
+		Param("container", container)
+
+	request.VersionedParams(&corev1.PodExecOptions{
+		Container: container,
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+	}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, http.MethodPost, request.URL())
+	if err != nil {
+		return "", "", fmt.Errorf("failed to create SPDY executor: %w", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		return "", "", err
+	}
+
+	return stdout.String(), stderr.String(), err
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a backport of #12477, manually done because of the ctrl-runtime changes, which caused a few minor conflicts.

**What type of PR is this?**
/kind bug
/kind deprecation
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The Kubermatic Installer will now validate the existing Minio filesystem before attempting a `kubermatic-seed` stack installation.
```

**Documentation**:
```documentation
NONE
```
