### PR TITLE
Update curl to 8.4.0 in charts/mla/grafana and util image

### DIFF
--- a/charts/mla/grafana/test/config.yaml.out
+++ b/charts/mla/grafana/test/config.yaml.out
@@ -6019,7 +6019,7 @@ spec:
             - name: storage
               mountPath: "/var/lib/grafana"
         - name: download-dashboards
-          image: "docker.io/curlimages/curl:7.85.0"
+          image: "docker.io/curlimages/curl:8.4.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh -x /etc/grafana/download_dashboards.sh" ]

--- a/charts/mla/grafana/test/default.yaml.out
+++ b/charts/mla/grafana/test/default.yaml.out
@@ -6019,7 +6019,7 @@ spec:
             - name: storage
               mountPath: "/var/lib/grafana"
         - name: download-dashboards
-          image: "docker.io/curlimages/curl:7.85.0"
+          image: "docker.io/curlimages/curl:8.4.0"
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args: [ "-c", "mkdir -p /var/lib/grafana/dashboards/default && /bin/sh -x /etc/grafana/download_dashboards.sh" ]

--- a/charts/mla/grafana/values.yaml
+++ b/charts/mla/grafana/values.yaml
@@ -125,7 +125,7 @@ grafana:
   # priorityClassName:
   downloadDashboardsImage:
     repository: docker.io/curlimages/curl
-    tag: 7.85.0
+    tag: 8.4.0
     sha: ""
     pullPolicy: IfNotPresent
   downloadDashboards:

--- a/hack/images/util/Dockerfile
+++ b/hack/images/util/Dockerfile
@@ -24,7 +24,7 @@ ENV MC_VERSION=RELEASE.2022-12-24T15-21-38Z \
 RUN apk add --no-cache -U \
     bash \
     ca-certificates \
-    curl \
+    'curl>=8.4.0-r0' \ # ensure that we install a curl version that fixes CVE-2023-38545 and CVE-2023-38546.
     git \
     iproute2 \
     iptables \

--- a/hack/images/util/release.sh
+++ b/hack/images/util/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/util
-VERSION=2.3.0
+VERSION=2.3.1
 SUFFIX=""
 
 docker build --no-cache --pull -t "${REPOSITORY}:${VERSION}${SUFFIX}" .


### PR DESCRIPTION
**What this PR does / why we need it**:
This is preparing a possible bump for curl to 8.4.0, the version fixing two pre-announced curl CVEs ([reference](https://github.com/curl/curl/discussions/12026)). Since details will only be announced tomorrow we will figure out tomorrow if this PR is required.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update curl in kubermatic/util image and mla/grafana chart to 8.4.0 (CVE-2023-38545 and CVE-2023-38546 do not affect KKP)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
