### PR TITLE
[release/v2.21] stop throttling KKP controllers (#12764)

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.yaml
@@ -28,14 +28,14 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 250m
+        cpu: "1"
         memory: 1Gi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
       # otherwise to an implementation-defined value.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       requests:
-        cpu: 100m
+        cpu: 200m
         memory: 150Mi
   # Auth defines keys and URLs for Dex. These must be defined unless the HeadlessInstallation
   # feature gate is set, which will disable the UI/API and its need for an OIDC provider entirely.
@@ -116,14 +116,14 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 100m
+        cpu: "1"
         memory: 400Mi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
       # otherwise to an implementation-defined value.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       requests:
-        cpu: 50m
+        cpu: 200m
         memory: 128Mi
   # Proxy allows to configure Kubermatic to use proxies to talk to the
   # world outside of its cluster.
@@ -274,7 +274,7 @@ spec:
       # Limits describes the maximum amount of compute resources allowed.
       # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
       limits:
-        cpu: 500m
+        cpu: "1"
         memory: 1Gi
       # Requests describes the minimum amount of compute resources required.
       # If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,

--- a/pkg/controller/operator/defaults/defaults.go
+++ b/pkg/controller/operator/defaults/defaults.go
@@ -95,22 +95,22 @@ var (
 
 	DefaultAPIResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("150Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
 	}
 
 	DefaultMasterControllerMgrResources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceCPU:    resource.MustParse("200m"),
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("400Mi"),
 		},
 	}
@@ -121,7 +121,7 @@ var (
 			corev1.ResourceMemory: resource.MustParse("100Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("500m"),
+			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #12764.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Increase default CPU limits for KKP API/seed/master-controller-managers to prevent general slowness.
```

**Documentation**:
```documentation
NONE
```
