### PR TITLE
Add error context (resource identifiers) to MLA cleanup functions

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -225,7 +225,7 @@ func (r *alertmanagerController) CleanUp(ctx context.Context) error {
 	}
 	for _, cluster := range clusterList.Items {
 		if err := r.handleDeletion(ctx, &cluster); err != nil {
-			return err
+			return fmt.Errorf("failed to handle alertmanager cleanup for cluster %s: %w", cluster.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/dashboard_grafana_controller.go
@@ -173,7 +173,7 @@ func (r *dashboardGrafanaController) CleanUp(ctx context.Context) error {
 			continue
 		}
 		if err := r.handleDeletion(ctx, r.log, &configMap, grafanaClient); err != nil {
-			return fmt.Errorf("handling deletion: %w", err)
+			return fmt.Errorf("failed to handle Grafana dashboard cleanup for ConfigMap %s/%s: %w", configMap.Namespace, configMap.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -408,7 +408,7 @@ func (r *datasourceGrafanaController) CleanUp(ctx context.Context) error {
 	}
 	for _, cluster := range clusterList.Items {
 		if err := r.handleDeletion(ctx, &cluster, nil); err != nil {
-			return err
+			return fmt.Errorf("failed to handle Grafana datasource cleanup for cluster %s: %w", cluster.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/org_grafana_controller.go
@@ -165,7 +165,7 @@ func (r *orgGrafanaController) CleanUp(ctx context.Context) error {
 	}
 	for _, project := range projectList.Items {
 		if err := r.handleDeletion(ctx, &project, grafanaClient); err != nil {
-			return err
+			return fmt.Errorf("failed to handle Grafana org cleanup for Project %s: %w", project.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/ratelimit_cortex_controller.go
@@ -215,7 +215,7 @@ func (r *ratelimitCortexController) CleanUp(ctx context.Context) error {
 	}
 	for _, mlaAdminSetting := range mlaAdminSettingList.Items {
 		if err := r.handleDeletion(ctx, r.log, &mlaAdminSetting); err != nil {
-			return fmt.Errorf("handling deletion: %w", err)
+			return fmt.Errorf("failed to handle Cortex ratelimit cleanup for MLAAdminSettings %s/%s: %w", mlaAdminSetting.Namespace, mlaAdminSetting.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -270,7 +270,7 @@ func (r *ruleGroupController) CleanUp(ctx context.Context) error {
 			return fmt.Errorf("failed to get request URL: %w", err)
 		}
 		if err := r.handleDeletion(ctx, &ruleGroup, requestURL); err != nil {
-			return fmt.Errorf("failed to handle deletion: %w", err)
+			return fmt.Errorf("failed to handle rule group cleanup for RuleGroup %s/%s: %w", ruleGroup.Namespace, ruleGroup.Name, err)
 		}
 		if err := r.Delete(ctx, &ruleGroup); err != nil {
 			return err

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -157,7 +157,7 @@ func (r *ruleGroupSyncController) CleanUp(ctx context.Context) error {
 	}
 	for _, ruleGroup := range ruleGroupList.Items {
 		if err := r.handleDeletion(ctx, r.log, &ruleGroup); err != nil {
-			return err
+			return fmt.Errorf("failed to handle rule group sync cleanup for RuleGroup %s/%s: %w", ruleGroup.Namespace, ruleGroup.Name, err)
 		}
 	}
 	return nil

--- a/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/user_grafana_controller.go
@@ -239,7 +239,7 @@ func (r *userGrafanaController) CleanUp(ctx context.Context) error {
 	}
 	for _, user := range userList.Items {
 		if err := r.handleDeletion(ctx, &user, grafanaClient); err != nil {
-			return err
+			return fmt.Errorf("failed to handle Grafana user cleanup for User %s: %w", user.Name, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
When the mla-controller tries to clean up something but fails, it often does not provide a lot of context for _which_ resource the cleanup fails. If you are unlucky, the error "chain" doesn't mention it at all.

This PR changes the error message on the individual `handleDeletion` functions per controller, which is often called while looping over the resource type that is being cleaned up.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
