### PR TITLE
Update velero's helm chart apiversion to v2

### DIFF
--- a/charts/backup/velero/Chart.yaml
+++ b/charts/backup/velero/Chart.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: v1
+apiVersion: v2
 name: velero
 version: v9.9.9-dev
 appVersion: v1.10.1


### PR DESCRIPTION
**What this PR does / why we need it**:
We tried installing the velero helm chart using Argocd on seed but the CRDs were not getting picked by argocd as it needs the chart's `apiversion` to be [v2](https://github.com/argoproj/argo-cd/issues/3784) for that. Most of the community helm charts including velero are already using v2 & many charts in the Kubermatic's charts folder are also using v2 so we can/should update this as well. 
**What type of PR is this?**

Optionally add one or more of the following kinds if applicable:
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Velero helm chart's apiVersion to v2; Helm 3 & above would be required to install it.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
