### PR TITLE
update list of supported k8s releases for EKS/AKS

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -463,25 +463,27 @@ spec:
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.24
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.28
+          - v1.27
+          - v1.26
+          - v1.25
+      eks:
+        # Default is the default version to offer users.
+        default: v1.27
+        # Updates is a list of available upgrades.
+        updates: null
+        # Versions lists the available versions.
+        versions:
+          - v1.27
+          - v1.26
           - v1.25
           - v1.24
           - v1.23
-      eks:
-        # Default is the default version to offer users.
-        default: v1.24
-        # Updates is a list of available upgrades.
-        updates: null
-        # Versions lists the available versions.
-        versions:
-          - v1.24
-          - v1.23
-          - v1.22
-          - v1.21
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -463,25 +463,27 @@ spec:
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.24
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.28
+          - v1.27
+          - v1.26
+          - v1.25
+      eks:
+        # Default is the default version to offer users.
+        default: v1.27
+        # Updates is a list of available upgrades.
+        updates: null
+        # Versions lists the available versions.
+        versions:
+          - v1.27
+          - v1.26
           - v1.25
           - v1.24
           - v1.23
-      eks:
-        # Default is the default version to offer users.
-        default: v1.24
-        # Updates is a list of available upgrades.
-        updates: null
-        # Versions lists the available versions.
-        versions:
-          - v1.24
-          - v1.23
-          - v1.22
-          - v1.21
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -382,23 +382,25 @@ var (
 	eksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-		Default: semver.NewSemverOrDie("v1.24"),
+		Default: semver.NewSemverOrDie("v1.27"),
 		Versions: []semver.Semver{
+			newSemver("v1.27"),
+			newSemver("v1.26"),
+			newSemver("v1.25"),
 			newSemver("v1.24"),
 			newSemver("v1.23"),
-			newSemver("v1.22"),
-			newSemver("v1.21"),
 		},
 	}
 
 	aksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
-		Default: semver.NewSemverOrDie("v1.24"),
+		Default: semver.NewSemverOrDie("v1.28"),
 		Versions: []semver.Semver{
+			newSemver("v1.28"),
+			newSemver("v1.27"),
+			newSemver("v1.26"),
 			newSemver("v1.25"),
-			newSemver("v1.24"),
-			newSemver("v1.23"),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates the list of supported k8s releases for EKS and AKS.

AKS lists 1.28 GA support beginning in September 2023. Anticipating that KKP 2.24 will be released _after_ that, I already included it in the list.

Similarily, assuming Amazon keeps 1.23/1.24 safe and bugfree, we still include these EOL releases in our list of versions. At least until Amazon themselves remove them from the documentation.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update supported Kubernetes releases for EKS/AKS.
```

**Documentation**:
```documentation
NONE
```
