### PR TITLE
[release/v2.22] Remove dynamic configuration logic from MachineDeployment generation

### DIFF
--- a/pkg/controller/shared/nodedeployment-migration/machine/machinedeployment.go
+++ b/pkg/controller/shared/nodedeployment-migration/machine/machinedeployment.go
@@ -95,23 +95,6 @@ func Deployment(cluster *kubermaticv1.Cluster, nd *apiv1.NodeDeployment, dc *kub
 
 	md.Spec.Template.Spec.Versions.Kubelet = nd.Spec.Template.Versions.Kubelet
 
-	// Deprecated: This is not supported for 1.24 and higher and is blocked by
-	// Validate for 1.24+. Can be removed once 1.23 support is dropped.
-	if nd.Spec.DynamicConfig != nil && *nd.Spec.DynamicConfig {
-		kubeletVersion, err := semverlib.NewVersion(nd.Spec.Template.Versions.Kubelet)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse kubelet version: %w", err)
-		}
-
-		md.Spec.Template.Spec.ConfigSource = &corev1.NodeConfigSource{
-			ConfigMap: &corev1.ConfigMapNodeConfigSource{
-				Namespace:        metav1.NamespaceSystem,
-				Name:             fmt.Sprintf("kubelet-config-%d.%d", kubeletVersion.Major(), kubeletVersion.Minor()),
-				KubeletConfigKey: "kubelet",
-			},
-		}
-	}
-
 	if len(cluster.Spec.MachineNetworks) > 0 {
 		// TODO(mrIncompetent): Rename this finalizer to not contain the word "kubermatic" (For whitelabeling purpose)
 		md.Spec.Template.Annotations = map[string]string{


### PR DESCRIPTION
**What this PR does / why we need it**:
An issue was found that resulted in `kkp-cluster-template-synchronizer` failing to migrate existing `ClusterTemplates` from the old content of `kubermatic.io/initial-machinedeployment-request` (which is its own API type called `NodeDeployment`) to a "native" `MachineDeployment` spec. It would error out like this:

```json
{"level":"error","time":"<time>","logger":"kkp-cluster-template-synchronizer","caller":"cluster-template-synchronizer/controller.go:106","msg":"ReconcilingError","template":"<template id>","error":"failed to migrate initial-machinedeployment annotation: failed to convert NodeDeployment: failed to parse kubelet version: Invalid Semantic Version"}
```

The problem turns out to be the code that this PR removes. By default, kubelet versions in ClusterTemplates are empty and are filled when a cluster is created from the template. The code in question still tried to parse the kubelet version if the [kubelet dynamic configuration feature](https://docs.kubermatic.com/kubermatic/v2.22/tutorials-howtos/kkp-configuration/dynamic-kubelet-config/) was (still) enabled. This feature was deprecated some time ago and has been removed in Kubernetes 1.24+.

We still had this code in place because technically, our controllers need to understand Kubernetes 1.23 before it's upgraded during the auto-upgrade of a KKP 2.21 to 2.22 upgrade. However, since 1.23 is no longer supported, and this feature should no longer be used, and this code is only used when migrating annotations from the old format to the new one, I would deem it acceptable to remove this code.

The settings on the `MachineDeployment` should never be set in KKP 2.22.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Migration logic for `kubermatic.io/initial-machinedeployment-request` annotation no longer checks for dynamic kubelet configuration, a feature unavailable in Kubernetes 1.24+. This caused cluster templates that enabled it previously to fail migration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
