### PR TITLE
Downgrade VCD CSI driver to v1.3.2

### DIFF
--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Sourced from:
-# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.4.0/manifests/csi-controller.yaml
+# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.3.2/manifests/csi-controller.yaml
 #
 # Changes:
 # - image source includes registry templating
@@ -165,7 +165,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image:  {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.4.0" }}
+          image:  {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.3.2" }}
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
@@ -187,7 +187,7 @@ spec:
               mountPath: /dev
               mountPropagation: HostToContainer
             - name: pv-dir
-              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
               mountPropagation: "Bidirectional"
             - name: vcloud-csi-config-volume
               mountPath: /etc/kubernetes/vcloud
@@ -209,7 +209,7 @@ spec:
             type: Directory
         - name: pv-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
             type: DirectoryOrCreate
         - name: vcloud-csi-config-volume
           configMap:

--- a/addons/csi/vmware-cloud-director/csi-driver.yaml
+++ b/addons/csi/vmware-cloud-director/csi-driver.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Sourced from:
-# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.4.0/manifests/csi-driver.yaml
+# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.3.2/manifests/csi-driver.yaml
 
 {{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 

--- a/addons/csi/vmware-cloud-director/csi-node.yaml
+++ b/addons/csi/vmware-cloud-director/csi-node.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Sourced from:
-# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.4.0/manifests/csi-node.yaml
+# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.3.2/manifests/csi-node.yaml
 #
 # Changes:
 # - image source includes registry templating
@@ -104,7 +104,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.4.0" }}
+          image: {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.3.2" }}
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
@@ -132,7 +132,7 @@ spec:
               mountPath: /dev
               mountPropagation: "HostToContainer"
             - name: pv-dir
-              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
               mountPropagation: "Bidirectional"
             - name: vcloud-csi-config-volume
               mountPath: /etc/kubernetes/vcloud
@@ -161,7 +161,7 @@ spec:
             type: Directory
         - name: pv-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/kubernetes.io/csi
+            path: /var/lib/kubelet/plugins/kubernetes.io/csi/pv
             type: DirectoryOrCreate
         - name: vcloud-csi-config-volume
           configMap:

--- a/addons/csi/vmware-cloud-director/vcloud-basic-auth.yaml
+++ b/addons/csi/vmware-cloud-director/vcloud-basic-auth.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Sourced from:
-# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.4.0/manifests/vcloud-basic-auth.yaml
+# - https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.3.2/manifests/vcloud-basic-auth.yaml
 
 {{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
VCD CSI driver has switched to [VCD SDK](https://github.com/vmware/cloud-provider-for-cloud-director/tree/main/pkg/vcdsdk) which is built primarily to support the VCD CSE Kubernetes offering by VMware. 

On testing it out, we found out that it's not working as expected with errors like the following:

```
E1021 11:47:11.062489       1 disks.go:888] error occurred when getting defined entity [groucho-sq6hd]; skipping upgrade of CSI status section: [{"minorErrorCode":"ACCESS_TO_RESOURCE_IS_FORBIDDEN","message":"[ 978417dc-41d6-47e3-9e7c-46041303febe ] This operation is denied.","stackTrace":null}]
E1021 11:47:11.290684       1 driver.go:148] unable to add error [RdeUpgradeError] into [CSI.Errors] in RDE [groucho-sq6hd], failed to get RDE [groucho-sq6hd] when adding error to the errorSet of [csi] ; expected http response [200], obtained [403]: resp: ["{\"minorErrorCode\":\"ACCESS_TO_RESOURCE_IS_FORBIDDEN\",\"message\":\"[ 10641f5f-1902-4d69-883b-877cf4ff46fa ] This operation is denied.\",\"stackTrace\":null}"]: [403 Forbidden]
panic: error while setting up driver: [CSI section upgrade failed when CAPVCD RDE is present, [error when getting defined entity [groucho-sq6hd] from VCD: [403 Forbidden]; skipping upgrade of CSI status section to Version [1.4.0]]]
```

This requires a bit more effort than expected and hence we are going to downgrade to v1.3.2 from v1.4.0. We upgraded to v1.4.0 as part of [adding support for Kubernetes 1.28](https://github.com/kubermatic/kubermatic/pull/12593). However this is completely unrelated since VCD CSI doesn't support k8s 1.28 anyways, the maximum k8s version that it supports is 1.25.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
xref #12748

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:
Not adding release notes since we never had a release note regarding upgrading to v1.4.0.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
