### PR TITLE
[release/v2.23] Update to `quay.io/kubermatic/util:2.3.1`

### DIFF
--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -179,7 +179,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.3.0'
+        image: 'quay.io/kubermatic/util:2.3.1'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -178,7 +178,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.3.0'
+        image: 'quay.io/kubermatic/util:2.3.1'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -178,7 +178,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.3.0'
+        image: 'quay.io/kubermatic/util:2.3.1'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -57,7 +57,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.3.0
+      tag: 2.3.1
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -25,7 +25,7 @@ grafana:
     tag: 9.5.1
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 2.3.0
+    tag: 2.3.1
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
     tag: 1.3.2

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -55,7 +55,7 @@ karma:
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util
-      tag: 2.3.0
+      tag: 2.3.1
       pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -46,7 +46,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.3.0
+      tag: 2.3.1
     timeout: 60m
 
   # Specify additional external labels which will be added to all

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: quay.io/kubermatic/util:2.3.0
+          image: quay.io/kubermatic/util:2.3.1
           args:
             - /bin/sh
             - -c

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -109,7 +109,7 @@ is_containerized() {
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.3.0}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.3.1}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
   local gomodcache="${CONTAINERIZE_GOMODCACHE:-/tmp/.gomodcache}"
   local skip="${NO_CONTAINERIZE:-}"

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -250,7 +250,7 @@ func masterDeploymentReconciler(seed *kubermaticv1.Seed, secret *corev1.Secret, 
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kubermatic/util:2.3.0")),
+					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kubermatic/util:2.3.1")),
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{

--- a/pkg/resources/encryption/job.go
+++ b/pkg/resources/encryption/job.go
@@ -75,7 +75,7 @@ func EncryptionJobCreator(data encryptionData, cluster *kubermaticv1.Cluster, se
 					Containers: []corev1.Container{
 						{
 							Name:    "encryption-runner",
-							Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.3.0")),
+							Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.3.1")),
 							Command: []string{"/bin/bash", "-c"},
 							Args: []string{
 								fmt.Sprintf(encryptionJobScript, resourceList),


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual cherry-pick of #12726, updating the util image to `quay.io/kubermatic/util:2.3.1` to pull in curl 8.4.0 to fix the recent CVE, even though the image is not used in a way that would suggest it's used in a vulnerable way.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update to `quay.io/kubermatic/util:2.3.1` as helper image (includes curl version patched against CVE-2023-38545 and CVE-2023-38546)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
