### PR TITLE
MLA: fix config reloader for monitoring and logging agents

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/logging-agent/daemonset.go
@@ -175,7 +175,7 @@ func DaemonSetReconciler(overrides *corev1.ResourceRequirements, imageRewriter r
 						// https://github.com/prometheus-operator/prometheus-operator/blob/v0.49.0/cmd/prometheus-config-reloader/main.go#L72-L108
 						"--listen-address=:8080",
 						"--watch-interval=10s",
-						fmt.Sprintf("--config-file=%s/%s.yaml", configVolumeMountPath, configFileName),
+						fmt.Sprintf("--config-file=%s/%s", configVolumeMountPath, configFileName),
 						fmt.Sprintf("--reload-url=http://localhost:%d/-/reload", containerPort),
 					},
 					Env: []corev1.EnvVar{

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
@@ -43,6 +43,7 @@ const (
 
 	configVolumeName       = "config-volume"
 	configPath             = "/etc/config"
+	configFileName         = "agent.yaml"
 	storageVolumeName      = "storage-volume"
 	storagePath            = "/data"
 	certificatesVolumeName = "certificates"
@@ -98,7 +99,7 @@ func DeploymentReconciler(overrides *corev1.ResourceRequirements, replicas *int3
 					Image:           registry.Must(imageRewriter(fmt.Sprintf("%s/%s:%s", resources.RegistryDocker, imageName, tag))),
 					ImagePullPolicy: corev1.PullAlways,
 					Args: []string{
-						fmt.Sprintf("--config.file=%s/agent.yaml", configPath),
+						fmt.Sprintf("--config.file=%s/%s", configPath, configFileName),
 						"-server.http.address=0.0.0.0:9090",
 						fmt.Sprintf("-metrics.wal-directory=%s/agent", storagePath),
 					},
@@ -161,7 +162,7 @@ func DeploymentReconciler(overrides *corev1.ResourceRequirements, replicas *int3
 						// https://github.com/prometheus-operator/prometheus-operator/blob/v0.49.0/cmd/prometheus-config-reloader/main.go#L72-L108
 						"--listen-address=:8080",
 						"--watch-interval=10s",
-						fmt.Sprintf("--config-file=%s/prometheus.yaml", configPath),
+						fmt.Sprintf("--config-file=%s/%s", configPath, configFileName),
 						fmt.Sprintf("--reload-url=http://localhost:%d/-/reload", containerPort),
 					},
 					Env: []corev1.EnvVar{


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes config reloader for grafana-agent (wrong config file name was used)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12501 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
mla: fixes configuration live reload for monitoring-agent and logging-agent
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
