### PR TITLE
[vsphere] do not validate the DC's default datastore if the cluster has a custom one

### DIFF
--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -168,9 +168,14 @@ func (v *VSphere) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Cloud
 	}
 	defer session.Logout(ctx)
 
-	if ds := v.dc.DefaultDatastore; ds != "" {
-		if _, err := session.Finder.Datastore(ctx, ds); err != nil {
-			return fmt.Errorf("failed to get default datastore provided by datacenter spec %q: %w", ds, err)
+	effectiveDatastore := v.dc.DefaultDatastore
+	if ds := spec.VSphere.Datastore; ds != "" {
+		effectiveDatastore = ds
+	}
+
+	if effectiveDatastore != "" {
+		if _, err := session.Finder.Datastore(ctx, effectiveDatastore); err != nil {
+			return fmt.Errorf("failed to get effective datastore %q: %w", effectiveDatastore, err)
 		}
 	}
 
@@ -183,12 +188,6 @@ func (v *VSphere) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Cloud
 	if dc := spec.VSphere.DatastoreCluster; dc != "" {
 		if _, err := session.Finder.DatastoreCluster(ctx, spec.VSphere.DatastoreCluster); err != nil {
 			return fmt.Errorf("failed to get datastore cluster provided by cluster spec %q: %w", dc, err)
-		}
-	}
-
-	if ds := spec.VSphere.Datastore; ds != "" {
-		if _, err = session.Finder.Datastore(ctx, ds); err != nil {
-			return fmt.Errorf("failed to get datastore cluster provided by cluste spec %q: %w", ds, err)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
If a Cluster's CloudSpec contains a datastore, one of the reasons could be that the default is, for whatever reason, not available (maybe just temporarily, who knows). In these cases, the cluster validation should not attempt to validate something that is ultimately irrelevant.

This PR changes the validation logic to only check the _effective_ datastore.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix vSphere cluster validation: If a Cluster uses a custom datastore, the Seed's default datastore should not be validated.
```

**Documentation**:
```documentation
NONE
```
