### PR TITLE
Support to configure node address type for kubelb

### DIFF
--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -985,6 +985,11 @@ type KubeLBDatacenterSettings struct {
 	Enabled bool `json:"enabled,omitempty"`
 	// Enforced is used to enforce kubeLB installation for all the user clusters belonging to this datacenter. Setting enforced to false will not uninstall kubeLB from the user clusters and it needs to be disabled manually.
 	Enforced bool `json:"enforced,omitempty"`
+	// NodeAddressType is used to configure the address type from node, used for load balancing.
+	// Optional: Defaults to ExternalIP.
+	// +kubebuilder:validation:Enum=InternalIP;ExternalIP
+	// +kubebuilder:default=ExternalIP
+	NodeAddressType string `json:"nodeAddressType,omitempty"`
 }
 
 // IsEtcdAutomaticBackupEnabled returns true if etcd automatic backup is configured for the seed.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -241,6 +241,13 @@ spec:
                                     type: string
                                 type: object
                                 x-kubernetes-map-type: atomic
+                              nodeAddressType:
+                                default: ExternalIP
+                                description: 'NodeAddressType is used to configure the address type from node, used for load balancing. Optional: Defaults to ExternalIP.'
+                                enum:
+                                  - InternalIP
+                                  - ExternalIP
+                                type: string
                             type: object
                           kubevirt:
                             description: Kubevirt configures a KubeVirt datacenter.

--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -203,7 +203,7 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 	}
 
 	// Create/update required resources in user cluster namespace in seed.
-	if err := r.createOrUpdateKubeLBSeedClusterResources(ctx, cluster, kubeLBManagementClient, cfg); err != nil {
+	if err := r.createOrUpdateKubeLBSeedClusterResources(ctx, cluster, kubeLBManagementClient, cfg, datacenter); err != nil {
 		return nil, err
 	}
 
@@ -300,7 +300,7 @@ func (r *reconciler) createOrUpdateKubeLBUserClusterResources(ctx context.Contex
 	return nil
 }
 
-func (r *reconciler) createOrUpdateKubeLBSeedClusterResources(ctx context.Context, cluster *kubermaticv1.Cluster, kubeLBManagementClient ctrlruntimeclient.Client, kubeconfig []byte) error {
+func (r *reconciler) createOrUpdateKubeLBSeedClusterResources(ctx context.Context, cluster *kubermaticv1.Cluster, kubeLBManagementClient ctrlruntimeclient.Client, kubeconfig []byte, dc kubermaticv1.Datacenter) error {
 	namespace := cluster.Status.NamespaceName
 
 	// Generate kubeconfig secret.
@@ -329,7 +329,7 @@ func (r *reconciler) createOrUpdateKubeLBSeedClusterResources(ctx context.Contex
 
 	// Create/update kubeLB deployment.
 	deploymentReconcilers := []reconciling.NamedDeploymentReconcilerFactory{
-		kubelbseedresources.DeploymentReconciler(kubelbseedresources.NewKubeLBData(ctx, cluster, r, r.overwriteRegistry)),
+		kubelbseedresources.DeploymentReconciler(kubelbseedresources.NewKubeLBData(ctx, cluster, r, r.overwriteRegistry, dc)),
 	}
 	if err := reconciling.ReconcileDeployments(ctx, deploymentReconcilers, namespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile the Deployments: %w", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This is required to configure the address type, private or public IP, that is going to be used for load balancing. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #12676

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support to configure node address type for kubelb at the datacenter level. 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
