### PR TITLE
Add NetworkPolicy for accessing the Seed Kubernetes API

### DIFF
--- a/pkg/resources/apiserver/networkpolicy.go
+++ b/pkg/resources/apiserver/networkpolicy.go
@@ -359,6 +359,30 @@ func OIDCIssuerAllowReconciler(egressIPs []net.IP) reconciling.NamedNetworkPolic
 	}
 }
 
+func SeedApiServerAllowReconciler(endpoints []net.IP) reconciling.NamedNetworkPolicyReconcilerFactory {
+	return func() (string, reconciling.NetworkPolicyReconciler) {
+		return resources.NetworkPolicySeedApiserverAllow, func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
+			np.Spec = networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						resources.AppLabelKey: name,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						To: ipListToPeers(endpoints),
+					},
+				},
+			}
+
+			return np, nil
+		}
+	}
+}
+
 func ipListToPeers(ips []net.IP) []networkingv1.NetworkPolicyPeer {
 	result := []networkingv1.NetworkPolicyPeer{}
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -986,6 +986,7 @@ const (
 	NetworkPolicyMetricsServerAllow                 = "metrics-server-allow"
 	NetworkPolicyClusterExternalAddrAllow           = "cluster-external-addr-allow"
 	NetworkPolicyOIDCIssuerAllow                    = "oidc-issuer-allow"
+	NetworkPolicySeedApiserverAllow                 = "seed-apiserver-allow"
 	NetworkPolicyApiserverInternalAllow             = "apiserver-internal-allow"
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

In #12450, I moved the `etcd-running` check from a plain script to `etcd-launcher`. However, `etcd-launcher` needs to fetch information from the Seed's Kubernetes API (mainly from the `Cluster` object).

Since the kube-apiserver Pod is locked down by the NetworkPolicies feature that is on by default, this can cause problems with i/o timeouts caused by `NetworkPolicies` blocking access.

This PR discovers IPs and FQDNs in the `EndpointSlices` for the `kubernetes.default` service and creates a corresponding `NetworkPolicy` object in the user cluster namespace so that the `etcd-running` InitContainer can successfully fetch information to discover the etcd cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Create a NetworkPolicy for user cluster kube-apiserver to access the Seed Kubernetes API
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
