### PR TITLE
[release/v2.21] Bump Cillium version to 1.12.15

### DIFF
--- a/addons/cilium/cilium_v1.12.yaml
+++ b/addons/cilium/cilium_v1.12.yaml
@@ -578,7 +578,7 @@ spec:
     spec:
       containers:
       - name: cilium-agent
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.9"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.15"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-agent
@@ -740,7 +740,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.9"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.15"
         imagePullPolicy: IfNotPresent
         env:
         - name: CGROUP_ROOT
@@ -779,7 +779,7 @@ spec:
               - SYS_CHROOT
               - SYS_PTRACE
       - name: apply-sysctl-overwrites
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.9"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.15"
         imagePullPolicy: IfNotPresent
         env:
         - name: BIN_PATH
@@ -819,7 +819,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.9"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.15"
         imagePullPolicy: IfNotPresent
         args:
         - 'mount | grep "/sys/fs/bpf type bpf" || mount -t bpf bpf /sys/fs/bpf'
@@ -835,7 +835,7 @@ spec:
           mountPath: /sys/fs/bpf
           mountPropagation: Bidirectional
       - name: clean-cilium-state
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.9"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.15"
         imagePullPolicy: IfNotPresent
         command:
         - /init-container.sh
@@ -901,7 +901,7 @@ spec:
             memory: 100Mi # wait-for-kube-proxy
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.9"
+        image: "{{ Registry "quay.io" }}/cilium/cilium:v1.12.15"
         imagePullPolicy: IfNotPresent
         command:
           - "/install-plugin.sh"
@@ -1044,7 +1044,7 @@ spec:
     spec:
       containers:
       - name: cilium-operator
-        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.12.9"
+        image: "{{ Registry "quay.io" }}/cilium/operator-generic:v1.12.15"
         imagePullPolicy: IfNotPresent
         command:
         - cilium-operator-generic

--- a/addons/hubble/hubble_v1.12.yaml
+++ b/addons/hubble/hubble_v1.12.yaml
@@ -53,10 +53,10 @@ data:
     cluster-name: default
     peer-service: "hubble-peer.kube-system.svc.cluster.local:443"
     listen-address: :4245
-    dial-timeout: 
-    retry-timeout: 
-    sort-buffer-len-max: 
-    sort-buffer-drain-timeout: 
+    dial-timeout:
+    retry-timeout:
+    sort-buffer-len-max:
+    sort-buffer-drain-timeout:
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
@@ -253,7 +253,7 @@ spec:
     spec:
       containers:
         - name: hubble-relay
-          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.12.9"
+          image: "{{ Registry "quay.io" }}/cilium/hubble-relay:v1.12.15"
           imagePullPolicy: IfNotPresent
           command:
             - hubble-relay
@@ -342,7 +342,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: frontend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.11.0"
+        image: "{{ Registry "quay.io" }}/cilium/hubble-ui:v0.12.1"
         imagePullPolicy: IfNotPresent
         ports:
         - name: http
@@ -355,7 +355,7 @@ spec:
             mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
-        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.11.0"
+        image: "{{ Registry "quay.io" }}/cilium/hubble-ui-backend:v0.12.1"
         imagePullPolicy: IfNotPresent
         env:
         - name: EVENTS_SERVER_PORT


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump Cilium CNI to 1.12.15.
Major fix to HTTP/2 "Rapid Reset" DoS Vulnerability([CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487))

Bless moving to Applications

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Cilium 1.12.15, mitigating an high CVE-2023-44487
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
