### PR TITLE
Provide CA bundle to Helm/Git operations in applications

### DIFF
--- a/cmd/user-cluster-controller-manager/main.go
+++ b/cmd/user-cluster-controller-manager/main.go
@@ -408,7 +408,14 @@ func main() {
 		log.Info("Registered constraintsyncer controller")
 	}
 
-	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, &applications.ApplicationManager{ApplicationCache: runOp.applicationCache, Kubeconfig: kubeconfigFlag.Value.String(), SecretNamespace: runOp.namespace}); err != nil {
+	appManager := &applications.ApplicationManager{
+		ApplicationCache: runOp.applicationCache,
+		Kubeconfig:       kubeconfigFlag.Value.String(),
+		SecretNamespace:  runOp.namespace,
+		CABundleFile:     runOp.caBundleFile,
+	}
+
+	if err := applicationinstallationcontroller.Add(rootCtx, log, seedMgr, mgr, isPausedChecker, appManager); err != nil {
 		log.Fatalw("Failed to add user Application Installation controller to mgr", zap.Error(err))
 	}
 	log.Info("Registered Application Installation controller")

--- a/pkg/applications/helmclient/client_integration_test.go
+++ b/pkg/applications/helmclient/client_integration_test.go
@@ -571,7 +571,7 @@ func uninstallTest(t *testing.T, ctx context.Context, client ctrlruntimeclient.C
 		Namespace:  &ns.Name,
 	}
 
-	helmClient, err := NewClient(ctx, restClientGetter, settings, ns.Name, kubermaticlog.Logger)
+	helmClient, err := NewClient(ctx, restClientGetter, settings, ns.Name, kubermaticlog.Logger, "")
 	if err != nil {
 		t.Fatalf("failed to create helm client: %s", err)
 	}
@@ -622,7 +622,7 @@ func buildHelClient(t *testing.T, ctx context.Context, ns *corev1.Namespace, cha
 		Namespace:  &ns.Name,
 	}
 
-	helmClient, err := NewClient(ctx, restClientGetter, settings, ns.Name, kubermaticlog.Logger)
+	helmClient, err := NewClient(ctx, restClientGetter, settings, ns.Name, kubermaticlog.Logger, "")
 	if err != nil {
 		t.Fatalf("failed to create helm client: %s", err)
 	}
@@ -819,7 +819,7 @@ func TestDownloadChart(t *testing.T) {
 				tf := cmdtesting.NewTestFactory().WithNamespace(defaultNs)
 				defer tf.Cleanup()
 
-				helmClient, err := NewClient(context.Background(), tf, settings, defaultNs, log)
+				helmClient, err := NewClient(context.Background(), tf, settings, defaultNs, log, "")
 				if err != nil {
 					t.Fatalf("can not init helm Client: %s", err)
 				}
@@ -1055,7 +1055,7 @@ func TestBuildDependencies(t *testing.T) {
 					}
 				}
 
-				helmClient, err := NewClient(context.Background(), tf, settings, defaultNs, log)
+				helmClient, err := NewClient(context.Background(), tf, settings, defaultNs, log, "")
 				if err != nil {
 					t.Fatalf("can not init helm client: %s", err)
 				}

--- a/pkg/applications/helmclient/client_test.go
+++ b/pkg/applications/helmclient/client_test.go
@@ -43,7 +43,7 @@ func TestNewShouldFailWhenRESTClientGetterNamespaceIsDifferentThanTargetNamespac
 	tf := cmdtesting.NewTestFactory().WithNamespace(defaultNs)
 	defer tf.Cleanup()
 
-	_, err := NewClient(context.Background(), tf, settings, "another-ns", log)
+	_, err := NewClient(context.Background(), tf, settings, "another-ns", log, "")
 	if err == nil {
 		t.Fatalf("helmclient.NewClient() should fail when RESTClientGetter namespace is different than targetNamespace : %s", err)
 	}

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -56,6 +56,9 @@ type ApplicationManager struct {
 
 	// Namespace where credentials secrets are stored.
 	SecretNamespace string
+
+	// CABundleFile is an optional path to a PEM-encoded CA bundle file.
+	CABundleFile string
 }
 
 func (a *ApplicationManager) GetAppCache() string {
@@ -64,7 +67,7 @@ func (a *ApplicationManager) GetAppCache() string {
 
 // DonwloadSource the application's source using the appropriate provider into downloadDest and returns the full path to the sources.
 func (a *ApplicationManager) DonwloadSource(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation, downloadDest string) (string, error) {
-	sourceProvider, err := providers.NewSourceProvider(ctx, log, seedClient, a.Kubeconfig, a.ApplicationCache, &applicationInstallation.Status.ApplicationVersion.Template.Source, a.SecretNamespace)
+	sourceProvider, err := providers.NewSourceProvider(ctx, log, seedClient, a.Kubeconfig, a.ApplicationCache, &applicationInstallation.Status.ApplicationVersion.Template.Source, a.SecretNamespace, a.CABundleFile)
 	if err != nil {
 		return "", fmt.Errorf("failed to initialize source provider: %w", err)
 	}
@@ -79,7 +82,7 @@ func (a *ApplicationManager) DonwloadSource(ctx context.Context, log *zap.Sugare
 
 // Apply creates the namespace where the application will be installed (if necessary) and installs the application.
 func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, appDefinition *appskubermaticv1.ApplicationDefinition, applicationInstallation *appskubermaticv1.ApplicationInstallation, appSourcePath string) (util.StatusUpdater, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	templateProvider, err := providers.NewTemplateProvider(ctx, log, seedClient, a.Kubeconfig, a.ApplicationCache, applicationInstallation, a.SecretNamespace, a.CABundleFile)
 	if err != nil {
 		return util.NoStatusUpdate, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
@@ -93,7 +96,7 @@ func (a *ApplicationManager) Apply(ctx context.Context, log *zap.SugaredLogger, 
 
 // Delete uninstalls the application where the application was installed if necessary.
 func (a *ApplicationManager) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
-	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	templateProvider, err := providers.NewTemplateProvider(ctx, log, seedClient, a.Kubeconfig, a.ApplicationCache, applicationInstallation, a.SecretNamespace, a.CABundleFile)
 	if err != nil {
 		return util.NoStatusUpdate, fmt.Errorf("failed to initialize template provider: %w", err)
 	}

--- a/pkg/applications/providers/source/git.go
+++ b/pkg/applications/providers/source/git.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"path"
 
@@ -38,7 +39,8 @@ import (
 
 // GitSource download the application's source from a git repository.
 type GitSource struct {
-	Ctx context.Context
+	Ctx          context.Context
+	CABundleFile string
 
 	// SeedClient to seed cluster.
 	SeedClient ctrlruntimeclient.Client
@@ -56,8 +58,16 @@ func (g GitSource) DownloadSource(destination string) (string, error) {
 		return "", err
 	}
 
+	var caBundle []byte
+	if g.CABundleFile != "" {
+		caBundle, err = os.ReadFile(g.CABundleFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to read CA bundle: %w", err)
+		}
+	}
+
 	checkout := g.getCheckoutStrategy()
-	if err := checkout(g.Ctx, destination, g.Source, auth); err != nil {
+	if err := checkout(g.Ctx, destination, g.Source, auth, caBundle); err != nil {
 		if errors.Is(err, exec.ErrNotFound) {
 			return "", errors.New("failed to clone repository: file protocol not supported, please check git remote url")
 		}
@@ -127,18 +137,18 @@ func (g GitSource) getCheckoutStrategy() checkoutFunc {
 		return checkoutFromTag
 
 	default: // this should not happen.
-		return func(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod) error {
+		return func(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod, caBundle []byte) error {
 			return fmt.Errorf("could not determine which reference to checkout")
 		}
 	}
 }
 
 // checkoutFunc define a function to clone and checkout code from repository defined in gitSource into destination using auth as credentials.
-type checkoutFunc func(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod) error
+type checkoutFunc func(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod, caBundle []byte) error
 
 // checkoutFromCommit clone the repository and checkout the desired commit. The commit must belongs to this branch.
 // A shallow clone is performed.
-func checkoutFromCommit(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod) error {
+func checkoutFromCommit(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod, caBundle []byte) error {
 	var repo *git.Repository
 	var err error
 
@@ -151,6 +161,7 @@ func checkoutFromCommit(ctx context.Context, destination string, gitSource *apps
 		ReferenceName: plumbing.NewBranchReferenceName(gitSource.Ref.Branch),
 		NoCheckout:    true,
 		Tags:          git.NoTags,
+		CABundle:      caBundle,
 	})
 	if err != nil {
 		return err
@@ -168,7 +179,7 @@ func checkoutFromCommit(ctx context.Context, destination string, gitSource *apps
 }
 
 // checkoutFromBranch clone the repository and checkout the desired branch. A shallow clone is performed.
-func checkoutFromBranch(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod) error {
+func checkoutFromBranch(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod, caBundle []byte) error {
 	_, err := git.PlainCloneContext(ctx, destination, false, &git.CloneOptions{
 		URL:           gitSource.Remote,
 		Auth:          auth,
@@ -177,12 +188,13 @@ func checkoutFromBranch(ctx context.Context, destination string, gitSource *apps
 		SingleBranch:  true,
 		Depth:         1,
 		Tags:          git.NoTags,
+		CABundle:      caBundle,
 	})
 	return err
 }
 
 // checkoutFromTag clone the repository and checkout the desired Tag. A shallow clone is performed.
-func checkoutFromTag(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod) error {
+func checkoutFromTag(ctx context.Context, destination string, gitSource *appskubermaticv1.GitSource, auth gogittransport.AuthMethod, caBundle []byte) error {
 	_, err := git.PlainCloneContext(ctx, destination, false, &git.CloneOptions{
 		URL:           gitSource.Remote,
 		Auth:          auth,
@@ -191,6 +203,7 @@ func checkoutFromTag(ctx context.Context, destination string, gitSource *appskub
 		SingleBranch:  true,
 		Depth:         1,
 		Tags:          git.NoTags,
+		CABundle:      caBundle,
 	})
 	return err
 }

--- a/pkg/applications/providers/source/helm.go
+++ b/pkg/applications/providers/source/helm.go
@@ -40,6 +40,7 @@ type HelmSource struct {
 	Source     *appskubermaticv1.HelmSource
 	// Namespace where credential secrets are stored.
 	SecretNamespace string
+	CABundleFile    string
 
 	// SeedClient to seed cluster.
 	SeedClient ctrlruntimeclient.Client
@@ -70,7 +71,9 @@ func (h HelmSource) DownloadSource(destination string) (string, error) {
 		restClientGetter,
 		helmclient.NewSettings(helmCacheDir),
 		ns,
-		h.Log)
+		h.Log,
+		h.CABundleFile,
+	)
 
 	if err != nil {
 		return "", err

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -52,6 +52,9 @@ type HelmTemplate struct {
 
 	// SeedClient to seed cluster.
 	SeedClient ctrlruntimeclient.Client
+
+	// CABundleFile is an optional file path to a PEM-encoded CA bundle.
+	CABundleFile string
 }
 
 // InstallOrUpgrade the chart located at chartLoc with parameters (releaseName, values) defined applicationInstallation into cluster.
@@ -85,7 +88,9 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, appDefinition *appskuber
 		restClientGetter,
 		helmclient.NewSettings(helmCacheDir),
 		applicationInstallation.Spec.Namespace.Name,
-		h.Log)
+		h.Log,
+		h.CABundleFile,
+	)
 
 	if err != nil {
 		return util.NoStatusUpdate, err
@@ -140,7 +145,9 @@ func (h HelmTemplate) Uninstall(applicationInstallation *appskubermaticv1.Applic
 		restClientGetter,
 		helmclient.NewSettings(helmCacheDir),
 		applicationInstallation.Spec.Namespace.Name,
-		h.Log)
+		h.Log,
+		h.CABundleFile,
+	)
 
 	if err != nil {
 		return util.NoStatusUpdate, err

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -111,7 +111,7 @@ func downloadAppSourceChart(appSource *appskubermaticv1.ApplicationSource, direc
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	sp, err := providers.NewSourceProvider(ctx, log.NewDefault().Sugar(), nil, "", directory, appSource, "")
+	sp, err := providers.NewSourceProvider(ctx, log.NewDefault().Sugar(), nil, "", directory, appSource, "", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create app source provider: %w", err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The applications code was so far not using the KKP-configured CA bundle, which can lead to errors like

> failed to download application source: can not download index file: Get "https://nexus.somewher.com/repository/helm-charts/index.yaml": x509: certificate signed by unknown authority . Please check your configuration or contact your KKP Administrator.

This PR fixes that by handing the CA bundle file into the Application Manager, which will then configure it for each component (which is fun, cause Helm needs a CA bundle filename, Go wants a x509.CertPool and go-git needs a []byte). 

**Which issue(s) this PR fixes**:
Fixes #12512

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
The idea behind configuring the CA bundle explicitly instead of relying on setting it globally is to make its use explicit, so it can be easier identified which component needs the custom bundle. While not so critical for the user-cluster-controller-manager (which runs for exactly 1 Cluster, and so only ever has to deal with 1 CA bundle), the other controller-managers would run into major trouble if the CA bundles are different per User Cluster, but we had tried setting it globally. With the explicit code paths is it much cleaner to see which bundle is injected.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KKP's CA bundle was not used when performing Application-related operations like installing a Helm chart from a private OCI registry
```

**Documentation**:
```documentation
NONE
```
