### PR TITLE
Introduce bool pointers for KubermaticSettings fields decorated with `omitempty`

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -59,7 +59,7 @@ type SettingSpec struct {
 	// +kubebuilder:default=false
 
 	// EnableWebTerminal enables the Web Terminal feature for the user clusters.
-	EnableWebTerminal *bool `json:"enableWebTerminal,omitempty"`
+	EnableWebTerminal bool `json:"enableWebTerminal,omitempty"`
 
 	// +kubebuilder:default=true
 
@@ -69,7 +69,7 @@ type SettingSpec struct {
 	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig"` //nolint:tagliatelle
 
 	// DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
-	DisableAdminKubeconfig *bool `json:"disableAdminKubeconfig,omitempty"`
+	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
 
 	// UserProjectsLimit is the maximum number of projects a user can create.
 	UserProjectsLimit       int64 `json:"userProjectsLimit"`

--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -59,17 +59,17 @@ type SettingSpec struct {
 	// +kubebuilder:default=false
 
 	// EnableWebTerminal enables the Web Terminal feature for the user clusters.
-	EnableWebTerminal bool `json:"enableWebTerminal,omitempty"`
+	EnableWebTerminal *bool `json:"enableWebTerminal,omitempty"`
 
 	// +kubebuilder:default=true
 
 	// EnableShareCluster enables the Share Cluster feature for the user clusters.
-	EnableShareCluster bool `json:"enableShareCluster,omitempty"`
+	EnableShareCluster *bool `json:"enableShareCluster,omitempty"`
 
 	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig"` //nolint:tagliatelle
 
 	// DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
-	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
+	DisableAdminKubeconfig *bool `json:"disableAdminKubeconfig,omitempty"`
 
 	// UserProjectsLimit is the maximum number of projects a user can create.
 	UserProjectsLimit       int64 `json:"userProjectsLimit"`

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -6193,18 +6193,8 @@ func (in *SettingSpec) DeepCopyInto(out *SettingSpec) {
 		*out = make(CustomLinks, len(*in))
 		copy(*out, *in)
 	}
-	if in.EnableWebTerminal != nil {
-		in, out := &in.EnableWebTerminal, &out.EnableWebTerminal
-		*out = new(bool)
-		**out = **in
-	}
 	if in.EnableShareCluster != nil {
 		in, out := &in.EnableShareCluster, &out.EnableShareCluster
-		*out = new(bool)
-		**out = **in
-	}
-	if in.DisableAdminKubeconfig != nil {
-		in, out := &in.DisableAdminKubeconfig, &out.DisableAdminKubeconfig
 		*out = new(bool)
 		**out = **in
 	}

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -6193,6 +6193,21 @@ func (in *SettingSpec) DeepCopyInto(out *SettingSpec) {
 		*out = make(CustomLinks, len(*in))
 		copy(*out, *in)
 	}
+	if in.EnableWebTerminal != nil {
+		in, out := &in.EnableWebTerminal, &out.EnableWebTerminal
+		*out = new(bool)
+		**out = **in
+	}
+	if in.EnableShareCluster != nil {
+		in, out := &in.EnableShareCluster, &out.EnableShareCluster
+		*out = new(bool)
+		**out = **in
+	}
+	if in.DisableAdminKubeconfig != nil {
+		in, out := &in.DisableAdminKubeconfig, &out.DisableAdminKubeconfig
+		*out = new(bool)
+		**out = **in
+	}
 	out.CleanupOptions = in.CleanupOptions
 	out.OpaOptions = in.OpaOptions
 	out.MlaOptions = in.MlaOptions


### PR DESCRIPTION
**What this PR does / why we need it**:
Without this change we are not able to use client-go for updating `KubermaticSettings`. When value for `enable ShareCluster` is set to `false`, the client removes it from request body and it results in defaulting to `true` (as this is defined in OpenAPI) before persisting in etcd.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubermatic/dashboard/issues/6329

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:
This change require updating KKP API's code.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
