### PR TITLE
[release/v2.21] Add user-cluster envoy-agent DaemonSet to list of mirrored images

### DIFF
--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -19,6 +19,7 @@ package images
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	kubernetescontroller "k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/mla"
 	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/monitoring"
+	envoyagent "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent"
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/konnectivity"
 	k8sdashboard "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/kubernetes-dashboard"
 	nodelocaldns "k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns"
@@ -170,6 +172,7 @@ func getImagesFromCreators(log logrus.FieldLogger, templateData *resources.Templ
 		templateData.ImageRegistry,
 	))
 	daemonsetCreators = append(daemonsetCreators, nodelocaldns.DaemonSetCreator(templateData.ImageRegistry))
+	daemonsetCreators = append(daemonsetCreators, envoyagent.DaemonSetCreator(net.IPv4(0, 0, 0, 0), kubermaticVersions, "", templateData.ImageRegistry))
 
 	for _, creatorGetter := range statefulsetCreators {
 		_, creator := creatorGetter()


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of #12537.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add missing images from envoy-agent DaemonSet in Tunneling expose strategy when running `kubermatic-installer mirror-images`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
