### PR TITLE
Add Minio Console and Ingress Expose Config Option

### DIFF
--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
         {{- end }}
         - server
         - /storage
+        {{- if .Values.minio.console.port }}
+        - --console-address
+        - :{{ .Values.minio.console.port}}
+        {{- end }}
         env:
         - name: MINIO_ROOT_USER
           valueFrom:

--- a/charts/minio/templates/ingress.yaml
+++ b/charts/minio/templates/ingress.yaml
@@ -1,0 +1,81 @@
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{ if ne .Values.minio.ingress.class "non-existent" }}
+{{- if .Values.minio.ingress.server.host }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Values.minio.ingress.class }}"
+    {{- with .Values.minio.certIssuer }}
+    {{- if eq .kind "ClusterIssuer" }}
+    cert-manager.io/cluster-issuer: {{ .name | quote }}
+    {{- else }}
+    cert-manager.io/issuer: {{ .name | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  tls:
+    - secretName: minio-tls
+      hosts:
+        - {{ .Values.minio.ingress.server.host }}
+  rules:
+    - host: {{ .Values.minio.ingress.server.host}}
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 9000
+{{- end }}
+---
+{{- if .Values.minio.ingress.console.host }}
+{{- if .Values.minio.console.port }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-console
+  annotations:
+    kubernetes.io/ingress.class: "{{ .Values.minio.ingress.class }}"
+    {{- with .Values.minio.certIssuer }}
+    {{- if eq .kind "ClusterIssuer" }}
+    cert-manager.io/cluster-issuer: {{ .name | quote }}
+    {{- else }}
+    cert-manager.io/issuer: {{ .name | quote }}
+    {{- end }}
+    {{- end }}
+spec:
+  tls:
+    - secretName: minio-console-tls
+      hosts:
+        - {{ .Values.minio.ingress.console.host }}
+  rules:
+    - host: {{ .Values.minio.ingress.console.host}}
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: {{ .Values.minio.console.port }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/charts/minio/templates/service.yaml
+++ b/charts/minio/templates/service.yaml
@@ -19,8 +19,15 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 9000
+    - name: server
+      port: 9000
       targetPort: 9000
       protocol: TCP
+    {{- if .Values.minio.console.port }}
+    - name: console
+      port: {{ .Values.minio.console.port }}
+      targetPort: {{ .Values.minio.console.port }}
+      protocol: TCP
+    {{- end }}
   selector:
     app: minio

--- a/charts/minio/test/enable-ingress.yaml
+++ b/charts/minio/test/enable-ingress.yaml
@@ -1,0 +1,21 @@
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+minio:
+  ingress:
+    class: "nginx"
+
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer

--- a/charts/minio/test/enable-ingress.yaml.out
+++ b/charts/minio/test/enable-ingress.yaml.out
@@ -71,12 +71,11 @@ metadata:
   labels:
     app: minio
 spec:
-  storageClassName: "minio-hdd"
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 500Gi
+      storage: 100Gi
 ---
 # Source: minio/templates/service.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
@@ -242,3 +241,53 @@ spec:
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+    - secretName: minio-tls
+      hosts:
+        - minio.kkp.example.com
+  rules:
+    - host: minio.kkp.example.com
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 9000
+---
+# Source: minio/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: minio-console
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+    - secretName: minio-console-tls
+      hosts:
+        - minio-console.kkp.example.com
+  rules:
+    - host: minio-console.kkp.example.com
+      http:
+        paths:
+          - path: "/"
+            pathType: Prefix
+            backend:
+              service:
+                name: minio
+                port:
+                  number: 80

--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -99,8 +99,13 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 9000
+    - name: server
+      port: 9000
       targetPort: 9000
+      protocol: TCP
+    - name: console
+      port: 80
+      targetPort: 80
       protocol: TCP
   selector:
     app: minio
@@ -152,6 +157,8 @@ spec:
         args:
         - server
         - /storage
+        - --console-address
+        - :80
         env:
         - name: MINIO_ROOT_USER
           valueFrom:
@@ -221,3 +228,18 @@ spec:
         {}
       tolerations:
         []
+---
+# Source: minio/templates/ingress.yaml
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -100,8 +100,13 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 9000
+    - name: server
+      port: 9000
       targetPort: 9000
+      protocol: TCP
+    - name: console
+      port: 80
+      targetPort: 80
       protocol: TCP
   selector:
     app: minio
@@ -151,6 +156,8 @@ spec:
         args:
         - server
         - /storage
+        - --console-address
+        - :80
         env:
         - name: MINIO_ROOT_USER
           valueFrom:
@@ -220,3 +227,18 @@ spec:
         {}
       tolerations:
         []
+---
+# Source: minio/templates/ingress.yaml
+# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -30,6 +30,11 @@ minio:
   # If you are enabling it, make sure to enable prometheus scraping for minio as well.
   certificateSecret: '' # tls secret used by minio.
 
+  # Management Console for Minio Access
+  console:
+    # configure a port enables the console
+    port: 80
+
   # These settings are required. Keys must be alphanumeric.
   credentials:
     accessKey: '' # 32 byte long
@@ -52,6 +57,24 @@ minio:
 
     # hide sensitive information from logging
     anonymous: false
+
+  # Optional: Expose Minio external
+  ingress:
+    # configure a host name enables the ingress deployment
+    server:
+      host: "minio.kkp.example.com"
+    console:
+      host: "minio-console.kkp.example.com"
+    # if set to "non-existent", no Ingress resource will be created
+    class: "nginx"
+
+  # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
+  # If you want to deploy your own certificate without relying on cert-manager
+  # uncomment the next line and remove subsequent certIssuer configuration.
+  # certIssuer: null
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
 
   backup:
     enabled: true

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -28,7 +28,7 @@ minio:
   # and restore from the local minio deployment. The TLS certificates should be
   # signed by the global KKP CA.
   # If you are enabling it, make sure to enable prometheus scraping for minio as well.
-  certificateSecret: '' # tls secret used by minio.
+  certificateSecret: "" # tls secret used by minio.
 
   # Management Console for Minio Access
   console:
@@ -37,8 +37,8 @@ minio:
 
   # These settings are required. Keys must be alphanumeric.
   credentials:
-    accessKey: '' # 32 byte long
-    secretKey: '' # 64 byte long
+    accessKey: "" # 32 byte long
+    secretKey: "" # 64 byte long
 
     # When set to true, a Secret will be created in the given namespace.
     # Kubermatic requires an "kubermatic-s3-credentials" Secret in the kube-system
@@ -66,15 +66,15 @@ minio:
     console:
       host: "minio-console.kkp.example.com"
     # if set to "non-existent", no Ingress resource will be created
-    class: "nginx"
+    class: "non-existent"
 
   # the cert-manager Issuer (or ClusterIssuer) responsible for managing the certificates
-  # If you want to deploy your own certificate without relying on cert-manager
-  # uncomment the next line and remove subsequent certIssuer configuration.
-  # certIssuer: null
-  certIssuer:
-    name: letsencrypt-prod
-    kind: ClusterIssuer
+  certIssuer: null
+  # If you want to deploy a certificate using cert-manager
+  # uncomment the next lines and remove certIssuer configuration above.
+  # certIssuer:
+  #   name: letsencrypt-prod
+  #   kind: ClusterIssuer
 
   backup:
     enabled: true

--- a/charts/nginx-ingress-controller/test/default.yaml.out
+++ b/charts/nginx-ingress-controller/test/default.yaml.out
@@ -53,6 +53,7 @@ metadata:
   namespace: default
 data:
   allow-snippet-annotations: "true"
+  proxy-body-size: "0"
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ce.yaml.out
@@ -53,6 +53,7 @@ metadata:
   namespace: default
 data:
   allow-snippet-annotations: "true"
+  proxy-body-size: "0"
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
+++ b/charts/nginx-ingress-controller/test/values.example.ee.yaml.out
@@ -53,6 +53,7 @@ metadata:
   namespace: default
 data:
   allow-snippet-annotations: "true"
+  proxy-body-size: "0"
 ---
 # Source: nginx-ingress-controller/charts/nginx/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/nginx-ingress-controller/values.yaml
+++ b/charts/nginx-ingress-controller/values.yaml
@@ -20,8 +20,10 @@ nginx:
   controller:
     hostNetwork: false
     replicaCount: 3
-    config: {}
-  #   load-balance: "least_conn"
+    config:
+      # Increased body size to handle Minio workload, , https://github.com/rancher/rancher/issues/14323
+      proxy-body-size: "0"
+      #load-balance: "least_conn"
     extraArgs: {}
     resources:
       requests:


### PR DESCRIPTION
- add proxy-body-size setting, to ensure stable ingress for minio workload
- Minio: Include configurable Minio Console and Ingress expose strategy to chart

**What this PR does / why we need it**:
Currently the provided minio chart is not allowing to get access to the minio console (the minio management UI). For easier Acccess to minio data or admin information, we can configure the exposement of 

a) the Minio ConSol UI (via Port)
b) Additional Ingress exposement of the s3 API and the Consol

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
Tested the deployment at the run-2 environment

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Extend Minio Configuration Options to:
- Enable Minio Consol Access
- Expose Minio API and Consol via Ingress
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
