### PR TITLE
[release/v2.23] installer: change kubevirt VM images back to http for local command

### DIFF
--- a/cmd/kubermatic-installer/local_kind_resources.go
+++ b/cmd/kubermatic-installer/local_kind_resources.go
@@ -176,21 +176,8 @@ var kindLocalSeed = kubermaticv1.Seed{
 						Images: kubermaticv1.KubeVirtImageSources{
 							HTTP: &kubermaticv1.KubeVirtHTTPSource{
 								OperatingSystems: map[providerconfig.OperatingSystem]kubermaticv1.OSVersions{
-									providerconfig.OperatingSystemCentOS: map[string]string{
-										"7": "docker://quay.io/kubermatic-virt-disks/centos:7",
-									},
-									providerconfig.OperatingSystemFlatcar: map[string]string{
-										"3374.2.2": "docker://quay.io/kubermatic-virt-disks/flatcar:3374.2.2",
-									},
-									providerconfig.OperatingSystemRHEL: map[string]string{
-										"8": "docker://quay.io/kubermatic-virt-disks/rhel:8",
-									},
-									providerconfig.OperatingSystemRockyLinux: map[string]string{
-										"8": "docker://quay.io/kubermatic-virt-disks/rockylinux:8",
-									},
 									providerconfig.OperatingSystemUbuntu: map[string]string{
-										"20.04": "docker://quay.io/kubermatic-virt-disks/ubuntu:20.04",
-										"22.04": "docker://quay.io/kubermatic-virt-disks/ubuntu:22.04",
+										"22.04": "https://dev.kubermatic.io/kubevirt-images/images/ubuntu-22.04.img",
 									},
 								},
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:
Partial revert for https://github.com/kubermatic/kubermatic/pull/12588. OCI served kubevirt images depend on a feature implemented in https://github.com/kubermatic/machine-controller/pull/1672, but this will be rolled out only in 2.24, not backported to 2.23.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
