### PR TITLE
machine-controller using http-prober with "static" CRD checking

### DIFF
--- a/cmd/http-prober/main.go
+++ b/cmd/http-prober/main.go
@@ -218,7 +218,7 @@ func staticCrdChecker(group, version, resource, namespace string, cfg *restclien
 	return func() error {
 		client, err := dynamic.NewForConfig(cfg)
 		if err != nil {
-			return fmt.Errorf("failed to create kube client: %v", err)
+			return fmt.Errorf("failed to create kube client: %w", err)
 		}
 
 		gvr := schema.GroupVersionResource{
@@ -230,7 +230,7 @@ func staticCrdChecker(group, version, resource, namespace string, cfg *restclien
 		listOpts := metav1.ListOptions{Limit: 1}
 
 		if _, err := client.Resource(gvr).Namespace(namespace).List(context.Background(), listOpts); err != nil {
-			return fmt.Errorf("failed to list %s/%s.%s %s: %v", namespace, group, version, resource, err)
+			return fmt.Errorf("failed to list %s/%s.%s %s: %w", namespace, group, version, resource, err)
 		}
 
 		return nil

--- a/cmd/http-prober/main.go
+++ b/cmd/http-prober/main.go
@@ -40,7 +40,10 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -196,12 +199,45 @@ func crdCheckersFactory(mvf multiValFlag) ([]func() error, error) {
 
 func crdCheckerFromFlag(flag string, cfg *rest.Config) (func() error, error) {
 	splitVal := strings.Split(flag, ",")
-	if n := len(splitVal); n != 2 {
-		return nil, fmt.Errorf("comma-separating the flag value did not yield exactly two results, but %d", n)
+	switch len(splitVal) {
+	case 2:
+		kind := splitVal[0]
+		apiVersion := splitVal[1]
+		return dynamicCrdChecker(kind, apiVersion, cfg), nil
+	case 4:
+		group := splitVal[0]
+		version := splitVal[1]
+		resource := splitVal[2]
+		namespace := splitVal[3]
+		return staticCrdChecker(group, version, resource, namespace, cfg), nil
 	}
-	kind := splitVal[0]
-	apiVersion := splitVal[1]
+	return nil, fmt.Errorf("comma-separating the flag value did not yield exactly two or four results, but %d", len(splitVal))
+}
 
+func staticCrdChecker(group, version, resource, namespace string, cfg *restclient.Config) func() error {
+	return func() error {
+		client, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create kube client: %v", err)
+		}
+
+		gvr := schema.GroupVersionResource{
+			Group:    group,
+			Version:  version,
+			Resource: resource,
+		}
+
+		listOpts := metav1.ListOptions{Limit: 1}
+
+		if _, err := client.Resource(gvr).Namespace(namespace).List(context.Background(), listOpts); err != nil {
+			return fmt.Errorf("failed to list %s/%s.%s %s: %v", namespace, group, version, resource, err)
+		}
+
+		return nil
+	}
+}
+
+func dynamicCrdChecker(kind, apiVersion string, cfg *restclient.Config) func() error {
 	list := &unstructured.UnstructuredList{}
 	list.SetKind(kind)
 	list.SetAPIVersion(apiVersion)
@@ -220,7 +256,7 @@ func crdCheckerFromFlag(flag string, cfg *rest.Config) (func() error, error) {
 		}
 
 		return nil
-	}, nil
+	}
 }
 
 func executeCheckers(checkers []func() error) error {

--- a/cmd/http-prober/release.sh
+++ b/cmd/http-prober/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ver=v0.3.3
+ver=v0.4.0
 
 set -euox pipefail
 

--- a/pkg/resources/apiserver/is-running.go
+++ b/pkg/resources/apiserver/is-running.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	tag                = "v0.3.3"
+	tag                = "v0.4.0"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -81,7 +81,7 @@ func DeploymentReconciler(data machinecontrollerData) reconciling.NamedDeploymen
 			if err != nil {
 				return nil, err
 			}
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, deployment.Spec.Template.Spec, sets.New(Name), "Machine,cluster.k8s.io/v1alpha1")
+			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, deployment.Spec.Template.Spec, sets.New(Name), "cluster.k8s.io,v1alpha1,machines,kube-system")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-webhook-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.25.0-usercluster-webhook.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller-webhook.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-operating-system-manager.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-controller-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-controller.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-webhook-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.25.0-usercluster-webhook.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller-webhook.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -96,7 +96,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-usercluster-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.25.0-usercluster-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller-webhook.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -96,7 +96,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -96,7 +96,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -96,7 +96,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-controller-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-webhook-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.25.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-operating-system-manager.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.25.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller-webhook.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-operating-system-manager.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-controller-externalCloudProvider.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-controller.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-webhook-externalCloudProvider.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.25.0-usercluster-webhook.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-machine-controller-webhook.yaml
@@ -133,7 +133,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -124,7 +124,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-usercluster-controller.yaml
@@ -130,7 +130,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.25.0-usercluster-webhook.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller-webhook.yaml
@@ -133,7 +133,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -124,7 +124,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-controller.yaml
@@ -130,7 +130,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-webhook.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -133,7 +133,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -124,7 +124,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
@@ -130,7 +130,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -133,7 +133,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -124,7 +124,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
@@ -130,7 +130,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager-externalCloudProvider.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller-webhook.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-externalCloudProvider.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-operating-system-manager.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-controller-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-controller.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-webhook-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-usercluster-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.25.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-node-external-cloud-provider","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -39,7 +39,7 @@ spec:
         - -command
         - '{"command":"/usr/local/bin/machine-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-node-csr-approver","-use-osm"]}'
         - --crd-to-wait-for
-        - Machine,cluster.k8s.io/v1alpha1
+        - cluster.k8s.io,v1alpha1,machines,kube-system
         command:
         - /http-prober-bin/http-prober
         env:
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.3.3
+        image: quay.io/kubermatic/http-prober:v0.4.0
         name: copy-http-prober
         resources: {}
         volumeMounts:


### PR DESCRIPTION
Static CRD checking is a new option on http-prober to support the --crd-to-wait-for option without creating dynamic RESTMapper. The dynamic RESTMapper dynamically discovers all CRDs in the cluster, which can take long enough on a cluster with many CRDs to exceed typical prober timeouts, e.g. the 30s initialDelaySeconds for machine-controller.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature

**Special notes for your reviewer**:

This happened to us in a user cluster with over 900 CRDs(!). Sent machine-controller into a crashloop because http-prober took longer than the container's initialDelaySeconds.

This adds to `--crd-to-wait-for` a 4-tuple option with group,version,resource,namespace that avoids dynamic discovery (e.g. `--crd-to-wait-for cluster.k8s.io,v1alpha1,machines,kube-system`) in addition to the existing 2-tuple option with kind and apiVersion, e.g. `--crd-to-wait-for Machine,cluster.k8s.io/v1alpha1`, which I kept to be compatible with existing (potentially 3rd-party) users of http-prober.

It's a pretty exotic thing, and the first time this particular failure mode has happened to us  in ~5 years of using our KKP fork with (currently) hundreds of user clusters. Maybe you guys still want to merge this.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve http-prober's performance in user clusters with a lot of CRDs.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
http-prober --crd-to-wait-for: Ability to avoid dynamic CRD discovery
```
