### PR TITLE
Remove deprecated setting in cilium application

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -370,6 +370,9 @@ func validateImmutableValues(newValues, oldValues map[string]any, fieldPath *fie
 				if excludedKeyExists(newValues, strings.Split(exclusion, ".")...) {
 					allowedValues[v] = true
 				}
+				if excludedKeyExists(oldValues, strings.Split(exclusion, ".")...) {
+					allowedValues[v] = true
+				}
 			}
 		}
 		if fmt.Sprint(oldValues[v]) != fmt.Sprint(newValues[v]) && !allowedValues[v] {

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -275,6 +275,7 @@ func GetAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 	}
 
 	ipamOperator := map[string]any{
+		"clusterPoolIPv4PodCIDR":     "",
 		"clusterPoolIPv4PodCIDRList": cluster.Spec.ClusterNetwork.Pods.GetIPv4CIDRs(),
 		"clusterPoolIPv4MaskSize":    fmt.Sprintf("%d", *cluster.Spec.ClusterNetwork.NodeCIDRMaskSizeIPv4),
 	}

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -275,7 +275,6 @@ func GetAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 	}
 
 	ipamOperator := map[string]any{
-		"clusterPoolIPv4PodCIDR":     "",
 		"clusterPoolIPv4PodCIDRList": cluster.Spec.ClusterNetwork.Pods.GetIPv4CIDRs(),
 		"clusterPoolIPv4MaskSize":    fmt.Sprintf("%d", *cluster.Spec.ClusterNetwork.NodeCIDRMaskSizeIPv4),
 	}

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -220,7 +220,7 @@ func (r *Reconciler) reconcile(ctx context.Context, logger *zap.SugaredLogger, c
 	}
 
 	// Ensure ApplicationInstallation of the CNI
-	if err := r.ensreCNIApplicationInstallation(ctx, cluster, initialValues); err != nil {
+	if err := r.ensureCNIApplicationInstallation(ctx, cluster, initialValues); err != nil {
 		return &reconcile.Result{}, err
 	}
 
@@ -309,7 +309,7 @@ func (r *Reconciler) parseAppDefDefaultValues(ctx context.Context, cluster *kube
 	return nil
 }
 
-func (r *Reconciler) ensreCNIApplicationInstallation(ctx context.Context, cluster *kubermaticv1.Cluster, initialValues map[string]any) error {
+func (r *Reconciler) ensureCNIApplicationInstallation(ctx context.Context, cluster *kubermaticv1.Cluster, initialValues map[string]any) error {
 	userClusterClient, err := r.userClusterConnectionProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get user cluster client: %w", err)
@@ -367,6 +367,12 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 			overrideValues := getCNIOverrideValues(cluster, overwriteRegistry)
 			if err := mergo.Merge(&values, overrideValues, mergo.WithOverride); err != nil {
 				return app, fmt.Errorf("failed to merge CNI values: %w", err)
+			}
+
+			if cluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCilium {
+				ipam := values["ipam"].(map[string]any)
+				operator := ipam["operator"].(map[string]any)
+				delete(operator, "clusterPoolIPv4PodCIDR")
 			}
 
 			// Set new values

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -151,7 +151,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		log.Debugw("Cluster is queued for deletion; skipping")
 		return reconcile.Result{}, nil
 	}
-
 	// Add a wrapping here, so we can emit an event on error
 	result, err := kubermaticv1helper.ClusterReconcileWrapper(
 		ctx,
@@ -369,6 +368,7 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 				return app, fmt.Errorf("failed to merge CNI values: %w", err)
 			}
 
+			// Remove deprecated value from older installations
 			if cluster.Spec.CNIPlugin.Type == kubermaticv1.CNIPluginTypeCilium {
 				ipam := values["ipam"].(map[string]any)
 				operator := ipam["operator"].(map[string]any)


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove deprecated `clusterPoolIPv4PodCIDR` field leftover during upgrade.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12840

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
