### PR TITLE
Alpine 3.18 / distroless for auxiliary container images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 ENV KUBERMATIC_CHARTS_DIRECTORY=/opt/charts/

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 ADD ./ /addons/

--- a/charts/mla/alertmanager-proxy/Chart.yaml
+++ b/charts/mla/alertmanager-proxy/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: alertmanager-proxy
 version: v9.9.9-dev
-appVersion: 0.2.1
+appVersion: 0.3.0
 description: A Helm chart to install KKP MLA Alertmanager Proxy.
 keywords:
   - kubermatic

--- a/charts/mla/alertmanager-proxy/templates/authzserver-deployment.yaml
+++ b/charts/mla/alertmanager-proxy/templates/authzserver-deployment.yaml
@@ -42,8 +42,6 @@ spec:
           image: '{{ .Values.alertmanagerProxy.authz.image.repository }}:{{ .Values.alertmanagerProxy.authz.image.tag }}'
           ports:
             - containerPort: 50051
-          command:
-            - /alertmanager-authorization-server
           args:
             - -log-debug=true
           resources:

--- a/charts/mla/alertmanager-proxy/test/default.yaml.out
+++ b/charts/mla/alertmanager-proxy/test/default.yaml.out
@@ -368,11 +368,9 @@ spec:
       serviceAccountName: alertmanager-authz-server
       containers:
         - name: authz-server
-          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.2.1'
+          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.3.0'
           ports:
             - containerPort: 50051
-          command:
-            - /alertmanager-authorization-server
           args:
             - -log-debug=true
           resources:

--- a/charts/mla/alertmanager-proxy/values.yaml
+++ b/charts/mla/alertmanager-proxy/values.yaml
@@ -46,7 +46,7 @@ alertmanagerProxy:
   authz:
     image:
       repository: "quay.io/kubermatic/alertmanager-authorization-server"
-      tag: "0.2.1"
+      tag: "0.3.0"
     # list of image pull secret references, e.g.
     # imagePullSecrets:
     #   - name: quay-io-pull-secret

--- a/charts/s3-exporter/Chart.yaml
+++ b/charts/s3-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: s3-exporter
 version: v9.9.9-dev
-appVersion: v0.6
+appVersion: v0.7
 keywords:
   - kubermatic
   - prometheus

--- a/charts/s3-exporter/templates/deployment.yaml
+++ b/charts/s3-exporter/templates/deployment.yaml
@@ -39,8 +39,6 @@ spec:
       containers:
         - name: s3-exporter
           image: '{{ .Values.s3Exporter.image.repository }}:{{ .Values.s3Exporter.image.tag }}'
-          command:
-          - /usr/local/bin/s3-exporter
           args:
           - -endpoint={{ .Values.s3Exporter.endpoint }}
           - -access-key-id=$(ACCESS_KEY_ID)

--- a/charts/s3-exporter/values.yaml
+++ b/charts/s3-exporter/values.yaml
@@ -15,7 +15,7 @@
 s3Exporter:
   image:
     repository: quay.io/kubermatic/s3-exporter
-    tag: v0.6
+    tag: v0.7
     # list of image pull secret references, e.g.
   # imagePullSecrets:
   #   - name: quay-io-pull-secret

--- a/cmd/alertmanager-authorization-server/Dockerfile
+++ b/cmd/alertmanager-authorization-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/alertmanager-authorization-server /

--- a/cmd/alertmanager-authorization-server/Dockerfile
+++ b/cmd/alertmanager-authorization-server/Dockerfile
@@ -15,4 +15,6 @@
 FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
-COPY ./_build/alertmanager-authorization-server /
+COPY ./_build/alertmanager-authorization-server /usr/local/bin/
+
+ENTRYPOINT ["alertmanager-authorization-server"]

--- a/cmd/alertmanager-authorization-server/Dockerfile
+++ b/cmd/alertmanager-authorization-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
+FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/alertmanager-authorization-server /

--- a/cmd/http-prober/Dockerfile
+++ b/cmd/http-prober/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/cmd/http-prober/Dockerfile
+++ b/cmd/http-prober/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
+FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/cmd/http-prober/Dockerfile
+++ b/cmd/http-prober/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/cmd/http-prober/Dockerfile
+++ b/cmd/http-prober/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/distroless/static-debian12
+FROM alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./http-prober /usr/local/bin/

--- a/cmd/http-prober/release.sh
+++ b/cmd/http-prober/release.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ver=v0.4.0
+ver=v0.5.0
 
 set -euox pipefail
 

--- a/cmd/kubeletdnat-controller/Dockerfile
+++ b/cmd/kubeletdnat-controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add -u --no-cache iptables

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/kubeletdnat-controller build
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add -u --no-cache iptables

--- a/cmd/network-interface-manager/Dockerfile
+++ b/cmd/network-interface-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
+FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/network-interface-manager /usr/local/bin/network-interface-manager

--- a/cmd/network-interface-manager/Dockerfile
+++ b/cmd/network-interface-manager/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/network-interface-manager /usr/local/bin/network-interface-manager

--- a/cmd/network-interface-manager/Dockerfile
+++ b/cmd/network-interface-manager/Dockerfile
@@ -15,5 +15,6 @@
 FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
-COPY ./_build/network-interface-manager /usr/local/bin/network-interface-manager
+COPY ./_build/network-interface-manager /usr/local/bin/
 
+ENTRYPOINT ["network-interface-manager"]

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/network-interface-manager build
 
-FROM docker.io/alpine:3.18
+FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/network-interface-manager/_build/network-interface-manager /usr/local/bin/network-interface-manager

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/network-interface-manager build
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/network-interface-manager/_build/network-interface-manager /usr/local/bin/network-interface-manager

--- a/cmd/nodeport-proxy/Dockerfile
+++ b/cmd/nodeport-proxy/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 ADD ./_build/lb-updater /

--- a/cmd/s3-exporter/Dockerfile
+++ b/cmd/s3-exporter/Dockerfile
@@ -16,3 +16,5 @@ FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./s3-exporter /usr/local/bin/
+
+ENTRYPOINT ["s3-exporter"]

--- a/cmd/s3-exporter/Dockerfile
+++ b/cmd/s3-exporter/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 RUN apk add --no-cache ca-certificates

--- a/cmd/s3-exporter/Dockerfile
+++ b/cmd/s3-exporter/Dockerfile
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
+FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
-
-RUN apk add --no-cache ca-certificates
 
 COPY ./s3-exporter /usr/local/bin/

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
+FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/user-ssh-keys-agent build
 
-FROM docker.io/alpine:3.18
+FROM gcr.io/distroless/static-debian12
 LABEL maintainer="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/user-ssh-keys-agent/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -28,7 +28,7 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/user-ssh-keys-agent build
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/user-ssh-keys-agent/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent

--- a/hack/images/grafana-plugins/Dockerfile
+++ b/hack/images/grafana-plugins/Dockerfile
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This image is used as an initContainer and a small shell script is run,
+# so distroless is currently not a choice.
+
 FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 

--- a/hack/images/grafana-plugins/Dockerfile
+++ b/hack/images/grafana-plugins/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.17
+FROM docker.io/alpine:3.18
 LABEL maintainer="support@kubermatic.com"
 
 RUN mkdir -p /plugins

--- a/hack/images/startup-script/Dockerfile
+++ b/hack/images/startup-script/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine
+FROM docker.io/alpine:3.18
+
 RUN apk add --no-cache bash util-linux
 ADD manage-startup-script.sh /
 CMD /manage-startup-script.sh

--- a/hack/images/startup-script/release.sh
+++ b/hack/images/startup-script/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)
 
 REPOSITORY=quay.io/kubermatic/startup-script
-TAG=v0.1.0
+TAG=v0.2.0
 
 docker build --no-cache --pull -t "${REPOSITORY}:${TAG}" .
 docker push "${REPOSITORY}:${TAG}"

--- a/hack/publish-s3-exporter.sh
+++ b/hack/publish-s3-exporter.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 
 REPOSITORY=quay.io/kubermatic/s3-exporter
-TAG=v0.6
+TAG=v0.7
 
 GOOS=linux GOARCH=amd64 make s3-exporter
 

--- a/hack/release-alertmanager-authorization-server-image.sh
+++ b/hack/release-alertmanager-authorization-server-image.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 
 REPOSITORY=quay.io/kubermatic/alertmanager-authorization-server
-TAG=0.2.1
+TAG=0.3.0
 
 GOOS=linux GOARCH=amd64 make alertmanager-authorization-server
 

--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -168,25 +168,21 @@ products:
       - goConstant:
           package: k8c.io/kubermatic/v2/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns
           constant: version
-  
-  - name: cluster-backup (Velero)
+
+  - name: Velero
     source: https://github.com/vmware-tanzu/velero
     occurrences:
+      - helmChart: { directory: charts/backup/velero }
       - goConstant:
           package: k8c.io/kubermatic/v2/pkg/ee/cluster-backup/resources/seed-cluster
           constant: version
-  
-  - name: cluster-backup (Velero-plugin)
+
+  - name: Velero AWS Plugin
     source: https://github.com/vmware-tanzu/velero-plugin-for-aws
     occurrences:
       - goConstant:
           package: k8c.io/kubermatic/v2/pkg/ee/cluster-backup/resources/seed-cluster
           constant: pluginVersion
- 
-  - name: Velero
-    source: https://github.com/vmware-tanzu/velero
-    occurrences:
-      - helmChart: { directory: charts/backup/velero }
 
   - name: cert-manager
     source: https://github.com/cert-manager/cert-manager

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -188,7 +188,11 @@ func getContainers(versions kubermatic.Versions, imageRewriter registry.ImageRew
 			Name:            resources.EnvoyAgentAssignAddressContainerName,
 			Image:           image,
 			ImagePullPolicy: corev1.PullIfNotPresent,
-			Command:         []string{"sh", "-c", fmt.Sprintf("network-interface-manager -mode probe -if envoyagent -addr %s", ip.String())},
+			Args: []string{
+				"-mode", "probe",
+				"-if", "envoyagent",
+				"-addr", ip.String(),
+			},
 			SecurityContext: &corev1.SecurityContext{
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{

--- a/pkg/resources/apiserver/is-running.go
+++ b/pkg/resources/apiserver/is-running.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	tag                = "v0.4.0"
+	tag                = "v0.5.0"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-machine-controller.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-usercluster-webhook.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
@@ -203,7 +203,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller-webhook.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-machine-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-controller.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-usercluster-webhook.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -116,7 +116,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller-webhook.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-machine-controller.yaml
@@ -96,7 +96,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-usercluster-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -96,7 +96,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -105,7 +105,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -96,7 +96,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
@@ -95,7 +95,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
@@ -193,7 +193,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -85,7 +85,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
@@ -100,7 +100,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller-webhook.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-machine-controller.yaml
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-controller.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-usercluster-webhook.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -146,7 +146,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -137,7 +137,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
@@ -143,7 +143,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
@@ -136,7 +136,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller-webhook.yaml
@@ -133,7 +133,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-machine-controller.yaml
@@ -124,7 +124,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-controller.yaml
@@ -130,7 +130,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-usercluster-webhook.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -133,7 +133,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -124,7 +124,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
@@ -130,7 +130,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
@@ -187,7 +187,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -133,7 +133,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -124,7 +124,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -79,7 +79,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
@@ -130,7 +130,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager-externalCloudProvider.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller-webhook.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-machine-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-controller.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-usercluster-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
@@ -191,7 +191,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
@@ -75,7 +75,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
@@ -170,7 +170,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -91,7 +91,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -92,7 +92,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
@@ -167,7 +167,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
@@ -114,7 +114,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.4.0
+        image: quay.io/kubermatic/http-prober:v0.5.0
         name: copy-http-prober
         resources: {}
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:
For containers where shells are later used, this PR bumps them to Alpine 3.18.

For others, like

* alertmanager-authorization-server
* network-interface-manager
* s3-exporter
* user-ssh-keys-agent

I finally got over myself and would like to propose using distroless or other base images.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Updated KKP images to Alpine 3.18; auxiliary single-binary images (alertmanager-authorization-server, network-interface-manager, s3-exporter and user-ssh-keys-agent) have been changed to use `gcr.io/distroless/static-debian12` as the base image.
```

**Documentation**:
```documentation
NONE
```
