### PR TITLE
prevent empty error messages in logs

### DIFF
--- a/pkg/ee/resource-quota/master-controller/controller.go
+++ b/pkg/ee/resource-quota/master-controller/controller.go
@@ -95,7 +95,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := r.masterClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get resource quota %q: %w", resourceQuota.Name, err)
+		return reconcile.Result{}, fmt.Errorf("failed to get resource quota: %w", err)
 	}
 
 	err := r.reconcile(ctx, resourceQuota, log)

--- a/pkg/ee/resource-quota/seed-controller/controller.go
+++ b/pkg/ee/resource-quota/seed-controller/controller.go
@@ -106,7 +106,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	resourceQuota := &kubermaticv1.ResourceQuota{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, resourceQuota); err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get resource quota %q: %w", resourceQuota.Name, err)
+		return reconcile.Result{}, fmt.Errorf("failed to get resource quota: %w", err)
 	}
 
 	err := r.reconcile(ctx, resourceQuota, log)


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes errors like

> protokol-2023.10.20T13.27.46/kubermatic/kubermatic-master-controller-manager-65b589977d-cwhdc_controller-manager_000.log:60383:{"level":"error","time":"2023-10-19T16:40:42.697Z","caller":"controller/controller.go:266","msg":"Reconciler error","controller":"kkp-master-resource-quota-controller","object":{"name":"project-q7jlhp76fm"},"namespace":"","name":"project-q7jlhp76fm","reconcileID":"cde533c4-13af-4d33-a496-68e67a90f138","error":"failed to get resource quota \"\": ResourceQuota.kubermatic.k8c.io \"project-q7jlhp76fm\" not found"}

For 404's, the object name is already part of `err`, so no need to try to mention it again.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
