### PR TITLE
[release/v2.23] Remove Cilium 1.14.1 unintentionally added to list of supported CNI versions

### DIFF
--- a/pkg/cni/version.go
+++ b/pkg/cni/version.go
@@ -54,7 +54,6 @@ var (
 			// NOTE: as of 1.13.0, we moved to Application infra for Cilium CNI management and started using real smever
 			// See pkg/cni/cilium docs for details on introducing a new version.
 			"1.13.6", // restores IPSec support (in 1.13.5) and fixes several security issues (in 1.13.5)
-			"1.14.1",
 		),
 		kubermaticv1.CNIPluginTypeNone: sets.New(""),
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
In #12635 I meant to just backport Cilium 1.13.6 from a cherry-pick'd commit. While doing the manual cherry-pick, I removed Cilium 1.14.1 as intended, but forgot to remove the entry into the list of supported versions. So 1.14 is offered through the dashboard for KKP 2.23.3, even though Cilium 1.14 is not available in KKP 2.23 (and wasn't meant to).

This PR fixes the list of CNI versions, we will also need to update kubermatic/dashboard once this has merged.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12662

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove Cilium 1.14.1 from list of supported CNI versions visible in the dashboard as it is not supported in KKP 2.23
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
