### PR TITLE
Option to disable admin kubeconfig endpoint

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -67,6 +67,10 @@ type SettingSpec struct {
 	EnableShareCluster bool `json:"enableShareCluster,omitempty"`
 
 	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig"` //nolint:tagliatelle
+
+	// DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
+	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
+
 	// UserProjectsLimit is the maximum number of projects a user can create.
 	UserProjectsLimit       int64 `json:"userProjectsLimit"`
 	RestrictProjectCreation bool  `json:"restrictProjectCreation"`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -101,6 +101,9 @@ spec:
                           x-kubernetes-int-or-string: true
                       type: object
                   type: object
+                disableAdminKubeconfig:
+                  description: DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
+                  type: boolean
                 disableChangelogPopup:
                   description: DisableChangelogPopup disables the changelog popup in KKP dashboard.
                   type: boolean


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a new field `DisableAdminKubeconfig`, in the KubermaticSettings to control the admin kubeconfig feature on the dashboard.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/dashboard/issues/6245

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Introduce `DisableAdminKubeconfig` flag in `KubermaticSettings` to disable the admin kubeconfig feature from dashboard
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
