### PR TITLE
[release/v2.22] update changelogs for 2.21.11 / 2.22.5

### DIFF
--- a/docs/changelogs/CHANGELOG-2.21.md
+++ b/docs/changelogs/CHANGELOG-2.21.md
@@ -20,6 +20,10 @@
 - Fix default url configuration of blackbox exporter ([#12412](https://github.com/kubermatic/kubermatic/pull/12412))
 - Metrics server write timeout increased ([#12314](https://github.com/kubermatic/kubermatic/pull/12314))
 
+### Updates
+
+- Update machine-controller to [v1.54.8](https://github.com/kubermatic/machine-controller/releases/tag/v1.54.8) ([#12391](https://github.com/kubermatic/kubermatic/pull/12498))
+
 ## [v2.21.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.10)
 
 ### Bugfixes
@@ -224,7 +228,7 @@ This release includes updated Kubernetes versions that fix CVE-2022-3162 and CVE
 - Update metering to version 1.0.1 ([#11293](https://github.com/kubermatic/kubermatic/pull/11293))
     * Add average-used-cpu-millicores to Cluster and Namespace reports
     * Add average-available-cpu-millicores add average-cluster-machines field to Cluster reports
-    * Fix a bug that causes wrong values if metric is not continuously present for the aggregation window 
+    * Fix a bug that causes wrong values if metric is not continuously present for the aggregation window
 
 ### Upcoming Changes
 

--- a/docs/changelogs/CHANGELOG-2.22.md
+++ b/docs/changelogs/CHANGELOG-2.22.md
@@ -21,6 +21,7 @@
 
 ### Updates
 
+- Update to Go 1.19.11 ([#12503](https://github.com/kubermatic/kubermatic/pull/12503))
 - Update machine-controller to [v1.56.4](https://github.com/kubermatic/machine-controller/releases/tag/v1.56.4) ([#12392](https://github.com/kubermatic/kubermatic/pull/12497))
 
 ### Misc


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the 2.21 changelog in the 2.22 branch.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
