### PR TITLE
remove unused kubelet configmap for <= 1.23

### DIFF
--- a/addons/kubelet-configmap/kubelet-configmap.yaml
+++ b/addons/kubelet-configmap/kubelet-configmap.yaml
@@ -15,98 +15,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kubelet-config-1.23
-  namespace: kube-system
-data:
-  kubelet: |
-    address: 0.0.0.0
-    apiVersion: kubelet.config.k8s.io/v1beta1
-    authentication:
-      anonymous:
-        enabled: false
-      webhook:
-        cacheTTL: 2m0s
-        enabled: true
-      x509:
-        clientCAFile: /etc/kubernetes/pki/ca.crt
-    authorization:
-      mode: Webhook
-      webhook:
-        cacheAuthorizedTTL: 5m0s
-        cacheUnauthorizedTTL: 30s
-    cgroupDriver: systemd
-    cgroupsPerQOS: true
-    clusterDNS:
-    - {{ .Cluster.Network.DNSResolverIP }}
-    clusterDomain: cluster.local
-    configMapAndSecretChangeDetectionStrategy: Watch
-    containerLogMaxFiles: 5
-    containerLogMaxSize: 10Mi
-    contentType: application/vnd.kubernetes.protobuf
-    cpuCFSQuota: true
-    cpuCFSQuotaPeriod: 100ms
-    cpuManagerPolicy: none
-    cpuManagerReconcilePeriod: 10s
-    enableControllerAttachDetach: true
-    enableDebuggingHandlers: true
-    enforceNodeAllocatable:
-    - pods
-    eventBurst: 10
-    eventRecordQPS: 5
-    evictionHard:
-      imagefs.available: 15%
-      memory.available: 100Mi
-      nodefs.available: 10%
-      nodefs.inodesFree: 5%
-    evictionPressureTransitionPeriod: 5m0s
-    failSwapOn: true
-    fileCheckFrequency: 20s
-    hairpinMode: promiscuous-bridge
-    healthzBindAddress: 127.0.0.1
-    healthzPort: 10248
-    httpCheckFrequency: 20s
-    imageGCHighThresholdPercent: 85
-    imageGCLowThresholdPercent: 80
-    imageMinimumGCAge: 2m0s
-    iptablesDropBit: 15
-    iptablesMasqueradeBit: 14
-    kind: KubeletConfiguration
-    kubeAPIBurst: 10
-    kubeAPIQPS: 5
-    makeIPTablesUtilChains: true
-    maxOpenFiles: 1000000
-    maxPods: 110
-    nodeLeaseDurationSeconds: 40
-    nodeStatusReportFrequency: 1m0s
-    nodeStatusUpdateFrequency: 10s
-    oomScoreAdj: -999
-    podPidsLimit: -1
-    port: 10250
-    registryBurst: 10
-    registryPullQPS: 5
-    resolvConf: /etc/resolv.conf
-    rotateCertificates: true
-    runtimeRequestTimeout: 2m0s
-    serializeImagePulls: true
-    staticPodPath: /etc/kubernetes/manifests
-    streamingConnectionIdleTimeout: 4h0m0s
-    syncFrequency: 1m0s
-    tlsCipherSuites:
-    - TLS_AES_128_GCM_SHA256
-    - TLS_AES_256_GCM_SHA384
-    - TLS_CHACHA20_POLY1305_SHA256
-    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
-    volumeStatsAggPeriod: 1m0s
----
-{{- if and (eq .Cluster.Version.Major 1) (ge .Cluster.Version.Minor 24) }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
   name: kubelet-config
   namespace: kube-system
 data:
@@ -129,7 +37,7 @@ data:
     cgroupDriver: systemd
     cgroupsPerQOS: true
     clusterDNS:
-    - {{ .Cluster.Network.DNSResolverIP }}
+      - {{ .Cluster.Network.DNSResolverIP }}
     clusterDomain: cluster.local
     configMapAndSecretChangeDetectionStrategy: Watch
     containerLogMaxFiles: 5
@@ -142,7 +50,7 @@ data:
     enableControllerAttachDetach: true
     enableDebuggingHandlers: true
     enforceNodeAllocatable:
-    - pods
+      - pods
     eventBurst: 10
     eventRecordQPS: 5
     evictionHard:
@@ -184,14 +92,13 @@ data:
     streamingConnectionIdleTimeout: 4h0m0s
     syncFrequency: 1m0s
     tlsCipherSuites:
-    - TLS_AES_128_GCM_SHA256
-    - TLS_AES_256_GCM_SHA384
-    - TLS_CHACHA20_POLY1305_SHA256
-    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
-    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
+      - TLS_AES_128_GCM_SHA256
+      - TLS_AES_256_GCM_SHA384
+      - TLS_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305
     volumeStatsAggPeriod: 1m0s
-  {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Forgot to remove this in #12570.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
