### PR TITLE
bump metering to v1.1.1

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	meteringName    = "metering"
-	meteringVersion = "v1.1.0"
+	meteringVersion = "v1.1.1"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings us https://github.com/kubermatic/metering/pull/170, which is urgently needed to fix the reports.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
ACTION REQUIRED: Update metering component to v1.1.1, fixing wildly inaccurate data in cluster reports.
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/1560
```
