### PR TITLE
Update the CE E2E provisioning test to k8s 1.27

### DIFF
--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -97,7 +97,7 @@ presubmits:
             limits:
               memory: 6Gi
 
-  - name: pre-kubermatic-e2e-aws-ubuntu-1.26-ce
+  - name: pre-kubermatic-e2e-aws-ubuntu-1.27-ce
     decorate: true
     run_if_changed: "(cmd/|codegen/|hack/|pkg/|charts/kubermatic|addons/|.prow/)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
@@ -121,7 +121,7 @@ presubmits:
             - name: EXCLUDE_TESTS
               value: "all"
             - name: RELEASES_TO_TEST
-              value: "1.26"
+              value: "1.27"
             - name: DISTRIBUTIONS
               value: ubuntu
             - name: SERVICE_ACCOUNT_KEY


### PR DESCRIPTION
**What this PR does / why we need it**:
Since this is usually the default E2E provisioning test for Community Edition, I'd much prefer to keep it pinned to n-1(latest minus 1) k8s version.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
