### PR TITLE
handle more recent RHEL OSImage values in node-labeller controller

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/node-labeler/api/api.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/api/api.go
@@ -44,7 +44,7 @@ const (
 var OSLabelMatchValues = map[string][]string{
 	CentOSLabelValue:      {"centos"},
 	UbuntuLabelValue:      {"ubuntu"},
-	RHELLabelValue:        {"rhel"},
+	RHELLabelValue:        {"rhel", "red hat enterprise"},
 	FlatcarLabelValue:     {"flatcar container linux"},
 	RockyLinuxLabelValue:  {"rockylinux", "rocky linux"},
 	AmazonLinuxLabelValue: {"amzn2"},

--- a/pkg/controller/user-cluster-controller-manager/node-labeler/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/controller_test.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/node-labeler/api"
-	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/test/diff"
 	"k8c.io/kubermatic/v2/pkg/test/fake"
 
@@ -118,6 +119,20 @@ func TestReconcile(t *testing.T) {
 			expectedLabels: map[string]string{"x-kubernetes.io/distribution": "rhel"},
 		},
 		{
+			name: "red hat label gets added",
+			node: &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: requestName,
+				},
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux 8.5 (Ootpa)",
+					},
+				},
+			},
+			expectedLabels: map[string]string{"x-kubernetes.io/distribution": "rhel"},
+		},
+		{
 			name: "rocky linux label gets added",
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -142,6 +157,8 @@ func TestReconcile(t *testing.T) {
 		},
 	}
 
+	ctx := context.Background()
+
 	for idx := range testCases {
 		tc := testCases[idx]
 		t.Run(tc.name, func(t *testing.T) {
@@ -154,13 +171,12 @@ func TestReconcile(t *testing.T) {
 
 			client := clientBuilder.Build()
 			r := &reconciler{
-				log:      kubermaticlog.Logger,
+				log:      zap.NewNop().Sugar(),
 				client:   client,
 				recorder: record.NewFakeRecorder(10),
 				labels:   tc.reconcilerLabels,
 			}
 
-			ctx := context.Background()
 			request := reconcile.Request{NamespacedName: types.NamespacedName{Name: requestName}}
 			_, err := r.Reconcile(ctx, request)
 			var actualErr string


### PR DESCRIPTION
**What this PR does / why we need it**:
During testing for #12741 we encountered

> {"level":"error","time":"2023-10-18T12:44:37.388Z","caller":"controller/controller.go:266","msg":"Reconciler error","controller":"kkp-node-labeler","object":{"name":"e2e-8ksks-c9f95d96d-x2hhj"},"namespace":"","name":"e2e-8ksks-c9f95d96d-x2hhj","reconcileID":"0abf296c-a88c-4876-bb5f-e183a0a4523d","error":"failed to apply distribution label: could not detect distribution from image name \"Red Hat Enterprise Linux 8.5 (Ootpa)\""}

From looking through older RHEL releases, at least since RHEL 7.7 the os-release info looks like this:

```
NAME="Red Hat Enterprise Linux Server"
VERSION="7.7 (Maipo)"
ID="rhel"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="7.7"
PRETTY_NAME="Red Hat Enterprise Linux Server 7.7 (Maipo)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:redhat:enterprise_linux:7.7:GA:server"
HOME_URL="https://www.redhat.com/"
BUG_REPORT_URL="https://bugzilla.redhat.com/"

REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
REDHAT_BUGZILLA_PRODUCT_VERSION=7.7
REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
REDHAT_SUPPORT_PRODUCT_VERSION="7.7"
```

This PR therefore extends the list of needles to search in the haystack of OSImages.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix node-labeller controller not applying the `x-kubernetes.io/distribution` label to RHEL nodes.
```

**Documentation**:
```documentation
NONE
```
