### PR TITLE
bump metering version to v1.1.0

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	meteringName    = "metering"
-	meteringVersion = "v1.0.3"
+	meteringVersion = "v1.1.0"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {


### PR DESCRIPTION
**What this PR does / why we need it**:

Metering upgrade with removal of 3 fields:

Cluster reports:
* Removal of `total-used-cpu-seconds`, use `average-used-cpu-millicores` instead
* Removal of `average-available-cpu-cores`, use `average-available-cpu-millicores` instead

Namespace reports:
* Removal of `total-used-cpu-seconds`, use `average-used-cpu-millicores` instead



**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Upgrade metering to v1.1.0. Following fields are removed:
  Cluster reports:
  * Removal of `total-used-cpu-seconds`, use `average-used-cpu-millicores` instead
  * Removal of `average-available-cpu-cores`, use `average-available-cpu-millicores` instead
  Namespace reports:
  * Removal of `total-used-cpu-seconds`, use `average-used-cpu-millicores` instead
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1239/
```
