### PR TITLE
fix: Add exclusions to immutable values validation in Cilium

### DIFF
--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -149,7 +149,6 @@ func TestValidateCiliumValuesUpdate(t *testing.T) {
 			testValuesModifier: func(values map[string]any) {
 				o := values["cni"].(map[string]any)
 				o["chainingMode"] = "portmap"
-
 			},
 			expectedError: "[]",
 		},
@@ -159,7 +158,6 @@ func TestValidateCiliumValuesUpdate(t *testing.T) {
 				ipam := values["ipam"].(map[string]any)
 				op := ipam["operator"].(map[string]any)
 				op["clusterPoolIPv4PodCIDR"] = "192.168.0.0/24"
-
 			},
 			expectedError: "[]",
 		},
@@ -169,7 +167,6 @@ func TestValidateCiliumValuesUpdate(t *testing.T) {
 				ipam := values["ipam"].(map[string]any)
 				op := ipam["operator"].(map[string]any)
 				op["clusterPoolIPv4PodCIDRList"] = []string{"192.168.0.0/24"}
-
 			},
 			expectedError: "[spec.values.ipam: Invalid value: map[string]interface {}{\"operator\":map[string]interface {}{\"clusterPoolIPv4MaskSize\":\"16\", \"clusterPoolIPv4PodCIDRList\":[]string{\"192.168.0.0/24\"}}}: value is immutable]",
 		},

--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -148,7 +148,7 @@ func TestValidateCiliumValuesUpdate(t *testing.T) {
 			name: "cni excluded field introduced under immutable value",
 			testValuesModifier: func(values map[string]any) {
 				o := values["cni"].(map[string]any)
-				o["chainingMode"] = "portmap"
+				o["chainingMode"] = "test"
 			},
 			expectedError: "[]",
 		},
@@ -165,7 +165,7 @@ func TestValidateCiliumValuesUpdate(t *testing.T) {
 			name: "Modified multiple immutable nested value in ipam and one is excluded",
 			testValuesModifier: func(values map[string]any) {
 				cni := values["cni"].(map[string]any)
-				cni["chainingMode"] = "portmap"
+				cni["chainingMode"] = "test"
 				ipam := values["ipam"].(map[string]any)
 				op := ipam["operator"].(map[string]any)
 				op["clusterPoolIPv4PodCIDRList"] = []string{"192.168.0.0/24"}

--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -162,8 +162,10 @@ func TestValidateCiliumValuesUpdate(t *testing.T) {
 			expectedError: "[]",
 		},
 		{
-			name: "Modified immutable nested value in ipam",
+			name: "Modified multiple immutable nested value in ipam and one is excluded",
 			testValuesModifier: func(values map[string]any) {
+				cni := values["cni"].(map[string]any)
+				cni["chainingMode"] = "portmap"
 				ipam := values["ipam"].(map[string]any)
 				op := ipam["operator"].(map[string]any)
 				op["clusterPoolIPv4PodCIDRList"] = []string{"192.168.0.0/24"}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR allows for specifying allowlist for fields in immutable values validation webhook.
It will help to unblock Cilium upgrade scenarios, whenever:
- new setting was introduced in restricted values
- some of the settings were deprecated

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12802

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
