### PR TITLE
cloud/azure: simplify Azure NSG by removing rules duplicating built-in defaults

### DIFF
--- a/pkg/provider/cloud/azure/security_group.go
+++ b/pkg/provider/cloud/azure/security_group.go
@@ -119,32 +119,6 @@ func targetSecurityGroup(cloud kubermaticv1.CloudSpec, location string, clusterN
 						Priority:                 pointer.Int32(100),
 					},
 				},
-				{
-					Name: pointer.String("inter_node_comm"),
-					Properties: &armnetwork.SecurityRulePropertiesFormat{
-						Direction:                &inbound,
-						Protocol:                 &all,
-						SourceAddressPrefix:      pointer.String("VirtualNetwork"),
-						SourcePortRange:          pointer.String("*"),
-						DestinationAddressPrefix: pointer.String("VirtualNetwork"),
-						DestinationPortRange:     pointer.String("*"),
-						Access:                   &allow,
-						Priority:                 pointer.Int32(200),
-					},
-				},
-				{
-					Name: pointer.String("azure_load_balancer"),
-					Properties: &armnetwork.SecurityRulePropertiesFormat{
-						Direction:                &inbound,
-						Protocol:                 &all,
-						SourceAddressPrefix:      pointer.String("AzureLoadBalancer"),
-						SourcePortRange:          pointer.String("*"),
-						DestinationAddressPrefix: pointer.String("*"),
-						DestinationPortRange:     pointer.String("*"),
-						Access:                   &allow,
-						Priority:                 pointer.Int32(300),
-					},
-				},
 				// outbound
 				{
 					Name: pointer.String("outbound_allow_all"),
@@ -171,7 +145,7 @@ func targetSecurityGroup(cloud kubermaticv1.CloudSpec, location string, clusterN
 		securityGroup.Properties.SecurityRules = append(securityGroup.Properties.SecurityRules, nodePortsAllowedIPRangesRule("node_ports_ingress_ipv6", 401, portRangeLow, portRangeHigh, nodePortsIPv6CIDRs))
 	}
 
-	securityGroup.Properties.SecurityRules = append(securityGroup.Properties.SecurityRules, icmpAllowAllRule(), tcpDenyAllRule(), udpDenyAllRule())
+	securityGroup.Properties.SecurityRules = append(securityGroup.Properties.SecurityRules, icmpAllowAllRule())
 
 	return securityGroup
 }
@@ -238,46 +212,6 @@ func nodePortsAllowedIPRangesRule(name string, priority int32, portRangeLow int,
 	}
 
 	return rule
-}
-
-func tcpDenyAllRule() *armnetwork.SecurityRule {
-	inbound := armnetwork.SecurityRuleDirectionInbound
-	tcp := armnetwork.SecurityRuleProtocolTCP
-	deny := armnetwork.SecurityRuleAccessDeny
-
-	return &armnetwork.SecurityRule{
-		Name: pointer.String(denyAllTCPSecGroupRuleName),
-		Properties: &armnetwork.SecurityRulePropertiesFormat{
-			Direction:                &inbound,
-			Protocol:                 &tcp,
-			SourceAddressPrefix:      pointer.String("*"),
-			SourcePortRange:          pointer.String("*"),
-			DestinationPortRange:     pointer.String("*"),
-			DestinationAddressPrefix: pointer.String("*"),
-			Access:                   &deny,
-			Priority:                 pointer.Int32(900),
-		},
-	}
-}
-
-func udpDenyAllRule() *armnetwork.SecurityRule {
-	inbound := armnetwork.SecurityRuleDirectionInbound
-	udp := armnetwork.SecurityRuleProtocolUDP
-	deny := armnetwork.SecurityRuleAccessDeny
-
-	return &armnetwork.SecurityRule{
-		Name: pointer.String(denyAllUDPSecGroupRuleName),
-		Properties: &armnetwork.SecurityRulePropertiesFormat{
-			Direction:                &inbound,
-			Protocol:                 &udp,
-			SourceAddressPrefix:      pointer.String("*"),
-			SourcePortRange:          pointer.String("*"),
-			DestinationPortRange:     pointer.String("*"),
-			DestinationAddressPrefix: pointer.String("*"),
-			Access:                   &deny,
-			Priority:                 pointer.Int32(901),
-		},
-	}
 }
 
 func icmpAllowAllRule() *armnetwork.SecurityRule {


### PR DESCRIPTION
**What this PR does / why we need it**:
After #12559 merged I took another look at the NSG (Network Security Group) as it's created on Azure and realised the following:

- Inter-node communication and Load Balancer access has always been allowed in low-priority rules that Azure attaches to any NSG.
- There is a catch-all "deny everything" rule at the end of each ruleset.
- We had to replicate rules because we had the "tcp/udp deny all" rules in place to work around ICMP limitations.

Since ICMP limitations are no longer true and were removed in the previous PR, we can remove a lot of the duplicate rules and let the Azure NSG default rules do their job instead.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove Azure NSG rules that only duplicated rules always present in NSGs
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
