### PR TITLE
Update machine-controller to v1.58.0

### DIFF
--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -54,7 +54,7 @@ var (
 
 const (
 	Name = "machine-controller"
-	Tag  = "34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421"
+	Tag  = "v1.58.0"
 )
 
 type machinecontrollerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -72,7 +72,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -75,7 +75,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -78,7 +78,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -81,7 +81,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -58,7 +58,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -61,7 +61,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -63,7 +63,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -66,7 +66,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -99,7 +99,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -86,7 +86,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -89,7 +89,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -70,7 +70,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -73,7 +73,7 @@ spec:
               fieldPath: metadata.namespace
         - name: PROBER_KUBECONFIG
           value: /etc/kubernetes/kubeconfig/kubeconfig
-        image: quay.io/kubermatic/machine-controller:34c7d12cae1b6ab595fd3a7c55109f6c4f9eb421
+        image: quay.io/kubermatic/machine-controller:v1.58.0
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates machine-controller to [v1.58.0](https://github.com/kubermatic/machine-controller/releases/tag/v1.58.0).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update machine-controller to [v1.58.0](https://github.com/kubermatic/machine-controller/releases/tag/v1.58.0)
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
