### PR TITLE
add version-reporter tool to collect third party dependency versions from the codebase

### DIFF
--- a/cmd/conformance-tester/pkg/types/options.go
+++ b/cmd/conformance-tester/pkg/types/options.go
@@ -22,10 +22,8 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"sort"
 	"time"
 
-	semverlib "github.com/Masterminds/semver/v3"
 	"go.uber.org/zap"
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
@@ -36,6 +34,7 @@ import (
 	kubermativsemver "k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/test"
 	"k8c.io/kubermatic/v2/pkg/util/flagopts"
+	"k8c.io/kubermatic/v2/pkg/version"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/kubernetes"
@@ -111,7 +110,7 @@ func NewDefaultOptions() *Options {
 		Client:                       "kube",
 		ScenarioOptions:              sets.New[string](),
 		Providers:                    sets.New[string](),
-		Releases:                     sets.New(getLatestMinorVersions(defaulting.DefaultKubernetesVersioning.Versions)...),
+		Releases:                     sets.New(version.GetLatestMinorVersions(defaulting.DefaultKubernetesVersioning.Versions)...),
 		ContainerRuntimes:            sets.New(resources.ContainerRuntimeContainerd),
 		EnableDistributions:          sets.New[string](),
 		ExcludeDistributions:         sets.New[string](),
@@ -297,25 +296,4 @@ func combineSets(include, exclude, all sets.Set[string], flagname string) (sets.
 	}
 
 	return chosen, nil
-}
-
-func getLatestMinorVersions(versions []kubermativsemver.Semver) []string {
-	minorMap := map[uint64]*semverlib.Version{}
-
-	for _, version := range versions {
-		sversion := version.Semver()
-		minor := sversion.Minor()
-
-		if existing := minorMap[minor]; existing == nil || existing.LessThan(sversion) {
-			minorMap[minor] = sversion
-		}
-	}
-
-	list := []string{}
-	for _, v := range minorMap {
-		list = append(list, "v"+v.String())
-	}
-	sort.Strings(list)
-
-	return list
 }

--- a/codegen/version-reporter/README.md
+++ b/codegen/version-reporter/README.md
@@ -1,0 +1,27 @@
+# Version Reporter
+
+This is a small, hackish tool that extracts version numbers from the KKP codebase. The idea is to be able to get a quick overview over the used/deployed pieces of software in a running KKP setup (i.e. not Go dependencies).
+
+## Mode of Operation
+
+Version numbers are used all over the place in KKP. Helm charts have versions, in `pkg/resources/` there are many version constants (for things like etcd's version, CoreDNS' version, etc.) and there are even more.
+
+The version reporter can be configured with a single YAML configuration file. In this file all software products that KKP uses are listed (like CoreDNS, etc, Prometheus, AWS CCM, ...). For each product, a list of occurrences is defined. Each occurrence is one single place in the codebase where a version is notated. An occurrence can be either
+
+* a Go constant (also supports private constants)
+* a function call (only to pre-defined helper functions, see below)
+* a Helm chart (either its `appVersion` or an arbitrary value from the `values.yaml`).
+
+When the version-reporter is run, it will scan all the occurrences and print a nice, human readable report.
+
+Note that each occurrence can not just produce a single version number, but multiple. This is used for things like the CCM versions, which depend on the user-cluster version. You would configure a single occurrence, usually a Go function call, and the version-reporter will call the function once for each supported Kubernetes _minor_ release (i.e. if `v1.27.2` and `v1.27.5` are supported, the function is called once with `v1.27.0`).
+
+## Usage
+
+Simply run `hack/versions-gen.sh`. Use `-json` for JSON output.
+
+## Maintenance
+
+When an occurrence cannot be resolved anymore, version-reporter will exit with a non-zero code, triggering a presubmit to fail. This is a sign to the developer that they somehow refactored the code in a way where the reporter is not sure what happened. If this was you, then it's now your task to simply update the `hack/versions.yaml` accordingly.
+
+When new software products are added to KKP, there is no mechanism that forces us to remember to add it to the `versions.yaml`.

--- a/codegen/version-reporter/main.go
+++ b/codegen/version-reporter/main.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+
+	"k8c.io/kubermatic/v2/codegen/version-reporter/pkg/config"
+	"k8c.io/kubermatic/v2/codegen/version-reporter/pkg/output"
+	"k8c.io/kubermatic/v2/codegen/version-reporter/pkg/reader"
+)
+
+type options struct {
+	configFile string
+	json       bool
+}
+
+func main() {
+	opt := options{}
+	flag.StringVar(&opt.configFile, "config", "", "path to the config file")
+	flag.BoolVar(&opt.json, "json", false, "output JSON instead of plaintext")
+	flag.Parse()
+
+	cfg, err := config.Load(opt.configFile)
+	if err != nil {
+		log.Fatalf("Failed to load configuration: %v", err)
+	}
+
+	// detect all versions
+	success := reader.ResolveConfig(cfg)
+
+	// cheat: remove common prefix from package names for easier readability
+	for pdx, product := range cfg.Products {
+		for odx, occ := range product.Occurrences {
+			if occ.GoConstant != nil {
+				newPackage := strings.TrimPrefix(occ.GoConstant.Package, "k8c.io/kubermatic/v2/")
+
+				cfg.Products[pdx].Occurrences[odx].GoConstant.Package = newPackage
+			}
+		}
+	}
+
+	// make output look nicer :)
+	cfg.Sort()
+
+	if opt.json {
+		err = output.FormatJSON(cfg, os.Stdout)
+	} else {
+		err = output.FormatTable(cfg, os.Stdout)
+	}
+
+	if err != nil {
+		log.Fatalf("Failed to output results: %v", err)
+	}
+
+	if !success {
+		os.Exit(1)
+	}
+}

--- a/codegen/version-reporter/pkg/config/config.go
+++ b/codegen/version-reporter/pkg/config/config.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Config struct {
+	Products []SoftwareProduct `yaml:"products" json:"products"`
+}
+
+type SoftwareProduct struct {
+	Name        string             `yaml:"name" json:"name"`
+	SourceURL   string             `yaml:"source" json:"source"`
+	Occurrences []VersionReference `yaml:"occurrences" json:"occurrences"`
+}
+
+// Unversioned is the key in the VersionReference.Versions
+// for all reference types that only produce a single version,
+// instead of depending on the user-cluster version.
+const Unversioned = "*"
+
+type VersionReference struct {
+	GoConstant *GoConstantReference `yaml:"goConstant,omitempty" json:"goConstant,omitempty"`
+	GoFunction *GoFunctionReference `yaml:"goFunction,omitempty" json:"goFunction,omitempty"`
+	HelmChart  *HelmChartReference  `yaml:"helmChart,omitempty" json:"helmChart,omitempty"`
+	YAMLFile   *YAMLFileReference   `yaml:"yamlFile,omitempty" json:"yamlFile,omitempty"`
+
+	// Versions is filled during runtime (JSON tag exists for output purposes)
+	Versions map[string]string `json:"versions"`
+}
+
+func (r VersionReference) String() string {
+	switch {
+	case r.GoConstant != nil:
+		return r.GoConstant.String()
+	case r.GoFunction != nil:
+		return r.GoFunction.String()
+	case r.HelmChart != nil:
+		return r.HelmChart.String()
+	case r.YAMLFile != nil:
+		return r.YAMLFile.String()
+	default:
+		return fmt.Sprintf("%#v", r)
+	}
+}
+
+func (r VersionReference) TypeName() string {
+	switch {
+	case r.GoConstant != nil:
+		return r.GoConstant.TypeName()
+	case r.GoFunction != nil:
+		return r.GoFunction.TypeName()
+	case r.HelmChart != nil:
+		return r.HelmChart.TypeName()
+	case r.YAMLFile != nil:
+		return r.YAMLFile.TypeName()
+	default:
+		return fmt.Sprintf("%T", r)
+	}
+}
+
+type GoConstantReference struct {
+	Package  string `yaml:"package" json:"package"`
+	Constant string `yaml:"constant" json:"constant"`
+}
+
+func (r GoConstantReference) TypeName() string {
+	return "Go const"
+}
+
+func (r GoConstantReference) String() string {
+	return fmt.Sprintf("%s.%s", r.Package, r.Constant)
+}
+
+type GoFunctionReference struct {
+	Function string `yaml:"function" json:"function"`
+}
+
+func (r GoFunctionReference) String() string {
+	return r.Function
+}
+
+func (r GoFunctionReference) TypeName() string {
+	return "Go func"
+}
+
+type HelmChartReference struct {
+	Directory string `yaml:"directory" json:"directory"`
+	ValuePath string `yaml:"valuePath,omitempty" json:"valuePath,omitempty"`
+}
+
+func (r HelmChartReference) String() string {
+	if r.ValuePath != "" {
+		return fmt.Sprintf("%s @ %s", r.Directory, r.ValuePath)
+	}
+	return r.Directory
+}
+
+func (r HelmChartReference) TypeName() string {
+	return "Helm chart"
+}
+
+type YAMLFileReference struct {
+	File      string `yaml:"file" json:"file"`
+	ValuePath string `yaml:"valuePath" json:"valuePath"`
+}
+
+func (r YAMLFileReference) String() string {
+	return fmt.Sprintf("%s @ %s", r.File, r.ValuePath)
+}
+
+func (r YAMLFileReference) TypeName() string {
+	return "YAML file"
+}
+
+func Load(filename string) (*Config, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	decoder.KnownFields(true)
+
+	cfg := &Config{}
+	if err := decoder.Decode(cfg); err != nil {
+		return nil, err
+	}
+
+	if err := validateConfig(cfg); err != nil {
+		return nil, fmt.Errorf("configuration is invalid: %w", err)
+	}
+
+	return cfg, nil
+}
+
+func (c *Config) Sort() {
+	sort.Slice(c.Products, func(i, j int) bool {
+		return strings.ToLower(c.Products[i].Name) < strings.ToLower(c.Products[j].Name)
+	})
+
+	for idx, product := range c.Products {
+		sort.Slice(product.Occurrences, func(i, j int) bool {
+			a := product.Occurrences[i]
+			b := product.Occurrences[j]
+
+			if a.TypeName() != b.TypeName() {
+				return a.TypeName() < b.TypeName()
+			}
+
+			return a.String() < b.String()
+		})
+
+		c.Products[idx] = product
+	}
+}
+
+func validateConfig(cfg *Config) error {
+	for idx, product := range cfg.Products {
+		if product.Name == "" {
+			return fmt.Errorf("product #%d has no name", idx)
+		}
+
+		if product.SourceURL == "" {
+			return fmt.Errorf("product %q has no source URL", product.Name)
+		}
+
+		for jdx, occ := range product.Occurrences {
+			switch {
+			case occ.GoConstant != nil:
+				continue
+			case occ.GoFunction != nil:
+				continue
+			case occ.HelmChart != nil:
+				continue
+			case occ.YAMLFile != nil:
+				continue
+			default:
+				return fmt.Errorf("occurrence #%d of %q has no valid locator defined", jdx, product.Name)
+			}
+		}
+	}
+
+	return nil
+}

--- a/codegen/version-reporter/pkg/output/json.go
+++ b/codegen/version-reporter/pkg/output/json.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"encoding/json"
+	"io"
+
+	"k8c.io/kubermatic/v2/codegen/version-reporter/pkg/config"
+)
+
+func FormatJSON(cfg *config.Config, dest io.Writer) error {
+	encoder := json.NewEncoder(dest)
+	encoder.SetIndent("", "  ")
+
+	return encoder.Encode(cfg)
+}

--- a/codegen/version-reporter/pkg/output/table.go
+++ b/codegen/version-reporter/pkg/output/table.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"io"
+
+	"github.com/olekukonko/tablewriter"
+
+	"k8c.io/kubermatic/v2/codegen/version-reporter/pkg/config"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func FormatTable(cfg *config.Config, dest io.Writer) error {
+	columns := []string{"Product", "Type", "Location"}
+	allVersions := getVersionSuperset(cfg)
+
+	if len(allVersions) > 0 {
+		columns = append(columns, allVersions...)
+	} else {
+		columns = append(columns, "Version")
+	}
+
+	versionColumns := func(versions map[string]string) []string {
+		result := []string{}
+
+		for _, versionKey := range allVersions {
+			if versions == nil {
+				result = append(result, "?")
+				continue
+			}
+
+			version, ok := versions[versionKey]
+			if ok {
+				result = append(result, version)
+			} else {
+				result = append(result, "")
+			}
+		}
+
+		return result
+	}
+
+	table := tablewriter.NewWriter(dest)
+	table.SetHeader(columns)
+	table.SetAutoWrapText(false)
+	table.SetAutoMergeCellsByColumnIndex([]int{0, 1})
+
+	for _, product := range cfg.Products {
+		for _, occ := range product.Occurrences {
+			row := []string{product.Name, occ.TypeName(), occ.String()}
+			table.Append(append(row, versionColumns(occ.Versions)...))
+		}
+	}
+
+	table.Render()
+
+	return nil
+}
+
+func getVersionSuperset(c *config.Config) []string {
+	superset := sets.New[string]()
+
+	for _, p := range c.Products {
+		for _, o := range p.Occurrences {
+			superset = superset.Union(sets.KeySet(o.Versions))
+		}
+	}
+
+	if superset.Len() == 1 && superset.Has(config.Unversioned) {
+		return nil
+	}
+
+	return sets.List(superset)
+}

--- a/codegen/version-reporter/pkg/reader/goconst.go
+++ b/codegen/version-reporter/pkg/reader/goconst.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"fmt"
+	"go/types"
+	"strconv"
+	"strings"
+
+	"golang.org/x/tools/go/packages"
+)
+
+func ReadGoConstantFromPackage(dir string, pkgToSearch string, constName string) (string, error) {
+	config := &packages.Config{
+		Dir:        dir,
+		BuildFlags: []string{"-tags=ee"},
+		Mode:       packages.NeedTypes | packages.NeedTypesInfo,
+	}
+
+	pkgs, err := packages.Load(config, pkgToSearch)
+	if err != nil {
+		return "", err
+	}
+
+	sourcePkg := pkgs[0]
+
+	// handle errors like no 'Go files found in pkg' upfront
+	for _, err := range sourcePkg.Errors {
+		return "", fmt.Errorf("failed to load package %q: %s", sourcePkg.ID, err.Msg) // we have to use sourcePkg.ID here, as fields like name are not set
+	}
+
+	for _, v := range sourcePkg.TypesInfo.Defs {
+		if v == nil || !isPackageScoped(v) {
+			continue
+		}
+
+		if constDef, constOk := v.(*types.Const); constOk && constDef.Name() == constName {
+			quotedValue := constDef.Val().ExactString()
+
+			return strconv.Unquote(quotedValue)
+		}
+	}
+
+	return "", ErrVersionNotFound
+}
+
+func isPackageScoped(obj types.Object) bool {
+	parent := obj.Parent()
+
+	return parent != nil && strings.HasPrefix(parent.String(), "package ")
+}

--- a/codegen/version-reporter/pkg/reader/gofunc.go
+++ b/codegen/version-reporter/pkg/reader/gofunc.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
+	"k8c.io/kubermatic/v2/pkg/resources/dns"
+	"k8c.io/kubermatic/v2/pkg/resources/konnectivity"
+	kubernetesdashboard "k8c.io/kubermatic/v2/pkg/resources/kubernetes-dashboard"
+	"k8c.io/kubermatic/v2/pkg/semver"
+	"k8c.io/kubermatic/v2/pkg/version"
+	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
+)
+
+type versionProviderFunc func(clusterVersion semver.Semver) (string, error)
+
+var versionProviderFuncs = map[string]versionProviderFunc{
+	"callAWSCCMVersion": func(clusterVersion semver.Semver) (string, error) {
+		return cloudcontroller.AWSCCMVersion(clusterVersion), nil
+	},
+	"callAzureCCMVersion":     cloudcontroller.AzureCCMVersion,
+	"callOpenStackCCMVersion": cloudcontroller.OpenStackCCMTag,
+	"callVSphereCCMVersion": func(clusterVersion semver.Semver) (string, error) {
+		return cloudcontroller.VSphereCCMVersion(clusterVersion), nil
+	},
+	"callCoreDNSVersion": func(clusterVersion semver.Semver) (string, error) {
+		return dns.CoreDNSVersion(clusterVersion.Semver()), nil
+	},
+	"callKonnectivityVersion": func(clusterVersion semver.Semver) (string, error) {
+		return konnectivity.NetworkProxyVersion(clusterVersion), nil
+	},
+	"callKubernetesDashboardVersion": kubernetesdashboard.DashboardVersion,
+	"getVPAVersion": func(clusterVersion semver.Semver) (string, error) {
+		return kubermatic.NewDefaultVersions().VPA, nil
+	},
+	"getEnvoyAgentVersion": func(clusterVersion semver.Semver) (string, error) {
+		return kubermatic.NewDefaultVersions().Envoy, nil
+	},
+}
+
+func CallGoFunction(function string) (map[string]string, error) {
+	fun, ok := versionProviderFuncs[function]
+	if !ok {
+		return nil, fmt.Errorf("unknown function %q", function)
+	}
+
+	clusterVersions := []semver.Semver{}
+
+	for _, version := range version.GetLatestMinorVersions(defaulting.DefaultKubernetesVersioning.Versions) {
+		clusterVersions = append(clusterVersions, *semver.NewSemverOrDie(version))
+	}
+
+	result := map[string]string{}
+	for _, clusterVersion := range clusterVersions {
+		componentVersion, err := fun(clusterVersion)
+		if err != nil {
+			return nil, fmt.Errorf("failed calling %q for %v: %w", function, clusterVersion, err)
+		}
+
+		result[clusterVersion.MajorMinor()] = componentVersion
+	}
+
+	return result, nil
+}

--- a/codegen/version-reporter/pkg/reader/helm.go
+++ b/codegen/version-reporter/pkg/reader/helm.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+func ReadHelmChartVersion(chart string, valuePath string) (string, error) {
+	if valuePath == "" {
+		return readHelmChartAppVersion(chart)
+	}
+
+	return readHelmChartValue(chart, valuePath)
+}
+
+type helmChart struct {
+	AppVersion string `yaml:"appVersion"`
+}
+
+func readHelmChartAppVersion(dir string) (string, error) {
+	yamlFile := filepath.Join(dir, "Chart.yaml")
+
+	f, err := os.Open(yamlFile)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	chart := helmChart{}
+	if err := yaml.NewDecoder(f).Decode(&chart); err != nil {
+		return "", err
+	}
+
+	return chart.AppVersion, nil
+}
+
+func readHelmChartValue(dir string, valuePath string) (string, error) {
+	return ReadYAMLVersion(filepath.Join(dir, "values.yaml"), valuePath)
+}

--- a/codegen/version-reporter/pkg/reader/reader.go
+++ b/codegen/version-reporter/pkg/reader/reader.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"errors"
+	"log"
+	"os"
+
+	"k8c.io/kubermatic/v2/codegen/version-reporter/pkg/config"
+)
+
+var (
+	ErrVersionNotFound = errors.New("no such constant")
+)
+
+func ResolveConfig(cfg *config.Config) bool {
+	success := true
+
+	for pdx, product := range cfg.Products {
+		log.Printf("Fetching versions for %s…", product.Name)
+
+		for odx, occ := range product.Occurrences {
+			versions, err := ResolveReference(occ)
+			if err != nil {
+				log.Printf("Error: failed to read version #%d for %s: %v", odx, product.Name, err)
+				success = false
+				continue
+			}
+
+			cfg.Products[pdx].Occurrences[odx].Versions = versions
+		}
+	}
+
+	return success
+}
+
+func ResolveReference(ref config.VersionReference) (map[string]string, error) {
+	switch {
+	case ref.GoConstant != nil:
+		return readGoConstantVersion(ref.GoConstant)
+	case ref.GoFunction != nil:
+		return readGoFunctionVersion(ref.GoFunction)
+	case ref.HelmChart != nil:
+		return readHelmChartVersion(ref.HelmChart)
+	case ref.YAMLFile != nil:
+		return readYAMLVersion(ref.YAMLFile)
+	default:
+		return nil, errors.New("unknown reference type")
+	}
+}
+
+func readGoConstantVersion(ref *config.GoConstantReference) (map[string]string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+
+	version, err := ReadGoConstantFromPackage(cwd, ref.Package, ref.Constant)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{config.Unversioned: version}, nil
+}
+
+func readGoFunctionVersion(ref *config.GoFunctionReference) (map[string]string, error) {
+	return CallGoFunction(ref.Function)
+}
+
+func readHelmChartVersion(ref *config.HelmChartReference) (map[string]string, error) {
+	version, err := ReadHelmChartVersion(ref.Directory, ref.ValuePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{config.Unversioned: version}, nil
+}
+
+func readYAMLVersion(ref *config.YAMLFileReference) (map[string]string, error) {
+	version, err := ReadYAMLVersion(ref.File, ref.ValuePath)
+	if err != nil {
+		return nil, err
+	}
+
+	return map[string]string{config.Unversioned: version}, nil
+}

--- a/codegen/version-reporter/pkg/reader/yaml.go
+++ b/codegen/version-reporter/pkg/reader/yaml.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reader
+
+import (
+	"os"
+	"strings"
+
+	"k8c.io/kubermatic/v2/pkg/util/yamled"
+)
+
+func ReadYAMLVersion(filename string, valuePath string) (string, error) {
+	path := yamled.Path{}
+	for _, step := range strings.Split(valuePath, ".") {
+		path = path.Append(step)
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	doc, err := yamled.Load(f)
+	if err != nil {
+		return "", err
+	}
+
+	value, ok := doc.GetString(path)
+	if !ok {
+		return "", ErrVersionNotFound
+	}
+
+	return value, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/kubermatic/machine-controller v1.57.1-0.20230704163314-5f4e903ddafe
 	github.com/minio/minio-go/v7 v7.0.59
 	github.com/nutanix-cloud-native/prism-go-client v0.3.4
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.27.8
 	github.com/open-policy-agent/frameworks/constraint v0.0.0-20230606213221-6ccacf85c2c5 // v0.9.0+

--- a/go.sum
+++ b/go.sum
@@ -841,6 +841,7 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/hack/ci/verify.sh
+++ b/hack/ci/verify.sh
@@ -64,6 +64,7 @@ try "Verify boilerplate" ./hack/verify-boilerplate.sh
 try "Verify Grafana dashboards" ./hack/verify-grafana-dashboards.sh
 try "Verify Prometheus rules" ./hack/verify-prometheus-rules.sh
 try "Verify User Cluster Prometheus rules" ./hack/ci/verify-user-cluster-prometheus-configs.sh
+try "Display Versioning Information" ./hack/versions-gen.sh
 
 # -l        list files whose formatting differs from shfmt's
 # -d        error with a diff when the formatting differs

--- a/hack/versions-gen.sh
+++ b/hack/versions-gen.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/..
+source hack/lib.sh
+
+mkdir -p _build
+go build -v -o _build/version-reporter ./codegen/version-reporter
+
+./_build/version-reporter -config hack/versions.yaml $@

--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -1,0 +1,287 @@
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Please refer to the codegen/version-reporter/README.md for more information.
+
+products:
+  - name: "CCM: Anexia"
+    source: https://github.com/anexia-it/k8s-anexia-ccm
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/cloudcontroller
+          constant: anexiaCCMVersion
+
+  - name: "CCM: AWS"
+    source: https://github.com/kubernetes/cloud-provider-aws
+    occurrences:
+      - goFunction:
+          function: callAWSCCMVersion
+
+  - name: "CCM: Azure"
+    source: https://github.com/kubernetes/cloud-provider-azure
+    occurrences:
+      - goFunction:
+          function: callAzureCCMVersion
+
+  - name: "CCM: DigitalOcean"
+    source: https://github.com/digitalocean/digitalocean-cloud-controller-manager
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/cloudcontroller
+          constant: DigitalOceanCCMVersion
+
+  - name: "CCM: Hetzner"
+    source: https://github.com/hetznercloud/hcloud-cloud-controller-manager
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/cloudcontroller
+          constant: hetznerCCMVersion
+
+  - name: "CCM: KubeVirt"
+    source: https://github.com/kubermatic/cloud-provider-kubevirt
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/cloudcontroller
+          constant: KubeVirtCCMTag
+
+  - name: "CCM: OpenStack"
+    source: https://github.com/kubernetes/cloud-provider-openstack
+    occurrences:
+      - goFunction:
+          function: callOpenStackCCMVersion
+
+  - name: "CCM: vSphere"
+    source: https://github.com/kubernetes/cloud-provider-vsphere
+    occurrences:
+      - goFunction:
+          function: callVSphereCCMVersion
+
+  - name: KubeVirt CSI
+    source: https://github.com/kubermatic/kubevirt-csi-driver-operator
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/csi/kubevirt
+          constant: csiVersion
+
+  - name: CoreDNS
+    source: https://github.com/kubernetes/kubernetes
+    occurrences:
+      - goFunction:
+          function: callCoreDNSVersion
+
+  - name: Konnectivity
+    source: https://github.com/kubernetes-sigs/apiserver-network-proxy
+    occurrences:
+      - goFunction:
+          function: callKonnectivityVersion
+
+  - name: OpenVPN
+    source: https://github.com/kubermatic/openvpn
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/openvpn
+          constant: version
+
+  - name: Kubernetes Dashboard
+    source: https://github.com/kubernetes/dashboard
+    occurrences:
+      - goFunction:
+          function: callKubernetesDashboardVersion
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard
+          constant: scraperTag
+
+  - name: machine-controller (MC)
+    source: https://github.com/kubermatic/machine-controller
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/machinecontroller
+          constant: Tag
+
+  - name: Operating System Manager (OSM)
+    source: https://github.com/kubermatic/operating-system-manager
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager
+          constant: Tag
+
+  - name: Metrics Server
+    source: https://github.com/kubernetes-sigs/metrics-server
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/metrics-server
+          constant: tag
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server
+          constant: imageTag
+
+  - name: KubeOne
+    source: https://github.com/kubermatic/kubeone
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources
+          constant: KubeOneImageTag
+
+  - name: Metering
+    source: https://github.com/kubermatic/kubermatic
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/ee/metering
+          constant: meteringVersion
+
+  - name: Gatekeeper (OPA)
+    source: https://github.com/open-policy-agent/gatekeeper
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper
+          constant: tag
+
+  - name: Vertical Pod Autoscaler (VPA)
+    source: https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
+    occurrences:
+      - goFunction:
+          function: getVPAVersion
+
+  - name: Envoy
+    source: https://github.com/envoyproxy/envoy/
+    occurrences:
+      - goFunction:
+          function: getEnvoyAgentVersion
+      - helmChart:
+          directory: charts/mla/alertmanager-proxy
+          valuePath: alertmanagerProxy.proxy.image.tag
+
+  - name: node-local-dns
+    source: https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns
+          constant: version
+
+  - name: Velero
+    source: https://github.com/vmware-tanzu/velero
+    occurrences:
+      - helmChart: { directory: charts/backup/velero }
+
+  - name: cert-manager
+    source: https://github.com/cert-manager/cert-manager
+    occurrences:
+      - helmChart: { directory: charts/cert-manager }
+
+  - name: IAP (oauth2-proxy)
+    source: https://github.com/oauth2-proxy/oauth2-proxy
+    occurrences:
+      - helmChart: { directory: charts/iap }
+
+  - name: Local KubeVirt
+    source: https://github.com/kubevirt/kubevirt
+    occurrences:
+      - helmChart: { directory: charts/local-kubevirt }
+
+  - name: Loki
+    source: https://github.com/grafana/loki
+    occurrences:
+      - helmChart: { directory: charts/logging/loki }
+      - helmChart: { directory: charts/mla/loki-distributed }
+
+  - name: Promtail
+    source: https://github.com/grafana/promtail
+    occurrences:
+      - helmChart: { directory: charts/logging/promtail }
+
+  - name: MinIO
+    source: https://github.com/minio/minio
+    occurrences:
+      - helmChart: { directory: charts/minio }
+      - helmChart: { directory: charts/mla/minio }
+
+  - name: Consul
+    source: https://github.com/hashicorp/consul
+    occurrences:
+      - helmChart: { directory: charts/mla/consul }
+
+  - name: Cortex
+    source: https://github.com/cortexproject/cortex-helm-chart
+    occurrences:
+      - helmChart: { directory: charts/mla/cortex }
+
+  - name: Alertmanager
+    source: https://github.com/prometheus/alertmanager
+    occurrences:
+      - helmChart: { directory: charts/monitoring/alertmanager }
+
+  - name: Blackbox Exporter
+    source: https://github.com/prometheus/blackbox_exporter
+    occurrences:
+      - helmChart: { directory: charts/monitoring/blackbox-exporter }
+
+  - name: Grafana
+    source: https://github.com/grafana/grafana
+    occurrences:
+      - helmChart:
+          directory: charts/monitoring/grafana
+      - helmChart:
+          directory: charts/mla/grafana
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent
+          constant: imageTag
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent
+          constant: tag
+
+  - name: Helm Exporter
+    source: https://github.com/sstarcher/helm-exporter
+    occurrences:
+      - helmChart: { directory: charts/monitoring/helm-exporter }
+
+  - name: Karma
+    source: https://github.com/prymitive/karma
+    occurrences:
+      - helmChart: { directory: charts/monitoring/karma }
+
+  - name: kube-state-metrics
+    source: https://github.com/kubernetes/kube-state-metrics
+    occurrences:
+      - helmChart:
+          directory: charts/monitoring/kube-state-metrics
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/kubestatemetrics
+          constant: version
+
+  - name: Node Exporter
+    source: https://github.com/prometheus/node_exporter
+    occurrences:
+      - helmChart: { directory: charts/monitoring/node-exporter }
+
+  - name: Prometheus
+    source: https://github.com/prometheus/prometheus
+    occurrences:
+      - helmChart:
+          directory: charts/monitoring/prometheus
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/prometheus
+          constant: tag
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/ee/metering/prometheus
+          constant: version
+
+  - name: "Ingress NGINX Controller"
+    source: https://github.com/kubernetes/ingress-nginx
+    occurrences:
+      - helmChart: { directory: charts/nginx-ingress-controller }
+
+  - name: "Dex"
+    source: https://github.com/dexidp/dex
+    occurrences:
+      - helmChart: { directory: charts/oauth }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/core-dns/deployment.go
@@ -147,7 +147,7 @@ func getContainers(clusterVersion *semverlib.Version, imageRewriter registry.Ima
 	return []corev1.Container{
 		{
 			Name:            resources.CoreDNSDeploymentName,
-			Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s", resources.RegistryK8S, dns.GetCoreDNSImage(clusterVersion)))),
+			Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s", resources.RegistryK8S, dns.CoreDNSImage(clusterVersion)))),
 			ImagePullPolicy: corev1.PullIfNotPresent,
 
 			Args: []string{"-conf", "/etc/coredns/Corefile"},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -31,6 +31,10 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const (
+	version = "1.22.20"
+)
+
 func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.NamedDaemonSetReconcilerFactory {
 	return func() (string, reconciling.DaemonSetReconciler) {
 		return resources.NodeLocalDNSDaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
@@ -87,7 +91,7 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:            "node-cache",
-					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/dns/k8s-dns-node-cache:1.22.20", resources.RegistryK8S))),
+					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/dns/k8s-dns-node-cache:%s", resources.RegistryK8S, version))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
 						"-localip",

--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -41,8 +41,12 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const (
+	version = "v2.37.0"
+)
+
 func getPrometheusImage(overwriter registry.ImageRewriter) string {
-	return registry.Must(overwriter(resources.RegistryQuay + "/prometheus/prometheus:v2.37.0"))
+	return registry.Must(overwriter(resources.RegistryQuay + "/prometheus/prometheus:" + version))
 }
 
 // prometheusStatefulSet creates a StatefulSet for prometheus.

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -52,11 +52,12 @@ import (
 )
 
 const (
-	meteringName = "metering"
+	meteringName    = "metering"
+	meteringVersion = "v1.0.3"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {
-	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.3"))
+	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:" + meteringVersion))
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.

--- a/pkg/resources/cloudcontroller/anexia.go
+++ b/pkg/resources/cloudcontroller/anexia.go
@@ -30,7 +30,10 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-const AnexiaCCMDeploymentName = "anx-cloud-controller-manager"
+const (
+	AnexiaCCMDeploymentName = "anx-cloud-controller-manager"
+	anexiaCCMVersion        = "1.5.4"
+)
 
 func anexiaDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (name string, create reconciling.DeploymentReconciler) {
@@ -56,7 +59,7 @@ func anexiaDeploymentReconciler(data *resources.TemplateData) reconciling.NamedD
 			deployment.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:  ccmContainerName,
-					Image: registry.Must(data.RewriteImage(resources.RegistryAnexia + "/anexia/anx-cloud-controller-manager:1.5.4")),
+					Image: registry.Must(data.RewriteImage(resources.RegistryAnexia + "/anexia/anx-cloud-controller-manager:" + anexiaCCMVersion)),
 					Command: []string{
 						"/app/ccm",
 						"--cloud-provider=anexia",

--- a/pkg/resources/cloudcontroller/aws.go
+++ b/pkg/resources/cloudcontroller/aws.go
@@ -75,7 +75,7 @@ func awsDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDepl
 				return nil, err
 			}
 
-			ccmVersion := getAWSCCMVersion(data.Cluster().Spec.Version)
+			ccmVersion := AWSCCMVersion(data.Cluster().Spec.Version)
 
 			flags := []string{
 				"/bin/aws-cloud-controller-manager",
@@ -139,7 +139,7 @@ func awsDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDepl
 	}
 }
 
-func getAWSCCMVersion(version semver.Semver) string {
+func AWSCCMVersion(version semver.Semver) string {
 	// https://github.com/kubernetes/cloud-provider-aws/releases
 
 	switch version.MajorMinor() {

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -76,7 +76,7 @@ func azureDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDe
 				return nil, err
 			}
 
-			version, err := getAzureVersion(data.Cluster().Status.Versions.ControlPlane)
+			version, err := AzureCCMVersion(data.Cluster().Status.Versions.ControlPlane)
 			if err != nil {
 				return nil, err
 			}
@@ -122,7 +122,7 @@ func azureDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDe
 	}
 }
 
-func getAzureVersion(version semver.Semver) (string, error) {
+func AzureCCMVersion(version semver.Semver) (string, error) {
 	// reminder: do not forget to update addons/azure-cloud-node-manager as well!
 	switch version.MajorMinor() {
 	case v123:

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -76,7 +76,7 @@ func openStackDeploymentReconciler(data *resources.TemplateData) reconciling.Nam
 				return nil, err
 			}
 
-			ccmImage, err := getOpenStackCCMImage(data.Cluster().Status.Versions.ControlPlane)
+			ccmImage, err := OpenStackCCMImage(data.Cluster().Status.Versions.ControlPlane)
 			if err != nil {
 				return nil, err
 			}
@@ -124,19 +124,50 @@ func getOSFlags(data *resources.TemplateData) []string {
 	return flags
 }
 
-func getOpenStackCCMImage(version semver.Semver) (string, error) {
+func OpenStackCCMRepository(version semver.Semver) (string, error) {
 	switch version.MajorMinor() {
 	case v123:
-		return resources.RegistryDocker + "/k8scloudprovider/openstack-cloud-controller-manager:v1.23.4", nil
+		return resources.RegistryDocker + "/k8scloudprovider/openstack-cloud-controller-manager", nil
 	case v124:
-		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager:v1.24.6", nil
+		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager", nil
 	case v125:
-		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager:v1.25.5", nil
+		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager", nil
 	case v126:
-		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager:v1.26.2", nil
+		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager", nil
 	case v127:
-		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager:v1.27.1", nil
+		return resources.RegistryK8S + "/provider-os/openstack-cloud-controller-manager", nil
 	default:
 		return "", fmt.Errorf("%v is not yet supported", version)
 	}
+}
+
+func OpenStackCCMTag(version semver.Semver) (string, error) {
+	switch version.MajorMinor() {
+	case v123:
+		return "v1.23.4", nil
+	case v124:
+		return "v1.24.6", nil
+	case v125:
+		return "v1.25.5", nil
+	case v126:
+		return "v1.26.2", nil
+	case v127:
+		return "v1.27.1", nil
+	default:
+		return "", fmt.Errorf("%v is not yet supported", version)
+	}
+}
+
+func OpenStackCCMImage(version semver.Semver) (string, error) {
+	repo, err := OpenStackCCMRepository(version)
+	if err != nil {
+		return "", err
+	}
+
+	tag, err := OpenStackCCMTag(version)
+	if err != nil {
+		return "", err
+	}
+
+	return repo + ":" + tag, nil
 }

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -74,7 +74,7 @@ func vsphereDeploymentReconciler(data *resources.TemplateData) reconciling.Named
 				return nil, err
 			}
 
-			version := getVSphereCCMVersion(data.Cluster().Status.Versions.ControlPlane)
+			version := VSphereCCMVersion(data.Cluster().Status.Versions.ControlPlane)
 			container := getVSphereCCMContainer(version, data)
 
 			dep.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
@@ -122,7 +122,7 @@ func getVSphereCCMContainer(version string, data *resources.TemplateData) corev1
 	return c
 }
 
-func getVSphereCCMVersion(version semver.Semver) string {
+func VSphereCCMVersion(version semver.Semver) string {
 	// https://github.com/kubernetes/cloud-provider-vsphere/releases
 	switch version.MajorMinor() {
 	case v123:

--- a/pkg/resources/csi/kubevirt/deployment.go
+++ b/pkg/resources/csi/kubevirt/deployment.go
@@ -29,6 +29,10 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const (
+	csiVersion = "cc71b72b8d5a205685985244c61707c5e40c9d5f"
+)
+
 // DeploymentsReconcilers returns the CSI controller Deployments for KubeVirt.
 func DeploymentsReconcilers(data *resources.TemplateData) []reconciling.NamedDeploymentReconcilerFactory {
 	creators := []reconciling.NamedDeploymentReconcilerFactory{
@@ -93,7 +97,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-driver",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/kubermatic/kubevirt-csi-driver:cc71b72b8d5a205685985244c61707c5e40c9d5f",
+					Image:           "quay.io/kubermatic/kubevirt-csi-driver:" + csiVersion,
 					Args: []string{
 						"--endpoint=$(CSI_ENDPOINT)",
 						fmt.Sprintf("--infra-cluster-namespace=%s", data.Cluster().Status.NamespaceName),

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -49,21 +49,25 @@ var (
 )
 
 // source: https://github.com/kubernetes/kubernetes/blob/vX.YY.0/cmd/kubeadm/app/constants/constants.go
-func GetCoreDNSImage(kubernetesVersion *semverlib.Version) string {
-	switch fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor()) {
+func CoreDNSVersion(clusterVersion *semverlib.Version) string {
+	switch fmt.Sprintf("%d.%d", clusterVersion.Major(), clusterVersion.Minor()) {
 	case "1.23":
 		fallthrough
 	case "1.24":
-		return "coredns/coredns:v1.8.6"
+		return "v1.8.6"
 	case "1.25":
 		fallthrough
 	case "1.26":
-		return "coredns/coredns:v1.9.3"
+		return "v1.9.3"
 	case "1.27":
 		fallthrough
 	default:
-		return "coredns/coredns:v1.10.1"
+		return "v1.10.1"
 	}
+}
+
+func CoreDNSImage(clusterVersion *semverlib.Version) string {
+	return fmt.Sprintf("coredns/coredns:%s", CoreDNSVersion(clusterVersion))
 }
 
 // ServiceReconciler returns the function to reconcile the DNS service.
@@ -126,7 +130,7 @@ func DeploymentReconciler(data deploymentReconcilerData) reconciling.NamedDeploy
 				{
 					Name: resources.DNSResolverDeploymentName,
 					// like etcd, this component follows the apiserver version and not the controller-manager version
-					Image: registry.Must(data.RewriteImage(resources.RegistryK8S + "/" + GetCoreDNSImage(data.Cluster().Status.Versions.Apiserver.Semver()))),
+					Image: registry.Must(data.RewriteImage(resources.RegistryK8S + "/" + CoreDNSImage(data.Cluster().Status.Versions.Apiserver.Semver()))),
 					Args:  []string{"-conf", "/etc/coredns/Corefile"},
 					VolumeMounts: []corev1.VolumeMount{
 						{

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -126,7 +126,7 @@ func getContainers(data kubernetesDashboardData, existingContainers []corev1.Con
 	securityContext.ReadOnlyRootFilesystem = pointer.Bool(true)
 	securityContext.AllowPrivilegeEscalation = pointer.Bool(false)
 
-	tag, err := getDashboardVersion(data.Cluster().Status.Versions.ControlPlane)
+	tag, err := DashboardVersion(data.Cluster().Status.Versions.ControlPlane)
 	if err != nil {
 		return nil, err
 	}
@@ -179,7 +179,7 @@ func getVolumes() []corev1.Volume {
 	}
 }
 
-func getDashboardVersion(clusterVersion semver.Semver) (string, error) {
+func DashboardVersion(clusterVersion semver.Semver) (string, error) {
 	// check the GitHub releases for find compat info on the dashboard:
 	// https://github.com/kubernetes/dashboard/releases
 

--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -65,6 +65,7 @@ const (
 	name         = "openvpn-server"
 	statusPath   = "/run/openvpn/openvpn-status"
 	exporterPort = 9176
+	version      = "v2.5.2-r0"
 )
 
 type openVPNDeploymentReconcilerData interface {
@@ -149,7 +150,7 @@ func DeploymentReconciler(data openVPNDeploymentReconcilerData) reconciling.Name
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{
 				{
 					Name:    "iptables-init",
-					Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/openvpn:v2.5.2-r0")),
+					Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/openvpn:" + version)),
 					Command: []string{"/bin/bash"},
 					Args: []string{
 						"-c", `# do not give a 10.20.0.0/24 route to clients (nodes) but

--- a/pkg/version/helpers.go
+++ b/pkg/version/helpers.go
@@ -18,10 +18,12 @@ package version
 
 import (
 	"fmt"
+	"sort"
 
 	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubermativsemver "k8c.io/kubermatic/v2/pkg/semver"
 )
 
 func IsSupported(version *semverlib.Version, provider kubermaticv1.ProviderType, incompatibilities []*ProviderIncompatibility, conditions ...kubermaticv1.ConditionType) (bool, error) {
@@ -67,4 +69,25 @@ func CheckUnconstrained(baseVersion *semverlib.Version, version string) (bool, e
 	}
 
 	return !c.Check(baseVersion), nil
+}
+
+func GetLatestMinorVersions(versions []kubermativsemver.Semver) []string {
+	minorMap := map[uint64]*semverlib.Version{}
+
+	for _, version := range versions {
+		sversion := version.Semver()
+		minor := sversion.Minor()
+
+		if existing := minorMap[minor]; existing == nil || existing.LessThan(sversion) {
+			minorMap[minor] = sversion
+		}
+	}
+
+	list := []string{}
+	for _, v := range minorMap {
+		list = append(list, "v"+v.String())
+	}
+	sort.Strings(list)
+
+	return list
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This is kind of inspired by @SimonTheLeg's new policy generator, which gave me the static code analysis brainworms.

When doing dependency upgrades, I often struggle to remember where we actually have version numbers (especially code nested deep in the user-cluster-ctrl-mgr is often overlooked). To combat this, a new `version-reporter` tool can be used to get a list of used versions. See the attached README.md for more information and check the verify job's logs, as they contain a sample output of the current report:

![screenshot-2023-07-25-155745](https://github.com/kubermatic/kubermatic/assets/127499/ebfd87dd-4d9e-485b-a8b3-43c549c84eef)

To make the extraction work, a few places in the codebase had to be adjusted to either have a new constant or make a function globally available to get the version depending on the user-cluster version.

This might later be used for new KKP releases to include a list of dependency versions?

**What type of PR is this?**
/kind documentation

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
