### PR TITLE
Add basePath configuration option for vSphere clusters and presets

### DIFF
--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -103,6 +103,53 @@ presubmits:
             limits:
               memory: 6Gi
 
+  - name: pre-kubermatic-e2e-vsphere-ubuntu-1.28-basepath
+    decorate: true
+    optional: true
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vsphere: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-4
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.28"
+            - name: PROVIDER
+              value: "vsphere"
+            - name: DISTRIBUTIONS
+              value: ubuntu
+            - name: SCENARIO_OPTIONS
+              value: "basepath"
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
+
+
   - name: pre-kubermatic-e2e-vsphere-ubuntu-1.28-datastore-cluster
     decorate: true
     run_if_changed: "(addons/csi/vsphere|pkg/provider/cloud/vsphere)"

--- a/cmd/conformance-tester/pkg/scenarios/generator.go
+++ b/cmd/conformance-tester/pkg/scenarios/generator.go
@@ -202,7 +202,12 @@ func providerScenario(
 	case kubermaticv1.VSphereCloudProvider:
 		scenario := &vSphereScenario{baseScenario: base}
 		scenario.customFolder = opts.ScenarioOptions.Has("custom-folder")
+		scenario.basePath = opts.ScenarioOptions.Has("basepath")
 		scenario.datastoreCluster = opts.ScenarioOptions.Has("datastore-cluster")
+
+		if scenario.customFolder && scenario.basePath {
+			return nil, fmt.Errorf("cannot run mutually exclusive %q scenarios 'custom-folder' and 'basepath' together", provider)
+		}
 
 		return scenario, nil
 	default:

--- a/cmd/conformance-tester/pkg/scenarios/vsphere.go
+++ b/cmd/conformance-tester/pkg/scenarios/vsphere.go
@@ -30,6 +30,7 @@ type vSphereScenario struct {
 	baseScenario
 
 	customFolder     bool
+	basePath         bool
 	datastoreCluster bool
 }
 
@@ -49,6 +50,10 @@ func (s *vSphereScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSp
 
 	if s.customFolder {
 		spec.Cloud.VSphere.Folder = fmt.Sprintf("%s/custom_folder_test", s.datacenter.Spec.VSphere.RootPath)
+	}
+
+	if s.basePath {
+		spec.Cloud.VSphere.BasePath = "basepath_subfolder"
 	}
 
 	if s.datastoreCluster {

--- a/hack/ci/run-conformance-tests.sh
+++ b/hack/ci/run-conformance-tests.sh
@@ -143,5 +143,6 @@ timeout -s 9 "${maxDuration}m" ./_build/conformance-tester $EXTRA_ARGS \
   -exclude-distributions="${EXCLUDE_DISTRIBUTIONS:-}" \
   -exclude-tests="${EXCLUDE_TESTS:-}" \
   -enable-osm=${KUBERMATIC_OSM_ENABLED:-true} \
+  -scenario-options="${SCENARIO_OPTIONS:-}" \
   -pushgateway-endpoint="pushgateway.monitoring.svc.cluster.local.:9091" \
   -results-file "$ARTIFACTS/conformance-tester-results.json"

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1060,6 +1060,12 @@ type VSphereCloudSpec struct {
 	// machines.
 	// +optional
 	Folder string `json:"folder"`
+	// Optional: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in.
+	// If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,
+	// the BasePath part will be appended to the RootPath (if set) to construct the full path.
+	// +optional
+	BasePath string `json:"basePath,omitempty"`
+
 	// If both Datastore and DatastoreCluster are not specified the virtual
 	// machines are stored in the `DefaultDatastore` specified for the
 	// Datacenter.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1060,7 +1060,7 @@ type VSphereCloudSpec struct {
 	// machines.
 	// +optional
 	Folder string `json:"folder"`
-	// Optional: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in.
+	// Optional: BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.
 	// If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,
 	// the BasePath part will be appended to the RootPath (if set) to construct the full path.
 	// +optional

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -174,6 +174,10 @@ type VSphere struct {
 	Datastore        string   `json:"datastore,omitempty"`
 	DatastoreCluster string   `json:"datastoreCluster,omitempty"`
 	ResourcePool     string   `json:"resourcePool,omitempty"`
+	// BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in.
+	// If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,
+	// the BasePath part will be appended to the RootPath to construct the full path.
+	BasePath string `json:"basePath,omitempty"`
 }
 
 func (s VSphere) IsValid() bool {

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -174,7 +174,7 @@ type VSphere struct {
 	Datastore        string   `json:"datastore,omitempty"`
 	DatastoreCluster string   `json:"datastoreCluster,omitempty"`
 	ResourcePool     string   `json:"resourcePool,omitempty"`
-	// BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in.
+	// BasePath configures a vCenter folder path that KKP will create an individual cluster folder in.
 	// If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path,
 	// the BasePath part will be appended to the RootPath to construct the full path.
 	BasePath string `json:"basePath,omitempty"`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -909,7 +909,7 @@ spec:
                       description: VSphereCloudSpec specifies access data to VSphere cloud.
                       properties:
                         basePath:
-                          description: 'Optional: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in. If it''s an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath (if set) to construct the full path.'
+                          description: 'Optional: BasePath configures a vCenter folder path that KKP will create an individual cluster folder in. If it''s an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath (if set) to construct the full path.'
                           type: string
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -908,6 +908,9 @@ spec:
                     vsphere:
                       description: VSphereCloudSpec specifies access data to VSphere cloud.
                       properties:
+                        basePath:
+                          description: 'Optional: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in. If it''s an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath (if set) to construct the full path.'
+                          type: string
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
                           properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -903,6 +903,9 @@ spec:
                     vsphere:
                       description: VSphereCloudSpec specifies access data to VSphere cloud.
                       properties:
+                        basePath:
+                          description: 'Optional: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in. If it''s an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath (if set) to construct the full path.'
+                          type: string
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
                           properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -904,7 +904,7 @@ spec:
                       description: VSphereCloudSpec specifies access data to VSphere cloud.
                       properties:
                         basePath:
-                          description: 'Optional: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in. If it''s an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath (if set) to construct the full path.'
+                          description: 'Optional: BasePath configures a vCenter folder path that KKP will create an individual cluster folder in. If it''s an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath (if set) to construct the full path.'
                           type: string
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -408,7 +408,7 @@ spec:
                 vsphere:
                   properties:
                     basePath:
-                      description: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in. If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath to construct the full path.
+                      description: BasePath configures a vCenter folder path that KKP will create an individual cluster folder in. If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath to construct the full path.
                       type: string
                     datacenter:
                       description: If datacenter is set, this preset is only applicable to the configured datacenter.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -407,6 +407,9 @@ spec:
                   type: object
                 vsphere:
                   properties:
+                    basePath:
+                      description: BasePath configures a vCenter folder path that KKP will create an individual "cluster-CLUSTER-ID" folder in. If it's an absolute path, the RootPath configured in the datacenter will be ignored. If it is a relative path, the BasePath part will be appended to the RootPath to construct the full path.
+                      type: string
                     datacenter:
                       description: If datacenter is set, this preset is only applicable to the configured datacenter.
                       type: string

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -107,7 +107,7 @@ func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 
 	// Only reconcile folders that are KKP managed at the clusterFolder location.
 	if cluster.Spec.Cloud.VSphere.Folder == "" || cluster.Spec.Cloud.VSphere.Folder == clusterFolder {
-		logger.Infow("reconciling vsphere folder", "folder", cluster.Spec.Cloud.VSphere.Folder)
+		logger.Infow("reconciling vsphere folder", "folder", clusterFolder)
 		session, err := newSession(ctx, v.dc, username, password, v.caBundle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create vCenter session: %w", err)

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"path/filepath"
 
 	vapitags "github.com/vmware/govmomi/vapi/tags"
 	"go.uber.org/zap"
@@ -95,6 +96,14 @@ func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 	rootPath := getVMRootPath(v.dc)
 
 	clusterFolder := path.Join(rootPath, cluster.Name)
+
+	if cluster.Spec.Cloud.VSphere.BasePath != "" {
+		if filepath.IsAbs(cluster.Spec.Cloud.VSphere.BasePath) {
+			clusterFolder = path.Join(cluster.Spec.Cloud.VSphere.BasePath, cluster.Name)
+		} else {
+			clusterFolder = path.Join(rootPath, cluster.Spec.Cloud.VSphere.BasePath, cluster.Name)
+		}
+	}
 
 	// Only reconcile folders that are KKP managed at the clusterFolder location.
 	if cluster.Spec.Cloud.VSphere.Folder == "" || cluster.Spec.Cloud.VSphere.Folder == clusterFolder {

--- a/pkg/provider/cloud/vsphere/utils.go
+++ b/pkg/provider/cloud/vsphere/utils.go
@@ -25,9 +25,9 @@ import (
 // getVMRootPath is a helper func to get the root path for VM's
 // We extracted it because we use it in several places.
 func getVMRootPath(dc *kubermaticv1.DatacenterSpecVSphere) string {
-	// Each datacenter root directory for VM's is: ${DATACENTER_NAME}/vm
+	// Each datacenter root directory for VMs is: ${DATACENTER_NAME}/vm
 	rootPath := path.Join("/", dc.Datacenter, "vm")
-	// We offer a different root path though in case people would like to store all Kubermatic VM's below a certain directory
+	// We offer a different root path though in case people would like to store all Kubermatic VMs below a certain directory
 	if dc.RootPath != "" {
 		rootPath = path.Clean(dc.RootPath)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
There has been a request to pass a "base path" in vSphere that user cluster folders get created in. The seed root path is not enough, as it needs to be flexible enough to provide different paths. This PR implements the feature in the following way:

- It adds a `basePath` field to the vSphere CloudSpec that the reconciling loop will use to construct the path for the user cluster folder. KKP will continue to only create the cluster folder, which means the full parent folder chain needs to exist.
- If the `basePath` is an absolute path, _the rootPath configured in the seed will be ignored_ and the target folder will be constructed as `<base path>/<cluster folder>`, if it's an relative path, the path will be constructed as `<root path>/<base path>/<cluster folder>`.

This PR requires a follow-up on the kubermatic/dashboard side to actually transfer the `basePath` field from the preset onto the cloud spec.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards #12632

**What type of PR is this?**
/kind feature


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `basePath` optional configuration for vSphere clusters that will be used to construct a cluster-specific folder path (`<root path>/<base path>/<cluster ID>` or `<base path>/<cluster ID>`)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
