### PR TITLE
Use JoinPath to construct vSphere url

### DIFF
--- a/pkg/provider/cloud/vsphere/client.go
+++ b/pkg/provider/cloud/vsphere/client.go
@@ -36,10 +36,12 @@ type RESTSession struct {
 }
 
 func newRESTSession(ctx context.Context, dc *kubermaticv1.DatacenterSpecVSphere, username, password string, caBundle *x509.CertPool) (*RESTSession, error) {
-	u, err := url.Parse(fmt.Sprintf("%s/sdk", dc.Endpoint))
+	endpoint, err := url.Parse(dc.Endpoint)
 	if err != nil {
 		return nil, err
 	}
+
+	u := endpoint.JoinPath("/sdk")
 
 	// creating the govmoni Client in roundabout way because we need to set the proper CA bundle: reference https://github.com/vmware/govmomi/issues/1200
 	soapClient := soap.NewClient(u, dc.AllowInsecure)


### PR DESCRIPTION
**What this PR does / why we need it**:
We shouldn't `fmt.Sprintf` the `/sdk` path for vSphere. Instead, we should use `url.JoinPath` to append it after parsing the initial datacenter URL. This makes endpoint parsing more robust.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12856

**What type of PR is this?**
/kind bug
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
No longer fail constructing vSphere endpoint when a `/` suffix is present in the datacenter configuration
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
