### PR TITLE
Fixed the ClusterRole resources for VPA 0.14

### DIFF
--- a/pkg/controller/operator/common/vpa/rbac.go
+++ b/pkg/controller/operator/common/vpa/rbac.go
@@ -96,7 +96,7 @@ func ClusterRoleReconcilers() []reconciling.NamedClusterRoleReconcilerFactory {
 		clusterRoleReconciler(StatusActorRoleName, []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"autoscaling.k8s.io"},
-				Resources: []string{"verticalpodautoscalers/status"},
+				Resources: []string{"verticalpodautoscalers","verticalpodautoscalers/status"},
 				Verbs:     []string{"get", "patch"},
 			},
 		}),

--- a/pkg/controller/operator/common/vpa/rbac.go
+++ b/pkg/controller/operator/common/vpa/rbac.go
@@ -96,7 +96,7 @@ func ClusterRoleReconcilers() []reconciling.NamedClusterRoleReconcilerFactory {
 		clusterRoleReconciler(StatusActorRoleName, []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"autoscaling.k8s.io"},
-				Resources: []string{"verticalpodautoscalers","verticalpodautoscalers/status"},
+				Resources: []string{"verticalpodautoscalers", "verticalpodautoscalers/status"},
 				Verbs:     []string{"get", "patch"},
 			},
 		}),


### PR DESCRIPTION
**What this PR does / why we need it**:
VPA recommender cannot recommend due to RBAC issue caused by incorrect permissions pushed mistakenly by VPA team.

More details and local fix is [here](https://github.com/kubernetes/autoscaler/issues/5982#issuecomment-1650656845)
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
NA

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
/kind chore

**Special notes for your reviewer**:
I see that VPA has been graduated to 1.0 and we should consider upgrading VPA to 1.0 when appropriate.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Applied a fix to VPA caused by [upstream release issue](https://github.com/kubernetes/autoscaler/issues/5982) which caused insufficient RBAC permission for VPA recommender pod
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
