### PR TITLE
do not return a RequeueAfter and an error at the same time

### DIFF
--- a/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-definition-synchronizer/controller.go
@@ -91,7 +91,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, applicationDef)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(applicationDef, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/application-secret-synchronizer/controller.go
@@ -108,7 +108,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, secret)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(secret, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -101,7 +101,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, clusterTemplate)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(clusterTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/master-controller-manager/kc-status-controller/controller.go
+++ b/pkg/controller/master-controller-manager/kc-status-controller/controller.go
@@ -104,12 +104,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.reconcile(ctx, logger, kc); err != nil {
+	err := r.reconcile(ctx, logger, kc)
+	if err != nil {
 		r.recorder.Event(kc, corev1.EventTypeWarning, "ReconcilingFailed", err.Error())
-		return reconcile.Result{}, fmt.Errorf("failed to reconcile kubermatic configuration %s: %w", kc.Name, err)
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, err
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, kc *kubermaticv1.KubermaticConfiguration) error {

--- a/pkg/controller/master-controller-manager/kubeone/controller.go
+++ b/pkg/controller/master-controller-manager/kubeone/controller.go
@@ -196,7 +196,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	log := r.log.With("externalcluster", request.Name)
-	log.Info("Processing...")
+	log.Debug("Processing")
 
 	return reconcile.Result{}, r.reconcile(ctx, request.Name, log)
 }

--- a/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-controller/controller.go
@@ -112,7 +112,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, constraint)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(constraint, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
+++ b/pkg/controller/master-controller-manager/master-constraint-template-controller/controller.go
@@ -115,9 +115,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, constraintTemplate)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(constraintTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/preset-synchronizer/controller.go
@@ -90,9 +90,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)
-	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
-	}
 
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
+++ b/pkg/controller/master-controller-manager/project-label-synchronizer/project_label_synchronizer.go
@@ -123,9 +123,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)
-	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
-	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/master-controller-manager/project-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller.go
@@ -167,10 +167,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if err != nil {
 		r.recorder.Event(project, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		return reconcile.Result{}, fmt.Errorf("reconciled project: %s: %w", project.Name, err)
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, err
 }
 
 func (r *reconciler) handleDeletion(ctx context.Context, log *zap.SugaredLogger, project *kubermaticv1.Project) error {

--- a/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
+++ b/pkg/controller/master-controller-manager/serviceaccount-projectbinding-controller/controller.go
@@ -128,7 +128,6 @@ func (r *reconcileServiceAccountProjectBinding) Reconcile(ctx context.Context, r
 	err := r.reconcile(ctx, log, sa)
 	if err != nil {
 		r.recorder.Event(sa, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		log.Errorw("failed to reconcile", zap.Error(err))
 	}
 
 	return reconcile.Result{}, err

--- a/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding-synchronizer/controller.go
@@ -141,8 +141,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if err != nil {
 		r.recorder.Event(userProjectBinding, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		return reconcile.Result{}, fmt.Errorf("reconciled userprojectbinding: %s: %w", userProjectBinding.Name, err)
+		return reconcile.Result{}, fmt.Errorf("reconciled userprojectbinding %s: %w", userProjectBinding.Name, err)
 	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/master-controller-manager/user-project-binding/controller.go
+++ b/pkg/controller/master-controller-manager/user-project-binding/controller.go
@@ -101,9 +101,6 @@ func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request rec
 	log.Debug("Reconciling")
 
 	err := r.reconcile(ctx, log, projectBinding)
-	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
-	}
 
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/master-controller-manager/user-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/user-synchronizer/controller.go
@@ -172,8 +172,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	})
 	if err != nil {
 		r.recorder.Event(user, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		return reconcile.Result{}, fmt.Errorf("reconciled user: %s: %w", user.Name, err)
+		return reconcile.Result{}, fmt.Errorf("reconciled user %s: %w", user.Name, err)
 	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-project-ownership/controller.go
@@ -120,7 +120,6 @@ func (r *reconcileSyncProjectBinding) Reconcile(ctx context.Context, request rec
 	err := r.reconcile(ctx, log, sshKey)
 	if err != nil {
 		r.recorder.Event(sshKey, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		log.Errorw("Reconciling failed", zap.Error(err))
 	}
 
 	return reconcile.Result{}, err

--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -124,9 +124,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Processing")
 
 	err := r.reconcile(ctx, log, request)
-	if err != nil {
-		log.Errorw("Reconciliation failed", zap.Error(err))
-	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/nodeport-proxy/envoymanager/controller.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller.go
@@ -106,9 +106,7 @@ type Reconciler struct {
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrlruntime.Request) (ctrlruntime.Result, error) {
 	r.log.Debugw("got reconcile request", "request", req)
 	err := r.sync(ctx)
-	if err != nil {
-		r.log.Errorw("failed to reconcile", zap.Error(err))
-	}
+
 	return ctrlruntime.Result{}, err
 }
 

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -77,9 +77,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Reconciling")
 
 	err := r.reconcile(ctx, log, request.Name)
-	if err != nil {
-		log.Errorw("failed to reconcile", zap.Error(err))
-	}
 
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -221,19 +221,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		},
 	)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(addon, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError",
 			"failed to reconcile Addon %q: %v", addon.Name, err)
-	}
-	if result == nil {
+	} else if result == nil {
 		// we check for this after the ClusterReconcileWrapper() call because otherwise the cluster would never reconcile since we always requeue
 		result = &reconcile.Result{}
 		if r.addonEnforceInterval != 0 { // addon enforce is enabled
 			// All is well, requeue in addonEnforceInterval minutes. We do this to enforce default addons and prevent cluster admins from disabling them.
+			// We only set this if err == nil, as controller-runtime would ignore it otherwise and log a warning.
 			result.RequeueAfter = time.Duration(r.addonEnforceInterval) * time.Minute
 		}
 	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -143,13 +143,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, log, cluster)
 		},
 	)
-	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/application-secret-cluster-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/application-secret-cluster-controller/controller.go
@@ -139,7 +139,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, secret)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(secret, corev1.EventTypeWarning, "SecretReconcileFailed", err.Error())
 	}
 

--- a/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/auto-update-controller/controller.go
@@ -123,13 +123,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, log, cluster)
 		},
 	)
-	if err != nil {
-		log.Errorw("Failed to reconcile cluster", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -117,13 +117,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, log, cluster)
 		},
 	)
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
 	if err != nil {
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		log.Errorw("Reconciling failed", zap.Error(err))
 	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/cluster-credentials-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-credentials-controller/controller.go
@@ -117,13 +117,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, log, cluster)
 		},
 	)
-	if err != nil {
-		log.Errorw("Failed to reconcile cluster", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-phase-controller/controller.go
@@ -89,7 +89,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, cluster)
 	if err != nil {
-		log.Errorw("Failed to reconcile", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -106,7 +106,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, instance, log)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(instance, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/seed-controller-manager/constraint-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-controller/controller.go
@@ -178,7 +178,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, constraint, log)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(constraint, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/constraint-template-controller/controller.go
@@ -128,9 +128,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, constraintTemplate)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(constraintTemplate, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/encryption-at-rest-controller/controller.go
@@ -167,13 +167,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, log, cluster)
 		},
 	)
-	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+
+	if result == nil || err != nil {
+		result = &reconcile.Result{}
 	}
 
-	if result == nil {
-		result = &reconcile.Result{}
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return *result, err

--- a/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdrestore/etcd_restore_controller.go
@@ -157,15 +157,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	result, err := r.reconcile(ctx, log, restore, cluster, seed)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(restore, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError",
 			"failed to reconcile etcd restore %q: %v", restore.Name, err)
 	}
 
-	if result == nil {
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -120,13 +120,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, cluster)
 		},
 	)
-	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-machinedeployment-controller/controller.go
@@ -117,13 +117,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, log, cluster)
 		},
 	)
-	if err != nil {
-		log.Errorw("Failed to reconcile cluster", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/ipam/controller.go
+++ b/pkg/controller/seed-controller-manager/ipam/controller.go
@@ -153,13 +153,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, cluster)
 		},
 	)
-	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/alertmanager_controller.go
@@ -162,13 +162,15 @@ func (r *alertmanagerReconciler) Reconcile(ctx context.Context, request reconcil
 			return r.alertmanagerController.reconcile(ctx, cluster)
 		},
 	)
-	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/datasource_grafana_controller.go
@@ -136,13 +136,15 @@ func (r *datasourceGrafanaReconciler) Reconcile(ctx context.Context, request rec
 			return r.datasourceGrafanaController.reconcile(ctx, cluster, log)
 		},
 	)
-	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_controller.go
@@ -188,13 +188,15 @@ func (r *ruleGroupReconciler) Reconcile(ctx context.Context, request reconcile.R
 			return r.ruleGroupController.reconcile(ctx, cluster, ruleGroup)
 		},
 	)
-	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
+++ b/pkg/controller/seed-controller-manager/mla/rulegroup_sync_controller.go
@@ -129,6 +129,7 @@ func (r *ruleGroupSyncReconciler) Reconcile(ctx context.Context, request reconci
 		r.recorder.Event(ruleGroup, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		return reconcile.Result{}, fmt.Errorf("failed to reconcle rulegroup %s: %w", ruleGroup.Name, err)
 	}
+
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
+++ b/pkg/controller/seed-controller-manager/operating-system-profile-synchronizer/controller.go
@@ -166,9 +166,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, osp)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(osp, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/seed-controller-manager/preset-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/preset-controller/controller.go
@@ -97,7 +97,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, preset, log)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(preset, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/seed-controller-manager/project/controller.go
+++ b/pkg/controller/seed-controller-manager/project/controller.go
@@ -92,7 +92,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (reconcile
 
 	err := r.reconcile(ctx, log, project)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(project, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
+++ b/pkg/controller/seed-controller-manager/pvwatcher/pvwatcher_controller.go
@@ -112,7 +112,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 	result, err := r.reconcile(ctx, log, request)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
+++ b/pkg/controller/seed-controller-manager/seedresourcesuptodatecondition/seedresourcesuptodatecondition_controller.go
@@ -99,9 +99,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// Add a wrapping here so we can emit an event on error
 	err := r.reconcile(ctx, cluster)
 	if err != nil {
-		r.log.With("cluster", request.Name).Errorw("Failed to reconcile cluster", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -136,12 +136,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return nil, r.reconcile(ctx, log, cluster)
 		},
 	)
-	if err != nil {
-		log.Errorw("Failed to reconcile", zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
+	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 
 	return *result, err

--- a/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -158,9 +158,7 @@ func Add(
 
 func (r *Reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 	err := r.reconcile(ctx)
-	if err != nil {
-		r.log.Errorw("Reconciliation failed", zap.Error(err))
-	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -136,12 +136,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, log, appInstallation)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.userRecorder.Event(appInstallation, corev1.EventTypeWarning, applicationInstallationReconcileFailedEvent, err.Error())
+		return reconcile.Result{}, err
 	}
 
 	log.Debug("Processed")
-	return reconcile.Result{RequeueAfter: appInstallation.Spec.ReconciliationInterval.Duration}, err
+	return reconcile.Result{RequeueAfter: appInstallation.Spec.ReconciliationInterval.Duration}, nil
 }
 
 func (r *reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, appInstallation *appskubermaticv1.ApplicationInstallation) error {

--- a/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ccm-csi-migrator/controller.go
@@ -117,7 +117,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, log, cluster)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.seedRecorder.Event(cluster, corev1.EventTypeWarning, "CCMCSIMigrationFailed", err.Error())
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/cluster-role-labeler/controller.go
@@ -96,7 +96,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, log, clusterRole)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(clusterRole, corev1.EventTypeWarning, "AddingLabelFailed", err.Error())
 	}
 	return reconcile.Result{}, err

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -107,9 +107,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, constraint, log)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(constraint, corev1.EventTypeWarning, "ConstraintReconcileFailed", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/user-cluster-controller-manager/ipam/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/ipam/controller.go
@@ -91,7 +91,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, machine)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(machine, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/kubevirt-vmi-eviction/controller.go
@@ -115,7 +115,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("failed to check cluster pause status: %w", err)
 	}
 	if paused {
-		log.Infof("Cluster paused. no reconcile")
+		log.Info("Cluster paused. no reconcile")
 		return reconcile.Result{}, nil
 	}
 
@@ -130,7 +130,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.deleteMachine(ctx, log, vmi)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
+		return reconcile.Result{}, fmt.Errorf("failed deleting Machine: %w", err)
 	}
 
 	return reconcile.Result{}, nil

--- a/pkg/controller/user-cluster-controller-manager/node-labeler/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/node-labeler/controller.go
@@ -96,7 +96,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, log, node)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(node, corev1.EventTypeWarning, "ApplyingLabelsFailed", err.Error())
 	}
 	return reconcile.Result{}, err

--- a/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
@@ -75,9 +75,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	r.log.Debug("Reconciling")
 
 	err := r.reconcile(ctx)
-	if err != nil {
-		r.log.Errorw("Reconciling failed", zap.Error(err))
-	}
 
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/user-cluster-controller-manager/owner-binding-creator/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/owner-binding-creator/controller.go
@@ -96,7 +96,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, log, request.Name)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(&rbacv1.ClusterRole{ObjectMeta: metav1.ObjectMeta{Name: request.Name}}, corev1.EventTypeWarning, "AddBindingFailed", err.Error())
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/rbac/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/rbac/reconciler.go
@@ -43,9 +43,6 @@ type reconciler struct {
 // Reconcile makes changes in response to ClusterRole and ClusterRoleBinding related changes.
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	err := r.reconcile(ctx, request)
-	if err != nil {
-		r.logger.Errorw("Reconciling failed", zap.Error(err))
-	}
 
 	return reconcile.Result{}, err
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/controller.go
@@ -309,7 +309,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if err := r.reconcile(ctx); err != nil {
-		r.log.Errorw("Reconciling failed", zap.Error(err))
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/role-cloner-controller/controller.go
@@ -122,9 +122,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, log, role)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(role, corev1.EventTypeWarning, "CloningRoleFailed", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -111,7 +111,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if err := r.updateAuthorizedKeys(secret.Data); err != nil {
-		r.log.Errorw("Failed reconciling user ssh key secret", zap.Error(err))
 		return reconcile.Result{}, fmt.Errorf("failed to reconcile user ssh keys: %w", err)
 	}
 

--- a/pkg/ee/allowed-registry-controller/reconcile.go
+++ b/pkg/ee/allowed-registry-controller/reconcile.go
@@ -84,9 +84,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, allowedRegistry)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(allowedRegistry, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/ee/group-project-binding/controller/reconciler.go
+++ b/pkg/ee/group-project-binding/controller/reconciler.go
@@ -96,7 +96,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if err := r.reconcile(ctx, r.Client, log, binding); err != nil {
 		r.recorder.Event(binding, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-		r.log.Errorw("reconciling failed", zap.Error(err))
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -155,13 +155,15 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, cluster)
 		},
 	)
-	if err != nil {
-		r.log.Errorw("Failed to reconcile cluster", "cluster", cluster.Name, zap.Error(err))
-		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
-	}
-	if result == nil {
+
+	if result == nil || err != nil {
 		result = &reconcile.Result{}
 	}
+
+	if err != nil {
+		r.recorder.Event(cluster, corev1.EventTypeWarning, "ReconcilingError", err.Error())
+	}
+
 	return *result, err
 }
 

--- a/pkg/ee/resource-quota/default-quota-controller/controller.go
+++ b/pkg/ee/resource-quota/default-quota-controller/controller.go
@@ -105,7 +105,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, setting, log)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(setting, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/ee/resource-quota/label-owner-controller/controller.go
+++ b/pkg/ee/resource-quota/label-owner-controller/controller.go
@@ -115,9 +115,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	err := r.reconcile(ctx, resourceQuota)
-	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
-	}
 
 	return reconcile.Result{}, err
 }

--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -100,7 +100,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, resourceQuota, log)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
+++ b/pkg/ee/resource-quota/resource-quota-synchronizer/synchronizer.go
@@ -113,9 +113,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	err := r.reconcile(ctx, log, resourceQuota)
-	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
-	}
 
 	return reconcile.Result{}, err
 }

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -111,7 +111,6 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err := r.reconcile(ctx, resourceQuota, log)
 	if err != nil {
-		log.Errorw("ReconcilingError", zap.Error(err))
 		r.recorder.Event(resourceQuota, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 	}
 

--- a/pkg/ee/resource-usage-controller/controller.go
+++ b/pkg/ee/resource-usage-controller/controller.go
@@ -117,9 +117,9 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	err = r.reconcile(ctx, cluster, machines)
 	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
 		r.recorder.Event(cluster, corev1.EventTypeWarning, "ClusterResourceUsageReconcileFailed", err.Error())
 	}
+
 	return reconcile.Result{}, err
 }
 

--- a/pkg/test/clusterexposer/controller/controller.go
+++ b/pkg/test/clusterexposer/controller/controller.go
@@ -117,9 +117,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	log.Debug("Reconciling")
 
 	err := r.reconcile(ctx, log, request)
-	if err != nil {
-		log.Errorw("Reconciling failed", zap.Error(err))
-	}
+
 	return reconcile.Result{}, err
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Since controller-runtime https://github.com/kubernetes-sigs/controller-runtime/pull/2451, a warning will be logged if a controller returns an error _and_ a non-zero result (i.e. a result with a RequeueAfter).

> {"level":"error","time":"2023-10-19T07:08:27.325Z","logger":"kkp-kubernetes-controller","caller":"kubernetes/cluster_controller.go:272","msg":"Reconciling failed","cluster":"kkp-1714890477536284672-mxd69","error":"failed to remove finalizers [kubermatic.k8c.io/cleanup-credentials-secrets] from Cluster /kkp-1714890477536284672-mxd69: clusters.kubermatic.k8c.io \"kkp-1714890477536284672-mxd69\" not found","errorCauses":[{"error":"failed to remove finalizers [kubermatic.k8c.io/cleanup-credentials-secrets] from Cluster /kkp-1714890477536284672-mxd69: clusters.kubermatic.k8c.io \"kkp-1714890477536284672-mxd69\" not found"}]}
> {"level":"info","time":"2023-10-19T07:08:27.325Z","caller":"controller/controller.go:266","msg":"Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler","controller":"kkp-kubernetes-controller","object":{"name":"kkp-1714890477536284672-mxd69"},"namespace":"","name":"kkp-1714890477536284672-mxd69","reconcileID":"62372ca4-c5cd-4937-bd8c-ead545e32340"}

This PR therefore adjusts all controllers to return errors "standalone", as an error itself will already trigger a reconciliation (with exponential backoff). Also, since controller-runtime already logs reconciling errors, I also removed all dedicated log statements. We lose a bit context and niceness, but at least every error isn't logged twice anymore.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
