### PR TITLE
Fix support for using IPv6 backed nodeport-proxy service

### DIFF
--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -217,20 +217,26 @@ func (m *ModifiersBuilder) getFrontProxyLBServiceData(frontProxyLoadBalancerServ
 	var publicIPv4, privateIPv4, privateIPv6, publicIPv6 []string
 
 	for _, ingress := range frontProxyLoadBalancerService.Status.LoadBalancer.Ingress {
-		if ingress.IP != "" && !net.ParseIP(ingress.IP).IsPrivate() && !utilnet.IsIPv6String(ingress.IP) {
-			publicIPv4 = append(publicIPv4, ingress.IP)
-		}
-		if ingress.IP != "" && net.ParseIP(ingress.IP).IsPrivate() && !utilnet.IsIPv6String(ingress.IP) {
-			privateIPv4 = append(privateIPv4, ingress.IP)
-		}
-		if ingress.IP != "" && utilnet.IsIPv6String(ingress.IP) && !net.ParseIP(ingress.IP).IsPrivate() {
-			publicIPv6 = append(publicIPv6, ingress.IP)
-		}
-		if ingress.IP != "" && utilnet.IsIPv6String(ingress.IP) && net.ParseIP(ingress.IP).IsPrivate() {
-			privateIPv6 = append(privateIPv6, ingress.IP)
-		}
 		if ingress.Hostname != "" {
 			serviceHostname = ingress.Hostname
+		}
+
+		if len(ingress.IP) == 0 {
+			continue
+		}
+
+		if utilnet.IsIPv4String(ingress.IP) {
+			if !net.ParseIP(ingress.IP).IsPrivate() {
+				publicIPv4 = append(publicIPv4, ingress.IP)
+			} else {
+				privateIPv4 = append(privateIPv4, ingress.IP)
+			}
+		} else if utilnet.IsIPv6String(ingress.IP) {
+			if !net.ParseIP(ingress.IP).IsPrivate() {
+				publicIPv6 = append(publicIPv6, ingress.IP)
+			} else {
+				privateIPv6 = append(privateIPv6, ingress.IP)
+			}
 		}
 	}
 

--- a/pkg/resources/address/address.go
+++ b/pkg/resources/address/address.go
@@ -146,7 +146,7 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 		} else if frontProxyLBServiceHostname != "" {
 			var err error
 			// Always lookup IP address, in case it changes
-			ip, err = m.getExternalIPv4(frontProxyLBServiceHostname)
+			ip, err = m.getExternalIP(frontProxyLBServiceHostname)
 			if err != nil {
 				return nil, err
 			}
@@ -156,7 +156,7 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 	case kubermaticv1.ExposeStrategyTunneling:
 		var err error
 		// Always lookup IP address, in case it changes (IP's on AWS LB's change)
-		ip, err = m.getExternalIPv4(externalName)
+		ip, err = m.getExternalIP(externalName)
 		if err != nil {
 			return nil, err
 		}
@@ -207,35 +207,46 @@ func (m *ModifiersBuilder) Build(ctx context.Context) ([]func(*kubermaticv1.Clus
 
 func (m *ModifiersBuilder) getFrontProxyLBServiceData(frontProxyLoadBalancerService *corev1.Service) (string, string) {
 	//  frontProxyLBServiceIP is set according to below priority
-	// 1. First public IP from the status list
-	// 2. First private IP from the status list
-	// 3. Default IP as per configured spec if status is not populated
+	// 1. First public IPv4 from the status list
+	// 2. First private IPv4 from the status list
+	// 3. First public IPv6 from the status list
+	// 4. First private IPv6 from the status list
+	// 5. Default IP as per configured spec if status is not populated
 	serviceIP := ""
 	serviceHostname := ""
-	if len(frontProxyLoadBalancerService.Status.LoadBalancer.Ingress) > 0 {
-		var tmpIP string
-		for _, ingress := range frontProxyLoadBalancerService.Status.LoadBalancer.Ingress {
-			if ingress.IP != "" && !net.ParseIP(ingress.IP).IsPrivate() && !utilnet.IsIPv6String(ingress.IP) && tmpIP == "" {
-				tmpIP = ingress.IP
-			}
-			if ingress.Hostname != "" {
-				serviceHostname = ingress.Hostname
-			}
-		}
+	var publicIPv4, privateIPv4, privateIPv6, publicIPv6 []string
 
-		if tmpIP != "" {
-			serviceIP = tmpIP
-		} else {
-			// select first non-ipv6 private IP
-			for _, ingress := range frontProxyLoadBalancerService.Status.LoadBalancer.Ingress {
-				if !utilnet.IsIPv6String(ingress.IP) {
-					serviceIP = ingress.IP
-					break
-				}
-			}
+	for _, ingress := range frontProxyLoadBalancerService.Status.LoadBalancer.Ingress {
+		if ingress.IP != "" && !net.ParseIP(ingress.IP).IsPrivate() && !utilnet.IsIPv6String(ingress.IP) {
+			publicIPv4 = append(publicIPv4, ingress.IP)
 		}
-		m.log.Debugw("Multiple ingress values in LB status, the following values will be used", "ip", serviceIP, "hostname", serviceHostname)
+		if ingress.IP != "" && net.ParseIP(ingress.IP).IsPrivate() && !utilnet.IsIPv6String(ingress.IP) {
+			privateIPv4 = append(privateIPv4, ingress.IP)
+		}
+		if ingress.IP != "" && utilnet.IsIPv6String(ingress.IP) && !net.ParseIP(ingress.IP).IsPrivate() {
+			publicIPv6 = append(publicIPv6, ingress.IP)
+		}
+		if ingress.IP != "" && utilnet.IsIPv6String(ingress.IP) && net.ParseIP(ingress.IP).IsPrivate() {
+			privateIPv6 = append(privateIPv6, ingress.IP)
+		}
+		if ingress.Hostname != "" {
+			serviceHostname = ingress.Hostname
+		}
 	}
+
+	switch {
+	case len(publicIPv4) > 0:
+		serviceIP = publicIPv4[0]
+	case len(privateIPv4) > 0:
+		serviceIP = privateIPv4[0]
+	case len(publicIPv6) > 0:
+		serviceIP = publicIPv6[0]
+	case len(privateIPv6) > 0:
+		serviceIP = privateIPv6[0]
+	}
+
+	m.log.Debugw("From the ingress values in LB status, the following values will be used", "ip", serviceIP, "hostname", serviceHostname)
+
 	// default in case the implementation doesn't populate the status
 	if len(frontProxyLoadBalancerService.Status.LoadBalancer.Ingress) == 0 {
 		serviceIP = frontProxyLoadBalancerService.Spec.LoadBalancerIP
@@ -244,7 +255,7 @@ func (m *ModifiersBuilder) getFrontProxyLBServiceData(frontProxyLoadBalancerServ
 	return serviceIP, serviceHostname
 }
 
-func (m *ModifiersBuilder) getExternalIPv4(hostname string) (string, error) {
+func (m *ModifiersBuilder) getExternalIP(hostname string) (string, error) {
 	resolvedIPs, err := m.lookupFunction(hostname)
 	if err != nil {
 		return "", fmt.Errorf("failed to lookup ip for %s: %w", hostname, err)
@@ -255,14 +266,23 @@ func (m *ModifiersBuilder) getExternalIPv4(hostname string) (string, error) {
 			ipList.Insert(ip.String())
 		}
 	}
+
+	// If no IPv4 address was found, look for IPv6 addresses.
+	if len(ipList) == 0 {
+		for _, ip := range resolvedIPs {
+			if ip.To16() != nil && len(ip.To16()) == net.IPv6len {
+				ipList.Insert(ip.String())
+			}
+		}
+	}
+
 	ips := sets.List(ipList)
 	if len(ips) == 0 {
 		return "", fmt.Errorf("no ip addresses found for %s: %w", hostname, err)
 	}
-
-	// Just one ipv4
+	// Return the first IP address.
 	if len(ips) > 1 {
-		m.log.Debugw("Lookup returned multiple ipv4 addresses. Picking the first one after sorting", "hostname", hostname, "foundAddresses", ips, "pickedAddress", ips[0])
+		m.log.Debugw("Lookup returned multiple IP addresses. Picking the first one after sorting", "hostname", hostname, "foundAddresses", ips, "pickedAddress", ips[0])
 	}
 	return ips[0], nil
 }

--- a/pkg/resources/address/address_test.go
+++ b/pkg/resources/address/address_test.go
@@ -30,16 +30,19 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/pointer"
 )
 
 const (
 	fakeClusterName          = "fake-cluster"
+	fakeClusterNameIPv6      = "fake-cluster-ipv6"
 	fakeDCName               = "europe-west3-c"
 	fakeExternalURL          = "dev.kubermatic.io"
 	fakeClusterNamespaceName = "cluster-ns"
 	externalIP               = "34.89.181.151"
 	loadbBalancerHostName    = "xyz.eu-central-1.cloudprovider.test"
 	testDomain               = "dns-test.kubermatic.io"
+	ipv6Address              = "2a01:4f8:1c0c:4b1d::1"
 )
 
 func testLookupFunction(host string) ([]net.IP, error) {
@@ -49,7 +52,9 @@ func testLookupFunction(host string) ([]net.IP, error) {
 	case "fake-cluster.europe-west3-c.dev.kubermatic.io":
 		fallthrough
 	case "fake-cluster.alias-europe-west3-c.dev.kubermatic.io":
-		return []net.IP{net.IPv4(34, 89, 181, 151)}, nil
+		return []net.IP{net.IPv4(34, 89, 181, 151), net.ParseIP("2a01:4f8:1c0c:4b1d::1")}, nil
+	case "fake-cluster-ipv6.europe-west3-c.dev.kubermatic.io":
+		return []net.IP{net.ParseIP("2a01:4f8:1c0c:4b1d::1")}, nil
 	case loadbBalancerHostName:
 		return []net.IP{net.IPv4(34, 89, 181, 151)}, nil
 	default:
@@ -57,12 +62,12 @@ func testLookupFunction(host string) ([]net.IP, error) {
 	}
 }
 
-func TestGetExternalIPv4(t *testing.T) {
+func TestGetExternalIP(t *testing.T) {
 	ip, err := NewModifiersBuilder(kubermaticlog.Logger).
 		lookupFunc(testLookupFunction).
-		getExternalIPv4(testDomain)
+		getExternalIP(testDomain)
 	if err != nil {
-		t.Fatalf("failed to get the external IPv4 address for %s: %v", testDomain, err)
+		t.Fatalf("failed to get the external IP address for %s: %v", testDomain, err)
 	}
 
 	if ip != "192.168.1.1" {
@@ -73,6 +78,7 @@ func TestGetExternalIPv4(t *testing.T) {
 func TestSyncClusterAddress(t *testing.T) {
 	testCases := []struct {
 		name                 string
+		clusterName          *string
 		apiserverService     corev1.Service
 		frontproxyService    corev1.Service
 		exposeStrategy       kubermaticv1.ExposeStrategy
@@ -102,6 +108,26 @@ func TestSyncClusterAddress(t *testing.T) {
 			expectedIP:           "1.2.3.4",
 			expectedPort:         int32(443),
 			expectedURL:          "https://1.2.3.4:443",
+		},
+		{
+			name: "Verify properties for service type LoadBalancer with IPv6",
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{NodePort: int32(443)}},
+				},
+			},
+			frontproxyService: corev1.Service{
+				Status: corev1.ServiceStatus{
+					LoadBalancer: corev1.LoadBalancerStatus{
+						Ingress: []corev1.LoadBalancerIngress{{IP: ipv6Address}},
+					},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyLoadBalancer,
+			expectedExternalName: ipv6Address,
+			expectedIP:           ipv6Address,
+			expectedPort:         int32(443),
+			expectedURL:          fmt.Sprintf("https://[%s]:443", ipv6Address),
 		},
 		{
 			name: "Verify properties for service type LoadBalancer dont change when seedDNSOverwrite is set",
@@ -288,6 +314,26 @@ func TestSyncClusterAddress(t *testing.T) {
 			expectedURL:          fmt.Sprintf("https://%s.%s.%s:6443", fakeClusterName, fakeDCName, fakeExternalURL),
 		},
 		{
+			name:        "Verify properties for Tunneling expose strategy with IPv6",
+			clusterName: pointer.String(fakeClusterNameIPv6),
+			apiserverService: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							Port:       int32(6443),
+							TargetPort: intstr.FromInt(6443),
+							NodePort:   32000,
+						}},
+				},
+			},
+			exposeStrategy:       kubermaticv1.ExposeStrategyTunneling,
+			expectedExternalName: fmt.Sprintf("%s.%s.%s", fakeClusterNameIPv6, fakeDCName, fakeExternalURL),
+			expectedIP:           ipv6Address,
+			expectedPort:         int32(6443),
+			expectedURL:          fmt.Sprintf("https://%s.%s.%s:6443", fakeClusterNameIPv6, fakeDCName, fakeExternalURL),
+		},
+		{
 			name: "Verify error when service has less than one ports",
 			apiserverService: corev1.Service{
 				Spec: corev1.ServiceSpec{
@@ -299,9 +345,14 @@ func TestSyncClusterAddress(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			clusterName := fakeClusterName
+			if tc.clusterName != nil {
+				clusterName = *tc.clusterName
+			}
+
 			cluster := &kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: fakeClusterName,
+					Name: clusterName,
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					Cloud: kubermaticv1.CloudSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

When using load balancer or tunneling expose strategies we were assuming in our code that the address for a user cluster(api-server) would always resolve to an IPv4 address. Although this is wrong since users can have environment where external services will resolve to IPv6 address instead. This is also a requirement for dual-stack networking since the IP could either be IPv4 or IPv6.

This PR intends to fix this issue while keeping IPv6 as a fallback when IPv4 addresses are not available. So IPv4 addresses are still prioritised when available.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue where IPv6 IPs were being ignored when determining the address of a user cluster
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
