### PR TITLE
kubelb: datacenter kubeconfig should have precedence over seed kubeconfig

### DIFF
--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -412,15 +412,16 @@ func (r *reconciler) getKubeLBManagementClusterClient(ctx context.Context, seed 
 
 func getKubeLBKubeconfigSecret(ctx context.Context, client ctrlruntimeclient.Client, seed *kubermaticv1.Seed, dc kubermaticv1.Datacenter) (*corev1.Secret, error) {
 	var name, namespace string
-	if seed.Spec.KubeLB == nil || seed.Spec.KubeLB.Kubeconfig.Name == "" {
-		if dc.Spec.KubeLB == nil || dc.Spec.KubeLB.Kubeconfig.Name == "" {
-			return nil, fmt.Errorf("kubeLB management kubeconfig not found")
-		}
+
+	switch {
+	case dc.Spec.KubeLB != nil && dc.Spec.KubeLB.Kubeconfig.Name != "":
 		name = dc.Spec.KubeLB.Kubeconfig.Name
 		namespace = dc.Spec.KubeLB.Kubeconfig.Namespace
-	} else {
+	case seed.Spec.KubeLB != nil && seed.Spec.KubeLB.Kubeconfig.Name != "":
 		name = seed.Spec.KubeLB.Kubeconfig.Name
 		namespace = seed.Spec.KubeLB.Kubeconfig.Namespace
+	default:
+		return nil, fmt.Errorf("kubeLB management kubeconfig not found")
 	}
 
 	secret := &corev1.Secret{}


### PR DESCRIPTION
**What this PR does / why we need it**:
Datacenter-level configuration for KubeLB management cluster should take precedence over the seed configurations.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
