### PR TITLE
[release/v2.23] Fix invalid YAML for charts/mla/minio values

### DIFF
--- a/charts/mla/minio/values.yaml
+++ b/charts/mla/minio/values.yaml
@@ -228,8 +228,8 @@ minio:
 
   ## Additional Annotations for the Kubernetes Batch (make-bucket-job)
   makeBucketJob:
-    podAnnotations:
-    annotations:
+    podAnnotations: {}
+    annotations: {}
     securityContext:
       enabled: false
       runAsUser: 1000
@@ -240,8 +240,8 @@ minio:
         memory: 128Mi
   ## Additional Annotations for the Kubernetes Batch (update-prometheus-secret)
   updatePrometheusJob:
-    podAnnotations:
-    annotations:
+    podAnnotations: {}
+    annotations: {}
     securityContext:
       enabled: false
       runAsUser: 1000
@@ -298,9 +298,6 @@ minio:
   ## and 'name' is left unspecified, the account 'default' will be used.
   serviceAccount:
     create: true
-    ## The name of the service account to use. If 'create' is 'true', a service account with that name
-    ## will be created. Otherwise, a name will be auto-generated.
-    name:
   metrics:
     # Metrics can not be disabled yet: https://github.com/minio/minio/issues/7493
     serviceMonitor:


### PR DESCRIPTION
**What this PR does / why we need it**:

Helm 3.13 has become more picky about Chart values and doesn't accept invalid YAML anymore. We had some bad YAML in `charts/mla/minio` that was flying under the radar so far. This is partial "backport" of #12697, which was a mistake in hindsight.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12804

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix Helm 3.13 failing to install the MLA Minio chart due to "resource name may not be empty" error
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
