### PR TITLE
Adapt kube-state-metrics scraping to new label

### DIFF
--- a/charts/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
+++ b/charts/monitoring/prometheus/config/scraping/kube-state-metrics.yaml
@@ -24,7 +24,7 @@ kubernetes_sd_configs:
     names:
     - '{{ .Release.Namespace }}'
 relabel_configs:
-- source_labels: [__meta_kubernetes_service_label_app]
+- source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
   separator: ;
   regex: kube-state-metrics
   replacement: $1
@@ -58,7 +58,7 @@ relabel_configs:
   target_label: job
   replacement: ${1}
   action: replace
-- source_labels: [__meta_kubernetes_service_label_app]
+- source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
   separator: ;
   regex: (.+)
   target_label: job


### PR DESCRIPTION

**What this PR does / why we need it**:
With #12102 the set of labels on the kube-state-metrics service was changed and the label `app` was dropped in favor of `app.kubernetes.io/name`. 
Scraping rules were not adapted though, which this PR fixes now.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The kube_service_labels metric was not scraped with all expected labels, due to a change in labels on the kube-state-metrics service. The related scraping config was adapted accordingly.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
``` documentation
NONE
```
