### PR TITLE
Fix RBAC for KubeLB

### DIFF
--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -240,7 +240,7 @@ func (r *reconciler) createOrUpdateKubeLBManagementClusterResources(ctx context.
 	}
 
 	roleBindingReconcilers := []reconciling.NamedRoleBindingReconcilerFactory{
-		kubelbmanagementresources.RoleBindingReconciler(),
+		kubelbmanagementresources.RoleBindingReconciler(namespace),
 	}
 
 	if err := reconciling.ReconcileRoleBindings(ctx, roleBindingReconcilers, namespace, client); err != nil {

--- a/pkg/ee/kubelb/resources/kubelb-cluster/rbac.go
+++ b/pkg/ee/kubelb/resources/kubelb-cluster/rbac.go
@@ -79,7 +79,7 @@ func RoleReconciler() reconciling.NamedRoleReconcilerFactory {
 	}
 }
 
-func RoleBindingReconciler() reconciling.NamedRoleBindingReconcilerFactory {
+func RoleBindingReconciler(namespace string) reconciling.NamedRoleBindingReconcilerFactory {
 	return func() (string, reconciling.RoleBindingReconciler) {
 		return roleBindingName, func(rb *rbacv1.RoleBinding) (*rbacv1.RoleBinding, error) {
 			rb.Labels = resources.BaseAppLabels(resources.KubeLBAppName, nil)
@@ -91,9 +91,9 @@ func RoleBindingReconciler() reconciling.NamedRoleBindingReconcilerFactory {
 			}
 			rb.Subjects = []rbacv1.Subject{
 				{
-					Kind:     rbacv1.UserKind,
-					Name:     serviceAccountName,
-					APIGroup: rbacv1.GroupName,
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      serviceAccountName,
+					Namespace: namespace,
 				},
 			}
 			return rb, nil

--- a/pkg/ee/kubelb/resources/user-cluster/role.go
+++ b/pkg/ee/kubelb/resources/user-cluster/role.go
@@ -65,8 +65,13 @@ func KubeSystemRoleReconciler() reconciling.NamedRoleReconcilerFactory {
 				{
 					APIGroups:     []string{"coordination.k8s.io"},
 					Resources:     []string{"leases"},
-					Verbs:         []string{"*"},
+					Verbs:         []string{"get", "update", "patch"},
 					ResourceNames: []string{"19f32e7b.ccm.kubelb.k8c.io"},
+				},
+				{
+					APIGroups: []string{"coordination.k8s.io"},
+					Resources: []string{"leases"},
+					Verbs:     []string{"create"},
 				},
 			}
 			return r, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the following issues for KubeLB integration as mentioned in https://github.com/kubermatic/kubermatic/issues/12676#issuecomment-1759800161:

1) for the lease in tenant cluster
```
E1012 13:42:44.043167       1 leaderelection.go:336] error initially creating leader election record: leases.coordination.k8s.io is forbidden: User "kubermatic:kubelb-ccm" cannot create resource "leases" in API group "coordination.k8s.io" in the namespace "kube-system"
```

2) for all sorts of things, including `LoadBalancer` in management cluster
```
E1012 14:31:14.617696       1 reflector.go:147] k8s.io/client-go@v0.28.2/tools/cache/reflector.go:229: Failed to watch *v1alpha1.LoadBalancer: failed to list *v1alpha1.LoadBalancer: loadbalancers.kubelb.k8c.io is forbidden: User "system:serviceaccount:cluster-d527f8dcpq:kubelb-ccm" cannot list resource "loadbalancers" in API group "kubelb.k8c.io" in the namespace "cluster-d527f8dcpq"
```


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref https://github.com/kubermatic/kubermatic/issues/12676

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
