### PR TITLE
Add changelogs for September 2023 patch releases

### DIFF
--- a/docs/changelogs/CHANGELOG-2.22.md
+++ b/docs/changelogs/CHANGELOG-2.22.md
@@ -7,6 +7,24 @@
 - [v2.22.4](#v2224)
 - [v2.22.5](#v2225)
 - [v2.22.6](#v2226)
+- [v2.22.7](#v2227)
+
+## [v2.22.7](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.7)
+
+### Supported Kubernetes Versions
+
+- Add support for Kubernetes 1.25.14 and 1.26.9 ([#12641](https://github.com/kubermatic/kubermatic/pull/12641))
+- Set default Kubernetes version to 1.25.14 ([#12641](https://github.com/kubermatic/kubermatic/pull/12641))
+
+### Bugfixes
+
+- Fix always defaulting allowed node port IP ranges for user clusters to 0.0.0.0/0 and ::/0, even when a more specific IP range was given ([#12589](https://github.com/kubermatic/kubermatic/pull/12589))
+- Migration logic for `kubermatic.io/initial-machinedeployment-request` annotation no longer checks for dynamic kubelet configuration, a feature unavailable in Kubernetes 1.24+. This caused cluster templates that enabled it previously to fail migration ([#12624](https://github.com/kubermatic/kubermatic/pull/12624))
+
+### Updates
+
+- Update to Go 1.19.12 ([#12643](https://github.com/kubermatic/kubermatic/pull/12643))
+- Update Vertical Pod Autoscaler to 0.14 (compatible with Kubernetes 1.25+) ([#12612](https://github.com/kubermatic/kubermatic/pull/12612))
 
 ## [v2.22.6](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.6)
 

--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -3,6 +3,28 @@
 - [v2.23.0](#v2230)
 - [v2.23.1](#v2231)
 - [v2.23.2](#v2232)
+- [v2.23.3](#v2233)
+
+## [v2.23.3](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.3)
+
+### Supported Kubernetes Versions
+
+- Add support for Kubernetes 1.25.14, 1.26.9 and 1.27.6 ([#12639](https://github.com/kubermatic/kubermatic/pull/12639))
+- Set default Kubernetes version to 1.26.9 ([#12639](https://github.com/kubermatic/kubermatic/pull/12639))
+
+### Bugfixes
+
+- Add missing cluster-autoscaler release for user clusters using Kubernetes 1.27 ([#12597](https://github.com/kubermatic/kubermatic/pull/12597))
+- Fix always defaulting allowed node port IP ranges for user clusters to 0.0.0.0/0 and ::/0, even when a more specific IP range was given ([#12589](https://github.com/kubermatic/kubermatic/pull/12589))
+- Mark MLA Grafana dashboards as non-editable as they are managed by KKP ([#12627](https://github.com/kubermatic/kubermatic/pull/12627))
+- MLA Grafana Kubernetes dashboards won't repeatedly ask to be saved ([#12614](https://github.com/kubermatic/kubermatic/pull/12614))
+
+### Updates
+
+- Update `d3fk/s3cmd` to version (latest "arch-stable") with `fb4c4dcf` hash ([#12644](https://github.com/kubermatic/kubermatic/pull/12644))
+- Update to Go 1.20.8 ([#12642](https://github.com/kubermatic/kubermatic/pull/12642))
+- Add Cilium 1.13.6 as supported CNI version and deprecate older versions 1.13.3 and 1.13.4 for security reasons (GHSA-pvgm-7jpg-pw5g, GHSA-69vr-g55c-v2v4, GHSA-mc6h-6j9x-v3gq, GHSA-7mhv-gr67-hq55) ([#12635](https://github.com/kubermatic/kubermatic/pull/12635))
+- Update Vertical Pod Autoscaler to 0.14 (compatible with Kubernetes 1.25+) ([#12611](https://github.com/kubermatic/kubermatic/pull/12611))
 
 ## [v2.23.2](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.2)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds release notes for KKP v2.23.3 and v2.22.7, the September 2023 patch releases. No v2.21 patch release is currently planned due to missing changes on release branches.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
