### PR TITLE
Fix random failures for application installation controller integration tests

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller_integration_test.go
@@ -215,9 +215,10 @@ func TestController(t *testing.T) {
 				expectStatusHasConditions(t, ctx, client, app.Name)
 
 				// Update application Installation.
+				oldApp := app.DeepCopy()
 				app.Spec.ApplicationRef.Version = "2.0.0"
-				if err := client.Update(ctx, &app); err != nil {
-					t.Fatalf("failed to update applicationInstallation: %s", err)
+				if err := client.Patch(ctx, &app, ctrlruntimeclient.MergeFrom(oldApp)); err != nil {
+					t.Fatalf("failed to patch applicationInstallation: %s", err)
 				}
 
 				if !utils.WaitFor(ctx, interval, timeout, func() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://public-prow.loodse.com/view/gs/prow-dev-public-data/pr-logs/pull/kubermatic_kubermatic/12737/pre-kubermatic-test-integration/1714187380908363776 for example.

Tests fail randomly due to conflicts when updating the resource:

```
controller/controller.go:143","msg":"Processed","applicationinstallation":"apps/app-5"}
    controller_integration_test.go:220: failed to update applicationInstallation: Operation cannot be fulfilled on applicationinstallations.apps.kubermatic.k8c.io "app-5": the object has been modified; please apply your changes to the latest version and try again
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind failing-test

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
``` documentation
NONE
```
