### PR TITLE
Use regex for hostnames in seed MLA dashboard "Resource Usage per Namespace"

### DIFF
--- a/charts/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
+++ b/charts/monitoring/grafana/dashboards/kubernetes/node-namespaces.json
@@ -159,7 +159,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=\"$hostname\",job=\"cadvisor\",container!=\"\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
+          "expr": "sum by (namespace) (container_memory_rss{kubernetes_io_hostname=~\"$hostname\",job=\"cadvisor\",container!=\"\",namespace!=\"\",namespace!~\"^$exclude.*\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ namespace }}",
@@ -169,7 +169,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "node_memory_MemTotal_bytes{node_name=\"$hostname\"}",
+          "expr": "node_memory_MemTotal_bytes{node_name=~\"$hostname\"}",
           "format": "time_series",
           "hide": false,
           "intervalFactor": 10,
@@ -295,7 +295,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "sum by (kubernetes_io_hostname, namespace) (rate(container_cpu_usage_seconds_total{kubernetes_io_hostname=\"$hostname\",job=\"cadvisor\",namespace!=\"\",namespace!~\"$exclude\",namespace!~\"^$exclude.*\"}[5m]))",
+          "expr": "sum by (kubernetes_io_hostname, namespace) (rate(container_cpu_usage_seconds_total{kubernetes_io_hostname=~\"$hostname\",job=\"cadvisor\",namespace!=\"\",namespace!~\"$exclude\",namespace!~\"^$exclude.*\"}[5m]))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ namespace }}",


### PR DESCRIPTION
**What this PR does / why we need it**:
The "Resource Usage per Namespace" dashboard in our Seed MLA stack supports selecting multiple hosts (and defaults to the "all" option). Some queries were not using the `$hostname` variable as regex, and were therefore failing for every selection except a single host.

This was initially reported to us in INC-6148.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix empty panels in Grafana dashboard "Resource Usage per Namespace" for Master/Seed MLA
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
