### PR TITLE
[WIP] vsphere: pass initial MD tags

### DIFF
--- a/pkg/machine/provider/vsphere.go
+++ b/pkg/machine/provider/vsphere.go
@@ -156,9 +156,13 @@ func CompleteVSphereProviderSpec(config *vsphere.RawConfig, cluster *kubermaticv
 			config.ResourcePool.Value = cluster.Spec.Cloud.VSphere.ResourcePool
 		}
 
-		for i, tag := range config.Tags {
-			if tag.CategoryID == "" {
-				config.Tags[i].CategoryID = cluster.Spec.Cloud.VSphere.Tags.CategoryID
+		if cluster.Spec.Cloud.VSphere.Tags != nil {
+			for _, tag := range cluster.Spec.Cloud.VSphere.Tags.Tags {
+				vsphereTag := vsphere.Tag{
+					Name:       tag,
+					CategoryID: cluster.Spec.Cloud.VSphere.Tags.CategoryID,
+				}
+				config.Tags = append(config.Tags, vsphereTag)
 			}
 		}
 	}

--- a/pkg/machine/provider/vsphere_test.go
+++ b/pkg/machine/provider/vsphere_test.go
@@ -111,3 +111,36 @@ func TestCompleteVSphereProviderConfigBasics(t *testing.T) {
 
 	runProviderTestcases(t, goodCluster, testcases)
 }
+
+func TestCompleteVSphereProviderConfigTags(t *testing.T) {
+	goodClusterWithTags := genCluster(kubermaticv1.CloudSpec{
+		ProviderName: string(kubermaticv1.VSphereCloudProvider),
+		VSphere: &kubermaticv1.VSphereCloudSpec{
+			Tags: &kubermaticv1.VSphereTag{
+				Tags:       []string{"vsphere_tag1"},
+				CategoryID: "vsphere_tag_category_id",
+			},
+		},
+	})
+
+	defaultMachine := NewVSphereConfig().WithAllowInsecure(false)
+	goodMachine := cloneBuilder(defaultMachine).WithFolder("/testcluster")
+	goodMachine.Tags = []vsphere.Tag{
+		{
+			Name:       "vsphere_tag1",
+			CategoryID: "vsphere_tag_category_id",
+		},
+	}
+
+	testcases := []testcase[vsphere.RawConfig]{
+		&vsphereTestcase{
+			baseTestcase: baseTestcase[vsphere.RawConfig, kubermaticv1.DatacenterSpecVSphere]{
+				name:       "should pass the Tags to initial MD",
+				datacenter: &kubermaticv1.DatacenterSpecVSphere{},
+				expected:   cloneBuilder(goodMachine),
+			},
+		},
+	}
+
+	runProviderTestcases(t, goodClusterWithTags, testcases)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Refactoring to the new initial MD algorithm in https://github.com/kubermatic/kubermatic/pull/11339 may have introduced unintentional regression regarding the vSphere tags propagation.

Reported externally:
> Now the problem. When I'm creating a cluster the configured tags for vSphere are not applied to the VMs.
I did some screenshots to describe the problem:
> - I can set the tags during cluster creation
> - the tags are also shown in the next step
> - but after the cluster is created the tags are missing in the machine deployment
> - and they are also missing in vCenter for the VMs
> - but the tags in general gets created, I can set them manually
> - and they get applied to the VMs
>
> just a hint. I tested it with KKP v2.23.0 and it worked out of the box.

afaict the refactoring was merged before 2.23.0 which would indicate it being operational in 2.22.x last.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vSphere: fix tag propagation to initial machine deployments
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
