### PR TITLE
Add `enableClusterBackup` to k8c settings

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -68,6 +68,9 @@ type SettingSpec struct {
 
 	EnableOIDCKubeconfig bool `json:"enableOIDCKubeconfig"` //nolint:tagliatelle
 
+	// EnableClusterBackup enables the Cluster Backup feature in the dashboard.
+	EnableClusterBackups *bool `json:"enableClusterBackup,omitempty"`
+
 	// DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
 	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
 

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -6205,6 +6205,11 @@ func (in *SettingSpec) DeepCopyInto(out *SettingSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableClusterBackups != nil {
+		in, out := &in.EnableClusterBackups, &out.EnableClusterBackups
+		*out = new(bool)
+		**out = **in
+	}
 	out.CleanupOptions = in.CleanupOptions
 	out.OpaOptions = in.OpaOptions
 	out.MlaOptions = in.MlaOptions

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -115,6 +115,9 @@ spec:
                 displayTermsOfService:
                   description: DisplayDemoInfo controls whether a a link to TOS is shown in the footer.
                   type: boolean
+                enableClusterBackup:
+                  description: EnableClusterBackup enables the Cluster Backup feature in the dashboard.
+                  type: boolean
                 enableDashboard:
                   description: EnableDashboard enables the link to the Kubernetes dashboard for a user cluster.
                   type: boolean


### PR DESCRIPTION
**What this PR does / why we need it**:
add new option in admin settings to enable/disable user cluster backups
**Which issue(s) this PR fixes**:
ref [#6404](https://github.com/kubermatic/dashboard/issues/6404)

**What type of PR is this?**
/kind feature

```release-note
add new admin option to enable/disable user cluster backups
```

```documentation
NONE
```
