### PR TITLE
Add changelog for November 2023 patch releases

### DIFF
--- a/docs/changelogs/CHANGELOG-2.21.md
+++ b/docs/changelogs/CHANGELOG-2.21.md
@@ -15,6 +15,15 @@
 - [v2.21.12](#v22112)
 - [v2.21.13](#v22113)
 - [v2.21.14](#v22114)
+- [v2.21.15](#v22115)
+
+## [v2.21.15](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.15)
+
+With this release, support for KKP v2.21.x ceases. Please upgrade to a supported version of KKP in the near future.
+
+### Bugfixes
+
+- Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12794](https://github.com/kubermatic/kubermatic/pull/12794))
 
 ## [v2.21.14](https://github.com/kubermatic/kubermatic/releases/tag/v2.21.14)
 

--- a/docs/changelogs/CHANGELOG-2.22.md
+++ b/docs/changelogs/CHANGELOG-2.22.md
@@ -10,6 +10,19 @@
 - [v2.22.7](#v2227)
 - [v2.22.8](#v2228)
 - [v2.22.9](#v2229)
+- [v2.22.10](#v22210)
+
+## [v2.22.10](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.10)
+
+### Action Required
+
+- **ACTION REQUIRED (EE ONLY):** Update metering component to v1.0.5, fixing highly inaccurate data in cluster reports. Reports generated in KKP v2.23.2+ or v2.22.5+ do not represent actual consumption. Ad-hoc reports for time frames that need correct consumption data can be generated [by following our documentation](https://docs.kubermatic.com/kubermatic/v2.23/tutorials-howtos/metering/#custom-reports) ([#12824](https://github.com/kubermatic/kubermatic/pull/12824))
+
+### Bugfixes
+
+- Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12793](https://github.com/kubermatic/kubermatic/pull/12793))
+- Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview" ([#12817](https://github.com/kubermatic/kubermatic/pull/12817))
+- Fix Helm 3.13 failing to install the MLA Minio chart due to "resource name may not be empty" error ([#12806](https://github.com/kubermatic/kubermatic/pull/12806))
 
 ## [v2.22.9](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.9)
 

--- a/docs/changelogs/CHANGELOG-2.22.md
+++ b/docs/changelogs/CHANGELOG-2.22.md
@@ -22,6 +22,7 @@
 
 - Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12793](https://github.com/kubermatic/kubermatic/pull/12793))
 - Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview" ([#12817](https://github.com/kubermatic/kubermatic/pull/12817))
+- Fix empty panels in Grafana dashboard "Resource Usage per Namespace" for Master/Seed MLA ([#12833](https://github.com/kubermatic/kubermatic/pull/12833))
 - Fix Helm 3.13 failing to install the MLA Minio chart due to "resource name may not be empty" error ([#12806](https://github.com/kubermatic/kubermatic/pull/12806))
 
 ## [v2.22.9](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.9)

--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -7,6 +7,19 @@
 - [v2.23.4](#v2234)
 - [v2.23.5](#v2235)
 - [v2.23.6](#v2236)
+- [v2.23.7](#v2237)
+
+## [v2.23.7](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.7)
+
+### Action Required
+
+- **ACTION REQUIRED (EE ONLY):** Update metering component to v1.0.5, fixing highly inaccurate data in cluster reports. Reports generated in KKP v2.23.2+ or v2.22.5+ do not represent actual consumption. Ad-hoc reports for time frames that need correct consumption data can be generated [by following our documentation](https://docs.kubermatic.com/kubermatic/v2.23/tutorials-howtos/metering/#custom-reports) ([#12823](https://github.com/kubermatic/kubermatic/pull/12823))
+
+### Bugfixes
+
+- Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12792](https://github.com/kubermatic/kubermatic/pull/12792))
+- Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview" ([#12814](https://github.com/kubermatic/kubermatic/pull/12814))
+- Fix Helm 3.13 failing to install the MLA Minio chart due to "resource name may not be empty" error ([#12806](https://github.com/kubermatic/kubermatic/pull/12806))
 
 ## [v2.23.6](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.6)
 

--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -19,6 +19,7 @@
 
 - Extend project-synchronizer controller in `kubermatic-master-controller-manager` to propagate labels from Projects in the master cluster to Projects in the seed cluster. This fixes an issue where the metering report doesn't contain project-labels in separate master/seed setups ([#12792](https://github.com/kubermatic/kubermatic/pull/12792))
 - Fix CPU Utilization graph showing no data for User Cluster MLA dashboard "Nodes Overview" ([#12814](https://github.com/kubermatic/kubermatic/pull/12814))
+- Fix empty panels in Grafana dashboard "Resource Usage per Namespace" for Master/Seed MLA ([#12816](https://github.com/kubermatic/kubermatic/pull/12816))
 - Fix Helm 3.13 failing to install the MLA Minio chart due to "resource name may not be empty" error ([#12806](https://github.com/kubermatic/kubermatic/pull/12806))
 
 ## [v2.23.6](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.6)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds changelogs for v2.23.7, v2.22.10 and v2.21.15. It also adds a note marking v2.21.15 as the last release of that series.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
