### PR TITLE
Fix defaulting for node ports allowed IP ranges

### DIFF
--- a/pkg/provider/cloud/aws/provider.go
+++ b/pkg/provider/cloud/aws/provider.go
@@ -86,14 +86,17 @@ func (a *AmazonEC2) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.Clu
 	if spec.Cloud.AWS == nil {
 		return errors.New("no AWS cloud spec found")
 	}
-	switch spec.ClusterNetwork.IPFamily {
-	case kubermaticv1.IPFamilyIPv4:
-		spec.Cloud.AWS.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
-		}
-	case kubermaticv1.IPFamilyDualStack:
-		spec.Cloud.AWS.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+
+	if spec.Cloud.AWS.NodePortsAllowedIPRanges == nil {
+		switch spec.ClusterNetwork.IPFamily {
+		case kubermaticv1.IPFamilyIPv4:
+			spec.Cloud.AWS.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
+			}
+		case kubermaticv1.IPFamilyDualStack:
+			spec.Cloud.AWS.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+			}
 		}
 	}
 	return nil

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -291,14 +291,16 @@ func (a *Azure) DefaultCloudSpec(ctx context.Context, clusterSpec *kubermaticv1.
 		clusterSpec.Cloud.Azure.LoadBalancerSKU = kubermaticv1.AzureBasicLBSKU
 	}
 
-	switch clusterSpec.ClusterNetwork.IPFamily {
-	case kubermaticv1.IPFamilyIPv4:
-		clusterSpec.Cloud.Azure.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
-		}
-	case kubermaticv1.IPFamilyDualStack:
-		clusterSpec.Cloud.Azure.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+	if clusterSpec.Cloud.Azure.NodePortsAllowedIPRanges == nil {
+		switch clusterSpec.ClusterNetwork.IPFamily {
+		case kubermaticv1.IPFamilyIPv4:
+			clusterSpec.Cloud.Azure.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
+			}
+		case kubermaticv1.IPFamilyDualStack:
+			clusterSpec.Cloud.Azure.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+			}
 		}
 	}
 

--- a/pkg/provider/cloud/gcp/provider.go
+++ b/pkg/provider/cloud/gcp/provider.go
@@ -118,14 +118,17 @@ func (g *gcp) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.ClusterSp
 	if spec.Cloud.GCP == nil {
 		return errors.New("no GCP cloud spec found")
 	}
-	switch spec.ClusterNetwork.IPFamily {
-	case kubermaticv1.IPFamilyIPv4:
-		spec.Cloud.GCP.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
-		}
-	case kubermaticv1.IPFamilyDualStack:
-		spec.Cloud.GCP.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+
+	if spec.Cloud.GCP.NodePortsAllowedIPRanges == nil {
+		switch spec.ClusterNetwork.IPFamily {
+		case kubermaticv1.IPFamilyIPv4:
+			spec.Cloud.GCP.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
+			}
+		case kubermaticv1.IPFamilyDualStack:
+			spec.Cloud.GCP.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+			}
 		}
 	}
 	return nil

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -99,14 +99,17 @@ func (os *Provider) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.Clu
 	if spec.Cloud.Openstack == nil {
 		return errors.New("no Openstack cloud spec found")
 	}
-	switch spec.ClusterNetwork.IPFamily {
-	case kubermaticv1.IPFamilyIPv4:
-		spec.Cloud.Openstack.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
-		}
-	case kubermaticv1.IPFamilyDualStack:
-		spec.Cloud.Openstack.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
-			CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+
+	if spec.Cloud.Openstack.NodePortsAllowedIPRanges == nil {
+		switch spec.ClusterNetwork.IPFamily {
+		case kubermaticv1.IPFamilyIPv4:
+			spec.Cloud.Openstack.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR},
+			}
+		case kubermaticv1.IPFamilyDualStack:
+			spec.Cloud.Openstack.NodePortsAllowedIPRanges = &kubermaticv1.NetworkRanges{
+				CIDRBlocks: []string{resources.IPv4MatchAnyCIDR, resources.IPv6MatchAnyCIDR},
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/kubermatic/kubermatic/pull/11583, we introduced defaulting for `nodePortsAllowedIPRanges` in the cloud provider specification for user clusters. Although this defaulting doesn't take into account the values already configured for `nodePortsAllowedIPRanges` and just overrides it with the default. This makes this field unusable since it will always be set to `0.0.0.0/0` or `::/0` which results in everything being whitelisted/allowed for the node ports.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix always defaulting allowed node port IP ranges for user clusters to 0.0.0.0/0 and ::/0, even when a more specific IP range was given
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
