### PR TITLE
installer: local command reference KubeVirt images from quay

### DIFF
--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -31,11 +31,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/zapr"
 	"github.com/google/uuid"
 	"github.com/jackpal/gateway"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"gopkg.in/yaml.v3"
+	"go.uber.org/zap"
+	"gopkg.in/yaml.v2"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/install/helm"
@@ -49,6 +51,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlruntimeconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -172,6 +175,7 @@ func localKind(logger *logrus.Logger, dir string) (ctrlruntimeclient.Client, con
 		logger.Fatalf("failed to initialize runtime config: %v", err)
 	}
 
+	ctrlruntimelog.SetLogger(zapr.NewLogger(zap.NewNop()))
 	mgr, err := manager.New(ctrlConfig, manager.Options{
 		MetricsBindAddress:     "0",
 		HealthProbeBindAddress: "0",

--- a/cmd/kubermatic-installer/local_kind_resources.go
+++ b/cmd/kubermatic-installer/local_kind_resources.go
@@ -176,12 +176,21 @@ var kindLocalSeed = kubermaticv1.Seed{
 						Images: kubermaticv1.KubeVirtImageSources{
 							HTTP: &kubermaticv1.KubeVirtHTTPSource{
 								OperatingSystems: map[providerconfig.OperatingSystem]kubermaticv1.OSVersions{
+									providerconfig.OperatingSystemCentOS: map[string]string{
+										"7": "docker://quay.io/kubermatic-virt-disks/centos:7",
+									},
+									providerconfig.OperatingSystemFlatcar: map[string]string{
+										"3374.2.2": "docker://quay.io/kubermatic-virt-disks/flatcar:3374.2.2",
+									},
+									providerconfig.OperatingSystemRHEL: map[string]string{
+										"8": "docker://quay.io/kubermatic-virt-disks/rhel:8",
+									},
+									providerconfig.OperatingSystemRockyLinux: map[string]string{
+										"8": "docker://quay.io/kubermatic-virt-disks/rockylinux:8",
+									},
 									providerconfig.OperatingSystemUbuntu: map[string]string{
-										// TODO: create image-repo cache on the local cluster?
-										// the MD at the moment takes about 18 minutes to get ready which is too long
-										// could be worth to start downloading this in the beginning of the call, cache
-										// locally deployed image-repo and then speed up the MD startup
-										"22.04": "https://dev.kubermatic.io/kubevirt-images/images/ubuntu-22.04.img",
+										"20.04": "docker://quay.io/kubermatic-virt-disks/ubuntu:20.04",
+										"22.04": "docker://quay.io/kubermatic-virt-disks/ubuntu:22.04",
 									},
 								},
 							},

--- a/go.mod
+++ b/go.mod
@@ -78,6 +78,7 @@ require (
 	google.golang.org/protobuf v1.31.0
 	gopkg.in/fsnotify.v1 v1.4.7
 	gopkg.in/gcfg.v1 v1.2.3
+	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.12.1
 	k8c.io/kubeone v1.6.2
@@ -337,7 +338,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	k8s.io/component-base v0.27.2 // indirect
 	k8s.io/gengo v0.0.0-20220902162205-c0856e24416d // indirect
 	k8s.io/klog v1.0.0 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the `kubermatic-installer local kind` pulls the VM images from HTTP source. This will switch the preconfigured default to pull from OCI registry https://quay.io/organization/kubermatic-virt-disks

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12341

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
installer: use OCI VM images as preconfigured default for local kubevirt setup
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
