### PR TITLE
Fix spelling across code base, ignore third-party CRDs

### DIFF
--- a/charts/mla/mla-secrets/values.yaml
+++ b/charts/mla/mla-secrets/values.yaml
@@ -14,7 +14,7 @@
 
 mlaSecrets:
   minio:
-    ## Set enabled to false if you want to re-use an existing secret for minio.
+    ## Set enabled to false if you want to reuse an existing secret for minio.
     enabled: true
     ## Set default accesskey, secretkey
     ## AccessKey and secretKey is generated when not set
@@ -42,7 +42,7 @@ mlaSecrets:
       clientCertKey: ""
 
   grafana:
-    ## Set enabled to false if you want to re-use an existing secret for grafana.
+    ## Set enabled to false if you want to reuse an existing secret for grafana.
     enabled: true
     adminUser: admin
   #  adminPassword: strongpassword

--- a/charts/values.example.mla.yaml
+++ b/charts/values.example.mla.yaml
@@ -14,14 +14,14 @@
 
 mlaSecrets:
   minio:
-    ## Set enabled to false if you want to re-use an existing secret for minio.
+    ## Set enabled to false if you want to reuse an existing secret for minio.
     enabled: true
     ## Set default accesskey, secretkey
     ## AccessKey and secretKey is generated when not set
     accessKey: "accesskey"
     secretKey: "secretkey"
   grafana:
-    ## Set enabled to false if you want to re-use an existing secret for grafana.
+    ## Set enabled to false if you want to reuse an existing secret for grafana.
     enabled: true
     adminUser: admin
     adminPassword: strongpassword

--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -111,7 +111,7 @@ func MirrorImagesCommand(logger *logrus.Logger, versions kubermaticversion.Versi
 	cmd.PersistentFlags().StringVar(&opt.RegistryPrefix, "registry-prefix", "", "Check source registries against this prefix and only include images that match it")
 	cmd.PersistentFlags().StringVar(&opt.LoadFrom, "load-from", "", "Path to an image-archive to (up)load to the provided registry")
 	cmd.PersistentFlags().BoolVar(&opt.DryRun, "dry-run", false, "Only print the names of source and destination images")
-	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides in the referenced KubermaticConfiguration to re-use a configuration that already specifies overrides (note that custom tags will still be observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
+	cmd.PersistentFlags().BoolVar(&opt.IgnoreRepositoryOverrides, "ignore-repository-overrides", true, "Ignore any configured registry overrides in the referenced KubermaticConfiguration to reuse a configuration that already specifies overrides (note that custom tags will still be observed and that this does not affect Helm charts configured via values.yaml; defaults to true)")
 
 	cmd.PersistentFlags().StringVar(&opt.AddonsPath, "addons-path", "", "Path to a local directory containing KKP addons. Takes precedence over --addons-image")
 	cmd.PersistentFlags().StringVar(&opt.AddonsImage, "addons-image", "", "Docker image containing KKP addons, if not given, falls back to the Docker image configured in the KubermaticConfiguration")

--- a/cmd/user-cluster-webhook/README.md
+++ b/cmd/user-cluster-webhook/README.md
@@ -1,5 +1,5 @@
 # User Cluster Webhook
 
-The webhook is desiged to configure validating and mutating admission configuration for workloads on user cluster.
+The webhook is designed to configure validating and mutating admission configuration for workloads on user cluster.
 
 This webhook exists on the seed and is deployed in the user cluster namespace.

--- a/docs/proposals/cni-mgmt-via-applications.md
+++ b/docs/proposals/cni-mgmt-via-applications.md
@@ -118,7 +118,7 @@ Within sig-networking, we also considered 2 other approaches to address the goal
 
 1) Introducing a new CRD for all cluster network configuration, factoring out the cluster network configuration from the KKP cluster API and introducing a specific controller managing all user-cluster networking components:
    - This turned out to be a too complex change and just by itself it would not serve all goals - we would still need to replace manifest-based CNI deployment with e.g. Helm-based CNI deployment.
-   - As we already have the Applications infra capable of doing it, it is much easier to just re-use it.
+   - As we already have the Applications infra capable of doing it, it is much easier to just reuse it.
    - If more complex networking use-cases come in the future, we can still proceed with this approach even later.
 
 2) Generic multi-CNI operator, running in the user cluster independently (similar to machine-controller):

--- a/docs/proposals/kubevirt-node-placement.md
+++ b/docs/proposals/kubevirt-node-placement.md
@@ -187,7 +187,7 @@ spec:
                       operator: In
                       values:
                         - md-kmvh888v9h-lvpfx9rptr              # A new label to add common to all VMi from the same MD
-                                                                # We can re-use machine.metadata.labels: machine=md-kmvh888v9h-lvpfx9rptr
+                                                                # We can reuse machine.metadata.labels: machine=md-kmvh888v9h-lvpfx9rptr
                                                                 # already common to all machine from the same MD
                 topologyKey: topologyKey:kubernetes.io/hostname
             # Section podAffinity present if:

--- a/docs/proposals/platform-extensions.md
+++ b/docs/proposals/platform-extensions.md
@@ -151,7 +151,7 @@ charts.  After installing these operators CR of the corresponding kind has to
 be created so the operator takes care of bringing the application up.
 
 Operators from operatorhub can be installed natively. The catalog of operators
-can be extended by 3rd-party catalogs or by bundeling own operators into
+can be extended by 3rd-party catalogs or by bundling own operators into
 catalogs.
 
 ### Kyma Service Calatlog: Helm Broker

--- a/docs/proposals/user-cluster-controller.md
+++ b/docs/proposals/user-cluster-controller.md
@@ -1,4 +1,4 @@
-# Title of the Poposal: **user-cluster-controller**
+# Title of the Proposal: **user-cluster-controller**
 
 **Author**: Tobias Hintze (thz)
 

--- a/docs/proposals/user-cluster-mla.md
+++ b/docs/proposals/user-cluster-mla.md
@@ -231,7 +231,7 @@ To enable multi-tenancy, KKP projects will be mapped
 to [Grafana Organizations](https://grafana.com/docs/grafana/latest/permissions/organization_roles/). For every cluster
 within a KKP project, logs and metrics data sources pointing to the respective MLA Gateways will be added to Grafana
 within the organization. The regular users won’t be able to manage data sources in Grafana, therefore they will be
-restricted to only see logs & matrics matching their organization. Also, Grafana can be configured with different
+restricted to only see logs & metrics matching their organization. Also, Grafana can be configured with different
 permission levels (admin / editor / viewer) for different users according to their permission levels in the KKP project.
 
 For Managed Service Provider users (superusers), who should be able to access data of all User Clusters, a superuser

--- a/hack/run-expose-strategy-e2e-test-in-kind.sh
+++ b/hack/run-expose-strategy-e2e-test-in-kind.sh
@@ -23,7 +23,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-# We replace the domain with a dns name relying on nip.io poining to the
+# We replace the domain with a dns name relying on nip.io pointing to the
 # nodeport-proxy service. This makes the testing of expose strategies relying
 # on nodeport-proxy very easy from within the kind cluster.
 # TODO Find another solution in case nip.io does not result to be

--- a/hack/run-seed-controller-manager.sh
+++ b/hack/run-seed-controller-manager.sh
@@ -26,7 +26,7 @@ KUBERMATIC_SEED=${KUBERMATIC_SEED:-hamburg}
 KUBERMATIC_EXTERNAL_URL=${KUBERMATIC_EXTERNAL_URL:-dev.kubermatic.io}
 PPROF_PORT=${PPROF_PORT:-6600}
 
-# Deploy a user-cluster/ipam-controller for which we actuallly
+# Deploy a user-cluster/ipam-controller for which we actually
 # have a pushed image
 echodate "Compiling seed-controller-manager..."
 export KUBERMATICCOMMIT="${KUBERMATICCOMMIT:-$(git rev-parse origin/main)}"

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -24,7 +24,7 @@ CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-3 containerize ./hac
 echodate "Running codespell..."
 
 codespell \
-  --skip .git,_build,_dist,vendor,go.mod,go.sum,*.jpg,*.jpeg,*.png,*.woff,*.woff2,*.pem,./charts/cert-manager/crd,./charts/backup/velero/crd,./charts/oauth/test \
+  --skip .git,_build,_dist,vendor,go.mod,go.sum,*.jpg,*.jpeg,*.png,*.woff,*.woff2,*.pem,./charts/cert-manager/crd,./charts/backup/velero/crd,./charts/oauth/test,./addons/multus/crds.yaml,./charts/local-kubevirt/crds \
   --ignore-words .codespell.exclude \
   --check-filenames \
   --check-hidden

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -353,7 +353,7 @@ const (
 	ClusterFeatureVsphereCSIClusterID = "vsphereCSIClusterID"
 
 	// ClusterFeatureEtcdLauncher enables features related to the experimental etcd-launcher. This includes user-cluster
-	// etcd scaling, automatic volume recovery and new backup/restore contorllers.
+	// etcd scaling, automatic volume recovery and new backup/restore controllers.
 	ClusterFeatureEtcdLauncher = "etcdLauncher"
 
 	// ApiserverNetworkPolicy enables the deployment of network policies that

--- a/pkg/applications/providers/template/helm_integration_test.go
+++ b/pkg/applications/providers/template/helm_integration_test.go
@@ -226,7 +226,7 @@ func TestHelmProvider(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: true, Timeout: metav1.Duration{Duration: 5 * time.Second}, Atomic: false}}
 
-				// Create an application that deploy a LB service that will never get Puplic Ip -> helm release will not be be successful.
+				// Create an application that deploy a LB service that will never get public ip -> helm release will not be be successful.
 				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.DeploySvcKey, true), deployOpts)
 
 				template := HelmTemplate{
@@ -263,7 +263,7 @@ func TestHelmProvider(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: true, Timeout: metav1.Duration{Duration: 5 * time.Second}, Atomic: false}}
 
-				// Create an application that deploy a LB service that will never get Puplic Ip -> helm release will not be be successful.
+				// Create an application that deploy a LB service that will never get public ip -> helm release will not be be successful.
 				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.DeploySvcKey, true), nil)
 
 				template := HelmTemplate{

--- a/pkg/cni/doc.go
+++ b/pkg/cni/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 /*
 Package cni contains supported CNI version definitions and helpers for managing CNIs in KKP.
-The CNIs are manged either as addons (e.g. Canal, see the `addons` folder) or via the Applications infra (e.g. Cilium
+The CNIs are managed either as addons (e.g. Canal, see the `addons` folder) or via the Applications infra (e.g. Cilium
 starting from version 1.13.0, see pkg/controller/seed-controller-manager/cni-application-installation-controller).
 */
 package cni

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -280,7 +280,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addo
 
 	// This is true when the addon: 1) is fully deployed, 2) doesn't have a `addonEnsureLabelKey` set to true.
 	// we do this to allow users to "edit/delete" resources deployed by unlabeled addons,
-	// while we enfornce the labeled ones
+	// while we enforce the labeled ones
 	if addonResourcesCreated(addon) && !hasEnsureResourcesLabel(addon) {
 		return nil, nil
 	}

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -198,7 +198,7 @@ func (r *reconciler) createCluster(ctx context.Context, log *zap.SugaredLogger, 
 		return fmt.Errorf("failed to get credentials: %w", err)
 	}
 
-	// re-use our reconciling framework, because this is a special place where right after the Cluster
+	// reuse our reconciling framework, because this is a special place where right after the Cluster
 	// creation, we must set some status fields and this requires us to wait for the Cluster object
 	// to appear in our caches.
 	name := types.NamespacedName{Name: newCluster.Name}

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/doc.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/doc.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 /*
 Package cniapplicationinstallationcontroller contains a controller that watches
-Cluster resources, and if the CNI for the Cluster is manged by the Applications infra,
+Cluster resources, and if the CNI for the Cluster is managed by the Applications infra,
 reconciles ApplicationInstallation Resources in the user cluster
 with necessary CNI configuration in ApplicationInstallation's Values.
 */

--- a/pkg/defaulting/cluster.go
+++ b/pkg/defaulting/cluster.go
@@ -66,7 +66,7 @@ func DefaultClusterSpec(ctx context.Context, spec *kubermaticv1.ClusterSpec, tem
 	}
 
 	// Checking and applying each field of the ComponentSettings is tedious,
-	// so we re-use mergo as well. Even though DefaultComponentSettings is
+	// so we reuse mergo as well. Even though DefaultComponentSettings is
 	// deprecated, we cannot remove its handling here, as the template can
 	// be unconfigured (i.e. nil).
 	if err := mergo.Merge(&spec.ComponentsOverride, seed.Spec.DefaultComponentSettings); err != nil {

--- a/pkg/provider/cloud/aws/client_test.go
+++ b/pkg/provider/cloud/aws/client_test.go
@@ -57,7 +57,7 @@ func TestIsNotFound(t *testing.T) {
 
 	for _, err := range errs {
 		if !isNotFound(err) {
-			t.Errorf("%v should have been recoginized as a notFound error.", err)
+			t.Errorf("%v should have been recognized as a notFound error.", err)
 		}
 	}
 }

--- a/pkg/provider/cloud/aws/util_test.go
+++ b/pkg/provider/cloud/aws/util_test.go
@@ -49,7 +49,7 @@ func getTestClientSet(ctx context.Context, t *testing.T) *ClientSet {
 }
 
 // makeCluster returns a KKP Cluster object with the AWS cloud spec inserted.
-// The cluster will have a random name, which helps to re-use the same localstack
+// The cluster will have a random name, which helps to reuse the same localstack
 // test environment without causing name clashes (or having to restart the
 // test env in between every test).
 func makeCluster(cloudSpec *kubermaticv1.AWSCloudSpec) *kubermaticv1.Cluster {

--- a/pkg/provider/cloud/eks/provider.go
+++ b/pkg/provider/cloud/eks/provider.go
@@ -133,7 +133,7 @@ func GetClusterConfig(ctx context.Context, accessKeyID, secretAccessKey, cluster
 		Cluster:  name,
 		AuthInfo: name,
 	}
-	// AWS specific configation; use cloud platform scope.
+	// AWS specific configuration; use cloud platform scope.
 	config.AuthInfos[name] = &api.AuthInfo{
 		Token: token.Token,
 	}

--- a/pkg/provider/cloud/gke/provider.go
+++ b/pkg/provider/cloud/gke/provider.go
@@ -88,7 +88,7 @@ func GetClusterConfig(ctx context.Context, sa, clusterName, zone string) (*api.C
 		Cluster:  name,
 		AuthInfo: name,
 	}
-	// GCP specific configation; use cloud platform scope.
+	// GCP specific configuration; use cloud platform scope.
 	config.AuthInfos[name] = &api.AuthInfo{
 		Token: token.AccessToken,
 	}

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -354,7 +354,7 @@ func getApiserverFlags(data *resources.TemplateData, etcdEndpoints []string, ena
 		"--profiling=false",
 	)
 
-	// pre-pend to have advertise-address as first argument and avoid
+	// prepend to have advertise-address as first argument and avoid
 	// triggering unneeded redeployments.
 	flags = append([]string{
 		// advertise-address is the external IP under which the apiserver is available.


### PR DESCRIPTION
**What this PR does / why we need it**:
Spellcheck suddenly started to care about typos in the `verify` Prow job. This fixes all spelling mistakes it could find from my local spellcheck installation, but it looks like it matches the Prow job failures.

I'm also excluding CRDs from third-party components that we shouldn't touch.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
