### PR TITLE
 [release/v2.23] Bump metering to v1.0.4 and prometheus to v2.37.9

### DIFF
--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -42,7 +42,7 @@ import (
 )
 
 func getPrometheusImage(overwriter registry.ImageRewriter) string {
-	return registry.Must(overwriter(resources.RegistryQuay + "/prometheus/prometheus:v2.37.0"))
+	return registry.Must(overwriter(resources.RegistryQuay + "/prometheus/prometheus:v2.37.9"))
 }
 
 // prometheusStatefulSet creates a StatefulSet for prometheus.

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -56,7 +56,7 @@ const (
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {
-	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.3"))
+	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.4"))
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport of latest metering performance enhancement.

Bumps the prometheus version to latest patch

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump metering to v1.0.4 with increased namespace report generation performance and prometheus to v2.37.9
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
