### PR TITLE
[release/v2.22] Add September 2023 Kubernetes patch releases

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -510,7 +510,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.25.11
+    default: v1.25.14
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -622,9 +622,11 @@ spec:
       - v1.25.6
       - v1.25.9
       - v1.25.11
+      - v1.25.14
       - v1.26.1
       - v1.26.4
       - v1.26.6
+      - v1.26.9
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -510,7 +510,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.25.11
+    default: v1.25.14
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -622,9 +622,11 @@ spec:
       - v1.25.6
       - v1.25.9
       - v1.25.11
+      - v1.25.14
       - v1.26.1
       - v1.26.4
       - v1.26.6
+      - v1.26.9
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -217,7 +217,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.25.11"),
+		Default: semver.NewSemverOrDie("v1.25.14"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -241,10 +241,12 @@ var (
 			newSemver("v1.25.6"),
 			newSemver("v1.25.9"),
 			newSemver("v1.25.11"),
+			newSemver("v1.25.14"),
 			// Kubernetes 1.26
 			newSemver("v1.26.1"),
 			newSemver("v1.26.4"),
 			newSemver("v1.26.6"),
+			newSemver("v1.26.9"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.23 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of #12638. This adds support for Kubernetes 1.25.14 and 1.26.9.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* Add support for Kubernetes 1.25.14 and 1.26.9
* Set default Kubernetes version to 1.25.14
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
