### PR TITLE
Support for configuring OIDC username and group prefix for user clusters

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -625,13 +625,15 @@ const (
 )
 
 type OIDCSettings struct {
-	IssuerURL     string `json:"issuerURL,omitempty"`
-	ClientID      string `json:"clientID,omitempty"`
-	ClientSecret  string `json:"clientSecret,omitempty"`
-	UsernameClaim string `json:"usernameClaim,omitempty"`
-	GroupsClaim   string `json:"groupsClaim,omitempty"`
-	RequiredClaim string `json:"requiredClaim,omitempty"`
-	ExtraScopes   string `json:"extraScopes,omitempty"`
+	IssuerURL      string `json:"issuerURL,omitempty"`
+	ClientID       string `json:"clientID,omitempty"`
+	ClientSecret   string `json:"clientSecret,omitempty"`
+	UsernameClaim  string `json:"usernameClaim,omitempty"`
+	GroupsClaim    string `json:"groupsClaim,omitempty"`
+	RequiredClaim  string `json:"requiredClaim,omitempty"`
+	ExtraScopes    string `json:"extraScopes,omitempty"`
+	UsernamePrefix string `json:"usernamePrefix,omitempty"`
+	GroupsPrefix   string `json:"groupsPrefix,omitempty"`
 }
 
 // EventRateLimitConfig configures the `EventRateLimit` admission plugin.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1920,11 +1920,15 @@ spec:
                       type: string
                     groupsClaim:
                       type: string
+                    groupsPrefix:
+                      type: string
                     issuerURL:
                       type: string
                     requiredClaim:
                       type: string
                     usernameClaim:
+                      type: string
+                    usernamePrefix:
                       type: string
                   type: object
                 opaIntegration:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1915,11 +1915,15 @@ spec:
                       type: string
                     groupsClaim:
                       type: string
+                    groupsPrefix:
+                      type: string
                     issuerURL:
                       type: string
                     requiredClaim:
                       type: string
                     usernameClaim:
+                      type: string
+                    usernamePrefix:
                       type: string
                   type: object
                 opaIntegration:

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -424,6 +424,12 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		if oidcSettings.RequiredClaim != "" {
 			flags = append(flags, "--oidc-required-claim", oidcSettings.RequiredClaim)
 		}
+		if oidcSettings.GroupsPrefix != "" {
+			flags = append(flags, "--oidc-groups-prefix", oidcSettings.GroupsPrefix)
+		}
+		if oidcSettings.UsernamePrefix != "" {
+			flags = append(flags, "--oidc-username-prefix", oidcSettings.UsernamePrefix)
+		}
 	} else if enableOIDCAuthentication {
 		flags = append(flags,
 			"--oidc-ca-file", fmt.Sprintf("/etc/kubernetes/pki/ca-bundle/%s", resources.CABundleConfigMapKey),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for configuring the following additional flags for configuring OIDC settings for user cluster's API server:

```sh
oidc-username-prefix 
oidc-groups-prefix
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12645

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for configuring OIDC username and group prefix for user clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
