### PR TITLE
charts: bump local-kubevirt to v1.1.0

### DIFF
--- a/charts/local-kubevirt/Chart.yaml
+++ b/charts/local-kubevirt/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: kubevirt
-version: v1.0.0
-appVersion: v1.0.0
+version: v1.1.0
+appVersion: v1.1.0
 description: KubeVirt chart for KKP local installation 
 keywords:
   - kubermatic

--- a/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
+++ b/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
@@ -363,8 +363,20 @@ spec:
                           description: MaxCpuSockets holds the maximum amount of sockets that can be hotplugged
                           format: int32
                           type: integer
+                        maxGuest:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MaxGuest defines the maximum amount memory that can be allocated to the guest using hotplug.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxHotplugRatio:
+                          description: 'MaxHotplugRatio is the ratio used to define the max amount of a hotplug resource that can be made available to a VM when the specific Max* setting is not defined (MaxCpuSockets, MaxGuest) Example: VM is configured with 512Mi of guest memory, if MaxGuest is not defined and MaxHotplugRatio is 2 then MaxGuest = 1Gi defaults to 4'
+                          format: int32
+                          type: integer
                       type: object
                     machineType:
+                      description: Deprecated. Use architectureConfiguration instead.
                       type: string
                     mediatedDevicesConfiguration:
                       description: MediatedDevicesConfiguration holds information about MDEV types to be defined, if available
@@ -462,6 +474,17 @@ spec:
                     network:
                       description: NetworkConfiguration holds network options
                       properties:
+                        binding:
+                          additionalProperties:
+                            properties:
+                              networkAttachmentDefinition:
+                                description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object. Format: <name>, <namespace>/<name>. If namespace is not specified, VMI namespace is assumed. version: 1alphav1'
+                                type: string
+                              sidecarImage:
+                                description: 'SidecarImage references a container image that runs in the virt-launcher pod. The sidecar handles (libvirt) domain configuration and optional services. version: 1alphav1'
+                                type: string
+                            type: object
+                          type: object
                         defaultNetworkInterface:
                           type: string
                         permitBridgeInterfaceOnPodNetwork:
@@ -505,10 +528,37 @@ spec:
                                 description: The vendor_id:product_id tuple of the PCI device
                                 type: string
                               resourceName:
-                                description: The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_nameThe name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name
+                                description: The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name
                                 type: string
                             required:
                               - pciVendorSelector
+                              - resourceName
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        usb:
+                          items:
+                            properties:
+                              externalResourceProvider:
+                                description: If true, KubeVirt will leave the allocation and monitoring to an external device plugin
+                                type: boolean
+                              resourceName:
+                                description: 'Identifies the list of USB host devices. e.g: kubevirt.io/storage, kubevirt.io/bootable-usb, etc'
+                                type: string
+                              selectors:
+                                items:
+                                  properties:
+                                    product:
+                                      type: string
+                                    vendor:
+                                      type: string
+                                  required:
+                                    - product
+                                    - vendor
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
                               - resourceName
                             type: object
                           type: array
@@ -626,6 +676,9 @@ spec:
                       properties:
                         disableFreePageReporting:
                           description: DisableFreePageReporting disable the free page reporting of memory balloon device https://libvirt.org/formatdomain.html#memory-balloon-device. This will have effect only if AutoattachMemBalloon is not false and the vmi is not requesting any high performance feature (dedicatedCPU/realtime/hugePages), in which free page reporting is always disabled.
+                          type: object
+                        disableSerialConsoleLog:
+                          description: DisableSerialConsoleLog disables logging the auto-attached default serial console. If not set, serial console logs will be written to a file and then streamed from a container named 'guest-console-log'. The value can be individually overridden for each VM, not relevant if AutoattachSerialConsole is disabled.
                           type: object
                       type: object
                     vmStateStorageClass:
@@ -2183,8 +2236,20 @@ spec:
                           description: MaxCpuSockets holds the maximum amount of sockets that can be hotplugged
                           format: int32
                           type: integer
+                        maxGuest:
+                          anyOf:
+                            - type: integer
+                            - type: string
+                          description: MaxGuest defines the maximum amount memory that can be allocated to the guest using hotplug.
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        maxHotplugRatio:
+                          description: 'MaxHotplugRatio is the ratio used to define the max amount of a hotplug resource that can be made available to a VM when the specific Max* setting is not defined (MaxCpuSockets, MaxGuest) Example: VM is configured with 512Mi of guest memory, if MaxGuest is not defined and MaxHotplugRatio is 2 then MaxGuest = 1Gi defaults to 4'
+                          format: int32
+                          type: integer
                       type: object
                     machineType:
+                      description: Deprecated. Use architectureConfiguration instead.
                       type: string
                     mediatedDevicesConfiguration:
                       description: MediatedDevicesConfiguration holds information about MDEV types to be defined, if available
@@ -2282,6 +2347,17 @@ spec:
                     network:
                       description: NetworkConfiguration holds network options
                       properties:
+                        binding:
+                          additionalProperties:
+                            properties:
+                              networkAttachmentDefinition:
+                                description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object. Format: <name>, <namespace>/<name>. If namespace is not specified, VMI namespace is assumed. version: 1alphav1'
+                                type: string
+                              sidecarImage:
+                                description: 'SidecarImage references a container image that runs in the virt-launcher pod. The sidecar handles (libvirt) domain configuration and optional services. version: 1alphav1'
+                                type: string
+                            type: object
+                          type: object
                         defaultNetworkInterface:
                           type: string
                         permitBridgeInterfaceOnPodNetwork:
@@ -2325,10 +2401,37 @@ spec:
                                 description: The vendor_id:product_id tuple of the PCI device
                                 type: string
                               resourceName:
-                                description: The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_nameThe name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name
+                                description: The name of the resource that is representing the device. Exposed by a device plugin and requested by VMs. Typically of the form vendor.com/product_name
                                 type: string
                             required:
                               - pciVendorSelector
+                              - resourceName
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        usb:
+                          items:
+                            properties:
+                              externalResourceProvider:
+                                description: If true, KubeVirt will leave the allocation and monitoring to an external device plugin
+                                type: boolean
+                              resourceName:
+                                description: 'Identifies the list of USB host devices. e.g: kubevirt.io/storage, kubevirt.io/bootable-usb, etc'
+                                type: string
+                              selectors:
+                                items:
+                                  properties:
+                                    product:
+                                      type: string
+                                    vendor:
+                                      type: string
+                                  required:
+                                    - product
+                                    - vendor
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
                               - resourceName
                             type: object
                           type: array
@@ -2446,6 +2549,9 @@ spec:
                       properties:
                         disableFreePageReporting:
                           description: DisableFreePageReporting disable the free page reporting of memory balloon device https://libvirt.org/formatdomain.html#memory-balloon-device. This will have effect only if AutoattachMemBalloon is not false and the vmi is not requesting any high performance feature (dedicatedCPU/realtime/hugePages), in which free page reporting is always disabled.
+                          type: object
+                        disableSerialConsoleLog:
+                          description: DisableSerialConsoleLog disables logging the auto-attached default serial console. If not set, serial console logs will be written to a file and then streamed from a container named 'guest-console-log'. The value can be individually overridden for each VM, not relevant if AutoattachSerialConsole is disabled.
                           type: object
                       type: object
                     vmStateStorageClass:

--- a/charts/local-kubevirt/templates/clusterrole-kubevirt-operator.yaml
+++ b/charts/local-kubevirt/templates/clusterrole-kubevirt-operator.yaml
@@ -46,18 +46,6 @@ rules:
       - delete
       - patch
   - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
-    verbs:
-      - get
-      - list
-      - watch
-      - delete
-      - update
-      - create
-      - patch
-  - apiGroups:
       - ""
     resources:
       - configmaps
@@ -203,22 +191,6 @@ rules:
       - watch
       - patch
   - apiGroups:
-      - flavor.kubevirt.io
-    resources:
-      - virtualmachineflavors
-      - virtualmachineclusterflavors
-      - virtualmachinepreferences
-      - virtualmachineclusterpreferences
-    verbs:
-      - get
-      - delete
-      - create
-      - update
-      - patch
-      - list
-      - watch
-      - deletecollection
-  - apiGroups:
       - ""
     resources:
       - pods
@@ -318,6 +290,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - instancetype.kubevirt.io
     resources:
       - virtualmachineinstancetypes
@@ -379,18 +359,6 @@ rules:
       - configmaps
       - endpoints
       - services
-    verbs:
-      - get
-      - list
-      - watch
-      - delete
-      - update
-      - create
-      - patch
-  - apiGroups:
-      - coordination.k8s.io
-    resources:
-      - leases
     verbs:
       - get
       - list
@@ -511,6 +479,8 @@ rules:
       - virtualmachineinstances/freeze
       - virtualmachineinstances/unfreeze
       - virtualmachineinstances/softreboot
+      - virtualmachineinstances/sev/setupsession
+      - virtualmachineinstances/sev/injectlaunchsecret
     verbs:
       - update
   - apiGroups:
@@ -525,8 +495,6 @@ rules:
       - network-attachment-definitions
     verbs:
       - get
-      - list
-      - watch
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -638,6 +606,18 @@ rules:
       - get
       - watch
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - update
+      - create
+      - patch
+  - apiGroups:
       - kubevirt.io
     resources:
       - virtualmachineinstances
@@ -744,6 +724,8 @@ rules:
       - virtualmachineinstances/guestosinfo
       - virtualmachineinstances/filesystemlist
       - virtualmachineinstances/userlist
+      - virtualmachineinstances/sev/fetchcertchain
+      - virtualmachineinstances/sev/querylaunchmeasurement
     verbs:
       - get
   - apiGroups:
@@ -756,6 +738,8 @@ rules:
       - virtualmachineinstances/freeze
       - virtualmachineinstances/unfreeze
       - virtualmachineinstances/softreboot
+      - virtualmachineinstances/sev/setupsession
+      - virtualmachineinstances/sev/injectlaunchsecret
     verbs:
       - update
   - apiGroups:
@@ -775,7 +759,6 @@ rules:
       - virtualmachines/removevolume
       - virtualmachines/migrate
       - virtualmachines/memorydump
-      - virtualmachines/addinterface
     verbs:
       - update
   - apiGroups:
@@ -889,6 +872,8 @@ rules:
       - virtualmachineinstances/guestosinfo
       - virtualmachineinstances/filesystemlist
       - virtualmachineinstances/userlist
+      - virtualmachineinstances/sev/fetchcertchain
+      - virtualmachineinstances/sev/querylaunchmeasurement
     verbs:
       - get
   - apiGroups:
@@ -901,6 +886,8 @@ rules:
       - virtualmachineinstances/freeze
       - virtualmachineinstances/unfreeze
       - virtualmachineinstances/softreboot
+      - virtualmachineinstances/sev/setupsession
+      - virtualmachineinstances/sev/injectlaunchsecret
     verbs:
       - update
   - apiGroups:
@@ -920,7 +907,6 @@ rules:
       - virtualmachines/removevolume
       - virtualmachines/migrate
       - virtualmachines/memorydump
-      - virtualmachines/addinterface
     verbs:
       - update
   - apiGroups:
@@ -1032,6 +1018,8 @@ rules:
       - virtualmachineinstances/guestosinfo
       - virtualmachineinstances/filesystemlist
       - virtualmachineinstances/userlist
+      - virtualmachineinstances/sev/fetchcertchain
+      - virtualmachineinstances/sev/querylaunchmeasurement
     verbs:
       - get
   - apiGroups:
@@ -1101,6 +1089,15 @@ rules:
       - migrations.kubevirt.io
     resources:
       - migrationpolicies
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - instancetype.kubevirt.io
+    resources:
+      - virtualmachineclusterinstancetypes
+      - virtualmachineclusterpreferences
     verbs:
       - get
       - list

--- a/charts/local-kubevirt/templates/deployment-virt-operator.yaml
+++ b/charts/local-kubevirt/templates/deployment-virt-operator.yaml
@@ -56,14 +56,14 @@ spec:
             - virt-operator
           env:
             - name: VIRT_OPERATOR_IMAGE
-              value: quay.io/kubevirt/virt-operator:v1.0.0
+              value: quay.io/kubevirt/virt-operator:v1.1.0
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['olm.targetNamespaces']
             - name: KUBEVIRT_VERSION
-              value: v1.0.0
-          image: quay.io/kubevirt/virt-operator:v1.0.0
+              value: v1.1.0
+          image: quay.io/kubevirt/virt-operator:v1.1.0
           imagePullPolicy: IfNotPresent
           name: virt-operator
           ports:

--- a/charts/local-kubevirt/templates/role-kubevirt-operator.yaml
+++ b/charts/local-kubevirt/templates/role-kubevirt-operator.yaml
@@ -68,3 +68,15 @@ rules:
       - routes/custom-host
     verbs:
       - create
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - update
+      - create
+      - patch


### PR DESCRIPTION
**What this PR does / why we need it**:
Bumping the `kubermatic-installer local kind` kubevirt chart to latest release https://github.com/kubevirt/kubevirt/releases/tag/v1.1.0.

There doesn't appear to be any breaking changes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubermatic-installer: update local KubeVirt chart to v1.1.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
