### PR TITLE
[release/v2.23] Add support for Cilium 1.13.6 and deprecate older 1.13 releases

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -101,6 +101,19 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 						},
 					},
 				},
+				{
+					Version: "1.13.6",
+					Template: appskubermaticv1.ApplicationTemplate{
+						Source: appskubermaticv1.ApplicationSource{
+							Helm: &appskubermaticv1.HelmSource{
+								ChartName:    ciliumHelmChartName,
+								ChartVersion: "1.13.6",
+								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								Credentials:  credentials,
+							},
+						},
+					},
+				},
 			}
 
 			// we want to allow overriding the default values, so reconcile them only if nil

--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -33,7 +33,7 @@ const CanalCNILastUnspecifiedVersion = "v3.8"
 var (
 	defaultCNIPluginVersion = map[kubermaticv1.CNIPluginType]string{
 		kubermaticv1.CNIPluginTypeCanal:  "v3.25",
-		kubermaticv1.CNIPluginTypeCilium: "1.13.4",
+		kubermaticv1.CNIPluginTypeCilium: "1.13.6",
 	}
 )
 
@@ -53,8 +53,8 @@ var (
 			"v1.12",
 			// NOTE: as of 1.13.0, we moved to Application infra for Cilium CNI management and started using real smever
 			// See pkg/cni/cilium docs for details on introducing a new version.
-			"1.13.3", // also affected by CVE-2023-34242, but kept here because 1.13.4 breaks IPSec support
-			"1.13.4",
+			"1.13.6", // restores IPSec support (in 1.13.5) and fixes several security issues (in 1.13.5)
+			"1.14.1",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
 	}
@@ -65,6 +65,8 @@ var (
 		kubermaticv1.CNIPluginTypeCanal: sets.New("v3.8", "v3.19", "v3.20", "v3.21", "v3.22"),
 		kubermaticv1.CNIPluginTypeCilium: sets.New(
 			"1.13.0", // CVE-2023-34242
+			"1.13.3", // CVE-2023-34242
+			"1.13.4", // GHSA-pvgm-7jpg-pw5g, GHSA-69vr-g55c-v2v4, GHSA-mc6h-6j9x-v3gq, GHSA-7mhv-gr67-hq55
 		),
 	}
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #12603.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Cilium 1.13.6 as supported CNI version and deprecate older versions 1.13.3 and 1.13.4 for security reasons (GHSA-pvgm-7jpg-pw5g, GHSA-69vr-g55c-v2v4, GHSA-mc6h-6j9x-v3gq, GHSA-7mhv-gr67-hq55)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
