### PR TITLE
cinder csi: allow topology support customization

### DIFF
--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -83,7 +83,7 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=3m"
             - "--default-fstype=ext4"
-            - "--feature-gates=Topology=true"
+            - "--feature-gates=Topology={{ .Cluster.CSI.CinderTopologyEnabled }}"
             - "--extra-create-metadata"
             - "--leader-election=true"
           env:

--- a/cmd/conformance-tester/pkg/clients/client_kube.go
+++ b/cmd/conformance-tester/pkg/clients/client_kube.go
@@ -25,6 +25,7 @@ import (
 	"go.uber.org/zap"
 
 	clusterv1alpha1 "github.com/kubermatic/machine-controller/pkg/apis/cluster/v1alpha1"
+	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/scenarios"
 	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -193,6 +194,12 @@ func (c *kubeClient) CreateCluster(ctx context.Context, log *zap.SugaredLogger, 
 		cluster.Spec.ClusterNetwork.IPFamily = kubermaticv1.IPFamilyDualStack
 	}
 
+	// Cilium became KKP's default CNI plugin but our CentOS images do not support it yet
+	// https://github.com/kubermatic/kubermatic/pull/12752
+	// https://github.com/kubermatic/kubermatic/pull/12878#issuecomment-1842451739
+	if scenario.OperatingSystem() == providerconfig.OperatingSystemCentOS {
+		cluster.Spec.CNIPlugin = &kubermaticv1.CNIPluginSettings{Type: kubermaticv1.CNIPluginTypeCanal}
+	}
 	if err := c.opts.SeedClusterClient.Create(ctx, cluster); err != nil {
 		return nil, fmt.Errorf("failed to create cluster: %w", err)
 	}

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -121,6 +121,9 @@ type CSIOptions struct {
 	// vmware Cloud Director
 	StorageProfile string
 	Filesystem     string
+
+	// openstack
+	CinderTopologyEnabled bool
 }
 
 type MLASettings struct {

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -213,6 +213,9 @@ spec:
           authURL: ""
           # Used to configure availability zone.
           availabilityZone: ""
+          # Optional: configures enablement of CSI Cinder plugin for topology support.
+          # This requires Nova and Cinder to have matching availability zones configured.
+          csiCinderTopologyEnabled: false
           # Used for automatic network creation
           dnsServers: []
           # Optional: List of enabled flavors for the given datacenter

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -213,7 +213,7 @@ spec:
           authURL: ""
           # Used to configure availability zone.
           availabilityZone: ""
-          # Optional: configures enablement of CSI Cinder plugin for topology support.
+          # Optional: configures enablement of topology support for the Cinder CSI Plugin.
           # This requires Nova and Cinder to have matching availability zones configured.
           csiCinderTopologyEnabled: false
           # Used for automatic network creation

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -216,7 +216,7 @@ spec:
           authURL: ""
           # Used to configure availability zone.
           availabilityZone: ""
-          # Optional: configures enablement of CSI Cinder plugin for topology support.
+          # Optional: configures enablement of topology support for the Cinder CSI Plugin.
           # This requires Nova and Cinder to have matching availability zones configured.
           csiCinderTopologyEnabled: false
           # Used for automatic network creation

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -216,6 +216,9 @@ spec:
           authURL: ""
           # Used to configure availability zone.
           availabilityZone: ""
+          # Optional: configures enablement of CSI Cinder plugin for topology support.
+          # This requires Nova and Cinder to have matching availability zones configured.
+          csiCinderTopologyEnabled: false
           # Used for automatic network creation
           dnsServers: []
           # Optional: List of enabled flavors for the given datacenter

--- a/pkg/addon/types.go
+++ b/pkg/addon/types.go
@@ -84,6 +84,10 @@ func NewTemplateData(
 		csiOptions.StorageProfile = cluster.Spec.Cloud.VMwareCloudDirector.CSI.StorageProfile
 	}
 
+	if cluster.Spec.Cloud.Openstack != nil {
+		csiOptions.CinderTopologyEnabled = cluster.Spec.Cloud.Openstack.CinderTopologyEnabled
+	}
+
 	csiMigration := metav1.HasAnnotation(cluster.ObjectMeta, kubermaticv1.CSIMigrationNeededAnnotation) || kubermaticv1helper.CCMMigrationCompleted(cluster)
 
 	var ipvs kubermaticv1.IPVSConfiguration
@@ -264,4 +268,7 @@ type CSIOptions struct {
 	// vmware Cloud Director
 	StorageProfile string
 	Filesystem     string
+
+	// openstack
+	CinderTopologyEnabled bool
 }

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1310,6 +1310,11 @@ type OpenstackCloudSpec struct {
 	// The suffix is set to `nip.io` by default. Can only be used with the external CCM and might be deprecated and removed in
 	// future versions as it is considered a workaround only.
 	IngressHostnameSuffix *string `json:"ingressHostnameSuffix,omitempty"`
+
+	// Flag to configure enablement of CSI Cinder plugin for topology support.
+	// This requires Nova and Cinder to have matching availability zones configured.
+	// +optional
+	CinderTopologyEnabled bool `json:"cinderTopologyEnabled,omitempty"`
 }
 
 // PacketCloudSpec specifies access data to a Packet cloud.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1311,7 +1311,7 @@ type OpenstackCloudSpec struct {
 	// future versions as it is considered a workaround only.
 	IngressHostnameSuffix *string `json:"ingressHostnameSuffix,omitempty"`
 
-	// Flag to configure enablement of CSI Cinder plugin for topology support.
+	// Flag to configure enablement of topology support for the Cinder CSI plugin.
 	// This requires Nova and Cinder to have matching availability zones configured.
 	// +optional
 	CinderTopologyEnabled bool `json:"cinderTopologyEnabled,omitempty"`

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -604,6 +604,9 @@ type DatacenterSpecOpenstack struct {
 	EnabledFlavors []string `json:"enabledFlavors,omitempty"`
 	// Optional: defines if the IPv6 is enabled for the datacenter
 	IPv6Enabled *bool `json:"ipv6Enabled,omitempty"`
+	// Optional: configures enablement of CSI Cinder plugin for topology support.
+	// This requires Nova and Cinder to have matching availability zones configured.
+	CSICinderTopologyEnabled bool `json:"csiCinderTopologyEnabled,omitempty"`
 }
 
 type OpenstackNodeSizeRequirements struct {

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -604,7 +604,7 @@ type DatacenterSpecOpenstack struct {
 	EnabledFlavors []string `json:"enabledFlavors,omitempty"`
 	// Optional: defines if the IPv6 is enabled for the datacenter
 	IPv6Enabled *bool `json:"ipv6Enabled,omitempty"`
-	// Optional: configures enablement of CSI Cinder plugin for topology support.
+	// Optional: configures enablement of topology support for the Cinder CSI Plugin.
 	// This requires Nova and Cinder to have matching availability zones configured.
 	CSICinderTopologyEnabled bool `json:"csiCinderTopologyEnabled,omitempty"`
 }

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -713,7 +713,7 @@ spec:
                         applicationCredentialSecret:
                           type: string
                         cinderTopologyEnabled:
-                          description: Flag to configure enablement of CSI Cinder plugin for topology support. This requires Nova and Cinder to have matching availability zones configured.
+                          description: Flag to configure enablement of topology support for the Cinder CSI plugin. This requires Nova and Cinder to have matching availability zones configured.
                           type: boolean
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -712,6 +712,9 @@ spec:
                           type: string
                         applicationCredentialSecret:
                           type: string
+                        cinderTopologyEnabled:
+                          description: Flag to configure enablement of CSI Cinder plugin for topology support. This requires Nova and Cinder to have matching availability zones configured.
+                          type: boolean
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
                           properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -707,6 +707,9 @@ spec:
                           type: string
                         applicationCredentialSecret:
                           type: string
+                        cinderTopologyEnabled:
+                          description: Flag to configure enablement of CSI Cinder plugin for topology support. This requires Nova and Cinder to have matching availability zones configured.
+                          type: boolean
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.
                           properties:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -708,7 +708,7 @@ spec:
                         applicationCredentialSecret:
                           type: string
                         cinderTopologyEnabled:
-                          description: Flag to configure enablement of CSI Cinder plugin for topology support. This requires Nova and Cinder to have matching availability zones configured.
+                          description: Flag to configure enablement of topology support for the Cinder CSI plugin. This requires Nova and Cinder to have matching availability zones configured.
                           type: boolean
                         credentialsReference:
                           description: GlobalObjectKeySelector is needed as we can not use v1.SecretKeySelector because it is not cross namespace.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -664,6 +664,9 @@ spec:
                               availabilityZone:
                                 description: Used to configure availability zone.
                                 type: string
+                              csiCinderTopologyEnabled:
+                                description: 'Optional: configures enablement of CSI Cinder plugin for topology support. This requires Nova and Cinder to have matching availability zones configured.'
+                                type: boolean
                               dnsServers:
                                 description: Used for automatic network creation
                                 items:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -665,7 +665,7 @@ spec:
                                 description: Used to configure availability zone.
                                 type: string
                               csiCinderTopologyEnabled:
-                                description: 'Optional: configures enablement of CSI Cinder plugin for topology support. This requires Nova and Cinder to have matching availability zones configured.'
+                                description: 'Optional: configures enablement of topology support for the Cinder CSI Plugin. This requires Nova and Cinder to have matching availability zones configured.'
                                 type: boolean
                               dnsServers:
                                 description: Used for automatic network creation

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -112,6 +112,8 @@ func (os *Provider) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.Clu
 			}
 		}
 	}
+
+	spec.Cloud.Openstack.CinderTopologyEnabled = os.dc.CSICinderTopologyEnabled
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces configurability over Cinder CSI plugin topology support. Openstack allows Nova and Cinder AZs to be named differently which breaks with the topology support enabled on the CSI driver making it impossible for volumes to get provisioned.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12877

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Openstack: allow configuring Cinder CSI topology support either on `Cluster` or `Seed` resource field `cinderTopologyEnabled`.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
