### PR TITLE
Extend project-synchronizer to sync labels

### DIFF
--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -38,6 +38,11 @@ import (
 
 const projectName = "project-test"
 
+var projectLabels = map[string]string{
+	"test":        "project",
+	"description": "test",
+}
+
 func TestReconcile(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -49,10 +54,10 @@ func TestReconcile(t *testing.T) {
 		{
 			name:            "scenario 1: sync project from master cluster to seed cluster",
 			requestName:     projectName,
-			expectedProject: generateProject(projectName, false),
+			expectedProject: generateProject(projectName, false, nil),
 			masterClient: fake.
 				NewClientBuilder().
-				WithObjects(generateProject(projectName, false), generator.GenTestSeed()).
+				WithObjects(generateProject(projectName, false, nil), generator.GenTestSeed()).
 				Build(),
 			seedClient: fake.
 				NewClientBuilder().
@@ -64,11 +69,23 @@ func TestReconcile(t *testing.T) {
 			expectedProject: nil,
 			masterClient: fake.
 				NewClientBuilder().
-				WithObjects(generateProject(projectName, true), generator.GenTestSeed()).
+				WithObjects(generateProject(projectName, true, nil), generator.GenTestSeed()).
 				Build(),
 			seedClient: fake.
 				NewClientBuilder().
-				WithObjects(generateProject(projectName, false), generator.GenTestSeed()).
+				WithObjects(generateProject(projectName, false, nil), generator.GenTestSeed()).
+				Build(),
+		},
+		{
+			name:            "scenario 3: sync project with labels from master cluster to seed cluster",
+			requestName:     projectName,
+			expectedProject: generateProject(projectName, false, projectLabels),
+			masterClient: fake.
+				NewClientBuilder().
+				WithObjects(generateProject(projectName, false, projectLabels), generator.GenTestSeed()).
+				Build(),
+			seedClient: fake.
+				NewClientBuilder().
 				Build(),
 		},
 	}
@@ -113,10 +130,11 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func generateProject(name string, deleted bool) *kubermaticv1.Project {
+func generateProject(name string, deleted bool, labels map[string]string) *kubermaticv1.Project {
 	project := &kubermaticv1.Project{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: labels,
 		},
 		Spec: kubermaticv1.ProjectSpec{
 			Name: fmt.Sprintf("project-%s", name),

--- a/pkg/controller/master-controller-manager/project-synchronizer/resources.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/resources.go
@@ -24,6 +24,12 @@ import (
 func projectReconcilerFactory(project *kubermaticv1.Project) reconciling.NamedProjectReconcilerFactory {
 	return func() (string, reconciling.ProjectReconciler) {
 		return project.Name, func(p *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+			if p.ObjectMeta.Labels == nil {
+				p.ObjectMeta.Labels = map[string]string{}
+			}
+			for k, v := range project.ObjectMeta.Labels {
+				p.ObjectMeta.Labels[k] = v
+			}
 			p.Spec = project.Spec
 			return p, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

We observed that the metering report doesn't contain data for project-labels when master and seed clusters are separate. After some additional investigation, we found out that the reason for that is that we don't sync labels from Project objects in the master cluster to Project objects in the seed clusters. Metering uses the `kubermatic_project_labels` to determine Project labels, and the data source is per-seed Prometheus running in the `monitoring` namespace.

`kubermatic_project_labels` is exported by both `kubermatic-master-controller-manager` and `kubermatic-seed-controller-manager`, but because this Prometheus is per-seed, only data exported by `kubermatic-seed-controller-manager` is accessible. For that to work properly, we also need to have labels on Project copy in the seed cluster. 

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Extend project-synchronizer controller in kubermatic-master-controller-manager to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups
```

**Documentation**:
```documentation
NONE
```

/assign @xrstf @embik 