### PR TITLE
add missing cluster-autoscaler release for Kubernetes 1.27

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -14,13 +14,16 @@
 
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.24" }}
-{{ $version = "v1.24.1"}}
+{{ $version = "v1.24.1" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.1"}}
+{{ $version = "v1.25.1" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.2"}}
+{{ $version = "v1.26.2" }}
+{{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.27" }}
+{{ $version = "v1.27.3" }}
 {{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}


### PR DESCRIPTION
**What this PR does / why we need it**:
I think I overlooked this when adding support for Kubernetes 1.27. :-/

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add missing cluster-autoscaler release for user clusters using Kubernetes 1.27
```

**Documentation**:
```documentation
NONE
```
