### PR TITLE
stop throttling KKP controllers

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -36,14 +36,14 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 250m
+        cpu: "1"
         memory: 1Gi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
       # otherwise to an implementation-defined value. Requests cannot exceed Limits.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 150Mi
   # Auth defines keys and URLs for Dex. These must be defined unless the HeadlessInstallation
   # feature gate is set, which will disable the UI/API and its need for an OIDC provider entirely.
@@ -133,14 +133,14 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 100m
+        cpu: "1"
         memory: 400Mi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
       # otherwise to an implementation-defined value. Requests cannot exceed Limits.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       requests:
-        cpu: 50m
+        cpu: 200m
         memory: 128Mi
   # Proxy allows to configure Kubermatic to use proxies to talk to the
   # world outside of its cluster.
@@ -246,7 +246,7 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 500m
+        cpu: "1"
         memory: 1Gi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -36,14 +36,14 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 250m
+        cpu: "1"
         memory: 1Gi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
       # otherwise to an implementation-defined value. Requests cannot exceed Limits.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 150Mi
   # Auth defines keys and URLs for Dex. These must be defined unless the HeadlessInstallation
   # feature gate is set, which will disable the UI/API and its need for an OIDC provider entirely.
@@ -133,14 +133,14 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 100m
+        cpu: "1"
         memory: 400Mi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
       # otherwise to an implementation-defined value. Requests cannot exceed Limits.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       requests:
-        cpu: 50m
+        cpu: 200m
         memory: 128Mi
   # Proxy allows to configure Kubermatic to use proxies to talk to the
   # world outside of its cluster.
@@ -246,7 +246,7 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 500m
+        cpu: "1"
         memory: 1Gi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -100,22 +100,22 @@ var (
 
 	DefaultAPIResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("150Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
 	}
 
 	DefaultMasterControllerMgrResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("400Mi"),
 		},
 	}
@@ -126,7 +126,7 @@ var (
 			corev1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The resource constraints for KKP seed/master controllers are ancient. I (apparently) set them in #3012, a time when there wasn't even a master-controller-manager, but only an "rbac generator". "100m" might have been a useful limit for something that generates RBAC only, but the master-ctrl-mgr nowadays does way more.

We have observed it hitting the 100m CPU limit very often, to a point where even 

> I1020 11:42:42.896768       1 trace.go:236] Trace[1992949100]: "DeltaFIFO Pop Process" ID:cluster-lrvfphkcvb/front-proxy-ca,Depth:91,Reason:slow event handlers blocking the queue (20-Oct-2023 11:42:42.695) (total time: 201ms):

warnings were logged.

This PR raises the limit considerably, which should make KKP reconciliations much smoother.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Increase default CPU limits for KKP API/seed/master-controller-managers to prevent general slowness.
```

**Documentation**:
```documentation
NONE
```
