### PR TITLE
[User-MLA] Dropped unused metrics and reduce label dimentions for many high cardinality metrics

### DIFF
--- a/addons/kube-state-metrics/scrape-config.yaml
+++ b/addons/kube-state-metrics/scrape-config.yaml
@@ -22,6 +22,7 @@ metadata:
 data:
   custom-scrape-configs.yaml: |+
     - job_name: kube-state-metrics
+      honor_timestamps: false
       scheme: https
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/addons/node-exporter/scrape-config.yaml
+++ b/addons/node-exporter/scrape-config.yaml
@@ -22,6 +22,7 @@ metadata:
 data:
   custom-scrape-configs.yaml: |+
     - job_name: node-exporter
+      honor_timestamps: false
       scheme: https
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/configmap.go
@@ -103,6 +103,7 @@ metrics:
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     - bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+      honor_timestamps: false
       job_name: kubernetes-nodes-cadvisor
       kubernetes_sd_configs:
       - role: node

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/configmap.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/configmap.go
@@ -89,7 +89,9 @@ metrics:
       - role: node
       relabel_configs:
       - action: labelmap
-        regex: __meta_kubernetes_node_label_(.+)
+        # By default regex was (.*) which adds every label from MachineDeployment which also picks up labels from user-cluster definition.
+        # Below regex keeps only most important labels and reduces label volume by 50 percent or more.
+        regex: __meta_kubernetes_node_label_(kubernetes_io_hostname|kubernetes_io_arch|kubernetes_io_os|x_kubernetes_io_distribution)
       - replacement: kubernetes.default.svc:443
         target_label: __address__
       - regex: (.+)
@@ -106,7 +108,9 @@ metrics:
       - role: node
       relabel_configs:
       - action: labelmap
-        regex: __meta_kubernetes_node_label_(.+)
+        # By default regex was (.*) which adds every label from MachineDeployment which also picks up labels from user-cluster definition.
+        # Below regex keeps only most important labels and reduces label volume by 50 percent or more.
+        regex: __meta_kubernetes_node_label_(kubernetes_io_hostname|kubernetes_io_arch|kubernetes_io_os|x_kubernetes_io_distribution)
       - replacement: kubernetes.default.svc:443
         target_label: __address__
       - regex: (.+)
@@ -114,6 +118,11 @@ metrics:
         source_labels:
         - __meta_kubernetes_node_name
         target_label: __metrics_path__
+      # Dropping some of the metrics which are usually not needed and have very high cardinality
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        action: drop
+        regex: 'container_(blkio_device_usage_total|tasks_state|memory_failures_total|network_(.*)_packets_(.*)total|fs_reads_total|fs_writes_total)|rest_client_(request_duration_seconds_bucket|rate_limiter_duration_seconds_bucket|(response|request)_size_bytes_bucket)'
       scheme: https
       tls_config:
         ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
@@ -101,6 +101,7 @@ func DeploymentReconciler(overrides *corev1.ResourceRequirements, replicas *int3
 					Args: []string{
 						fmt.Sprintf("--config.file=%s/%s", configPath, configFileName),
 						"-server.http.address=0.0.0.0:9090",
+						"-disable-reporting",
 						fmt.Sprintf("-metrics.wal-directory=%s/agent", storagePath),
 					},
 					Ports: []corev1.ContainerPort{


### PR DESCRIPTION
Also disabled reporting for grafana agent in monitoring agent.

**What this PR does / why we need it**:
User-MLA cortex-compactor has been very unstable from it's inception. It refuses to start as it tries to do cleanup and compaction. But this process takes unusually large time. We suspect that this is due to sheer volume of data it need to process.

This PR drops many largely unused metrics from getting sent to cortex as well as it shrinks the no of labels that get attached to every metric related to node and node-cadvisor jobs. This will reduce the data stored in cortex significantly and then cortex compactor can process the information rather quickly.

This PR also stop honoring timestamps sent by cAdvisor, kube-state-metrics, node-exporter. There are many evidences that they create problems.. like [this](https://github.com/prometheus-operator/kube-prometheus/pull/695) and [this](https://github.com/google/cadvisor/issues/2526#issuecomment-1630159016)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes: None

**What type of PR is this?**
/kind feature
/kind chore

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Some of high cardinality metrics were dropped from User-Cluster MLA prometheus. If your KKP installation was using some of those metrics for custom Grafana dashboards for user-clusters, your dashboards might stop showing some of the charts
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
