### PR TITLE
Properly format components table generated from `hack/ci/update-docs.sh`

### DIFF
--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -66,7 +66,7 @@ make runbook
 hack/render-crds.sh
 
 # update components page
-components_file=content/kubermatic/main/architecture/compatibility/KKP-components-versioning/_index.en.md
+components_file=content/kubermatic/main/architecture/compatibility/kkp-components-versioning/_index.en.md
 cat > ${components_file} << EOT
 +++
 title = "KKP Components"

--- a/hack/ci/update-docs.sh
+++ b/hack/ci/update-docs.sh
@@ -22,6 +22,10 @@ set -euo pipefail
 cd $(dirname $0)/../..
 source hack/lib.sh
 
+line() {
+  printf "| %-30s | %-30s |\n" "$1" "$2"
+}
+
 TARGET_DIR=docs_sync
 REVISION=$(git rev-parse --short HEAD)
 
@@ -76,8 +80,8 @@ weight = 2
 The following list is only applicable for the KKP version that is currently available. Kubermatic has a strong emphasis on security and reliability
 of provided software and therefore releases updates regularly that also include component updates.
 
-| KKP Components                | Version                      |
-| ----------------------------- | ---------------------------- |
+| KKP Components                 | Version                        |
+| ------------------------------ | ------------------------------ |
 EOT
 
 # iterate over all charts to extract version information
@@ -87,7 +91,7 @@ for filepath in $(find ../charts -name Chart.yaml | sort); do
   # read appVersion from Chart.yaml and normalize version format by removing a "v" prefix
   app_version=$(yq '.appVersion' ${filepath} | sed -e 's/^v//g')
   # append information to components markdown file
-  echo "| ${chart_name} | ${app_version} |" >> ${components_file}
+  line ${chart_name} ${app_version} >> ${components_file}
 done
 
 # update repo


### PR DESCRIPTION
**What this PR does / why we need it**:
This copies logic from https://github.com/kubermatic/docs/blob/master/hack/prepare-release.sh to properly format the automatically generated components table.

Also addresses a filename issue introduced by https://github.com/kubermatic/docs/pull/1564.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
