### PR TITLE
update list of k8s versions on EKS

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -474,16 +474,16 @@ spec:
           - v1.25
       eks:
         # Default is the default version to offer users.
-        default: v1.27
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.28
           - v1.27
           - v1.26
           - v1.25
           - v1.24
-          - v1.23
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -474,16 +474,16 @@ spec:
           - v1.25
       eks:
         # Default is the default version to offer users.
-        default: v1.27
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.28
           - v1.27
           - v1.26
           - v1.25
           - v1.24
-          - v1.23
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -320,13 +320,13 @@ var (
 	eksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-		Default: semver.NewSemverOrDie("v1.27"),
+		Default: semver.NewSemverOrDie("v1.28"),
 		Versions: []semver.Semver{
+			newSemver("v1.28"),
 			newSemver("v1.27"),
 			newSemver("v1.26"),
 			newSemver("v1.25"),
 			newSemver("v1.24"),
-			newSemver("v1.23"),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds 1.28 and removes 1.23 (1.23 is only on extended support on EKS side) to the EKS versions.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add Kubernetes 1.28 to EKS versions, remove Kubernetes 1.23
```

**Documentation**:
```documentation
NONE
```
