### PR TITLE
[release/v2.23] fix Digitalocean CSI addon failing to render

### DIFF
--- a/addons/csi/digitalocean/csi-driver.yaml
+++ b/addons/csi/digitalocean/csi-driver.yaml
@@ -36,7 +36,7 @@
 {{ $version = "v4.5.1"}}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.27" }}
-{{ $version = "v4.5.1"}} {/* 1.27 is technically 4.6+ */}
+{{ $version = "v4.5.1"}} {{/* 1.27 is technically 4.6+ */}}
 {{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}


### PR DESCRIPTION
**What this PR does / why we need it**:
I broke the CSI addon because I forgot how to do comments in Go templates :-( This causes

> failed to reconcile Addon "csi": failed to deploy the addon manifests into the cluster: failed to add the addon specific label to all addon resources: parsing unstructured failed: Object 'Kind' is missing in '{"/* 1.27 is technically 4.6+ */":null}'

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix Digitalocean CSI addon failing to render
```

**Documentation**:
```documentation
NONE
```
