### PR TITLE
Option to disable csi driver installation on user clusters

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -81,6 +81,9 @@ spec:
           # Datacenter location, e.g. "ams3". A list of existing datacenters can be found
           # at https://www.digitalocean.com/docs/platform/availability-matrix/
           region: ""
+        # Optional: DisableCSIDriver disables the installation of CSI driver on every clusters within the DC
+        # If true it can't be over-written in the cluster configuration
+        disableCsiDriver: false
         # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -81,6 +81,9 @@ spec:
           # Datacenter location, e.g. "ams3". A list of existing datacenters can be found
           # at https://www.digitalocean.com/docs/platform/availability-matrix/
           region: ""
+        # Optional: DisableCSIDriver disables the installation of CSI driver on every clusters within the DC
+        # If true it can't be over-written in the cluster configuration
+        disableCsiDriver: false
         # Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC,
         # ignoring cluster-specific settings.
         enforceAuditLogging: false

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -247,6 +247,10 @@ type ClusterSpec struct {
 
 	// Enables more verbose logging in KKP's user-cluster-controller-manager.
 	DebugLog bool `json:"debugLog,omitempty"`
+
+	// Optional: DisableCSIDriver disables the installation of CSI driver on the cluster
+	// If this is true at the data center then it can't be over-written in the cluster configuration
+	DisableCSIDriver bool `json:"disableCsiDriver,omitempty"`
 }
 
 func (c ClusterSpec) IsOperatingSystemManagerEnabled() bool {

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -450,6 +450,10 @@ type DatacenterSpec struct {
 
 	// Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
 	MachineFlavorFilter *MachineFlavorFilter `json:"machineFlavorFilter,omitempty"`
+
+	// Optional: DisableCSIDriver disables the installation of CSI driver on every clusters within the DC
+	// If true it can't be over-written in the cluster configuration
+	DisableCSIDriver bool `json:"disableCsiDriver,omitempty"`
 }
 
 var (

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -55,6 +55,7 @@ const (
 
 	kubeProxyAddonName = "kube-proxy"
 	openVPNAddonName   = "openvpn"
+	CSIAddonName       = "csi"
 )
 
 type Reconciler struct {
@@ -320,6 +321,9 @@ func skipAddonInstallation(addon kubermaticv1.Addon, cluster *kubermaticv1.Clust
 	}
 	if addon.Name == openVPNAddonName && cluster.Spec.ClusterNetwork.KonnectivityEnabled != nil && *cluster.Spec.ClusterNetwork.KonnectivityEnabled {
 		return true // skip openvpn if Konnectivity is enabled
+	}
+	if addon.Name == CSIAddonName && cluster.Spec.DisableCSIDriver {
+		return true // skip csi driver installation if DisableCSIDriver is true
 	}
 	return false
 }

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1644,6 +1644,9 @@ spec:
                 debugLog:
                   description: Enables more verbose logging in KKP's user-cluster-controller-manager.
                   type: boolean
+                disableCsiDriver:
+                  description: 'Optional: DisableCSIDriver disables the installation of CSI driver on the cluster If this is true at the data center then it can''t be over-written in the cluster configuration'
+                  type: boolean
                 enableOperatingSystemManager:
                   description: 'Optional: Enables operating-system-manager (OSM), which is responsible for creating and managing worker node configuration. This field is enabled(true) by default.'
                   type: boolean

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1639,6 +1639,9 @@ spec:
                 debugLog:
                   description: Enables more verbose logging in KKP's user-cluster-controller-manager.
                   type: boolean
+                disableCsiDriver:
+                  description: 'Optional: DisableCSIDriver disables the installation of CSI driver on the cluster If this is true at the data center then it can''t be over-written in the cluster configuration'
+                  type: boolean
                 enableOperatingSystemManager:
                   description: 'Optional: Enables operating-system-manager (OSM), which is responsible for creating and managing worker node configuration. This field is enabled(true) by default.'
                   type: boolean

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -158,6 +158,9 @@ spec:
                             required:
                               - region
                             type: object
+                          disableCsiDriver:
+                            description: 'Optional: DisableCSIDriver disables the installation of CSI driver on every clusters within the DC If true it can''t be over-written in the cluster configuration'
+                            type: boolean
                           enforceAuditLogging:
                             description: 'Optional: EnforceAuditLogging enforces audit logging on every cluster within the DC, ignoring cluster-specific settings.'
                             type: boolean

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -101,6 +101,11 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 		}
 	}
 
+	// Enforce DisableCSIDriver
+	if datacenter.Spec.DisableCSIDriver {
+		spec.DisableCSIDriver = true
+	}
+
 	// Enforce PodSecurityPolicy
 	if datacenter.Spec.EnforcePodSecurityPolicy {
 		spec.UsePodSecurityPolicyAdmissionPlugin = true

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -101,11 +101,6 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 		}
 	}
 
-	// Enforce DisableCSIDriver
-	if datacenter.Spec.DisableCSIDriver {
-		spec.DisableCSIDriver = true
-	}
-
 	// Enforce PodSecurityPolicy
 	if datacenter.Spec.EnforcePodSecurityPolicy {
 		spec.UsePodSecurityPolicyAdmissionPlugin = true

--- a/pkg/mutation/cluster/mutation.go
+++ b/pkg/mutation/cluster/mutation.go
@@ -47,6 +47,10 @@ func MutateCreate(newCluster *kubermaticv1.Cluster, config *kubermaticv1.Kuberma
 		return fieldErr
 	}
 
+	// Enforce DisableCSIDriver
+	if datacenter.Spec.DisableCSIDriver {
+		newCluster.Spec.DisableCSIDriver = true
+	}
 	// Always enable external CCM for supported providers in new clusters unless the user
 	// explicitly disabled the external CCM. For regular users this is not important (most
 	// won't disable the CCM), but the ccm-migration e2e tests require to create a cluster

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -231,6 +231,11 @@ func ValidateClusterUpdate(ctx context.Context, newCluster, oldCluster *kubermat
 		allErrs = append(allErrs, field.Invalid(specPath.Child("features").Key(kubermaticv1.ClusterFeatureEtcdLauncher), v, fmt.Sprintf("feature gate %q cannot be disabled once it's enabled", kubermaticv1.ClusterFeatureEtcdLauncher)))
 	}
 
+	// Validate datacenter setting for disabling CSI driver installation if true, is not being over-written.
+	if dc.Spec.DisableCSIDriver && !newCluster.Spec.DisableCSIDriver {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("DisableCSIDriver"), "CSI driver installation is disabled on the datacenter, can't be enabled on cluster"))
+	}
+
 	if oldCluster.Spec.ExposeStrategy != "" {
 		if _, ok := newCluster.Labels[UnsafeExposeStrategyMigrationLabel]; !ok { // allow expose strategy migration if labeled explicitly
 			allErrs = append(allErrs, apimachineryvalidation.ValidateImmutableField(


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Partially fixes #12008

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
-->

**Special notes for your reviewer**:
This PR provides the option for disabling CSI driver installation at the data centre and cluster levels. Another PR will follow that will take care of uninstalling the CSI drivers on existing user clusters if the admin/users disabled it at the dc/cluster level.

**Does this PR introduce a user-facing change? Then add your Release Note here**:


```release-note
Add support for disabling CSI drivers for user clusters. This can be configured at a user cluster and datacenter level. If the admin disables CSI drivers at a datacenter level then the user is prohibited from enabling them at the user cluster level.
```

**Documentation**:
```
TBD
```