### PR TITLE
make Digitalocean CCM version depend on the cluster version

### DIFF
--- a/codegen/version-reporter/pkg/reader/gofunc.go
+++ b/codegen/version-reporter/pkg/reader/gofunc.go
@@ -35,7 +35,10 @@ var versionProviderFuncs = map[string]versionProviderFunc{
 	"callAWSCCMVersion": func(clusterVersion semver.Semver) (string, error) {
 		return cloudcontroller.AWSCCMVersion(clusterVersion), nil
 	},
-	"callAzureCCMVersion":     cloudcontroller.AzureCCMVersion,
+	"callAzureCCMVersion": cloudcontroller.AzureCCMVersion,
+	"callDigitaloceanCCMVersion": func(clusterVersion semver.Semver) (string, error) {
+		return cloudcontroller.DigitaloceanCCMVersion(clusterVersion), nil
+	},
 	"callOpenStackCCMVersion": cloudcontroller.OpenStackCCMTag,
 	"callVSphereCCMVersion": func(clusterVersion semver.Semver) (string, error) {
 		return cloudcontroller.VSphereCCMVersion(clusterVersion), nil

--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -37,9 +37,8 @@ products:
   - name: "CCM: DigitalOcean"
     source: https://github.com/digitalocean/digitalocean-cloud-controller-manager
     occurrences:
-      - goConstant:
-          package: k8c.io/kubermatic/v2/pkg/resources/cloudcontroller
-          constant: DigitalOceanCCMVersion
+      - goFunction:
+          function: callDigitaloceanCCMVersion
 
   - name: "CCM: Hetzner"
     source: https://github.com/hetznercloud/hcloud-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.44
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.44
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.44
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.44
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Digitalocean has a "follow us" compatibility policy and while DO and KKP usually support the same range of Kubernetes versions, I felt that it was still a bit wobbly and would rather use the same mechanism we use for all other CCMs: Make the CCM version depend on the cluster version.

This PR therefore changes the const into a function and leaves some comments behind.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Digitalocean CCM versions now depend on the user cluster version, following the loose [upstream compatibility guarantees](https://github.com/digitalocean/digitalocean-cloud-controller-manager#releases).
```

**Documentation**:
```documentation
NONE
```
