### PR TITLE
charts: bump local-kubevirt cdi to 1.58.0

### DIFF
--- a/charts/local-kubevirt/crds/customresourcedefinition-cdis.cdi.kubevirt.io.yaml
+++ b/charts/local-kubevirt/crds/customresourcedefinition-cdis.cdi.kubevirt.io.yaml
@@ -16,7 +16,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: cdis.cdi.kubevirt.io
 spec:
   group: cdi.kubevirt.io
@@ -143,6 +143,10 @@ spec:
                       items:
                         type: string
                       type: array
+                    logVerbosity:
+                      description: LogVerbosity overrides the default verbosity level used to initialize loggers
+                      format: int32
+                      type: integer
                     podResourceRequirements:
                       description: ResourceRequirements describes the compute resource requirements.
                       properties:
@@ -1417,6 +1421,10 @@ spec:
                       items:
                         type: string
                       type: array
+                    logVerbosity:
+                      description: LogVerbosity overrides the default verbosity level used to initialize loggers
+                      format: int32
+                      type: integer
                     podResourceRequirements:
                       description: ResourceRequirements describes the compute resource requirements.
                       properties:

--- a/charts/local-kubevirt/templates/clusterrole-cdi-operator-cluster.yaml
+++ b/charts/local-kubevirt/templates/clusterrole-cdi-operator-cluster.yaml
@@ -25,7 +25,12 @@ rules:
       - clusterrolebindings
       - clusterroles
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
   - apiGroups:
       - security.openshift.io
     resources:
@@ -37,22 +42,17 @@ rules:
       - update
       - create
   - apiGroups:
-      - ""
-    resources:
-      - pods
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-      - delete
-  - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
       - customresourcedefinitions/status
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
   - apiGroups:
       - cdi.kubevirt.io
       - upload.cdi.kubevirt.io
@@ -66,13 +66,44 @@ rules:
       - validatingwebhookconfigurations
       - mutatingwebhookconfigurations
     verbs:
-      - '*'
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resourceNames:
+      - cdi-api-dataimportcron-validate
+      - cdi-api-populator-validate
+      - cdi-api-datavolume-validate
+      - cdi-api-validate
+      - objecttransfer-api-validate
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+      - delete
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resourceNames:
+      - cdi-api-datavolume-mutate
+    resources:
+      - mutatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+      - delete
   - apiGroups:
       - apiregistration.k8s.io
     resources:
       - apiservices
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
   - apiGroups:
       - authorization.k8s.io
     resources:
@@ -117,7 +148,6 @@ rules:
     resources:
       - datasources
     verbs:
-      - list
       - get
   - apiGroups:
       - cdi.kubevirt.io
@@ -130,7 +160,7 @@ rules:
     resources:
       - cdis/finalizers
     verbs:
-      - '*'
+      - update
   - apiGroups:
       - ""
     resources:
@@ -141,7 +171,6 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - persistentvolumes
       - persistentvolumeclaims
     verbs:
       - get
@@ -152,6 +181,15 @@ rules:
       - delete
       - deletecollection
       - patch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - get
+      - list
+      - watch
+      - update
   - apiGroups:
       - ""
     resources:
@@ -203,9 +241,22 @@ rules:
   - apiGroups:
       - snapshot.storage.k8s.io
     resources:
-      - '*'
+      - volumesnapshots
+      - volumesnapshotclasses
+      - volumesnapshotcontents
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - snapshot.storage.k8s.io
+    resources:
+      - volumesnapshots
+    verbs:
+      - update
+      - deletecollection
   - apiGroups:
       - apiextensions.k8s.io
     resources:
@@ -236,20 +287,6 @@ rules:
       - secrets
     verbs:
       - create
-  - apiGroups:
-      - batch
-    resources:
-      - cronjobs
-    verbs:
-      - list
-      - watch
-  - apiGroups:
-      - batch
-    resources:
-      - jobs
-    verbs:
-      - list
-      - watch
   - apiGroups:
       - kubevirt.io
     resources:

--- a/charts/local-kubevirt/templates/deployment-cdi-operator.yaml
+++ b/charts/local-kubevirt/templates/deployment-cdi-operator.yaml
@@ -40,25 +40,25 @@ spec:
             - name: DEPLOY_CLUSTER_RESOURCES
               value: "true"
             - name: OPERATOR_VERSION
-              value: v1.57.0
+              value: v1.58.0
             - name: CONTROLLER_IMAGE
-              value: quay.io/kubevirt/cdi-controller:v1.57.0
+              value: quay.io/kubevirt/cdi-controller:v1.58.0
             - name: IMPORTER_IMAGE
-              value: quay.io/kubevirt/cdi-importer:v1.57.0
+              value: quay.io/kubevirt/cdi-importer:v1.58.0
             - name: CLONER_IMAGE
-              value: quay.io/kubevirt/cdi-cloner:v1.57.0
+              value: quay.io/kubevirt/cdi-cloner:v1.58.0
             - name: APISERVER_IMAGE
-              value: quay.io/kubevirt/cdi-apiserver:v1.57.0
+              value: quay.io/kubevirt/cdi-apiserver:v1.58.0
             - name: UPLOAD_SERVER_IMAGE
-              value: quay.io/kubevirt/cdi-uploadserver:v1.57.0
+              value: quay.io/kubevirt/cdi-uploadserver:v1.58.0
             - name: UPLOAD_PROXY_IMAGE
-              value: quay.io/kubevirt/cdi-uploadproxy:v1.57.0
+              value: quay.io/kubevirt/cdi-uploadproxy:v1.58.0
             - name: VERBOSITY
               value: "1"
             - name: PULL_POLICY
               value: IfNotPresent
             - name: MONITORING_NAMESPACE
-          image: quay.io/kubevirt/cdi-operator:v1.57.0
+          image: quay.io/kubevirt/cdi-operator:v1.58.0
           imagePullPolicy: IfNotPresent
           name: cdi-operator
           ports:
@@ -67,7 +67,7 @@ spec:
               protocol: TCP
           resources:
             requests:
-              cpu: 10m
+              cpu: 100m
               memory: 150Mi
           securityContext:
             allowPrivilegeEscalation: false

--- a/charts/local-kubevirt/templates/role-cdi-operator.yaml
+++ b/charts/local-kubevirt/templates/role-cdi-operator.yaml
@@ -28,7 +28,12 @@ rules:
       - rolebindings
       - roles
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
   - apiGroups:
       - ""
     resources:
@@ -38,21 +43,36 @@ rules:
       - secrets
       - services
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
   - apiGroups:
       - apps
     resources:
       - deployments
       - deployments/finalizers
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
   - apiGroups:
       - route.openshift.io
     resources:
       - routes
       - routes/custom-host
     verbs:
-      - '*'
+      - get
+      - list
+      - watch
+      - create
+      - update
   - apiGroups:
       - config.openshift.io
     resources:
@@ -79,4 +99,95 @@ rules:
     resources:
       - leases
     verbs:
-      - '*'
+      - get
+      - create
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - delete
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - list
+      - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - route.openshift.io
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating the version of `kubermatic-instller local kind` local-kubevirt chart with latest release of the CDI

https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.58.0

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubermatic-installer: update local KubeVirt CDI chart to v1.58.0
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
