### PR TITLE
[release/v2.22] bump metering to v1.0.5

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -56,7 +56,7 @@ const (
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {
-	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.4"))
+	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.5"))
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a spiritual backport of #12822.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
ACTION REQUIRED: Update metering component to v1.0.5, fixing wildly inaccurate data in cluster reports.
```

**Documentation**:
```documentation
NONE
```
