### PR TITLE
Update API docs for kubelb

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -114,8 +114,6 @@ spec:
           # While machines can be in multiple networks, a single one must be chosen for the
           # HCloud CCM to work.
           network: ""
-        # Optional: KubeLB holds the configuration for the kubeLB at the data center level.
-        kubeLb: null
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
           # Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
@@ -450,8 +448,6 @@ spec:
   etcdBackupRestore: null
   # Optional: ExposeStrategy explicitly sets the expose strategy for this seed cluster, if not set, the default provided by the master is used.
   exposeStrategy: NodePort
-  # KubeLB holds the configuration for the kubeLB at the Seed level. This component is responsible for managing load balancers.
-  kubeLb: null
   # A reference to the Kubeconfig of this cluster. The Kubeconfig must
   # have cluster-admin privileges. This field is mandatory for every
   # seed, even if there are no datacenters defined yet.

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -115,7 +115,8 @@ spec:
           # HCloud CCM to work.
           network: ""
         # Optional: KubeLB holds the configuration for the kubeLB at the data center level.
-        kubeLb: null
+        # Only available in Enterprise Edition.
+        kubelb: null
         # Kubevirt configures a KubeVirt datacenter.
         kubevirt:
           # Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
@@ -450,8 +451,6 @@ spec:
   etcdBackupRestore: null
   # Optional: ExposeStrategy explicitly sets the expose strategy for this seed cluster, if not set, the default provided by the master is used.
   exposeStrategy: NodePort
-  # KubeLB holds the configuration for the kubeLB at the Seed level. This component is responsible for managing load balancers.
-  kubeLb: null
   # A reference to the Kubeconfig of this cluster. The Kubeconfig must
   # have cluster-admin privileges. This field is mandatory for every
   # seed, even if there are no datacenters defined yet.
@@ -481,6 +480,9 @@ spec:
     # UID of the referent.
     # More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
     uid: ""
+  # KubeLB holds the configuration for the kubeLB at the Seed level. This component is responsible for managing load balancers.
+  # Only available in Enterprise Edition.
+  kubelb: null
   # Optional: Detailed location of the cluster, like "Hamburg" or "Datacenter 7".
   # For informational purposes in the Kubermatic dashboard only.
   location: ""

--- a/hack/update-docs.sh
+++ b/hack/update-docs.sh
@@ -40,9 +40,13 @@ $sed -i "s/,omitempty/,$dummy/g" pkg/apis/kubermatic/v1/*.go vendor/k8s.io/api/c
 # there are some fields that we do actually want to ignore
 $sed -i 's/omitgenyaml/omitempty/g' pkg/apis/kubermatic/v1/*.go
 
-for edition in ce ee; do
-  go run -tags $edition codegen/example-yaml/main.go . docs
-done
+# generate docs for ce version
+$sed -i "s/,omitcegenyaml/,omitempty,ce/g" pkg/apis/kubermatic/v1/*.go
+go run -tags ce codegen/example-yaml/main.go . docs
+$sed -i "s/omitempty,ce/omitcegenyaml/g" pkg/apis/kubermatic/v1/*.go
+
+# generate docs for ee version
+go run -tags ee codegen/example-yaml/main.go . docs
 
 # revert our changes
 $sed -i 's/omitempty/omitgenyaml/g' pkg/apis/kubermatic/v1/*.go

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -219,7 +219,8 @@ type ClusterSpec struct {
 	EnableOperatingSystemManager *bool `json:"enableOperatingSystemManager,omitempty"`
 
 	// KubeLB holds the configuration for the kubeLB component.
-	KubeLB *KubeLB `json:"kubeLb,omitempty"`
+	// Only available in Enterprise Edition.
+	KubeLB *KubeLB `json:"kubelb,omitempty"`
 
 	// KubernetesDashboard holds the configuration for the kubernetes-dashboard component.
 	KubernetesDashboard *KubernetesDashboard `json:"kubernetesDashboard,omitempty"`
@@ -277,6 +278,7 @@ func (c ClusterSpec) IsKubernetesDashboardEnabled() bool {
 }
 
 // KubeLB contains settings for the kubeLB component as part of the cluster control plane. This component is responsible for managing load balancers.
+// Only available in Enterprise Edition.
 type KubeLB struct {
 	// Controls whether kubeLB is deployed or not.
 	Enabled bool `json:"enabled"`
@@ -1419,7 +1421,7 @@ type ExtendedClusterHealth struct {
 	MLAGateway                   *HealthStatus `json:"mlaGateway,omitempty"`
 	OperatingSystemManager       *HealthStatus `json:"operatingSystemManager,omitempty"`
 	KubernetesDashboard          *HealthStatus `json:"kubernetesDashboard,omitempty"`
-	KubeLB                       *HealthStatus `json:"kubeLb,omitempty"`
+	KubeLB                       *HealthStatus `json:"kubelb,omitempty"`
 }
 
 // ControlPlaneHealthy returns if all Kubernetes control plane components are healthy.

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -300,7 +300,11 @@ type SeedSpec struct {
 	// OIDCProviderConfiguration allows to configure OIDC provider at the Seed level.
 	OIDCProviderConfiguration *OIDCProviderConfiguration `json:"oidcProviderConfiguration,omitempty"`
 	// KubeLB holds the configuration for the kubeLB at the Seed level. This component is responsible for managing load balancers.
-	KubeLB *KubeLBSettings `json:"kubeLb,omitempty"`
+	// Only available in Enterprise Edition.
+	//
+	//nolint:staticcheck
+	//lint:ignore SA5008 omitcegenyaml is used by the example-yaml-generator
+	KubeLB *KubeLBSettings `json:"kubelb,omitempty,omitcegenyaml"`
 }
 
 // EtcdBackupRestore holds the configuration of the automatic backup and restores.
@@ -458,7 +462,11 @@ type DatacenterSpec struct {
 	DisableCSIDriver bool `json:"disableCsiDriver,omitempty"`
 
 	// Optional: KubeLB holds the configuration for the kubeLB at the data center level.
-	KubeLB *KubeLBDatacenterSettings `json:"kubeLb,omitempty"`
+	// Only available in Enterprise Edition.
+	//
+	//nolint:staticcheck
+	//lint:ignore SA5008 omitcegenyaml is used by the example-yaml-generator
+	KubeLB *KubeLBDatacenterSettings `json:"kubelb,omitempty,omitcegenyaml"`
 }
 
 var (
@@ -967,16 +975,16 @@ type OIDCProviderConfiguration struct {
 
 type KubeLBSettings struct {
 	// Kubeconfig is reference to the Kubeconfig for the kubeLB management cluster.
-	Kubeconfig corev1.ObjectReference `json:"kubeconfig"`
+	Kubeconfig corev1.ObjectReference `json:"kubeconfig,omitempty"`
 }
 
 type KubeLBDatacenterSettings struct {
 	// Used to configure and override the default kubeLB settings.
 	KubeLBSettings `json:",inline"`
 	// Enabled is used to enable/disable kubeLB for the datacenter. This is used to control whether installing kubeLB is allowed or not for the datacenter.
-	Enabled bool `json:"enabled"`
+	Enabled bool `json:"enabled,omitempty"`
 	// Enforced is used to enforce kubeLB installation for all the user clusters belonging to this datacenter. Setting enforced to false will not uninstall kubeLB from the user clusters and it needs to be disabled manually.
-	Enforced bool `json:"enforced"`
+	Enforced bool `json:"enforced,omitempty"`
 }
 
 // IsEtcdAutomaticBackupEnabled returns true if etcd automatic backup is configured for the seed.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -1797,8 +1797,8 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
-                kubeLb:
-                  description: KubeLB holds the configuration for the kubeLB component.
+                kubelb:
+                  description: KubeLB holds the configuration for the kubeLB component. Only available in Enterprise Edition.
                   properties:
                     enabled:
                       description: Controls whether kubeLB is deployed or not.
@@ -2233,7 +2233,7 @@ spec:
                         - HealthStatusUp
                         - HealthStatusProvisioning
                       type: string
-                    kubeLb:
+                    kubelb:
                       enum:
                         - HealthStatusDown
                         - HealthStatusUp

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -1792,8 +1792,8 @@ spec:
                       type: string
                   type: object
                   x-kubernetes-map-type: atomic
-                kubeLb:
-                  description: KubeLB holds the configuration for the kubeLB component.
+                kubelb:
+                  description: KubeLB holds the configuration for the kubeLB component. Only available in Enterprise Edition.
                   properties:
                     enabled:
                       description: Controls whether kubeLB is deployed or not.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -207,8 +207,8 @@ spec:
                               - datacenter
                               - network
                             type: object
-                          kubeLb:
-                            description: 'Optional: KubeLB holds the configuration for the kubeLB at the data center level.'
+                          kubelb:
+                            description: 'Optional: KubeLB holds the configuration for the kubeLB at the data center level. Only available in Enterprise Edition.'
                             properties:
                               enabled:
                                 description: Enabled is used to enable/disable kubeLB for the datacenter. This is used to control whether installing kubeLB is allowed or not for the datacenter.
@@ -242,10 +242,6 @@ spec:
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
-                            required:
-                              - enabled
-                              - enforced
-                              - kubeconfig
                             type: object
                           kubevirt:
                             description: Kubevirt configures a KubeVirt datacenter.
@@ -1406,8 +1402,34 @@ spec:
                     - LoadBalancer
                     - Tunneling
                   type: string
-                kubeLb:
-                  description: KubeLB holds the configuration for the kubeLB at the Seed level. This component is responsible for managing load balancers.
+                kubeconfig:
+                  description: A reference to the Kubeconfig of this cluster. The Kubeconfig must have cluster-admin privileges. This field is mandatory for every seed, even if there are no datacenters defined yet.
+                  properties:
+                    apiVersion:
+                      description: API version of the referent.
+                      type: string
+                    fieldPath:
+                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
+                      type: string
+                    kind:
+                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                      type: string
+                    namespace:
+                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                      type: string
+                    resourceVersion:
+                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                      type: string
+                    uid:
+                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                      type: string
+                  type: object
+                  x-kubernetes-map-type: atomic
+                kubelb:
+                  description: KubeLB holds the configuration for the kubeLB at the Seed level. This component is responsible for managing load balancers. Only available in Enterprise Edition.
                   properties:
                     kubeconfig:
                       description: Kubeconfig is reference to the Kubeconfig for the kubeLB management cluster.
@@ -1435,35 +1457,7 @@ spec:
                           type: string
                       type: object
                       x-kubernetes-map-type: atomic
-                  required:
-                    - kubeconfig
                   type: object
-                kubeconfig:
-                  description: A reference to the Kubeconfig of this cluster. The Kubeconfig must have cluster-admin privileges. This field is mandatory for every seed, even if there are no datacenters defined yet.
-                  properties:
-                    apiVersion:
-                      description: API version of the referent.
-                      type: string
-                    fieldPath:
-                      description: 'If referring to a piece of an object instead of an entire object, this string should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2]. For example, if the object reference is to a container within a pod, this would take on a value like: "spec.containers{name}" (where "name" refers to the name of the container that triggered the event) or if no container name is specified "spec.containers[2]" (container with index 2 in this pod). This syntax is chosen only to have some well-defined way of referencing a part of an object. TODO: this design is not final and this field is subject to change in the future.'
-                      type: string
-                    kind:
-                      description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                      type: string
-                    name:
-                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                      type: string
-                    namespace:
-                      description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                      type: string
-                    resourceVersion:
-                      description: 'Specific resourceVersion to which this reference is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                      type: string
-                    uid:
-                      description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                      type: string
-                  type: object
-                  x-kubernetes-map-type: atomic
                 location:
                   description: 'Optional: Detailed location of the cluster, like "Hamburg" or "Datacenter 7". For informational purposes in the Kubermatic dashboard only.'
                   type: string

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -164,6 +164,11 @@ func ValidateClusterSpec(spec *kubermaticv1.ClusterSpec, dc *kubermaticv1.Datace
 		allErrs = append(allErrs, errs...)
 	}
 
+	// KubeLB can only be enabled on the cluster if it's either enforced or enabled at the datacenter level.
+	if spec.IsKubeLBEnabled() && (dc.Spec.KubeLB == nil || !(dc.Spec.KubeLB.Enabled || dc.Spec.KubeLB.Enforced)) {
+		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("kubeLB"), "KubeLB is not enabled on this datacenter"))
+	}
+
 	return allErrs
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the documentation for KubeLB in seed and cluster APIs. This PR also adds validation for KubeLB at the cluster level; KubeLB can only be enabled on the cluster if it's either enforced or enabled at the datacenter level.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
