### PR TITLE
charts/mla/grafana: use correct `job=node-exporter` label on CPU queries

### DIFF
--- a/charts/mla/grafana/files/kkp-kubernetes-nodes-overview.json
+++ b/charts/mla/grafana/files/kkp-kubernetes-nodes-overview.json
@@ -79,7 +79,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{ node_name }}",
@@ -188,7 +188,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "avg (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+          "expr": "avg (100 - (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
           "format": "time_series",
           "intervalFactor": 2,
           "refId": "A"

--- a/charts/mla/grafana/test/config.yaml.out
+++ b/charts/mla/grafana/test/config.yaml.out
@@ -193,7 +193,7 @@ data:
               "datasource": {
                 "uid": "$datasource"
               },
-              "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ node_name }}",
@@ -302,7 +302,7 @@ data:
               "datasource": {
                 "uid": "$datasource"
               },
-              "expr": "avg (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg (100 - (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"

--- a/charts/mla/grafana/test/default.yaml.out
+++ b/charts/mla/grafana/test/default.yaml.out
@@ -193,7 +193,7 @@ data:
               "datasource": {
                 "uid": "$datasource"
               },
-              "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg by (node_name) (100 - (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{ node_name }}",
@@ -302,7 +302,7 @@ data:
               "datasource": {
                 "uid": "$datasource"
               },
-              "expr": "avg (100 - (rate(node_cpu_seconds_total{app=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
+              "expr": "avg (100 - (rate(node_cpu_seconds_total{job=\"node-exporter\", mode=\"idle\", node_name=~\"$nodes\"}[2m]) * 100))",
               "format": "time_series",
               "intervalFactor": 2,
               "refId": "A"


### PR DESCRIPTION
**What this PR does / why we need it**:

Discovered this on QA, should be easily reproducible. All other queries in this dashboard use `job=node-exporter`, but this one uses `app=node-exporter`, which ends up resulting in no data.

Graph in question:

<img width="1349" alt="Screenshot 2023-11-03 at 15 24 57" src="https://github.com/kubermatic/kubermatic/assets/10295525/e9300bf3-5598-48ef-b2dd-dde0be5fc1eb">


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview"
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
