### PR TITLE
[release/v2.22] Fix reconcile loop for seed-proxy on Kubernetes 1.27 (#12557)

### DIFF
--- a/.golangci.apis.yml
+++ b/.golangci.apis.yml
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 run:
+  timeout: 3m
   modules-download-mode: readonly
   skip-files:
     - zz_generated.*.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ run:
   # concurrency=1 lowers memory usage a bit
   concurrency: 1
   modules-download-mode: readonly
-  deadline: 20m
+  timeout: 30m
   build-tags:
     - ce
     - cloud


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports #12557.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix reconcile loop for `seed-proxy-token` Secret on Kubernetes 1.27
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
