### PR TITLE
Verify that Hetzner found server type before using reference

### DIFF
--- a/pkg/provider/cloud/hetzner/provider.go
+++ b/pkg/provider/cloud/hetzner/provider.go
@@ -63,8 +63,12 @@ func (h *hetzner) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Cloud
 		// this validates the token
 		_, _, err = client.ServerType.List(timeout, hcloud.ServerTypeListOpts{})
 	} else {
+		var net *hcloud.Network
 		// this validates network and implicitly the token
-		_, _, err = client.Network.GetByName(timeout, spec.Hetzner.Network)
+		net, _, err = client.Network.GetByName(timeout, spec.Hetzner.Network)
+		if err == nil && net == nil {
+			return fmt.Errorf("network %q not found", spec.Hetzner.Network)
+		}
 	}
 
 	return err

--- a/pkg/provider/cloud/hetzner/provider.go
+++ b/pkg/provider/cloud/hetzner/provider.go
@@ -125,6 +125,12 @@ func GetServerType(ctx context.Context, token string, serverTypeName string) (*p
 		return nil, fmt.Errorf("failed to get server type %q: %w", serverTypeName, err)
 	}
 
+	// if the server type isn't found, hClient.ServerType.Get returns no error but sets
+	// the ServerType return value to nil.
+	if serverType == nil {
+		return nil, fmt.Errorf("Hetzner server type %q not found", serverTypeName)
+	}
+
 	capacity := provider.NewNodeCapacity()
 	capacity.WithCPUCount(serverType.Cores)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On our production setup, the user-cluster-controller-manager is currently running into a nil pointer exception because the code for checking resource requirements accesses `serverType` (a pointer) without checking if it's not `nil`. But the documentation for `hClient.ServerType.Get` states:

> If the server type does not exist, nil is returned.

Same goes for `client.Network.GetByName`, so I've also adjusted Hetzner's `ValidateCloudSpec` to validate that the network actually exists.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Correctly validate Hetzner API response for server type while calculating resource requirements and for networks while validating cloud spec
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
