### PR TITLE
Add dex frontend issuer to configmap

### DIFF
--- a/charts/oauth/templates/configmap.yaml
+++ b/charts/oauth/templates/configmap.yaml
@@ -34,6 +34,9 @@ data:
     frontend:
       dir: /srv/dex/web
       logoURL: theme/logo.svg
+{{- if .Values.dex.frontend }}{{- if .Values.dex.frontend.issuer }}
+      issuer: {{ .Values.dex.frontend.issuer }}
+{{- end }}{{- end }}
     telemetry:
       http: 0.0.0.0:5558
 {{ if .Values.dex.expiry }}

--- a/charts/oauth/templates/configmap.yaml
+++ b/charts/oauth/templates/configmap.yaml
@@ -34,9 +34,7 @@ data:
     frontend:
       dir: /srv/dex/web
       logoURL: theme/logo.svg
-{{- if .Values.dex.frontend }}{{- if .Values.dex.frontend.issuer }}
-      issuer: {{ .Values.dex.frontend.issuer }}
-{{- end }}{{- end }}
+      issuer: {{ ((.Values.dex).frontend).issuer | default "dex" }}
     telemetry:
       http: 0.0.0.0:5558
 {{ if .Values.dex.expiry }}

--- a/charts/oauth/test/default.yaml.out
+++ b/charts/oauth/test/default.yaml.out
@@ -118,6 +118,7 @@ data:
     frontend:
       dir: /srv/dex/web
       logoURL: theme/logo.svg
+      issuer: dex
     telemetry:
       http: 0.0.0.0:5558
 
@@ -243,7 +244,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
-        checksum/config: 8bade3cd7c5628f6bcab4ee4a08b9596c6aa5a52b7412041b5fe5af6edadf7b0
+        checksum/config: b0bbf504419c5de9208e3de68ce6f1a527113729cd6a820b19f8ec9acbb01683
         checksum/secrets: 14780be2ecc3df3e4c622bcd96f0e8b79630d685e9580d082ed178d50f62d78a
     spec:
       serviceAccountName: dex

--- a/charts/oauth/test/image-pull-secret.yaml.out
+++ b/charts/oauth/test/image-pull-secret.yaml.out
@@ -118,6 +118,7 @@ data:
     frontend:
       dir: /srv/dex/web
       logoURL: theme/logo.svg
+      issuer: dex
     telemetry:
       http: 0.0.0.0:5558
 
@@ -243,7 +244,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
-        checksum/config: 8bade3cd7c5628f6bcab4ee4a08b9596c6aa5a52b7412041b5fe5af6edadf7b0
+        checksum/config: b0bbf504419c5de9208e3de68ce6f1a527113729cd6a820b19f8ec9acbb01683
         checksum/secrets: 14780be2ecc3df3e4c622bcd96f0e8b79630d685e9580d082ed178d50f62d78a
     spec:
       serviceAccountName: dex

--- a/charts/oauth/test/theme-with-overwrites.yaml.out
+++ b/charts/oauth/test/theme-with-overwrites.yaml.out
@@ -119,6 +119,7 @@ data:
     frontend:
       dir: /srv/dex/web
       logoURL: theme/logo.svg
+      issuer: dex
     telemetry:
       http: 0.0.0.0:5558
 
@@ -244,7 +245,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
-        checksum/config: 8bade3cd7c5628f6bcab4ee4a08b9596c6aa5a52b7412041b5fe5af6edadf7b0
+        checksum/config: b0bbf504419c5de9208e3de68ce6f1a527113729cd6a820b19f8ec9acbb01683
         checksum/secrets: 94174345cecf03681cc88e92181cc021203807d4f0bb2ef247038ba28c3f1303
     spec:
       serviceAccountName: dex

--- a/charts/oauth/test/values.example.ce.yaml.out
+++ b/charts/oauth/test/values.example.ce.yaml.out
@@ -118,6 +118,7 @@ data:
     frontend:
       dir: /srv/dex/web
       logoURL: theme/logo.svg
+      issuer: dex
     telemetry:
       http: 0.0.0.0:5558
 
@@ -267,7 +268,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
-        checksum/config: 2d5a09c76ad90c67b94901db1230d8aef705f537d700eda1596d8482f56bd5ee
+        checksum/config: d05f0723557402cffb219d4b52616a7fcfe59d82acc8bb7a75485cd3dd17a758
         checksum/secrets: 14780be2ecc3df3e4c622bcd96f0e8b79630d685e9580d082ed178d50f62d78a
     spec:
       serviceAccountName: dex

--- a/charts/oauth/test/values.example.ee.yaml.out
+++ b/charts/oauth/test/values.example.ee.yaml.out
@@ -118,6 +118,7 @@ data:
     frontend:
       dir: /srv/dex/web
       logoURL: theme/logo.svg
+      issuer: dex
     telemetry:
       http: 0.0.0.0:5558
 
@@ -267,7 +268,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
-        checksum/config: 2d5a09c76ad90c67b94901db1230d8aef705f537d700eda1596d8482f56bd5ee
+        checksum/config: d05f0723557402cffb219d4b52616a7fcfe59d82acc8bb7a75485cd3dd17a758
         checksum/secrets: 14780be2ecc3df3e4c622bcd96f0e8b79630d685e9580d082ed178d50f62d78a
     spec:
       serviceAccountName: dex

--- a/charts/oauth/values.yaml
+++ b/charts/oauth/values.yaml
@@ -47,6 +47,9 @@ dex:
   expiry:
     signingKeys: "6h"
     idTokens: "24h"
+  # frontend:
+  #   issuer: dex
+
   #  connectors:
   #  - type: github
   #    id: github


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the option to specify the web frontend issuer in Dex. If not specified Dex will display "dex" by default on its web frontend, this PR allows overwriting that value.

**Which issue(s) this PR fixes**:

Fixes #

**What type of PR is this?**

/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:

```release-note
New configuration option for Dex/oauth: allow modification of web frontend issuer
```

**Documentation**:

```documentation
NONE
```
