### PR TITLE
[release/v2.23] Bump d3fk/s3cmd image to latest hash of `arch-stable` image

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -204,7 +204,7 @@ spec:
     # This container is only relevant when the new backup/restore controllers are enabled.
     backupDeleteContainer: |
       name: delete-container
-      image: d3fk/s3cmd@sha256:2061883abbf0ebcf0ea3d5d218558c9c229f212e9c08af4acdaa3758980eb67a
+      image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
       command:
       - /bin/sh
       - -c

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -204,7 +204,7 @@ spec:
     # This container is only relevant when the new backup/restore controllers are enabled.
     backupDeleteContainer: |
       name: delete-container
-      image: d3fk/s3cmd@sha256:2061883abbf0ebcf0ea3d5d218558c9c229f212e9c08af4acdaa3758980eb67a
+      image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
       command:
       - /bin/sh
       - -c

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -806,7 +806,7 @@ volumeMounts:
 
 const DefaultNewBackupStoreContainer = `
 name: store-container
-image: d3fk/s3cmd@sha256:2061883abbf0ebcf0ea3d5d218558c9c229f212e9c08af4acdaa3758980eb67a
+image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
 command:
 - /bin/sh
 - -c
@@ -831,7 +831,7 @@ volumeMounts:
 
 const DefaultNewBackupDeleteContainer = `
 name: delete-container
-image: d3fk/s3cmd@sha256:2061883abbf0ebcf0ea3d5d218558c9c229f212e9c08af4acdaa3758980eb67a
+image: d3fk/s3cmd@sha256:fb4c4dcf3b842c3d0ead58bda26d05d045b77546e11ac2143d90abca02cbe823
 command:
 - /bin/sh
 - -c


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of ##12640. Since the previous image is from 2020, it's a good idea to update this in our release branches so we pull in security fixes and updates to the CA store in this image.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bump `d3fk/s3cmd` to version (latest "arch-stable") with `fb4c4dcf` hash 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
