### PR TITLE
Migrate vSphere `CSIDriver` resource on upgrade to match upstream

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -70,6 +70,8 @@ const (
 	migratedVsphereCSIAddon   = "kubermatic.k8c.io/migrated-vsphere-csi-addon"
 	csiAddonStorageClassLabel = "kubermatic-addon=csi"
 	CSIAddonName              = "csi"
+
+	yes = "yes"
 )
 
 // KubeconfigProvider provides functionality to get a clusters admin kubeconfig.
@@ -593,7 +595,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 	if addon.Name == "csi" {
 		if cluster.Spec.Cloud.Hetzner != nil &&
 			cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
-			cluster.Annotations[migratedHetznerCSIAddon] != "yes" {
+			cluster.Annotations[migratedHetznerCSIAddon] != yes {
 			// Between v2.22 and v2.23, there was a change to hetzner CSI driver immutable field fsGroupPolicy
 			// as a result, the CSDriver resource has to be redeployed
 			// https://github.com/kubermatic/kubermatic/issues/12429
@@ -603,24 +605,23 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 			if cluster.Annotations == nil {
 				cluster.Annotations = make(map[string]string)
 			}
-			cluster.Annotations[migratedHetznerCSIAddon] = "yes"
+			cluster.Annotations[migratedHetznerCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
 				log.Errorf("failed to set %q cluster annotation: %w", migratedHetznerCSIAddon, err)
 			}
 		} else if cluster.Spec.Cloud.VSphere != nil &&
 			cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
-			cluster.Annotations[migratedVsphereCSIAddon] != "yes" {
+			cluster.Annotations[migratedVsphereCSIAddon] != yes {
 			if err := r.migrateVsphereCSIDriver(ctx, log, cluster); err != nil {
 				return fmt.Errorf("failed to migrate CSI Driver: %w", err)
 			}
 			if cluster.Annotations == nil {
 				cluster.Annotations = make(map[string]string)
 			}
-			cluster.Annotations[migratedVsphereCSIAddon] = "yes"
+			cluster.Annotations[migratedVsphereCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
 				log.Errorf("failed to set %q cluster annotation: %w", migratedVsphereCSIAddon, err)
 			}
-
 		}
 	}
 

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -67,6 +67,7 @@ const (
 	cleanupFinalizerName      = "cleanup-manifests"
 	addonEnsureLabelKey       = "addons.kubermatic.io/ensure"
 	migratedHetznerCSIAddon   = "kubermatic.k8c.io/migrated-hetzner-csi-addon"
+	migratedVsphereCSIAddon   = "kubermatic.k8c.io/migrated-vsphere-csi-addon"
 	csiAddonStorageClassLabel = "kubermatic-addon=csi"
 	CSIAddonName              = "csi"
 )
@@ -540,6 +541,31 @@ func (r *Reconciler) migrateHetznerCSIDriver(ctx context.Context, log *zap.Sugar
 	return nil
 }
 
+// Between v2.23 and v2.24, there was a change to the vSphere CSI driver immutable field volumeLifecycleModes
+// as a result, the CSDriver resource has to be redeployed
+// https://github.com/kubermatic/kubermatic/issues/12801
+func (r *Reconciler) migrateVsphereCSIDriver(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
+	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to get kube client: %w", err)
+	}
+
+	driver := &storagev1.CSIDriver{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "csi.vsphere.vmware.com"}, driver); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get CSIDriver: %w", err)
+	}
+
+	if len(driver.Spec.VolumeLifecycleModes) > 1 || (len(driver.Spec.VolumeLifecycleModes) == 1 && driver.Spec.VolumeLifecycleModes[0] != storagev1.VolumeLifecyclePersistent) {
+		log.Debug("deleting hetzner CSIDriver to allow upgrade")
+		if err := cl.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete old CSIDriver: %w", err)
+		}
+	}
+	return nil
+}
+
 func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) error {
 	kubeconfigFilename, manifestFilename, done, err := r.setupManifestInteraction(ctx, log, addon, cluster)
 	if err != nil {
@@ -564,22 +590,37 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 		return fmt.Errorf("failed to create command: %w", err)
 	}
 
-	if addon.Name == "csi" &&
-		cluster.Spec.Cloud.Hetzner != nil &&
-		cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
-		cluster.Annotations[migratedHetznerCSIAddon] != "yes" {
-		// Between v2.22 and v2.23, there was a change to hetzner CSI driver immutable field fsGroupPolicy
-		// as a result, the CSDriver resource has to be redeployed
-		// https://github.com/kubermatic/kubermatic/issues/12429
-		if err := r.migrateHetznerCSIDriver(ctx, log, cluster); err != nil {
-			return fmt.Errorf("failed to migrate CSI Driver: %w", err)
-		}
-		if cluster.Annotations == nil {
-			cluster.Annotations = make(map[string]string)
-		}
-		cluster.Annotations[migratedHetznerCSIAddon] = "yes"
-		if err := r.Update(ctx, cluster); err != nil {
-			log.Errorf("failed to set %q cluster annotation: %w", migratedHetznerCSIAddon, err)
+	if addon.Name == "csi" {
+		if cluster.Spec.Cloud.Hetzner != nil &&
+			cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
+			cluster.Annotations[migratedHetznerCSIAddon] != "yes" {
+			// Between v2.22 and v2.23, there was a change to hetzner CSI driver immutable field fsGroupPolicy
+			// as a result, the CSDriver resource has to be redeployed
+			// https://github.com/kubermatic/kubermatic/issues/12429
+			if err := r.migrateHetznerCSIDriver(ctx, log, cluster); err != nil {
+				return fmt.Errorf("failed to migrate CSI Driver: %w", err)
+			}
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+			cluster.Annotations[migratedHetznerCSIAddon] = "yes"
+			if err := r.Update(ctx, cluster); err != nil {
+				log.Errorf("failed to set %q cluster annotation: %w", migratedHetznerCSIAddon, err)
+			}
+		} else if cluster.Spec.Cloud.VSphere != nil &&
+			cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
+			cluster.Annotations[migratedVsphereCSIAddon] != "yes" {
+			if err := r.migrateVsphereCSIDriver(ctx, log, cluster); err != nil {
+				return fmt.Errorf("failed to migrate CSI Driver: %w", err)
+			}
+			if cluster.Annotations == nil {
+				cluster.Annotations = make(map[string]string)
+			}
+			cluster.Annotations[migratedVsphereCSIAddon] = "yes"
+			if err := r.Update(ctx, cluster); err != nil {
+				log.Errorf("failed to set %q cluster annotation: %w", migratedVsphereCSIAddon, err)
+			}
+
 		}
 	}
 

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -607,7 +607,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 			}
 			cluster.Annotations[migratedHetznerCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
-				log.Errorf("failed to set %q cluster annotation: %w", migratedHetznerCSIAddon, err)
+				log.Errorw("failed to set %q cluster annotation: %w", migratedHetznerCSIAddon, err)
 			}
 		} else if cluster.Spec.Cloud.VSphere != nil &&
 			cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
@@ -620,7 +620,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 			}
 			cluster.Annotations[migratedVsphereCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
-				log.Errorf("failed to set %q cluster annotation: %w", migratedVsphereCSIAddon, err)
+				log.Errorw("failed to set %q cluster annotation: %w", migratedVsphereCSIAddon, err)
 			}
 		}
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -607,7 +607,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 			}
 			cluster.Annotations[migratedHetznerCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
-				log.Errorw("failed to set cluster annotation", zap.Error(err), "cluster", cluster.Name, "annotation", migratedHetznerCSIAddon)
+				log.Errorw("failed to set cluster annotation", zap.Error(err), "annotation", migratedHetznerCSIAddon)
 			}
 		} else if cluster.Spec.Cloud.VSphere != nil &&
 			cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
@@ -620,7 +620,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 			}
 			cluster.Annotations[migratedVsphereCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
-				log.Errorw("failed to set cluster annotation", zap.Error(err), "cluster", cluster.Name, "annotation", migratedVsphereCSIAddon)
+				log.Errorw("failed to set cluster annotation", zap.Error(err), "annotation", migratedVsphereCSIAddon)
 			}
 		}
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -607,7 +607,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 			}
 			cluster.Annotations[migratedHetznerCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
-				log.Errorw("failed to set %q cluster annotation: %w", migratedHetznerCSIAddon, err)
+				log.Errorw("failed to set cluster annotation", zap.Error(err), "cluster", cluster.Name, "annotation", migratedHetznerCSIAddon)
 			}
 		} else if cluster.Spec.Cloud.VSphere != nil &&
 			cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] &&
@@ -620,7 +620,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 			}
 			cluster.Annotations[migratedVsphereCSIAddon] = yes
 			if err := r.Update(ctx, cluster); err != nil {
-				log.Errorw("failed to set %q cluster annotation: %w", migratedVsphereCSIAddon, err)
+				log.Errorw("failed to set cluster annotation", zap.Error(err), "cluster", cluster.Name, "annotation", migratedVsphereCSIAddon)
 			}
 		}
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -558,7 +558,7 @@ func (r *Reconciler) migrateVsphereCSIDriver(ctx context.Context, log *zap.Sugar
 	}
 
 	if len(driver.Spec.VolumeLifecycleModes) > 1 || (len(driver.Spec.VolumeLifecycleModes) == 1 && driver.Spec.VolumeLifecycleModes[0] != storagev1.VolumeLifecyclePersistent) {
-		log.Debug("deleting hetzner CSIDriver to allow upgrade")
+		log.Debug("deleting vSphere CSIDriver to allow upgrade")
 		if err := cl.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete old CSIDriver: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Settle down kids because this story might take a while.

Long back, #7280 added support for vSphere external CCM and CSI driver. CSI support was based on the 2.2.1 release of [vsphere-csi-driver](https://github.com/kubernetes-sigs/vsphere-csi-driver). For some reason that has been lost to history and the unwillingness to write proper PR descriptions, the original PR set `volumeLifecycleModes` on the `CSIDriver` resource. This was not set in the [corresponding upstream manifests](https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/release-2.2/manifests/v2.2.1/deploy/vsphere-csi-controller-deployment.yaml#L189) for v2.2.1, and I cannot find any meaningful references to `volumeLifecycleModes` in the upstream or k8c issue trackers.

We have run into this exact problem (as described in #12801) once already: #8769 reverted settings to ensure that the `CSIDriver` object could be reconciled. I also don't see any reason _why_ this needs to be set in those PRs, I suspect it was done simply because of the exact same error this PR is now trying to solve permanently.

#12593 then upgraded the CSI driver to 3.0, and removed the `volumeLifecycleModes` settings from the `CSIDriver` _again_ because the change was not documented and not matching upstream manifests.

I've done some additional research and believe that the CSI driver [does not support ephemeral volumes](https://github.com/kubernetes-sigs/vsphere-csi-driver/issues/20#issuecomment-663282318) (which is indicated by `Ephemeral` in `volumeLifecycleModes`), so the old `CSIDriver` object is incorrect.

This PR adapts logic implemented in #12432 to also clean up the vSphere `CSIDriver` object to allow redeployment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12801

**What type of PR is this?**
/kind bug
/kind regression
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Migrate `CSIDriver` `csi.vsphere.vmware.com` to no longer advertise inline ephemeral volumes as supported
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
