### PR TITLE
Update vSphere CCM for Kubernetes 1.27

### DIFF
--- a/pkg/resources/cloudcontroller/aws.go
+++ b/pkg/resources/cloudcontroller/aws.go
@@ -149,7 +149,7 @@ func AWSCCMVersion(version semver.Semver) string {
 		return "v1.25.3"
 	case v126:
 		return "v1.26.1"
-	//	By default return latest version
+	// By default return latest version
 	default:
 		return "v1.27.1"
 	}

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -133,7 +133,7 @@ func VSphereCCMVersion(version semver.Semver) string {
 		return "1.26.2"
 	case v127:
 		fallthrough
-	//	By default return latest version
+	// By default return latest version
 	default:
 		return "1.27.0"
 	}

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -130,11 +130,11 @@ func VSphereCCMVersion(version semver.Semver) string {
 	case v125:
 		return "1.25.2"
 	case v126:
-		fallthrough
+		return "1.26.2"
 	case v127:
 		fallthrough
 	//	By default return latest version
 	default:
-		return "1.26.1"
+		return "1.27.0"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.1
+        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.2
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.26.1
+        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.27.0
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
I randomly saw in our verify job that we've used the same CCM version for 1.26, 1.27 and 1.28 (in #12593). To make a possible backport easier, I made this dedicated PR to just bump the vSphere CCM for k8s 1.27 to a 1.27.x release.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update vSphere CCM to 1.27.2 for Kubernetes 1.27 user clusters.
```

**Documentation**:
```documentation
NONE
```
