### PR TITLE
Add support for Cilium 1.13.6 and deprecate older 1.13 releases

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -101,6 +101,20 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 					},
 				},
 				{
+					Version: "1.13.6",
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
+								ChartName:    ciliumHelmChartName,
+								ChartVersion: "1.13.6",
+								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								Credentials:  credentials,
+							},
+						},
+					},
+				},
+
+				{
 					Version: "1.14.1",
 					Template: appskubermaticv1.ApplicationTemplate{
 						Source: appskubermaticv1.ApplicationSource{

--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -53,8 +53,7 @@ var (
 			"v1.12",
 			// NOTE: as of 1.13.0, we moved to Application infra for Cilium CNI management and started using real smever
 			// See pkg/cni/cilium docs for details on introducing a new version.
-			"1.13.3", // also affected by CVE-2023-34242, but kept here because 1.13.4 breaks IPSec support
-			"1.13.4",
+			"1.13.6", // restores IPSec support and fixes several security issues (in 1.13.5)
 			"1.14.1",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
@@ -66,6 +65,8 @@ var (
 		kubermaticv1.CNIPluginTypeCanal: sets.New("v3.8", "v3.19", "v3.20", "v3.21", "v3.22", "v3.23"),
 		kubermaticv1.CNIPluginTypeCilium: sets.New(
 			"1.13.0", // CVE-2023-34242
+			"1.13.3", // also affected by CVE-2023-34242, but kept here because 1.13.4 breaks IPSec support
+			"1.13.4",
 		),
 	}
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Cilium [1.13.6](https://github.com/cilium/cilium/releases/tag/v1.13.6). The Helm chart has been mirrored already.

Two reasons for this PR:

1. IPSec support in Cilium is (mostly) fixed now, finally.
2. The previous Cilium release [1.13.5](https://github.com/cilium/cilium/releases/tag/v1.13.5) fixed a bunch of security issues, mostly in Envoy. None of them seem very urgent but we still want to provide a fixed version if we can.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Add Cilium 1.13.6 as supported CNI version and deprecate older versions 1.13.3 and 1.13.4 for security reasons (GHSA-pvgm-7jpg-pw5g, GHSA-69vr-g55c-v2v4, GHSA-mc6h-6j9x-v3gq, GHSA-7mhv-gr67-hq55)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
