### PR TITLE
[release/v2.21] Update OSM container image to v1.1.4

### DIFF
--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -191,7 +191,7 @@ spec:
           enforceFloatingIP: true
           images:
             centos: "CentOS 8 (2021-07-05)"
-            ubuntu: "Ubuntu Focal 20.04 (2021-07-01)"
+            ubuntu: "Ubuntu Focal 20.04 (2022-10-26)"
           nodeSizeRequirements:
             minimumMemory: 0
             minimumVCPUs: 0

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -53,7 +53,7 @@ var (
 
 const (
 	Name = "operating-system-manager"
-	Tag  = "v1.1.3"
+	Tag  = "v1.1.4"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.22.1-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.23.5-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-node-kubelet-feature-gates","CSIMigrationAWS=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.24.0-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01","-node-kubelet-feature-gates","CSIMigrationAWS=false"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager-externalCloudProvider.yaml
@@ -59,7 +59,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.22.1-operating-system-manager.yaml
@@ -59,7 +59,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -59,7 +59,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.23.5-operating-system-manager.yaml
@@ -59,7 +59,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -59,7 +59,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.24.0-operating-system-manager.yaml
@@ -59,7 +59,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.22.1-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.23.5-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.24.0-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.22.1-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.23.5-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.24.0-operating-system-manager.yaml
@@ -38,7 +38,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","cluster-de-test-01"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.22.1-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.23.5-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.24.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager-externalCloudProvider.yaml
@@ -51,7 +51,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.22.1-operating-system-manager.yaml
@@ -51,7 +51,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager-externalCloudProvider.yaml
@@ -51,7 +51,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.23.5-operating-system-manager.yaml
@@ -51,7 +51,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager-externalCloudProvider.yaml
@@ -51,7 +51,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.24.0-operating-system-manager.yaml
@@ -51,7 +51,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.1.3
+        image: quay.io/kubermatic/operating-system-manager:v1.1.4
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This updates OSM to [v1.1.4](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.1.4), fixing issues with the latest Flatcar version failing to bootstrap as node.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update OSM to [v1.1.4](https://github.com/kubermatic/operating-system-manager/releases/tag/v1.1.4)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
