### PR TITLE
fix error message in conformance-tester

### DIFF
--- a/cmd/conformance-tester/main.go
+++ b/cmd/conformance-tester/main.go
@@ -90,7 +90,6 @@ func main() {
 		"providers", sets.List(opts.Providers),
 		"operatingsystems", sets.List(opts.Distributions),
 		"versions", opts.Versions,
-		"containerruntimes", sets.List(opts.ContainerRuntimes),
 		"tests", sets.List(opts.Tests),
 		"osm", opts.OperatingSystemManagerEnabled,
 		"dualstack", opts.DualStackEnabled,
@@ -122,7 +121,6 @@ func main() {
 	scenarios, err := scenarios.NewGenerator().
 		WithCloudProviders(sets.List(opts.Providers)...).
 		WithOperatingSystems(sets.List(opts.Distributions)...).
-		WithContainerRuntimes(sets.List(opts.ContainerRuntimes)...).
 		WithOSM(opts.OperatingSystemManagerEnabled).
 		WithDualstack(opts.DualStackEnabled).
 		WithVersions(opts.Versions...).

--- a/cmd/conformance-tester/pkg/runner/result.go
+++ b/cmd/conformance-tester/pkg/runner/result.go
@@ -200,7 +200,6 @@ type ScenarioResult struct {
 
 	CloudProvider     kubermaticv1.ProviderType      `json:"cloudProvider"`
 	OperatingSystem   providerconfig.OperatingSystem `json:"operatingSystem"`
-	ContainerRuntime  string                         `json:"containerRuntime"`
 	KubernetesRelease string                         `json:"kubernetesRelease"`
 	KubernetesVersion semver.Semver                  `json:"kubernetesVersion"`
 	KubermaticVersion string                         `json:"kubermaticVersion"`
@@ -228,7 +227,6 @@ func (sr *ScenarioResult) Equals(other ScenarioResult) bool {
 	return true &&
 		other.CloudProvider == sr.CloudProvider &&
 		other.OperatingSystem == sr.OperatingSystem &&
-		other.ContainerRuntime == sr.ContainerRuntime &&
 		other.KubernetesVersion == sr.KubernetesVersion
 }
 
@@ -236,7 +234,6 @@ func (sr *ScenarioResult) MatchesScenario(scenario scenarios.Scenario) bool {
 	return true &&
 		scenario.CloudProvider() == sr.CloudProvider &&
 		scenario.OperatingSystem() == sr.OperatingSystem &&
-		scenario.ContainerRuntime() == sr.ContainerRuntime &&
 		scenario.ClusterVersion() == sr.KubernetesVersion
 }
 

--- a/cmd/conformance-tester/pkg/runner/runner.go
+++ b/cmd/conformance-tester/pkg/runner/runner.go
@@ -152,7 +152,6 @@ func (r *TestRunner) scenarioWorker(ctx context.Context, scenarios <-chan scenar
 			scenarioName:      scenario.Name(),
 			CloudProvider:     scenario.CloudProvider(),
 			OperatingSystem:   scenario.OperatingSystem(),
-			ContainerRuntime:  scenario.ContainerRuntime(),
 			KubernetesRelease: clusterVersion.MajorMinor(),
 			KubernetesVersion: clusterVersion,
 		}
@@ -212,21 +211,9 @@ func (r *TestRunner) scenarioWorker(ctx context.Context, scenarios <-chan scenar
 }
 
 func (r *TestRunner) isValidNewScenario(scenario scenarios.Scenario) error {
-	// check if the CRI is enabled by the user
-	if !r.opts.ContainerRuntimes.Has(scenario.ContainerRuntime()) {
-		return fmt.Errorf("CRI is not enabled")
-	}
-
 	// check if the OS is enabled by the user
 	if !r.opts.Distributions.Has(string(scenario.OperatingSystem())) {
 		return fmt.Errorf("OS is not enabled")
-	}
-
-	// apply static filters
-	clusterVersion := scenario.ClusterVersion()
-	dockerSupported := clusterVersion.LessThan(semver.NewSemverOrDie("1.24"))
-	if !dockerSupported && scenario.ContainerRuntime() == resources.ContainerRuntimeDocker {
-		return fmt.Errorf("CRI is not supported in this Kubernetes version")
 	}
 
 	return scenario.IsValid()

--- a/cmd/conformance-tester/pkg/scenarios/alibaba.go
+++ b/cmd/conformance-tester/pkg/scenarios/alibaba.go
@@ -18,15 +18,35 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type alibabaScenario struct {
 	baseScenario
+}
+
+func (s *alibabaScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+}
+
+func (s *alibabaScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
+	}
+
+	return nil
 }
 
 func (s *alibabaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {

--- a/cmd/conformance-tester/pkg/scenarios/alibaba.go
+++ b/cmd/conformance-tester/pkg/scenarios/alibaba.go
@@ -34,7 +34,13 @@ type alibabaScenario struct {
 }
 
 func (s *alibabaScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRHEL,
+		providerconfig.OperatingSystemFlatcar,
+		providerconfig.OperatingSystemRockyLinux,
+	)
 }
 
 func (s *alibabaScenario) IsValid() error {

--- a/cmd/conformance-tester/pkg/scenarios/alibaba.go
+++ b/cmd/conformance-tester/pkg/scenarios/alibaba.go
@@ -31,7 +31,6 @@ type alibabaScenario struct {
 
 func (s *alibabaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Alibaba.KKPDatacenter,
 			Alibaba: &kubermaticv1.AlibabaCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/anexia.go
+++ b/cmd/conformance-tester/pkg/scenarios/anexia.go
@@ -51,7 +51,6 @@ func (s *anexiaScenario) IsValid() error {
 
 func (s *anexiaScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Anexia.KKPDatacenter,
 			Anexia: &kubermaticv1.AnexiaCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/anexia.go
+++ b/cmd/conformance-tester/pkg/scenarios/anexia.go
@@ -18,13 +18,15 @@ package scenarios
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -37,13 +39,19 @@ type anexiaScenario struct {
 	baseScenario
 }
 
+func (s *anexiaScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemFlatcar,
+	)
+}
+
 func (s *anexiaScenario) IsValid() error {
 	if err := s.baseScenario.IsValid(); err != nil {
 		return err
 	}
 
-	if s.operatingSystem != providerconfig.OperatingSystemFlatcar {
-		return errors.New("provider only supports Flatcar")
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
 	}
 
 	return nil

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -24,6 +24,7 @@ import (
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
@@ -41,6 +42,22 @@ const (
 
 type awsScenario struct {
 	baseScenario
+}
+
+func (s *awsScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+}
+
+func (s *awsScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
+	}
+
+	return nil
 }
 
 func (s *awsScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {

--- a/cmd/conformance-tester/pkg/scenarios/aws.go
+++ b/cmd/conformance-tester/pkg/scenarios/aws.go
@@ -45,7 +45,6 @@ type awsScenario struct {
 
 func (s *awsScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.AWS.KKPDatacenter,
 			AWS: &kubermaticv1.AWSCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/azure.go
+++ b/cmd/conformance-tester/pkg/scenarios/azure.go
@@ -38,7 +38,13 @@ type azureScenario struct {
 }
 
 func (s *azureScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRHEL,
+		providerconfig.OperatingSystemFlatcar,
+		providerconfig.OperatingSystemRockyLinux,
+	)
 }
 
 func (s *azureScenario) IsValid() error {

--- a/cmd/conformance-tester/pkg/scenarios/azure.go
+++ b/cmd/conformance-tester/pkg/scenarios/azure.go
@@ -18,11 +18,15 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -31,6 +35,22 @@ const (
 
 type azureScenario struct {
 	baseScenario
+}
+
+func (s *azureScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+}
+
+func (s *azureScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
+	}
+
+	return nil
 }
 
 func (s *azureScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {

--- a/cmd/conformance-tester/pkg/scenarios/azure.go
+++ b/cmd/conformance-tester/pkg/scenarios/azure.go
@@ -35,7 +35,6 @@ type azureScenario struct {
 
 func (s *azureScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Azure.KKPDatacenter,
 			Azure: &kubermaticv1.AzureCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/base.go
+++ b/cmd/conformance-tester/pkg/scenarios/base.go
@@ -40,7 +40,6 @@ type Scenario interface {
 
 	CloudProvider() kubermaticv1.ProviderType
 	OperatingSystem() providerconfig.OperatingSystem
-	ContainerRuntime() string
 	ClusterVersion() semver.Semver
 	Datacenter() *kubermaticv1.Datacenter
 	Name() string
@@ -56,7 +55,6 @@ type baseScenario struct {
 	cloudProvider    kubermaticv1.ProviderType
 	operatingSystem  providerconfig.OperatingSystem
 	clusterVersion   semver.Semver
-	containerRuntime string
 	dualstackEnabled bool
 	datacenter       *kubermaticv1.Datacenter
 }
@@ -73,10 +71,6 @@ func (s *baseScenario) ClusterVersion() semver.Semver {
 	return s.clusterVersion
 }
 
-func (s *baseScenario) ContainerRuntime() string {
-	return s.containerRuntime
-}
-
 func (s *baseScenario) Datacenter() *kubermaticv1.Datacenter {
 	return s.datacenter
 }
@@ -86,7 +80,6 @@ func (s *baseScenario) Log(log *zap.SugaredLogger) *zap.SugaredLogger {
 		"provider", s.cloudProvider,
 		"os", s.operatingSystem,
 		"version", s.clusterVersion.String(),
-		"cri", s.containerRuntime,
 	)
 }
 
@@ -95,7 +88,7 @@ func (s *baseScenario) NamedLog(log *zap.SugaredLogger) *zap.SugaredLogger {
 }
 
 func (s *baseScenario) Name() string {
-	return fmt.Sprintf("%s-%s-%s-%s", s.cloudProvider, s.operatingSystem, s.containerRuntime, s.clusterVersion.String())
+	return fmt.Sprintf("%s-%s-%s", s.cloudProvider, s.operatingSystem, s.clusterVersion.String())
 }
 
 func (s *baseScenario) IsValid() error {

--- a/cmd/conformance-tester/pkg/scenarios/digitalocean.go
+++ b/cmd/conformance-tester/pkg/scenarios/digitalocean.go
@@ -57,7 +57,6 @@ func (s *digitaloceanScenario) IsValid() error {
 
 func (s *digitaloceanScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Digitalocean.KKPDatacenter,
 			Digitalocean: &kubermaticv1.DigitaloceanCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/digitalocean.go
+++ b/cmd/conformance-tester/pkg/scenarios/digitalocean.go
@@ -37,19 +37,21 @@ type digitaloceanScenario struct {
 	baseScenario
 }
 
+func (s *digitaloceanScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRockyLinux,
+		providerconfig.OperatingSystemUbuntu,
+	)
+}
+
 func (s *digitaloceanScenario) IsValid() error {
 	if err := s.baseScenario.IsValid(); err != nil {
 		return err
 	}
 
-	supported := sets.New(
-		string(providerconfig.OperatingSystemCentOS),
-		string(providerconfig.OperatingSystemRockyLinux),
-		string(providerconfig.OperatingSystemUbuntu),
-	)
-
-	if !supported.Has(string(s.operatingSystem)) {
-		return fmt.Errorf("provider only supports %v", sets.List(supported))
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
 	}
 
 	return nil

--- a/cmd/conformance-tester/pkg/scenarios/generator.go
+++ b/cmd/conformance-tester/pkg/scenarios/generator.go
@@ -34,20 +34,18 @@ import (
 )
 
 type Generator struct {
-	cloudProviders    sets.Set[string]
-	operatingSystems  sets.Set[string]
-	versions          sets.Set[string]
-	containerRuntimes sets.Set[string]
-	enableOSM         bool
-	enableDualstack   bool
+	cloudProviders   sets.Set[string]
+	operatingSystems sets.Set[string]
+	versions         sets.Set[string]
+	enableOSM        bool
+	enableDualstack  bool
 }
 
 func NewGenerator() *Generator {
 	return &Generator{
-		cloudProviders:    sets.New[string](),
-		operatingSystems:  sets.New[string](),
-		versions:          sets.New[string](),
-		containerRuntimes: sets.New[string](),
+		cloudProviders:   sets.New[string](),
+		operatingSystems: sets.New[string](),
+		versions:         sets.New[string](),
 	}
 }
 
@@ -68,13 +66,6 @@ func (g *Generator) WithOperatingSystems(operatingSystems ...string) *Generator 
 func (g *Generator) WithVersions(versions ...*semver.Semver) *Generator {
 	for _, version := range versions {
 		g.versions.Insert(version.String())
-	}
-	return g
-}
-
-func (g *Generator) WithContainerRuntimes(runtimes ...string) *Generator {
-	for _, runtime := range runtimes {
-		g.containerRuntimes.Insert(runtime)
 	}
 	return g
 }
@@ -105,14 +96,12 @@ func (g *Generator) Scenarios(ctx context.Context, opts *types.Options, log *zap
 			}
 
 			for _, operatingSystem := range sets.List(g.operatingSystems) {
-				for _, cri := range sets.List(g.containerRuntimes) {
-					scenario, err := providerScenario(opts, kubermaticv1.ProviderType(providerName), providerconfig.OperatingSystem(operatingSystem), *s, cri, datacenter)
-					if err != nil {
-						return nil, err
-					}
-
-					scenarios = append(scenarios, scenario)
+				scenario, err := providerScenario(opts, kubermaticv1.ProviderType(providerName), providerconfig.OperatingSystem(operatingSystem), *s, datacenter)
+				if err != nil {
+					return nil, err
 				}
+
+				scenarios = append(scenarios, scenario)
 			}
 		}
 	}
@@ -162,14 +151,12 @@ func providerScenario(
 	provider kubermaticv1.ProviderType,
 	os providerconfig.OperatingSystem,
 	version semver.Semver,
-	containerRuntime string,
 	datacenter *kubermaticv1.Datacenter,
 ) (Scenario, error) {
 	base := baseScenario{
 		cloudProvider:    provider,
 		operatingSystem:  os,
 		clusterVersion:   version,
-		containerRuntime: containerRuntime,
 		datacenter:       datacenter,
 		dualstackEnabled: opts.DualStackEnabled,
 	}

--- a/cmd/conformance-tester/pkg/scenarios/google.go
+++ b/cmd/conformance-tester/pkg/scenarios/google.go
@@ -46,7 +46,6 @@ func (s *googleScenario) IsValid() error {
 
 func (s *googleScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.GCP.KKPDatacenter,
 			GCP: &kubermaticv1.GCPCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/google.go
+++ b/cmd/conformance-tester/pkg/scenarios/google.go
@@ -19,17 +19,25 @@ package scenarios
 import (
 	"context"
 	"encoding/base64"
-	"errors"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 type googleScenario struct {
 	baseScenario
+}
+
+func (s *googleScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+	)
 }
 
 func (s *googleScenario) IsValid() error {
@@ -37,8 +45,8 @@ func (s *googleScenario) IsValid() error {
 		return err
 	}
 
-	if s.operatingSystem != providerconfig.OperatingSystemUbuntu {
-		return errors.New("provider only supports Ubuntu")
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
 	}
 
 	return nil

--- a/cmd/conformance-tester/pkg/scenarios/hetzner.go
+++ b/cmd/conformance-tester/pkg/scenarios/hetzner.go
@@ -57,7 +57,6 @@ func (s *hetznerScenario) IsValid() error {
 
 func (s *hetznerScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Hetzner.KKPDatacenter,
 			Hetzner: &kubermaticv1.HetznerCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/hetzner.go
+++ b/cmd/conformance-tester/pkg/scenarios/hetzner.go
@@ -37,19 +37,21 @@ type hetznerScenario struct {
 	baseScenario
 }
 
+func (s *hetznerScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRockyLinux,
+		providerconfig.OperatingSystemUbuntu,
+	)
+}
+
 func (s *hetznerScenario) IsValid() error {
 	if err := s.baseScenario.IsValid(); err != nil {
 		return err
 	}
 
-	supported := sets.New(
-		string(providerconfig.OperatingSystemCentOS),
-		string(providerconfig.OperatingSystemRockyLinux),
-		string(providerconfig.OperatingSystemUbuntu),
-	)
-
-	if !supported.Has(string(s.operatingSystem)) {
-		return fmt.Errorf("provider only supports %v", sets.List(supported))
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
 	}
 
 	return nil

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -43,7 +43,6 @@ type kubevirtScenario struct {
 
 func (s *kubevirtScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Kubevirt.KKPDatacenter,
 			Kubevirt: &kubermaticv1.KubevirtCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -43,7 +43,13 @@ type kubevirtScenario struct {
 }
 
 func (s *kubevirtScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRHEL,
+		providerconfig.OperatingSystemFlatcar,
+		providerconfig.OperatingSystemRockyLinux,
+	)
 }
 
 func (s *kubevirtScenario) IsValid() error {

--- a/cmd/conformance-tester/pkg/scenarios/kubevirt.go
+++ b/cmd/conformance-tester/pkg/scenarios/kubevirt.go
@@ -26,6 +26,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 )
 
@@ -39,6 +40,22 @@ const (
 
 type kubevirtScenario struct {
 	baseScenario
+}
+
+func (s *kubevirtScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+}
+
+func (s *kubevirtScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
+	}
+
+	return nil
 }
 
 func (s *kubevirtScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {

--- a/cmd/conformance-tester/pkg/scenarios/nutanix.go
+++ b/cmd/conformance-tester/pkg/scenarios/nutanix.go
@@ -18,11 +18,15 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -33,6 +37,22 @@ const (
 
 type nutanixScenario struct {
 	baseScenario
+}
+
+func (s *nutanixScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+}
+
+func (s *nutanixScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
+	}
+
+	return nil
 }
 
 func (s *nutanixScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {

--- a/cmd/conformance-tester/pkg/scenarios/nutanix.go
+++ b/cmd/conformance-tester/pkg/scenarios/nutanix.go
@@ -37,7 +37,6 @@ type nutanixScenario struct {
 
 func (s *nutanixScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Nutanix.KKPDatacenter,
 			Nutanix: &kubermaticv1.NutanixCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/nutanix.go
+++ b/cmd/conformance-tester/pkg/scenarios/nutanix.go
@@ -40,7 +40,13 @@ type nutanixScenario struct {
 }
 
 func (s *nutanixScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRHEL,
+		providerconfig.OperatingSystemFlatcar,
+		providerconfig.OperatingSystemRockyLinux,
+	)
 }
 
 func (s *nutanixScenario) IsValid() error {

--- a/cmd/conformance-tester/pkg/scenarios/openstack.go
+++ b/cmd/conformance-tester/pkg/scenarios/openstack.go
@@ -42,7 +42,13 @@ type openStackScenario struct {
 }
 
 func (s *openStackScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRHEL,
+		providerconfig.OperatingSystemFlatcar,
+		providerconfig.OperatingSystemRockyLinux,
+	)
 }
 
 func (s *openStackScenario) IsValid() error {

--- a/cmd/conformance-tester/pkg/scenarios/openstack.go
+++ b/cmd/conformance-tester/pkg/scenarios/openstack.go
@@ -39,7 +39,6 @@ type openStackScenario struct {
 
 func (s *openStackScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.OpenStack.KKPDatacenter,
 			Openstack: &kubermaticv1.OpenstackCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/openstack.go
+++ b/cmd/conformance-tester/pkg/scenarios/openstack.go
@@ -18,12 +18,16 @@ package scenarios
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -35,6 +39,22 @@ const (
 
 type openStackScenario struct {
 	baseScenario
+}
+
+func (s *openStackScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+}
+
+func (s *openStackScenario) IsValid() error {
+	if err := s.baseScenario.IsValid(); err != nil {
+		return err
+	}
+
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
+	}
+
+	return nil
 }
 
 func (s *openStackScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {

--- a/cmd/conformance-tester/pkg/scenarios/packet.go
+++ b/cmd/conformance-tester/pkg/scenarios/packet.go
@@ -37,20 +37,22 @@ type packetScenario struct {
 	baseScenario
 }
 
+func (s *packetScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemFlatcar,
+		providerconfig.OperatingSystemRockyLinux,
+		providerconfig.OperatingSystemUbuntu,
+	)
+}
+
 func (s *packetScenario) IsValid() error {
 	if err := s.baseScenario.IsValid(); err != nil {
 		return err
 	}
 
-	supported := sets.New(
-		string(providerconfig.OperatingSystemCentOS),
-		string(providerconfig.OperatingSystemFlatcar),
-		string(providerconfig.OperatingSystemRockyLinux),
-		string(providerconfig.OperatingSystemUbuntu),
-	)
-
-	if !supported.Has(string(s.operatingSystem)) {
-		return fmt.Errorf("provider only supports %v", sets.List(supported))
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
 	}
 
 	return nil

--- a/cmd/conformance-tester/pkg/scenarios/packet.go
+++ b/cmd/conformance-tester/pkg/scenarios/packet.go
@@ -58,7 +58,6 @@ func (s *packetScenario) IsValid() error {
 
 func (s *packetScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	return &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.Packet.KKPDatacenter,
 			Packet: &kubermaticv1.PacketCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -47,7 +47,7 @@ func (s *vmwareCloudDirectorScenario) IsValid() error {
 	}
 
 	if s.operatingSystem != providerconfig.OperatingSystemUbuntu {
-		return errors.New("provider only supports Flatcar")
+		return errors.New("provider only supports Ubuntu")
 	}
 
 	return nil

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -55,7 +55,6 @@ func (s *vmwareCloudDirectorScenario) IsValid() error {
 
 func (s *vmwareCloudDirectorScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	spec := &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.VMwareCloudDirector.KKPDatacenter,
 			VMwareCloudDirector: &kubermaticv1.VMwareCloudDirectorCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -18,13 +18,15 @@ package scenarios
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/machine/provider"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -41,13 +43,19 @@ type vmwareCloudDirectorScenario struct {
 	baseScenario
 }
 
+func (s *vmwareCloudDirectorScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+	)
+}
+
 func (s *vmwareCloudDirectorScenario) IsValid() error {
 	if err := s.baseScenario.IsValid(); err != nil {
 		return err
 	}
 
-	if s.operatingSystem != providerconfig.OperatingSystemUbuntu {
-		return errors.New("provider only supports Ubuntu")
+	if compat := s.compatibleOperatingSystems(); !compat.Has(s.operatingSystem) {
+		return fmt.Errorf("provider supports only %v", sets.List(compat))
 	}
 
 	return nil

--- a/cmd/conformance-tester/pkg/scenarios/vsphere.go
+++ b/cmd/conformance-tester/pkg/scenarios/vsphere.go
@@ -36,7 +36,6 @@ type vSphereScenario struct {
 
 func (s *vSphereScenario) Cluster(secrets types.Secrets) *kubermaticv1.ClusterSpec {
 	spec := &kubermaticv1.ClusterSpec{
-		ContainerRuntime: s.containerRuntime,
 		Cloud: kubermaticv1.CloudSpec{
 			DatacenterName: secrets.VSphere.KKPDatacenter,
 			VSphere: &kubermaticv1.VSphereCloudSpec{

--- a/cmd/conformance-tester/pkg/scenarios/vsphere.go
+++ b/cmd/conformance-tester/pkg/scenarios/vsphere.go
@@ -38,7 +38,13 @@ type vSphereScenario struct {
 }
 
 func (s *vSphereScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
-	return sets.New[providerconfig.OperatingSystem](providerconfig.AllOperatingSystems...)
+	return sets.New[providerconfig.OperatingSystem](
+		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemCentOS,
+		providerconfig.OperatingSystemRHEL,
+		providerconfig.OperatingSystemFlatcar,
+		providerconfig.OperatingSystemRockyLinux,
+	)
 }
 
 func (s *vSphereScenario) IsValid() error {


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes 2 typos where a scenario reported that only distribution X would be allowed, when in reality distribution Y was allowed only. After I fixed that typo, I made the distribution check to be a more consistent across all providers and then also removed the old `-container-runtimes` flag, as containerd is the only supported CRI since Kubernetes 1.24.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
