### PR TITLE
[release/v2.23] Add release notes for v2.23.4

### DIFF
--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -4,6 +4,14 @@
 - [v2.23.1](#v2231)
 - [v2.23.2](#v2232)
 - [v2.23.3](#v2233)
+- [v2.23.4](#v2234)
+
+## [v2.23.4](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.4)
+
+### Bugfixes
+
+- Fix vSphere cluster validation: If a Cluster uses a custom datastore, the Seed's default datastore should not be validated ([#12655](https://github.com/kubermatic/kubermatic/pull/12655))
+- Remove Cilium 1.14.1 from list of supported CNI versions visible in the dashboard as it is not supported in KKP 2.23 ([#12659](https://github.com/kubermatic/kubermatic/pull/12659))
 
 ## [v2.23.3](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.3)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a changelog entry for v2.23.4, the out-of-band patch release to fix the Cilium 1.14.1 regression (#12662).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
