### PR TITLE
fix panic in addon controller

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -220,11 +220,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return r.reconcile(ctx, log, addon, cluster)
 		},
 	)
+
 	if err != nil {
 		r.recorder.Event(addon, corev1.EventTypeWarning, "ReconcilingError", err.Error())
 		r.recorder.Eventf(cluster, corev1.EventTypeWarning, "ReconcilingError",
 			"failed to reconcile Addon %q: %v", addon.Name, err)
-	} else if result == nil {
+
+		return reconcile.Result{}, err
+	}
+
+	if result == nil {
 		// we check for this after the ClusterReconcileWrapper() call because otherwise the cluster would never reconcile since we always requeue
 		result = &reconcile.Result{}
 		if r.addonEnforceInterval != 0 { // addon enforce is enabled
@@ -234,7 +239,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	return *result, err
+	return *result, nil
 }
 
 // garbageCollectAddon is called when the cluster that owns the addon is gone


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixing 

```
{"level":"info","time":"2023-10-25T09:26:55.720Z","caller":"runtime/panic.go:914","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"kkp-addon-controller","object":{"name":"default-storage-class","namespace":"cluster-vssksm4wjs"},"namespace":"cluster-vssksm4wjs","name":"default-storage-class","reconcileID":"7883b550-a788-4606-8e0e-bff32d645acc"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1ade069]

goroutine 1067 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x3dcfb40?, 0x7248af0?})
	runtime/panic.go:914 +0x21f
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).Reconcile(0xc000178d80, {0x4da99d8, 0xc00a1cf2f0}, {{{0xc000b0aaf8, 0x12}, {0xc000b0aae0, 0x15}}})
	k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:237 +0x729
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x4dae328?, {0x4da99d8?, 0xc00a1cf2f0?}, {{{0xc000b0aaf8?, 0xb?}, {0xc000b0aae0?, 0x0?}}})
	sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:119 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000997860, {0x4da9a10, 0xc000568140}, {0x40dc700?, 0xc003794400?})
	sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:316 +0x3c5
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000997860, {0x4da9a10, 0xc000568140})
	sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:266 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
	sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:227 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 305
	sigs.k8s.io/controller-runtime@v0.16.2/pkg/internal/controller/controller.go:223 +0x565
```

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
