### PR TITLE
[release/v2.23] Extend project-synchronizer to sync labels

### DIFF
--- a/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/controller_test.go
@@ -44,6 +44,11 @@ func init() {
 
 const projectName = "project-test"
 
+var projectLabels = map[string]string{
+	"test":        "project",
+	"description": "test",
+}
+
 func TestReconcile(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -55,11 +60,11 @@ func TestReconcile(t *testing.T) {
 		{
 			name:            "scenario 1: sync project from master cluster to seed cluster",
 			requestName:     projectName,
-			expectedProject: generateProject(projectName, false),
+			expectedProject: generateProject(projectName, false, nil),
 			masterClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
-				WithObjects(generateProject(projectName, false), generator.GenTestSeed()).
+				WithObjects(generateProject(projectName, false, nil), generator.GenTestSeed()).
 				Build(),
 			seedClient: fakectrlruntimeclient.
 				NewClientBuilder().
@@ -73,12 +78,27 @@ func TestReconcile(t *testing.T) {
 			masterClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
-				WithObjects(generateProject(projectName, true), generator.GenTestSeed()).
+				WithObjects(generateProject(projectName, true, nil), generator.GenTestSeed()).
 				Build(),
 			seedClient: fakectrlruntimeclient.
 				NewClientBuilder().
 				WithScheme(scheme.Scheme).
-				WithObjects(generateProject(projectName, false), generator.GenTestSeed()).
+				WithObjects(generateProject(projectName, false, nil), generator.GenTestSeed()).
+				Build(),
+		},
+		{
+			name:            "scenario 3: sync project with labels from master cluster to seed cluster",
+			requestName:     projectName,
+			expectedProject: nil,
+			masterClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, true, projectLabels), generator.GenTestSeed()).
+				Build(),
+			seedClient: fakectrlruntimeclient.
+				NewClientBuilder().
+				WithScheme(scheme.Scheme).
+				WithObjects(generateProject(projectName, false, projectLabels), generator.GenTestSeed()).
 				Build(),
 		},
 	}
@@ -123,10 +143,11 @@ func TestReconcile(t *testing.T) {
 	}
 }
 
-func generateProject(name string, deleted bool) *kubermaticv1.Project {
+func generateProject(name string, deleted bool, labels map[string]string) *kubermaticv1.Project {
 	project := &kubermaticv1.Project{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			Name:   name,
+			Labels: labels,
 		},
 		Spec: kubermaticv1.ProjectSpec{
 			Name: fmt.Sprintf("project-%s", name),

--- a/pkg/controller/master-controller-manager/project-synchronizer/resources.go
+++ b/pkg/controller/master-controller-manager/project-synchronizer/resources.go
@@ -24,6 +24,12 @@ import (
 func projectReconcilerFactory(project *kubermaticv1.Project) reconciling.NamedProjectReconcilerFactory {
 	return func() (string, reconciling.ProjectReconciler) {
 		return project.Name, func(p *kubermaticv1.Project) (*kubermaticv1.Project, error) {
+			if p.ObjectMeta.Labels == nil {
+				p.ObjectMeta.Labels = map[string]string{}
+			}
+			for k, v := range project.ObjectMeta.Labels {
+				p.ObjectMeta.Labels[k] = v
+			}
 			p.Spec = project.Spec
 			return p, nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual cherry-pick of #12791 to the `release/v2.23` branch

**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Extend project-synchronizer controller in kubermatic-master-controller-manager to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups
```

**Documentation**:
```documentation
NONE
```

/assign @xrstf 