### PR TITLE
fix mirror-images command in installer

### DIFF
--- a/cmd/kubermatic-installer/cmd_mirror_images.go
+++ b/cmd/kubermatic-installer/cmd_mirror_images.go
@@ -189,7 +189,6 @@ func getAddonsPath(ctx context.Context, logger *logrus.Logger, options *MirrorIm
 	if err != nil {
 		return "", fmt.Errorf("failed to create local addons path: %w", err)
 	}
-	defer os.RemoveAll(tempDir)
 
 	return tempDir, nil
 }
@@ -224,6 +223,7 @@ func MirrorImagesFunc(logger *logrus.Logger, versions kubermaticversion.Versions
 				if err != nil {
 					return fmt.Errorf("failed to get addons path: %w", err)
 				}
+				defer os.RemoveAll(options.AddonsPath)
 			}
 
 			allAddons, err := addonutil.LoadAddonsFromDirectory(options.AddonsPath)


### PR DESCRIPTION
**What this PR does / why we need it**:
Not quite sure why the function to extract the addons would instantly remove them. I presume this is a leftover from refactoring, which now has triggered the defer statement too early?

**Which issue(s) this PR fixes**:
Fixes #12866

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix `mirror-images` command in installer not being able to extract the addons.
```

**Documentation**:
```documentation
NONE
```
