### PR TITLE
vSphere: support for propagating cluster tags to folders

### DIFF
--- a/pkg/provider/cloud/vsphere/folder_test.go
+++ b/pkg/provider/cloud/vsphere/folder_test.go
@@ -50,22 +50,22 @@ func TestProvider_GetVMFolders(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			session, err := newSession(context.Background(), test.dc, vSphereUsername, vSpherePassword, nil)
+			ctx := context.Background()
+			session, err := newSession(ctx, test.dc, vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			restSession, err := newRESTSession(context.Background(), test.dc, vSphereUsername, vSpherePassword, nil)
+			restSession, err := newRESTSession(ctx, test.dc, vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal("failed to create REST client session: %w", err)
 			}
-			defer restSession.Logout(context.TODO())
+			defer restSession.Logout(ctx)
 
-			if err := createVMFolder(context.Background(), session, test.expectedFolder); err != nil {
+			if err := ensureVMFolder(ctx, session, restSession, test.expectedFolder, nil); err != nil {
 				t.Fatal(err)
 			}
-
-			folders, err := GetVMFolders(context.Background(), test.dc, vSphereUsername, vSpherePassword, nil)
+			folders, err := GetVMFolders(ctx, test.dc, vSphereUsername, vSpherePassword, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -75,8 +75,7 @@ func TestProvider_GetVMFolders(t *testing.T) {
 			for _, folder := range folders {
 				if folder.Path == test.expectedFolder {
 					folderFound = true
-
-					if err := deleteVMFolder(context.Background(), session, test.expectedFolder); err != nil {
+					if err := deleteVMFolder(ctx, session, test.expectedFolder); err != nil {
 						t.Fatal(err)
 					}
 				}

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -69,7 +69,6 @@ func (v *VSphere) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 
 func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	logger := v.log.With("cluster", cluster.Name)
-
 	username, password, err := getCredentialsForCluster(cluster.Spec.Cloud, v.secretKeySelector, v.dc)
 	if err != nil {
 		return nil, err
@@ -106,7 +105,7 @@ func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 		}
 		defer session.Logout(ctx)
 
-		cluster, err = reconcileFolder(ctx, session, clusterFolder, cluster, update)
+		cluster, err = reconcileFolder(ctx, session, restSession, clusterFolder, cluster, update)
 		if err != nil {
 			return nil, fmt.Errorf("failed to reconcile cluster folder: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
For vSphere, this PR adds support for propagating the tags specified at the user cluster level to the folders managed by KKP. 

Currently, admins can specify tags against a pre-existing tag category at the cluster level. These tags are then managed by KKP. With the changes from this PR, these tags will now be propagated to the folders managed by KKP as well. Please note that these tags will NOT be attached to pre-existing folders that were created outside of KKP.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12554

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
vSphere: support for propagating cluster tags to folders created by KKP
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```