### PR TITLE
Update memory limit of kube-state-metrics to 600Mi

### DIFF
--- a/addons/kube-state-metrics/deployment.yaml
+++ b/addons/kube-state-metrics/deployment.yaml
@@ -47,7 +47,7 @@ spec:
           resources:
             limits:
               cpu: 100m
-              memory: 250Mi
+              memory: 600Mi
             requests:
               cpu: 10m
               memory: 190Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

It increases the memory limit for the **kube-state-metrics addon** to `600Mi`

Bigger clusters with a lot of namespaces and metrics have an increased memory usage for the kube-state-metrics pods which results in OOM kills. The increased limit makes it possible to use the addon on bigger clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12689, kind of

**What type of PR is this?**

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Increase memory limit of kube-state-metrics addon to 600Mi
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
