### PR TITLE
bump telemetry-agent to 0.4.1

### DIFF
--- a/charts/telemetry/Chart.yaml
+++ b/charts/telemetry/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 name: telemetry
 description: A Helm chart to install Kubermatic telemetry agents
 version: v9.9.9-dev
-appVersion: v0.3.0
+appVersion: v0.4.1
 keywords:
   - telemetry
 maintainers:

--- a/charts/telemetry/values.yaml
+++ b/charts/telemetry/values.yaml
@@ -23,17 +23,17 @@ telemetry:
   kubermaticAgent:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.3.0"
+      tag: "v0.4.1"
 
   kubernetesAgent:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.3.0"
+      tag: "v0.4.1"
 
   reporter:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.3.0"
+      tag: "v0.4.1"
 
   resources:
     limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
This just bumps the telemetry-agent version. Between 0.3 and 0.4.1 just a few things happened:

* Go types were put in their own package.
* Go 1.21 update
* lots of dependency updates

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update telemetry-agent to v0.4.1.
```

**Documentation**:
```documentation
NONE
```
