### PR TITLE
Fix reconcile loop for seed-proxy on Kubernetes 1.27

### DIFF
--- a/.golangci.apis.yml
+++ b/.golangci.apis.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 run:
+  timeout: 3m
   modules-download-mode: readonly
   skip-files:
     - zz_generated.*.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ run:
   # concurrency=1 lowers memory usage a bit
   concurrency: 1
   modules-download-mode: readonly
-  deadline: 30m
+  timeout: 30m
   build-tags:
     - ce
     - cloud


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes a reconcile loop in KKP:

![2023-08-15T13-33-24](https://github.com/kubermatic/kubermatic/assets/127499/3185d6cd-3fcf-4cc2-a78f-6c173b48d8da)

With this patch, KKP will not overwrite unrelated labels on seed-proxy resources anymore.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix reconcile loop for `seed-proxy-token` Secret on Kubernetes 1.27
```

**Documentation**:
```documentation
NONE
```
