### PR TITLE
Use latest kubeVersion as helm parameter when rendering charts in mirror-images

### DIFF
--- a/pkg/install/helm/cli.go
+++ b/pkg/install/helm/cli.go
@@ -202,13 +202,14 @@ func (c *cli) UninstallRelease(namespace string, name string) error {
 	return err
 }
 
-func (c *cli) RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string) ([]byte, error) {
+func (c *cli) RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) ([]byte, error) {
 	command := []string{"template"}
 
 	if valuesFile != "" {
 		command = append(command, "--values", valuesFile)
 	}
 
+	command = append(command, flags...)
 	command = append(command, valuesToFlags(values)...)
 	command = append(command, releaseName, chartDirectory)
 

--- a/pkg/install/helm/interface.go
+++ b/pkg/install/helm/interface.go
@@ -32,6 +32,6 @@ type Client interface {
 	GetRelease(namespace string, name string) (*Release, error)
 	ListReleases(namespace string) ([]Release, error)
 	UninstallRelease(namespace string, name string) error
-	RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string) ([]byte, error)
+	RenderChart(namespace string, releaseName string, chartDirectory string, valuesFile string, values map[string]string, flags []string) ([]byte, error)
 	GetValues(namespace string, releaseName string) (*yamled.Document, error)
 }

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -97,7 +97,7 @@ func getImagesFromApplicationDefinition(logger logrus.FieldLogger, helmClient he
 			return nil, fmt.Errorf("failed to pull app chart: %w", err)
 		}
 		// get images
-		chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, valuesFile, registryPrefix)
+		chartImages, err := GetImagesForHelmChart(appVerLog, nil, helmClient, chartPath, valuesFile, registryPrefix, "") // since we don't have the version constraints in AppDefs yet, we can leave kubeVersion parameter empty
 		if err != nil {
 			return nil, fmt.Errorf("failed to get images for chart: %w", err)
 		}

--- a/pkg/install/images/images_test.go
+++ b/pkg/install/images/images_test.go
@@ -94,7 +94,7 @@ func TestProcessImagesFromHelmChartsAndSystemApps(t *testing.T) {
 	}
 
 	var images []string
-	chartImages, err := GetImagesForHelmCharts(context.Background(), log, config, helmClient, "../../../charts/monitoring", "", "")
+	chartImages, err := GetImagesForHelmCharts(context.Background(), log, config, helmClient, "../../../charts/monitoring", "", "", "")
 	if err != nil {
 		t.Errorf("error calling GetImagesForHelmCharts: %v", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes the issue where the mirror-images command is going to fail when using it with charts that specify a Kubernetes version greater than 1.20. This is currently the case for the consul chart.

Tested with the current installer from the latest KKP Github release:

```sh
./kubermatic-installer mirror-images registry.example.com --config examples/kubermatic.example.yaml --dry-run
INFO[0003] 🚀 Collecting images…
INFO[0147] 🚀 Rendering Helm charts…                      charts-directory=charts
ERRO[0168] ❌ Operation failed: failed to get images: failed to get images for Helm chart: failed to render Helm chart "consul": Error: chart requires kubeVersion: >=1.21.0-0 which is incompatible with Kubernetes v1.20.0
```

---
The reason for this is a little bit entertaining. Helm actually uses a kubeVersion flag to specify how a chart should be rendered. This is by default hardcoded to 1.20 (see https://github.com/helm/helm/blob/main/pkg/chartutil/capabilities.go#L32-L48 & https://github.com/helm/helm/blob/main/pkg/chartutil/capabilities_test.go#L45) and therefore can collide with charts that specify a kubeVersion greater than 1.20.


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

Two changes in this PR should be reviewed closer:
1. This introduces the ability to pass flags into the RenderChart func. This is done in accordance with other funcs in the interface which allow similar features (e.g InstallChart)
2. The mirror-images command now uses the latest Kubernetes version we support in KKP as the basis for the render. I have written a longer comment in the the func to explain this. PTAL if that behaviour makes sense to you.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue in the kubermatic-installer mirror-images command, which led to failure on the mla-consul chart
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
