### PR TITLE
Make metering retention configurable

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -238,7 +238,6 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 			Metering: &kubermaticv1.MeteringConfiguration{
 				Enabled:          false,
 				StorageClassName: "kubermatic-fast",
-				StorageSize:      "100Gi",
 				ReportConfigurations: map[string]*kubermaticv1.MeteringReportConfiguration{
 					"weekly": {
 						Schedule: "0 1 * * 6",

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -504,9 +504,12 @@ spec:
         schedule: 0 1 * * 6
         # Types of reports to generate. Available report types are cluster and namespace. By default, all types of reports are generated.
         type: null
-    # StorageClassName is the name of the storage class that the metering prometheus instance uses to store metric data for reporting.
+    # RetentionDays is the number of days for which data should be kept in Prometheus. Default value is 90.
+    retentionDays: 90
+    # StorageClassName is the name of the storage class that the metering Prometheus instance uses to store metric data for reporting.
     storageClassName: kubermatic-fast
-    # StorageSize is the size of the storage class. Default value is 100Gi.
+    # StorageSize is the size of the storage class. Default value is 100Gi. Changing this value requires
+    # manual deletion of the existing Prometheus PVC (and thereby removing all metering data).
     storageSize: 100Gi
   # Optional: MLA allows configuring seed level MLA (Monitoring, Logging & Alerting) stack settings.
   mla:

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -510,9 +510,12 @@ spec:
         schedule: 0 1 * * 6
         # Types of reports to generate. Available report types are cluster and namespace. By default, all types of reports are generated.
         type: null
-    # StorageClassName is the name of the storage class that the metering prometheus instance uses to store metric data for reporting.
+    # RetentionDays is the number of days for which data should be kept in Prometheus. Default value is 90.
+    retentionDays: 90
+    # StorageClassName is the name of the storage class that the metering Prometheus instance uses to store metric data for reporting.
     storageClassName: kubermatic-fast
-    # StorageSize is the size of the storage class. Default value is 100Gi.
+    # StorageSize is the size of the storage class. Default value is 100Gi. Changing this value requires
+    # manual deletion of the existing Prometheus PVC (and thereby removing all metering data).
     storageSize: 100Gi
   # Optional: MLA allows configuring seed level MLA (Monitoring, Logging & Alerting) stack settings.
   mla:

--- a/hack/ci/testdata/seed.yaml
+++ b/hack/ci/testdata/seed.yaml
@@ -40,7 +40,7 @@ spec:
         interval: 7
         schedule: 0 1 * * 6
     storageClassName: standard
-    storageSize: 75Gi
+    storageSize: 5Gi
   datacenters:
     byo-kubernetes:
       location: Frankfurt

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -903,10 +903,13 @@ type SeedMLASettings struct {
 type MeteringConfiguration struct {
 	Enabled bool `json:"enabled"`
 
-	// StorageClassName is the name of the storage class that the metering prometheus instance uses to store metric data for reporting.
+	// StorageClassName is the name of the storage class that the metering Prometheus instance uses to store metric data for reporting.
 	StorageClassName string `json:"storageClassName"`
-	// StorageSize is the size of the storage class. Default value is 100Gi.
-	StorageSize string `json:"storageSize"`
+	// StorageSize is the size of the storage class. Default value is 100Gi. Changing this value requires
+	// manual deletion of the existing Prometheus PVC (and thereby removing all metering data).
+	StorageSize string `json:"storageSize,omitempty"`
+	// RetentionDays is the number of days for which data should be kept in Prometheus. Default value is 90.
+	RetentionDays int `json:"retentionDays,omitempty"`
 
 	// +kubebuilder:default:={weekly: {schedule: "0 1 * * 6", interval: 7}}
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -1511,16 +1511,18 @@ spec:
                           schedule: 0 1 * * 6
                       description: ReportConfigurations is a map of report configuration definitions.
                       type: object
+                    retentionDays:
+                      description: RetentionDays is the number of days for which data should be kept in Prometheus. Default value is 90.
+                      type: integer
                     storageClassName:
-                      description: StorageClassName is the name of the storage class that the metering prometheus instance uses to store metric data for reporting.
+                      description: StorageClassName is the name of the storage class that the metering Prometheus instance uses to store metric data for reporting.
                       type: string
                     storageSize:
-                      description: StorageSize is the size of the storage class. Default value is 100Gi.
+                      description: StorageSize is the size of the storage class. Default value is 100Gi. Changing this value requires manual deletion of the existing Prometheus PVC (and thereby removing all metering data).
                       type: string
                   required:
                     - enabled
                     - storageClassName
-                    - storageSize
                   type: object
                 mla:
                   description: 'Optional: MLA allows configuring seed level MLA (Monitoring, Logging & Alerting) stack settings.'

--- a/pkg/defaulting/seed.go
+++ b/pkg/defaulting/seed.go
@@ -27,8 +27,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-// DefaultBackupInterval defines the default interval used to create backups.
-const DefaultBackupInterval = "20m"
+const (
+	// DefaultBackupInterval defines the default interval used to create backups.
+	DefaultBackupInterval = "20m"
+
+	// DefaultMeteringStorageSize is the default size for the metering Prometheus PVC.
+	DefaultMeteringStorageSize = "100Gi"
+	// DefaultMeteringRetentionDays is the default number of days for which the metering Prometheus
+	// should keep data.
+	DefaultMeteringRetentionDays = 90
+)
 
 // DefaultSeed fills in missing values in the Seed's spec by copying them from the global
 // defaults in the KubermaticConfiguration (in which some fields might already be deprecated,
@@ -42,6 +50,16 @@ func DefaultSeed(seed *kubermaticv1.Seed, config *kubermaticv1.KubermaticConfigu
 
 	if seedCopy.Spec.ExposeStrategy == "" {
 		seedCopy.Spec.ExposeStrategy = config.Spec.ExposeStrategy
+	}
+
+	if seedCopy.Spec.Metering != nil {
+		if seedCopy.Spec.Metering.RetentionDays <= 0 {
+			seedCopy.Spec.Metering.RetentionDays = DefaultMeteringRetentionDays
+		}
+
+		if seedCopy.Spec.Metering.StorageSize == "" {
+			seedCopy.Spec.Metering.StorageSize = DefaultMeteringStorageSize
+		}
 	}
 
 	if err := defaultDockerRepo(&seedCopy.Spec.NodeportProxy.Envoy.DockerRepository, DefaultEnvoyDockerRepository, "nodeportProxy.envoy.dockerRepository", logger); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Depending on the setup, it might sense to store more than 90 days worth of metering data. This PR makes that possible.

This PR also fixes the missing defaulting for the StorageSize, which was documented to default to "100Gi", but didn't.

I also removed the CLI flags to enable Prometheus consoles, a feature I wasn't even aware existed (https://prometheus.io/docs/visualization/consoles/). In this specific usecase however, all of the default consoles shipped with Prometheus were empty (e.g. http://localhost:9090/consoles/prometheus.html) because this special Prometheus simply does not ingest "normal" metrics. There is therefore no point in enabling these consoles.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add `Seed.spec.metering.retentionDays` to configure the Prometheus retention; fix missing defaulting for `Seed.spec.metering.storageSize`
```

**Documentation**:
```documentation
NONE
```
