### PR TITLE
Limit user-ssh-keys-agent cache to specific resource (again)

### DIFF
--- a/pkg/controller/usersshkeysagent/usersshkeys_controller.go
+++ b/pkg/controller/usersshkeysagent/usersshkeys_controller.go
@@ -253,7 +253,9 @@ func updateOwnAndPermissions(path string) error {
 func CacheOptions() cache.Options {
 	return cache.Options{
 		DefaultNamespaces: map[string]cache.Config{
-			metav1.NamespaceSystem: {},
+			metav1.NamespaceSystem: {
+				FieldSelector: fields.SelectorFromSet(fields.Set{"metadata.name": resources.UserSSHKeys}),
+			},
 		},
 		ByObject: map[ctrlruntimeclient.Object]cache.ByObject{
 			&corev1.Secret{}: {


### PR DESCRIPTION
**What this PR does / why we need it**:
We went through the same issue in #8329 and fixed it, but apparently we are seeing the same issue in 2.24 / `main` again now. 2.23 is not affected as per a brief test I did.

`user-ssh-keys-agent` fails to properly run and logs:

```
W1019 14:00:19.339651       1 reflector.go:535] pkg/mod/k8s.io/client-go@v0.28.2/tools/cache/reflector.go:229: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
E1019 14:00:19.339701       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.28.2/tools/cache/reflector.go:229: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:kube-system:user-ssh-keys-agent" cannot list resource "secrets" in API group "" in the namespace "kube-system"
```

I suspect we introduced a regression in #12609 by adding the default namespace cache config. This attempts to fix that.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
