### PR TITLE
[release/v2.22] Option to disable admin kubeconfig endpoint

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -57,6 +57,10 @@ type SettingSpec struct {
 	EnableWebTerminal bool `json:"enableWebTerminal,omitempty"`
 
 	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig"` //nolint:tagliatelle
+
+	// DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
+	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
+
 	// UserProjectsLimit is the maximum number of projects a user can create.
 	UserProjectsLimit           int64 `json:"userProjectsLimit"`
 	RestrictProjectCreation     bool  `json:"restrictProjectCreation"`

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -96,6 +96,9 @@ spec:
                           x-kubernetes-int-or-string: true
                       type: object
                   type: object
+                disableAdminKubeconfig:
+                  description: DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
+                  type: boolean
                 displayAPIDocs:
                   description: DisplayDemoInfo controls whether a a link to the KKP API documentation is shown in the footer.
                   type: boolean


### PR DESCRIPTION
This is an manual cherry-pick of #12679

/assign ahmedwaleedmalik

```release-note
Introduce `DisableAdminKubeconfig` flag in `KubermaticSettings` to disable the admin kubeconfig feature from dashboard
```