### PR TITLE
Upgraded cortex to v1.14.1

### DIFF
--- a/charts/mla/cortex/Chart.lock
+++ b/charts/mla/cortex/Chart.lock
@@ -1,27 +1,6 @@
 dependencies:
 - name: cortex
   repository: https://cortexproject.github.io/cortex-helm-chart
-  version: 1.7.0
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  version: 6.3.1
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  version: 6.3.1
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  version: 6.3.1
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  version: 6.3.1
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  version: 6.3.1
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  version: 6.3.1
-- name: memcached
-  repository: https://charts.bitnami.com/bitnami
-  version: 6.3.1
-digest: sha256:ff8edee24ed15583e386eb601903eea5f862f688bf41de84054a395678bbaaba
-generated: "2022-12-14T15:03:58.703975471+01:00"
+  version: 2.1.0
+digest: sha256:7cddb7331732b8779ba3bd94f8a4f27ee3166a13d3057bb757b7a9830b4e4af6
+generated: "2023-12-21T09:08:18.061272245+05:30"

--- a/charts/mla/cortex/Chart.yaml
+++ b/charts/mla/cortex/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 version: v9.9.9-dev
-appVersion: v1.13.1
+appVersion: v1.14.1
 description: 'Horizontally scalable, highly available, multi-tenant, long term Prometheus.'
 home: https://cortexmetrics.io/
 kubeVersion: ^1.19.0-0
@@ -24,42 +24,4 @@ sources:
 dependencies:
 - name: cortex
   repository: https://cortexproject.github.io/cortex-helm-chart
-  version: 1.7.0
-- name: memcached
-  alias: memcached
-  version: 6.3.1
-  repository: https://charts.bitnami.com/bitnami
-  condition: memcached.enabled
-- name: memcached
-  alias: memcached-index-read
-  version: 6.3.1
-  repository: https://charts.bitnami.com/bitnami
-  condition: memcached-index-read.enabled
-- name: memcached
-  alias: memcached-index-write
-  version: 6.3.1
-  repository: https://charts.bitnami.com/bitnami
-  condition: memcached-index-write.enabled
-- name: memcached
-  alias: memcached-frontend
-  version: 6.3.1
-  repository: https://charts.bitnami.com/bitnami
-  condition: memcached-frontend.enabled
-- name: memcached
-  alias: memcached-blocks-index
-  version: 6.3.1
-  repository: https://charts.bitnami.com/bitnami
-  tags:
-    - blocks-storage-memcached
-- name: memcached
-  alias: memcached-blocks
-  version: 6.3.1
-  repository: https://charts.bitnami.com/bitnami
-  tags:
-    - blocks-storage-memcached
-- name: memcached
-  alias: memcached-blocks-metadata
-  version: 6.3.1
-  repository: https://charts.bitnami.com/bitnami
-  tags:
-    - blocks-storage-memcached
+  version: 2.1.0

--- a/charts/mla/cortex/test/config.yaml.out
+++ b/charts/mla/cortex/test/config.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: release-name-cortex-alertmanager
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: release-name-cortex-distributor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: release-name-cortex-ingester
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
 spec:
@@ -62,6 +62,27 @@ spec:
       app.kubernetes.io/component: ingester
   maxUnavailable: 1
 ---
+# Source: cortex/charts/cortex/templates/querier/querier-poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-cortex-querier
+  namespace: default
+  labels:
+    helm.sh/chart: cortex-2.1.0
+    app.kubernetes.io/name: cortex
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.14.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: querier
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cortex
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/component: querier
+  maxUnavailable: 1
+---
 # Source: cortex/charts/cortex/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -69,10 +90,10 @@ metadata:
   name: release-name-cortex
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -85,13 +106,163 @@ metadata:
   name: release-name-cortex
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
 data:
-  cortex.yaml: YWxlcnRtYW5hZ2VyOgogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvYWxlcnQtZGF0YQogIGVuYWJsZV9hcGk6IHRydWUKICBleHRlcm5hbF91cmw6IC9hcGkvcHJvbS9hbGVydG1hbmFnZXIKICBzdG9yYWdlOgogICAgczM6CiAgICAgIGJ1Y2tldG5hbWVzOiBhbGVydG1hbmFnZXIKICAgICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgICAgaW5zZWN1cmU6IHRydWUKICAgICAgczNmb3JjZXBhdGhzdHlsZTogdHJ1ZQogICAgdHlwZTogczMKYXBpOgogIHByb21ldGhldXNfaHR0cF9wcmVmaXg6IC9wcm9tZXRoZXVzCiAgcmVzcG9uc2VfY29tcHJlc3Npb25fZW5hYmxlZDogdHJ1ZQphdXRoX2VuYWJsZWQ6IHRydWUKYmxvY2tzX3N0b3JhZ2U6CiAgYmFja2VuZDogczMKICBidWNrZXRfc3RvcmU6CiAgICBidWNrZXRfaW5kZXg6CiAgICAgIGVuYWJsZWQ6IHRydWUKICAgIGlnbm9yZV9kZWxldGlvbl9tYXJrX2RlbGF5OiAxaAogICAgc3luY19kaXI6IC9kYXRhCiAgczM6CiAgICBidWNrZXRfbmFtZTogY29ydGV4CiAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgaW5zZWN1cmU6IHRydWUKICB0c2RiOgogICAgY2xvc2VfaWRsZV90c2RiX3RpbWVvdXQ6IDM2NW0KICAgIGRpcjogL2RhdGEKICAgIGZsdXNoX2Jsb2Nrc19vbl9zaHV0ZG93bjogdHJ1ZQogICAgcmV0ZW50aW9uX3BlcmlvZDogMzY1bQogICAgd2FsX2NvbXByZXNzaW9uX2VuYWJsZWQ6IHRydWUKY2h1bmtfc3RvcmU6CiAgY2h1bmtfY2FjaGVfY29uZmlnOgogICAgbWVtY2FjaGVkOgogICAgICBleHBpcmF0aW9uOiAxaAogICAgbWVtY2FjaGVkX2NsaWVudDoKICAgICAgdGltZW91dDogMXMKY29tcGFjdG9yOgogIGJsb2NrX2RlbGV0aW9uX21hcmtzX21pZ3JhdGlvbl9lbmFibGVkOiBmYWxzZQogIGNvbXBhY3Rpb25faW50ZXJ2YWw6IDMwbQogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvY29tcGFjdG9yCiAgc2hhcmRpbmdfZW5hYmxlZDogdHJ1ZQogIHNoYXJkaW5nX3Jpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdApkaXN0cmlidXRvcjoKICBoYV90cmFja2VyOgogICAgZW5hYmxlX2hhX3RyYWNrZXI6IHRydWUKICAgIGt2c3RvcmU6CiAgICAgIGNvbnN1bDoKICAgICAgICBob3N0OiBjb25zdWwtY29uc3VsLXNlcnZlcjo4NTAwCiAgICAgIHN0b3JlOiBjb25zdWwKICBwb29sOgogICAgaGVhbHRoX2NoZWNrX2luZ2VzdGVyczogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHNoYXJkX2J5X2FsbF9sYWJlbHM6IHRydWUKZnJvbnRlbmQ6CiAgbG9nX3F1ZXJpZXNfbG9uZ2VyX3RoYW46IDEwcwppbmdlc3RlcjoKICBsaWZlY3ljbGVyOgogICAgZmluYWxfc2xlZXA6IDBzCiAgICBqb2luX2FmdGVyOiAwcwogICAgbnVtX3Rva2VuczogNTEyCiAgICBvYnNlcnZlX3BlcmlvZDogMTBzCiAgICByaW5nOgogICAgICBrdnN0b3JlOgogICAgICAgIGNvbnN1bDoKICAgICAgICAgIGNvbnNpc3RlbnRfcmVhZHM6IHRydWUKICAgICAgICAgIGhvc3Q6IGNvbnN1bDo4NTAwCiAgICAgICAgICBodHRwX2NsaWVudF90aW1lb3V0OiAyMHMKICAgICAgICBwcmVmaXg6IGNvbGxlY3RvcnMvCiAgICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICAgICAgcmVwbGljYXRpb25fZmFjdG9yOiAzCiAgbWF4X3RyYW5zZmVyX3JldHJpZXM6IDAKaW5nZXN0ZXJfY2xpZW50OgogIGdycGNfY2xpZW50X2NvbmZpZzoKICAgIG1heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICAgIG1heF9zZW5kX21zZ19zaXplOiAxMDQ4NTc2MDAKbGltaXRzOgogIGFjY2VwdF9oYV9zYW1wbGVzOiB0cnVlCiAgZW5mb3JjZV9tZXRyaWNfbmFtZTogZmFsc2UKICBtYXhfbGFiZWxfbmFtZXNfcGVyX3NlcmllczogNDAKICBtYXhfcXVlcnlfbG9va2JhY2s6IDE2OGgKICByZWplY3Rfb2xkX3NhbXBsZXM6IHRydWUKICByZWplY3Rfb2xkX3NhbXBsZXNfbWF4X2FnZTogMTY4aAptZW1iZXJsaXN0OgogIGJpbmRfcG9ydDogNzk0NgogIGpvaW5fbWVtYmVyczoKICAtIGNvcnRleC1pbmdlc3Rlci1oZWFkbGVzcwpxdWVyaWVyOgogIGFjdGl2ZV9xdWVyeV90cmFja2VyX2RpcjogL2RhdGEvY29ydGV4L3F1ZXJpZXIKICBxdWVyeV9pbmdlc3RlcnNfd2l0aGluOiAzNjVtCiAgcXVlcnlfc3RvcmVfYWZ0ZXI6IDM2MG0KICBzdG9yZV9nYXRld2F5X2FkZHJlc3NlczogfC0KICAgIApxdWVyeV9yYW5nZToKICBhbGlnbl9xdWVyaWVzX3dpdGhfc3RlcDogdHJ1ZQogIGNhY2hlX3Jlc3VsdHM6IHRydWUKICByZXN1bHRzX2NhY2hlOgogICAgY2FjaGU6CiAgICAgIG1lbWNhY2hlZDoKICAgICAgICBleHBpcmF0aW9uOiAxaAogICAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICAgIHRpbWVvdXQ6IDFzCiAgc3BsaXRfcXVlcmllc19ieV9pbnRlcnZhbDogMjRoCnJ1bGVyOgogIGFsZXJ0bWFuYWdlcl91cmw6IGh0dHA6Ly9faHR0cC1tZXRyaWNzLl90Y3AuY29ydGV4LWFsZXJ0bWFuYWdlci1oZWFkbGVzcy1ra3AvYXBpL3Byb20vYWxlcnRtYW5hZ2VyLwogIGVuYWJsZV9hbGVydG1hbmFnZXJfZGlzY292ZXJ5OiB0cnVlCiAgZW5hYmxlX2FwaTogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHN0b3JhZ2U6CiAgICBzMzoKICAgICAgYnVja2V0bmFtZXM6IGNvcnRleC1ydWxlcgogICAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgICBpbnNlY3VyZTogdHJ1ZQogICAgICBzM2ZvcmNlcGF0aHN0eWxlOiB0cnVlCiAgICB0eXBlOiBzMwpydW50aW1lX2NvbmZpZzoKICBmaWxlOiAvZXRjL2NvcnRleC1ydW50aW1lLWNmZy9ydW50aW1lLWNvbmZpZy55YW1sCiAgcGVyaW9kOiAxMHMKc2NoZW1hOgogIGNvbmZpZ3M6CiAgLSBjaHVua3M6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGNodW5rc18KICAgIGZyb206ICIyMDIwLTExLTAxIgogICAgaW5kZXg6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGluZGV4XwogICAgb2JqZWN0X3N0b3JlOiBjYXNzYW5kcmEKICAgIHNjaGVtYTogdjEwCiAgICBzdG9yZTogY2Fzc2FuZHJhCnNlcnZlcjoKICBncnBjX2xpc3Rlbl9wb3J0OiA5MDk1CiAgZ3JwY19zZXJ2ZXJfbWF4X2NvbmN1cnJlbnRfc3RyZWFtczogMTAwMAogIGdycGNfc2VydmVyX21heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICBncnBjX3NlcnZlcl9tYXhfc2VuZF9tc2dfc2l6ZTogMTA0ODU3NjAwCiAgaHR0cF9saXN0ZW5fcG9ydDogODA4MApzdG9yYWdlOgogIGF6dXJlOgogICAgYWNjb3VudF9rZXk6IG51bGwKICAgIGFjY291bnRfbmFtZTogbnVsbAogICAgY29udGFpbmVyX25hbWU6IG51bGwKICBjYXNzYW5kcmE6CiAgICBhZGRyZXNzZXM6IG51bGwKICAgIGF1dGg6IHRydWUKICAgIGtleXNwYWNlOiBjb3J0ZXgKICAgIHBhc3N3b3JkOiBudWxsCiAgICB1c2VybmFtZTogbnVsbAogIGVuZ2luZTogYmxvY2tzCiAgaW5kZXhfcXVlcmllc19jYWNoZV9jb25maWc6CiAgICBtZW1jYWNoZWQ6CiAgICAgIGV4cGlyYXRpb246IDFoCiAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICB0aW1lb3V0OiAxcwpzdG9yZV9nYXRld2F5OgogIHNoYXJkaW5nX2VuYWJsZWQ6IHRydWUKICBzaGFyZGluZ19yaW5nOgogICAga3ZzdG9yZToKICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICAgIHJlcGxpY2F0aW9uX2ZhY3RvcjogMgp0YWJsZV9tYW5hZ2VyOgogIHJldGVudGlvbl9kZWxldGVzX2VuYWJsZWQ6IGZhbHNlCiAgcmV0ZW50aW9uX3BlcmlvZDogMHM=
+  cortex.yaml: YWxlcnRtYW5hZ2VyOgogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvYWxlcnQtZGF0YQogIGVuYWJsZV9hcGk6IHRydWUKICBleHRlcm5hbF91cmw6IC9hcGkvcHJvbS9hbGVydG1hbmFnZXIKYWxlcnRtYW5hZ2VyX3N0b3JhZ2U6CiAgczM6CiAgICBidWNrZXRfbmFtZTogYWxlcnRtYW5hZ2VyCiAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgaW5zZWN1cmU6IHRydWUKYXBpOgogIHByb21ldGhldXNfaHR0cF9wcmVmaXg6IC9wcm9tZXRoZXVzCiAgcmVzcG9uc2VfY29tcHJlc3Npb25fZW5hYmxlZDogdHJ1ZQphdXRoX2VuYWJsZWQ6IHRydWUKYmxvY2tzX3N0b3JhZ2U6CiAgYnVja2V0X3N0b3JlOgogICAgYnVja2V0X2luZGV4OgogICAgICBlbmFibGVkOiB0cnVlCiAgICBpZ25vcmVfZGVsZXRpb25fbWFya19kZWxheTogMWgKICAgIHN5bmNfZGlyOiAvZGF0YQogIHMzOgogICAgYnVja2V0X25hbWU6IGNvcnRleAogICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgIGluc2VjdXJlOiB0cnVlCiAgdHNkYjoKICAgIGNsb3NlX2lkbGVfdHNkYl90aW1lb3V0OiAzNjVtCiAgICBkaXI6IC9kYXRhCiAgICBmbHVzaF9ibG9ja3Nfb25fc2h1dGRvd246IHRydWUKICAgIHJldGVudGlvbl9wZXJpb2Q6IDM2NW0KICAgIHdhbF9jb21wcmVzc2lvbl9lbmFibGVkOiB0cnVlCmNvbXBhY3RvcjoKICBkYXRhX2RpcjogL2RhdGEvY29ydGV4L2NvbXBhY3RvcgogIHNoYXJkaW5nX2VuYWJsZWQ6IHRydWUKICBzaGFyZGluZ19yaW5nOgogICAga3ZzdG9yZToKICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKZGlzdHJpYnV0b3I6CiAgaGFfdHJhY2tlcjoKICAgIGVuYWJsZV9oYV90cmFja2VyOiB0cnVlCiAgICBrdnN0b3JlOgogICAgICBjb25zdWw6CiAgICAgICAgaG9zdDogY29uc3VsLWNvbnN1bC1zZXJ2ZXI6ODUwMAogICAgICBzdG9yZTogY29uc3VsCiAgcG9vbDoKICAgIGhlYWx0aF9jaGVja19pbmdlc3RlcnM6IHRydWUKICByaW5nOgogICAga3ZzdG9yZToKICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICBzaGFyZF9ieV9hbGxfbGFiZWxzOiB0cnVlCmZyb250ZW5kOgogIGxvZ19xdWVyaWVzX2xvbmdlcl90aGFuOiAxMHMKaW5nZXN0ZXI6CiAgbGlmZWN5Y2xlcjoKICAgIGZpbmFsX3NsZWVwOiAzMHMKICAgIGpvaW5fYWZ0ZXI6IDEwcwogICAgbnVtX3Rva2VuczogNTEyCiAgICBvYnNlcnZlX3BlcmlvZDogMTBzCiAgICByaW5nOgogICAgICBrdnN0b3JlOgogICAgICAgIHN0b3JlOiBtZW1iZXJsaXN0CiAgICAgIHJlcGxpY2F0aW9uX2ZhY3RvcjogMwppbmdlc3Rlcl9jbGllbnQ6CiAgZ3JwY19jbGllbnRfY29uZmlnOgogICAgbWF4X3JlY3ZfbXNnX3NpemU6IDEwNDg1NzYwCiAgICBtYXhfc2VuZF9tc2dfc2l6ZTogMTA0ODU3NjAKbGltaXRzOgogIGFjY2VwdF9oYV9zYW1wbGVzOiB0cnVlCiAgZW5mb3JjZV9tZXRyaWNfbmFtZTogdHJ1ZQogIG1heF9sYWJlbF9uYW1lc19wZXJfc2VyaWVzOiA0MAogIG1heF9xdWVyeV9sb29rYmFjazogMHMKICByZWplY3Rfb2xkX3NhbXBsZXM6IHRydWUKICByZWplY3Rfb2xkX3NhbXBsZXNfbWF4X2FnZTogMTY4aAptZW1iZXJsaXN0OgogIGJpbmRfcG9ydDogNzk0NgogIGpvaW5fbWVtYmVyczoKICAtIGNvcnRleC1pbmdlc3Rlci1oZWFkbGVzcwpxdWVyaWVyOgogIGFjdGl2ZV9xdWVyeV90cmFja2VyX2RpcjogL2RhdGEvYWN0aXZlLXF1ZXJ5LXRyYWNrZXIKICBxdWVyeV9pbmdlc3RlcnNfd2l0aGluOiAzNjVtCiAgcXVlcnlfc3RvcmVfYWZ0ZXI6IDM2MG0KICBzdG9yZV9nYXRld2F5X2FkZHJlc3NlczogfC0KICAgIApxdWVyeV9yYW5nZToKICBhbGlnbl9xdWVyaWVzX3dpdGhfc3RlcDogdHJ1ZQogIGNhY2hlX3Jlc3VsdHM6IHRydWUKICByZXN1bHRzX2NhY2hlOgogICAgY2FjaGU6CiAgICAgIG1lbWNhY2hlZDoKICAgICAgICBleHBpcmF0aW9uOiAxaAogICAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICAgIHRpbWVvdXQ6IDFzCiAgc3BsaXRfcXVlcmllc19ieV9pbnRlcnZhbDogMjRoCnJ1bGVyOgogIGVuYWJsZV9hbGVydG1hbmFnZXJfZGlzY292ZXJ5OiB0cnVlCiAgZW5hYmxlX2FwaTogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdApydWxlcl9zdG9yYWdlOgogIHMzOgogICAgYnVja2V0X25hbWU6IGNvcnRleC1ydWxlcgogICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgIGluc2VjdXJlOiB0cnVlCnJ1bnRpbWVfY29uZmlnOgogIGZpbGU6IC9ldGMvY29ydGV4LXJ1bnRpbWUtY2ZnL3J1bnRpbWUtY29uZmlnLnlhbWwKICBwZXJpb2Q6IDEwcwpzZXJ2ZXI6CiAgZ3JwY19saXN0ZW5fcG9ydDogOTA5NQogIGdycGNfc2VydmVyX21heF9jb25jdXJyZW50X3N0cmVhbXM6IDEwMDAwCiAgZ3JwY19zZXJ2ZXJfbWF4X3JlY3ZfbXNnX3NpemU6IDEwNDg1NzYwCiAgZ3JwY19zZXJ2ZXJfbWF4X3NlbmRfbXNnX3NpemU6IDEwNDg1NzYwCiAgaHR0cF9saXN0ZW5fcG9ydDogODA4MApzdG9yYWdlOgogIGVuZ2luZTogYmxvY2tzCnN0b3JlX2dhdGV3YXk6CiAgc2hhcmRpbmdfZW5hYmxlZDogdHJ1ZQogIHNoYXJkaW5nX3Jpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogICAgcmVwbGljYXRpb25fZmFjdG9yOiAy
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-index/templates/metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-index-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-index
+    helm.sh/chart: memcached-blocks-index-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+  annotations:
+    prometheus.io/port: '9150'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 9150
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: memcached-blocks-index
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-index/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-index
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-index
+    helm.sh/chart: memcached-blocks-index-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached-blocks-index
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-metadata/templates/metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-metadata-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    helm.sh/chart: memcached-blocks-metadata-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+  annotations:
+    prometheus.io/port: '9150'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 9150
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-metadata/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-metadata
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    helm.sh/chart: memcached-blocks-metadata-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks/templates/metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks
+    helm.sh/chart: memcached-blocks-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+  annotations:
+    prometheus.io/port: '9150'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 9150
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: memcached-blocks
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks
+    helm.sh/chart: memcached-blocks-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached-blocks
+    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/charts/cortex/templates/alertmanager/alertmanager-svc-headless.yaml
 apiVersion: v1
@@ -100,10 +271,10 @@ metadata:
   name: release-name-cortex-alertmanager-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
   annotations:
@@ -129,10 +300,10 @@ metadata:
   name: release-name-cortex-alertmanager
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
   annotations:
@@ -156,10 +327,10 @@ metadata:
   name: release-name-cortex-compactor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: compactor
   annotations:
@@ -183,10 +354,10 @@ metadata:
   name: release-name-cortex-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
   annotations:
@@ -212,10 +383,10 @@ metadata:
   name: release-name-cortex-distributor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
   annotations:
@@ -239,10 +410,10 @@ metadata:
   name: release-name-cortex-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
   annotations:
@@ -267,10 +438,10 @@ metadata:
   name: release-name-cortex-ingester
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
   annotations:
@@ -294,10 +465,10 @@ metadata:
   name: release-name-cortex-querier
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
   annotations:
@@ -321,10 +492,10 @@ metadata:
   name: release-name-cortex-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
   annotations:
@@ -350,10 +521,10 @@ metadata:
   name: release-name-cortex-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
   annotations:
@@ -377,10 +548,10 @@ metadata:
   name: release-name-cortex-ruler
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
   annotations:
@@ -404,10 +575,10 @@ metadata:
   name: release-name-cortex-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
   annotations:
@@ -432,10 +603,10 @@ metadata:
   name: release-name-cortex-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
   annotations:
@@ -459,11 +630,13 @@ metadata:
   name: release-name-cortex-memberlist
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -476,156 +649,6 @@ spec:
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/part-of: memberlist
----
-# Source: cortex/charts/memcached-blocks-index/templates/metrics-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-index-metrics
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-index
-    helm.sh/chart: memcached-blocks-index-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-  annotations:
-    prometheus.io/port: '9150'
-    prometheus.io/scrape: "true"
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: metrics
-      port: 9150
-      targetPort: metrics
-  selector:
-    app.kubernetes.io/name: memcached-blocks-index
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks-index/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-index
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-index
-    helm.sh/chart: memcached-blocks-index-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: memcache
-      port: 11211
-      targetPort: memcache
-      nodePort: null
-  selector:
-    app.kubernetes.io/name: memcached-blocks-index
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks-metadata/templates/metrics-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-metadata-metrics
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    helm.sh/chart: memcached-blocks-metadata-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-  annotations:
-    prometheus.io/port: '9150'
-    prometheus.io/scrape: "true"
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: metrics
-      port: 9150
-      targetPort: metrics
-  selector:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks-metadata/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-metadata
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    helm.sh/chart: memcached-blocks-metadata-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: memcache
-      port: 11211
-      targetPort: memcache
-      nodePort: null
-  selector:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks/templates/metrics-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-metrics
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks
-    helm.sh/chart: memcached-blocks-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-  annotations:
-    prometheus.io/port: '9150'
-    prometheus.io/scrape: "true"
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: metrics
-      port: 9150
-      targetPort: metrics
-  selector:
-    app.kubernetes.io/name: memcached-blocks
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks
-    helm.sh/chart: memcached-blocks-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: memcache
-      port: 11211
-      targetPort: memcache
-      nodePort: null
-  selector:
-    app.kubernetes.io/name: memcached-blocks
-    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/templates/cortex-alertmanager-headless-kkp.yaml
 # Copyright 2022 The Kubermatic Kubernetes Platform contributors.
@@ -672,10 +695,10 @@ metadata:
   name: release-name-cortex-distributor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
@@ -696,15 +719,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -713,7 +736,7 @@ spec:
         []
       containers:
         - name: distributor
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -792,16 +815,16 @@ metadata:
   name: release-name-cortex-querier
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
   annotations:
     {}
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
@@ -815,14 +838,14 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -831,7 +854,7 @@ spec:
         []
       containers:
         - name: querier
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -926,10 +949,10 @@ metadata:
   name: release-name-cortex-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
   annotations:
@@ -949,14 +972,14 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -965,7 +988,7 @@ spec:
         []
       containers:
         - name: query-frontend
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -1038,10 +1061,10 @@ metadata:
   name: release-name-cortex-ruler
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
@@ -1062,15 +1085,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1079,11 +1102,12 @@ spec:
         []
       containers:
         - name: rules
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ruler"
             - "-config.file=/etc/cortex/cortex.yaml"
+            - "-ruler.alertmanager-url=http://_http-metrics._tcp.cortex-alertmanager-headless.default.svc.cluster.local/api/prom/alertmanager/"
             
             - "-blocks-storage.bucket-store.index-cache.backend=memcached"
             - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+release-name-memcached-blocks-index.default.svc.cluster.local:11211"
@@ -1091,8 +1115,8 @@ spec:
             - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+release-name-memcached-blocks.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
             - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+release-name-memcached-blocks-metadata.default.svc.cluster.local:11211"
-            - "-ruler.storage.s3.access-key-id=$(ACCESS_KEY)"
-            - "-ruler.storage.s3.secret-access-key=$(SECRET_KEY)"
+            - "-ruler-storage.s3.access-key-id=$(ACCESS_KEY)"
+            - "-ruler-storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
             - mountPath: /etc/cortex-runtime-cfg
               name: cortex-runtime-config
@@ -1162,6 +1186,396 @@ spec:
             name: cortex-runtime-config
           name: cortex-runtime-config
 ---
+# Source: cortex/charts/cortex/charts/memcached-blocks-index/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-memcached-blocks-index
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-index
+    helm.sh/chart: memcached-blocks-index-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached-blocks-index
+      app.kubernetes.io/instance: release-name
+  replicas: 2
+  podManagementPolicy: "Parallel"
+  serviceName: release-name-memcached-blocks-index
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached-blocks-index
+        helm.sh/chart: memcached-blocks-index-6.3.12
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        prometheus.io/port: '9150'
+        prometheus.io/scrape: "true"
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: memcached-blocks-index
+                    app.kubernetes.io/instance: release-name
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      containers:
+        - name: memcached
+          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MEMCACHED_PORT_NUMBER
+              value: "11211"
+            - name: MEMCACHED_CACHE_SIZE
+              value: "1024"
+            - name: MEMCACHED_MAX_CONNECTIONS
+              value: "1024"
+            - name: MEMCACHED_THREADS
+              value: "4"
+          ports:
+            - name: memcache
+              containerPort: 11211
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: memcache
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            tcpSocket:
+              port: memcache
+          resources:
+            limits: {}
+            requests:
+              cpu: 5m
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        - name: metrics
+          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          ports:
+            - name: metrics
+              containerPort: 9150
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /metrics
+              port: 9150
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+            httpGet:
+              path: /metrics
+              port: 9150
+          resources:
+            limits: {}
+            requests: {}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-metadata/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-memcached-blocks-metadata
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    helm.sh/chart: memcached-blocks-metadata-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached-blocks-metadata
+      app.kubernetes.io/instance: release-name
+  replicas: 2
+  podManagementPolicy: "Parallel"
+  serviceName: release-name-memcached-blocks-metadata
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached-blocks-metadata
+        helm.sh/chart: memcached-blocks-metadata-6.3.12
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        prometheus.io/port: '9150'
+        prometheus.io/scrape: "true"
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: memcached-blocks-metadata
+                    app.kubernetes.io/instance: release-name
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      containers:
+        - name: memcached
+          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MEMCACHED_PORT_NUMBER
+              value: "11211"
+            - name: MEMCACHED_CACHE_SIZE
+              value: "1024"
+            - name: MEMCACHED_MAX_CONNECTIONS
+              value: "1024"
+            - name: MEMCACHED_THREADS
+              value: "4"
+          ports:
+            - name: memcache
+              containerPort: 11211
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: memcache
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            tcpSocket:
+              port: memcache
+          resources:
+            limits: {}
+            requests:
+              cpu: 5m
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        - name: metrics
+          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          ports:
+            - name: metrics
+              containerPort: 9150
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /metrics
+              port: 9150
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+            httpGet:
+              path: /metrics
+              port: 9150
+          resources:
+            limits: {}
+            requests: {}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-memcached-blocks
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks
+    helm.sh/chart: memcached-blocks-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached-blocks
+      app.kubernetes.io/instance: release-name
+  replicas: 2
+  podManagementPolicy: "Parallel"
+  serviceName: release-name-memcached-blocks
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached-blocks
+        helm.sh/chart: memcached-blocks-6.3.12
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        prometheus.io/port: '9150'
+        prometheus.io/scrape: "true"
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: memcached-blocks
+                    app.kubernetes.io/instance: release-name
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      containers:
+        - name: memcached
+          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MEMCACHED_PORT_NUMBER
+              value: "11211"
+            - name: MEMCACHED_CACHE_SIZE
+              value: "1024"
+            - name: MEMCACHED_MAX_CONNECTIONS
+              value: "1024"
+            - name: MEMCACHED_THREADS
+              value: "4"
+          ports:
+            - name: memcache
+              containerPort: 11211
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: memcache
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            tcpSocket:
+              port: memcache
+          resources:
+            limits: {}
+            requests:
+              cpu: 5m
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        - name: metrics
+          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          ports:
+            - name: metrics
+              containerPort: 9150
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /metrics
+              port: 9150
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+            httpGet:
+              path: /metrics
+              port: 9150
+          resources:
+            limits: {}
+            requests: {}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
 # Source: cortex/charts/cortex/templates/alertmanager/alertmanager-statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1169,10 +1583,10 @@ metadata:
   name: release-name-cortex-alertmanager
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
@@ -1202,15 +1616,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1246,13 +1660,13 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: alertmanager
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=alertmanager"
             - "-config.file=/etc/cortex/cortex.yaml"
-            - "-alertmanager.storage.s3.access-key-id=$(ACCESS_KEY)"
-            - "-alertmanager.storage.s3.secret-access-key=$(SECRET_KEY)"
+            - "-alertmanager-storage.s3.access-key-id=$(ACCESS_KEY)"
+            - "-alertmanager-storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
             - mountPath: /tmp
               name: storage
@@ -1307,10 +1721,10 @@ metadata:
   name: release-name-cortex-compactor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
@@ -1340,15 +1754,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1384,7 +1798,7 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: compactor
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -1441,10 +1855,10 @@ metadata:
   name: release-name-cortex-ingester
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
@@ -1475,15 +1889,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1519,7 +1933,7 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: ingester
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -1552,19 +1966,6 @@ spec:
             - name: gossip
               containerPort: 7946
               protocol: TCP
-          startupProbe:
-            failureThreshold: 60
-            httpGet:
-              path: /ready
-              port: http-metrics
-              scheme: HTTP
-            initialDelaySeconds: 120
-            periodSeconds: 30
-          livenessProbe:
-            httpGet:
-              path: /ready
-              port: http-metrics
-              scheme: HTTP
           readinessProbe:
             httpGet:
               path: /ready
@@ -1597,10 +1998,10 @@ metadata:
   name: release-name-cortex-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
@@ -1630,15 +2031,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1674,7 +2075,7 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: store-gateway
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"
@@ -1740,366 +2141,3 @@ spec:
                 secretKeyRef:
                   key: rootPassword
                   name: minio
----
-# Source: cortex/charts/memcached-blocks-index/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: release-name-memcached-blocks-index
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-index
-    helm.sh/chart: memcached-blocks-index-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: memcached-blocks-index
-      app.kubernetes.io/instance: release-name
-  replicas: 2
-  podManagementPolicy: "Parallel"
-  serviceName: release-name-memcached-blocks-index
-  updateStrategy:
-    rollingUpdate: {}
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: memcached-blocks-index
-        helm.sh/chart: memcached-blocks-index-6.3.1
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-      annotations:
-        prometheus.io/port: '9150'
-        prometheus.io/scrape: "true"
-    spec:
-      
-      affinity:
-        podAffinity:
-          
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: memcached-blocks-index
-                    app.kubernetes.io/instance: release-name
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-        nodeAffinity:
-          
-      securityContext:
-        fsGroup: 1001
-      serviceAccountName: default
-      containers:
-        - name: memcached
-          image: docker.io/bitnami/memcached:1.6.17-debian-11-r25
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MEMCACHED_PORT_NUMBER
-              value: "11211"
-          ports:
-            - name: memcache
-              containerPort: 11211
-          livenessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            tcpSocket:
-              port: memcache
-          readinessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
-            tcpSocket:
-              port: memcache
-          resources:
-            limits: {}
-            requests:
-              cpu: 5m
-              memory: 256Mi
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-        - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.10.0-debian-11-r51
-          imagePullPolicy: "IfNotPresent"
-          ports:
-            - name: metrics
-              containerPort: 9150
-          livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            httpGet:
-              path: /metrics
-              port: 9150
-          readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            httpGet:
-              path: /metrics
-              port: 9150
-          resources:
-            limits: {}
-            requests: {}
-      volumes:
-        - name: tmp
-          emptyDir: {}
----
-# Source: cortex/charts/memcached-blocks-metadata/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: release-name-memcached-blocks-metadata
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    helm.sh/chart: memcached-blocks-metadata-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: memcached-blocks-metadata
-      app.kubernetes.io/instance: release-name
-  replicas: 2
-  podManagementPolicy: "Parallel"
-  serviceName: release-name-memcached-blocks-metadata
-  updateStrategy:
-    rollingUpdate: {}
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: memcached-blocks-metadata
-        helm.sh/chart: memcached-blocks-metadata-6.3.1
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-      annotations:
-        prometheus.io/port: '9150'
-        prometheus.io/scrape: "true"
-    spec:
-      
-      affinity:
-        podAffinity:
-          
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: memcached-blocks-metadata
-                    app.kubernetes.io/instance: release-name
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-        nodeAffinity:
-          
-      securityContext:
-        fsGroup: 1001
-      serviceAccountName: default
-      containers:
-        - name: memcached
-          image: docker.io/bitnami/memcached:1.6.17-debian-11-r25
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MEMCACHED_PORT_NUMBER
-              value: "11211"
-          ports:
-            - name: memcache
-              containerPort: 11211
-          livenessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            tcpSocket:
-              port: memcache
-          readinessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
-            tcpSocket:
-              port: memcache
-          resources:
-            limits: {}
-            requests:
-              cpu: 5m
-              memory: 256Mi
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-        - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.10.0-debian-11-r51
-          imagePullPolicy: "IfNotPresent"
-          ports:
-            - name: metrics
-              containerPort: 9150
-          livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            httpGet:
-              path: /metrics
-              port: 9150
-          readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            httpGet:
-              path: /metrics
-              port: 9150
-          resources:
-            limits: {}
-            requests: {}
-      volumes:
-        - name: tmp
-          emptyDir: {}
----
-# Source: cortex/charts/memcached-blocks/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: release-name-memcached-blocks
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks
-    helm.sh/chart: memcached-blocks-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: memcached-blocks
-      app.kubernetes.io/instance: release-name
-  replicas: 2
-  podManagementPolicy: "Parallel"
-  serviceName: release-name-memcached-blocks
-  updateStrategy:
-    rollingUpdate: {}
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: memcached-blocks
-        helm.sh/chart: memcached-blocks-6.3.1
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-      annotations:
-        prometheus.io/port: '9150'
-        prometheus.io/scrape: "true"
-    spec:
-      
-      affinity:
-        podAffinity:
-          
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: memcached-blocks
-                    app.kubernetes.io/instance: release-name
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-        nodeAffinity:
-          
-      securityContext:
-        fsGroup: 1001
-      serviceAccountName: default
-      containers:
-        - name: memcached
-          image: docker.io/bitnami/memcached:1.6.17-debian-11-r25
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MEMCACHED_PORT_NUMBER
-              value: "11211"
-          ports:
-            - name: memcache
-              containerPort: 11211
-          livenessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            tcpSocket:
-              port: memcache
-          readinessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
-            tcpSocket:
-              port: memcache
-          resources:
-            limits: {}
-            requests:
-              cpu: 5m
-              memory: 256Mi
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-        - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.10.0-debian-11-r51
-          imagePullPolicy: "IfNotPresent"
-          ports:
-            - name: metrics
-              containerPort: 9150
-          livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            httpGet:
-              path: /metrics
-              port: 9150
-          readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            httpGet:
-              path: /metrics
-              port: 9150
-          resources:
-            limits: {}
-            requests: {}
-      volumes:
-        - name: tmp
-          emptyDir: {}

--- a/charts/mla/cortex/test/default.yaml.out
+++ b/charts/mla/cortex/test/default.yaml.out
@@ -6,10 +6,10 @@ metadata:
   name: release-name-cortex-alertmanager
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
 spec:
@@ -27,10 +27,10 @@ metadata:
   name: release-name-cortex-distributor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
 spec:
@@ -48,10 +48,10 @@ metadata:
   name: release-name-cortex-ingester
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
 spec:
@@ -62,6 +62,27 @@ spec:
       app.kubernetes.io/component: ingester
   maxUnavailable: 1
 ---
+# Source: cortex/charts/cortex/templates/querier/querier-poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: release-name-cortex-querier
+  namespace: default
+  labels:
+    helm.sh/chart: cortex-2.1.0
+    app.kubernetes.io/name: cortex
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/version: "v1.14.1"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: querier
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cortex
+      app.kubernetes.io/instance: release-name
+      app.kubernetes.io/component: querier
+  maxUnavailable: 1
+---
 # Source: cortex/charts/cortex/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -69,10 +90,10 @@ metadata:
   name: release-name-cortex
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     {}
@@ -85,13 +106,163 @@ metadata:
   name: release-name-cortex
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
 data:
-  cortex.yaml: YWxlcnRtYW5hZ2VyOgogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvYWxlcnQtZGF0YQogIGVuYWJsZV9hcGk6IHRydWUKICBleHRlcm5hbF91cmw6IC9hcGkvcHJvbS9hbGVydG1hbmFnZXIKICBzdG9yYWdlOgogICAgczM6CiAgICAgIGJ1Y2tldG5hbWVzOiBhbGVydG1hbmFnZXIKICAgICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgICAgaW5zZWN1cmU6IHRydWUKICAgICAgczNmb3JjZXBhdGhzdHlsZTogdHJ1ZQogICAgdHlwZTogczMKYXBpOgogIHByb21ldGhldXNfaHR0cF9wcmVmaXg6IC9wcm9tZXRoZXVzCiAgcmVzcG9uc2VfY29tcHJlc3Npb25fZW5hYmxlZDogdHJ1ZQphdXRoX2VuYWJsZWQ6IHRydWUKYmxvY2tzX3N0b3JhZ2U6CiAgYmFja2VuZDogczMKICBidWNrZXRfc3RvcmU6CiAgICBidWNrZXRfaW5kZXg6CiAgICAgIGVuYWJsZWQ6IHRydWUKICAgIGlnbm9yZV9kZWxldGlvbl9tYXJrX2RlbGF5OiAxaAogICAgc3luY19kaXI6IC9kYXRhCiAgczM6CiAgICBidWNrZXRfbmFtZTogY29ydGV4CiAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgaW5zZWN1cmU6IHRydWUKICB0c2RiOgogICAgY2xvc2VfaWRsZV90c2RiX3RpbWVvdXQ6IDM2NW0KICAgIGRpcjogL2RhdGEKICAgIGZsdXNoX2Jsb2Nrc19vbl9zaHV0ZG93bjogdHJ1ZQogICAgcmV0ZW50aW9uX3BlcmlvZDogMzY1bQogICAgd2FsX2NvbXByZXNzaW9uX2VuYWJsZWQ6IHRydWUKY2h1bmtfc3RvcmU6CiAgY2h1bmtfY2FjaGVfY29uZmlnOgogICAgbWVtY2FjaGVkOgogICAgICBleHBpcmF0aW9uOiAxaAogICAgbWVtY2FjaGVkX2NsaWVudDoKICAgICAgdGltZW91dDogMXMKY29tcGFjdG9yOgogIGJsb2NrX2RlbGV0aW9uX21hcmtzX21pZ3JhdGlvbl9lbmFibGVkOiBmYWxzZQogIGNvbXBhY3Rpb25faW50ZXJ2YWw6IDMwbQogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvY29tcGFjdG9yCiAgc2hhcmRpbmdfZW5hYmxlZDogdHJ1ZQogIHNoYXJkaW5nX3Jpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdApkaXN0cmlidXRvcjoKICBoYV90cmFja2VyOgogICAgZW5hYmxlX2hhX3RyYWNrZXI6IHRydWUKICAgIGt2c3RvcmU6CiAgICAgIGNvbnN1bDoKICAgICAgICBob3N0OiBjb25zdWwtY29uc3VsLXNlcnZlcjo4NTAwCiAgICAgIHN0b3JlOiBjb25zdWwKICBwb29sOgogICAgaGVhbHRoX2NoZWNrX2luZ2VzdGVyczogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHNoYXJkX2J5X2FsbF9sYWJlbHM6IHRydWUKZnJvbnRlbmQ6CiAgbG9nX3F1ZXJpZXNfbG9uZ2VyX3RoYW46IDEwcwppbmdlc3RlcjoKICBsaWZlY3ljbGVyOgogICAgZmluYWxfc2xlZXA6IDBzCiAgICBqb2luX2FmdGVyOiAwcwogICAgbnVtX3Rva2VuczogNTEyCiAgICBvYnNlcnZlX3BlcmlvZDogMTBzCiAgICByaW5nOgogICAgICBrdnN0b3JlOgogICAgICAgIGNvbnN1bDoKICAgICAgICAgIGNvbnNpc3RlbnRfcmVhZHM6IHRydWUKICAgICAgICAgIGhvc3Q6IGNvbnN1bDo4NTAwCiAgICAgICAgICBodHRwX2NsaWVudF90aW1lb3V0OiAyMHMKICAgICAgICBwcmVmaXg6IGNvbGxlY3RvcnMvCiAgICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICAgICAgcmVwbGljYXRpb25fZmFjdG9yOiAzCiAgbWF4X3RyYW5zZmVyX3JldHJpZXM6IDAKaW5nZXN0ZXJfY2xpZW50OgogIGdycGNfY2xpZW50X2NvbmZpZzoKICAgIG1heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICAgIG1heF9zZW5kX21zZ19zaXplOiAxMDQ4NTc2MDAKbGltaXRzOgogIGFjY2VwdF9oYV9zYW1wbGVzOiB0cnVlCiAgZW5mb3JjZV9tZXRyaWNfbmFtZTogZmFsc2UKICBtYXhfbGFiZWxfbmFtZXNfcGVyX3NlcmllczogNDAKICBtYXhfcXVlcnlfbG9va2JhY2s6IDE2OGgKICByZWplY3Rfb2xkX3NhbXBsZXM6IHRydWUKICByZWplY3Rfb2xkX3NhbXBsZXNfbWF4X2FnZTogMTY4aAptZW1iZXJsaXN0OgogIGJpbmRfcG9ydDogNzk0NgogIGpvaW5fbWVtYmVyczoKICAtIGNvcnRleC1pbmdlc3Rlci1oZWFkbGVzcwpxdWVyaWVyOgogIGFjdGl2ZV9xdWVyeV90cmFja2VyX2RpcjogL2RhdGEvY29ydGV4L3F1ZXJpZXIKICBxdWVyeV9pbmdlc3RlcnNfd2l0aGluOiAzNjVtCiAgcXVlcnlfc3RvcmVfYWZ0ZXI6IDM2MG0KICBzdG9yZV9nYXRld2F5X2FkZHJlc3NlczogfC0KICAgIApxdWVyeV9yYW5nZToKICBhbGlnbl9xdWVyaWVzX3dpdGhfc3RlcDogdHJ1ZQogIGNhY2hlX3Jlc3VsdHM6IHRydWUKICByZXN1bHRzX2NhY2hlOgogICAgY2FjaGU6CiAgICAgIG1lbWNhY2hlZDoKICAgICAgICBleHBpcmF0aW9uOiAxaAogICAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICAgIHRpbWVvdXQ6IDFzCiAgc3BsaXRfcXVlcmllc19ieV9pbnRlcnZhbDogMjRoCnJ1bGVyOgogIGFsZXJ0bWFuYWdlcl91cmw6IGh0dHA6Ly9faHR0cC1tZXRyaWNzLl90Y3AuY29ydGV4LWFsZXJ0bWFuYWdlci1oZWFkbGVzcy1ra3AvYXBpL3Byb20vYWxlcnRtYW5hZ2VyLwogIGVuYWJsZV9hbGVydG1hbmFnZXJfZGlzY292ZXJ5OiB0cnVlCiAgZW5hYmxlX2FwaTogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogIHN0b3JhZ2U6CiAgICBzMzoKICAgICAgYnVja2V0bmFtZXM6IGNvcnRleC1ydWxlcgogICAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgICBpbnNlY3VyZTogdHJ1ZQogICAgICBzM2ZvcmNlcGF0aHN0eWxlOiB0cnVlCiAgICB0eXBlOiBzMwpydW50aW1lX2NvbmZpZzoKICBmaWxlOiAvZXRjL2NvcnRleC1ydW50aW1lLWNmZy9ydW50aW1lLWNvbmZpZy55YW1sCiAgcGVyaW9kOiAxMHMKc2NoZW1hOgogIGNvbmZpZ3M6CiAgLSBjaHVua3M6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGNodW5rc18KICAgIGZyb206ICIyMDIwLTExLTAxIgogICAgaW5kZXg6CiAgICAgIHBlcmlvZDogMTY4aAogICAgICBwcmVmaXg6IGluZGV4XwogICAgb2JqZWN0X3N0b3JlOiBjYXNzYW5kcmEKICAgIHNjaGVtYTogdjEwCiAgICBzdG9yZTogY2Fzc2FuZHJhCnNlcnZlcjoKICBncnBjX2xpc3Rlbl9wb3J0OiA5MDk1CiAgZ3JwY19zZXJ2ZXJfbWF4X2NvbmN1cnJlbnRfc3RyZWFtczogMTAwMAogIGdycGNfc2VydmVyX21heF9yZWN2X21zZ19zaXplOiAxMDQ4NTc2MDAKICBncnBjX3NlcnZlcl9tYXhfc2VuZF9tc2dfc2l6ZTogMTA0ODU3NjAwCiAgaHR0cF9saXN0ZW5fcG9ydDogODA4MApzdG9yYWdlOgogIGF6dXJlOgogICAgYWNjb3VudF9rZXk6IG51bGwKICAgIGFjY291bnRfbmFtZTogbnVsbAogICAgY29udGFpbmVyX25hbWU6IG51bGwKICBjYXNzYW5kcmE6CiAgICBhZGRyZXNzZXM6IG51bGwKICAgIGF1dGg6IHRydWUKICAgIGtleXNwYWNlOiBjb3J0ZXgKICAgIHBhc3N3b3JkOiBudWxsCiAgICB1c2VybmFtZTogbnVsbAogIGVuZ2luZTogYmxvY2tzCiAgaW5kZXhfcXVlcmllc19jYWNoZV9jb25maWc6CiAgICBtZW1jYWNoZWQ6CiAgICAgIGV4cGlyYXRpb246IDFoCiAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICB0aW1lb3V0OiAxcwpzdG9yZV9nYXRld2F5OgogIHNoYXJkaW5nX2VuYWJsZWQ6IHRydWUKICBzaGFyZGluZ19yaW5nOgogICAga3ZzdG9yZToKICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICAgIHJlcGxpY2F0aW9uX2ZhY3RvcjogMgp0YWJsZV9tYW5hZ2VyOgogIHJldGVudGlvbl9kZWxldGVzX2VuYWJsZWQ6IGZhbHNlCiAgcmV0ZW50aW9uX3BlcmlvZDogMHM=
+  cortex.yaml: YWxlcnRtYW5hZ2VyOgogIGRhdGFfZGlyOiAvZGF0YS9jb3J0ZXgvYWxlcnQtZGF0YQogIGVuYWJsZV9hcGk6IHRydWUKICBleHRlcm5hbF91cmw6IC9hcGkvcHJvbS9hbGVydG1hbmFnZXIKYWxlcnRtYW5hZ2VyX3N0b3JhZ2U6CiAgczM6CiAgICBidWNrZXRfbmFtZTogYWxlcnRtYW5hZ2VyCiAgICBlbmRwb2ludDogbWluaW86OTAwMAogICAgaW5zZWN1cmU6IHRydWUKYXBpOgogIHByb21ldGhldXNfaHR0cF9wcmVmaXg6IC9wcm9tZXRoZXVzCiAgcmVzcG9uc2VfY29tcHJlc3Npb25fZW5hYmxlZDogdHJ1ZQphdXRoX2VuYWJsZWQ6IHRydWUKYmxvY2tzX3N0b3JhZ2U6CiAgYnVja2V0X3N0b3JlOgogICAgYnVja2V0X2luZGV4OgogICAgICBlbmFibGVkOiB0cnVlCiAgICBpZ25vcmVfZGVsZXRpb25fbWFya19kZWxheTogMWgKICAgIHN5bmNfZGlyOiAvZGF0YQogIHMzOgogICAgYnVja2V0X25hbWU6IGNvcnRleAogICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgIGluc2VjdXJlOiB0cnVlCiAgdHNkYjoKICAgIGNsb3NlX2lkbGVfdHNkYl90aW1lb3V0OiAzNjVtCiAgICBkaXI6IC9kYXRhCiAgICBmbHVzaF9ibG9ja3Nfb25fc2h1dGRvd246IHRydWUKICAgIHJldGVudGlvbl9wZXJpb2Q6IDM2NW0KICAgIHdhbF9jb21wcmVzc2lvbl9lbmFibGVkOiB0cnVlCmNvbXBhY3RvcjoKICBkYXRhX2RpcjogL2RhdGEvY29ydGV4L2NvbXBhY3RvcgogIHNoYXJkaW5nX2VuYWJsZWQ6IHRydWUKICBzaGFyZGluZ19yaW5nOgogICAga3ZzdG9yZToKICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKZGlzdHJpYnV0b3I6CiAgaGFfdHJhY2tlcjoKICAgIGVuYWJsZV9oYV90cmFja2VyOiB0cnVlCiAgICBrdnN0b3JlOgogICAgICBjb25zdWw6CiAgICAgICAgaG9zdDogY29uc3VsLWNvbnN1bC1zZXJ2ZXI6ODUwMAogICAgICBzdG9yZTogY29uc3VsCiAgcG9vbDoKICAgIGhlYWx0aF9jaGVja19pbmdlc3RlcnM6IHRydWUKICByaW5nOgogICAga3ZzdG9yZToKICAgICAgc3RvcmU6IG1lbWJlcmxpc3QKICBzaGFyZF9ieV9hbGxfbGFiZWxzOiB0cnVlCmZyb250ZW5kOgogIGxvZ19xdWVyaWVzX2xvbmdlcl90aGFuOiAxMHMKaW5nZXN0ZXI6CiAgbGlmZWN5Y2xlcjoKICAgIGZpbmFsX3NsZWVwOiAzMHMKICAgIGpvaW5fYWZ0ZXI6IDEwcwogICAgbnVtX3Rva2VuczogNTEyCiAgICBvYnNlcnZlX3BlcmlvZDogMTBzCiAgICByaW5nOgogICAgICBrdnN0b3JlOgogICAgICAgIHN0b3JlOiBtZW1iZXJsaXN0CiAgICAgIHJlcGxpY2F0aW9uX2ZhY3RvcjogMwppbmdlc3Rlcl9jbGllbnQ6CiAgZ3JwY19jbGllbnRfY29uZmlnOgogICAgbWF4X3JlY3ZfbXNnX3NpemU6IDEwNDg1NzYwCiAgICBtYXhfc2VuZF9tc2dfc2l6ZTogMTA0ODU3NjAKbGltaXRzOgogIGFjY2VwdF9oYV9zYW1wbGVzOiB0cnVlCiAgZW5mb3JjZV9tZXRyaWNfbmFtZTogdHJ1ZQogIG1heF9sYWJlbF9uYW1lc19wZXJfc2VyaWVzOiA0MAogIG1heF9xdWVyeV9sb29rYmFjazogMHMKICByZWplY3Rfb2xkX3NhbXBsZXM6IHRydWUKICByZWplY3Rfb2xkX3NhbXBsZXNfbWF4X2FnZTogMTY4aAptZW1iZXJsaXN0OgogIGJpbmRfcG9ydDogNzk0NgogIGpvaW5fbWVtYmVyczoKICAtIGNvcnRleC1pbmdlc3Rlci1oZWFkbGVzcwpxdWVyaWVyOgogIGFjdGl2ZV9xdWVyeV90cmFja2VyX2RpcjogL2RhdGEvYWN0aXZlLXF1ZXJ5LXRyYWNrZXIKICBxdWVyeV9pbmdlc3RlcnNfd2l0aGluOiAzNjVtCiAgcXVlcnlfc3RvcmVfYWZ0ZXI6IDM2MG0KICBzdG9yZV9nYXRld2F5X2FkZHJlc3NlczogfC0KICAgIApxdWVyeV9yYW5nZToKICBhbGlnbl9xdWVyaWVzX3dpdGhfc3RlcDogdHJ1ZQogIGNhY2hlX3Jlc3VsdHM6IHRydWUKICByZXN1bHRzX2NhY2hlOgogICAgY2FjaGU6CiAgICAgIG1lbWNhY2hlZDoKICAgICAgICBleHBpcmF0aW9uOiAxaAogICAgICBtZW1jYWNoZWRfY2xpZW50OgogICAgICAgIHRpbWVvdXQ6IDFzCiAgc3BsaXRfcXVlcmllc19ieV9pbnRlcnZhbDogMjRoCnJ1bGVyOgogIGVuYWJsZV9hbGVydG1hbmFnZXJfZGlzY292ZXJ5OiB0cnVlCiAgZW5hYmxlX2FwaTogdHJ1ZQogIHJpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdApydWxlcl9zdG9yYWdlOgogIHMzOgogICAgYnVja2V0X25hbWU6IGNvcnRleC1ydWxlcgogICAgZW5kcG9pbnQ6IG1pbmlvOjkwMDAKICAgIGluc2VjdXJlOiB0cnVlCnJ1bnRpbWVfY29uZmlnOgogIGZpbGU6IC9ldGMvY29ydGV4LXJ1bnRpbWUtY2ZnL3J1bnRpbWUtY29uZmlnLnlhbWwKICBwZXJpb2Q6IDEwcwpzZXJ2ZXI6CiAgZ3JwY19saXN0ZW5fcG9ydDogOTA5NQogIGdycGNfc2VydmVyX21heF9jb25jdXJyZW50X3N0cmVhbXM6IDEwMDAwCiAgZ3JwY19zZXJ2ZXJfbWF4X3JlY3ZfbXNnX3NpemU6IDEwNDg1NzYwCiAgZ3JwY19zZXJ2ZXJfbWF4X3NlbmRfbXNnX3NpemU6IDEwNDg1NzYwCiAgaHR0cF9saXN0ZW5fcG9ydDogODA4MApzdG9yYWdlOgogIGVuZ2luZTogYmxvY2tzCnN0b3JlX2dhdGV3YXk6CiAgc2hhcmRpbmdfZW5hYmxlZDogdHJ1ZQogIHNoYXJkaW5nX3Jpbmc6CiAgICBrdnN0b3JlOgogICAgICBzdG9yZTogbWVtYmVybGlzdAogICAgcmVwbGljYXRpb25fZmFjdG9yOiAy
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-index/templates/metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-index-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-index
+    helm.sh/chart: memcached-blocks-index-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+  annotations:
+    prometheus.io/port: '9150'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 9150
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: memcached-blocks-index
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-index/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-index
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-index
+    helm.sh/chart: memcached-blocks-index-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached-blocks-index
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-metadata/templates/metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-metadata-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    helm.sh/chart: memcached-blocks-metadata-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+  annotations:
+    prometheus.io/port: '9150'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 9150
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-metadata/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-metadata
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    helm.sh/chart: memcached-blocks-metadata-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks/templates/metrics-svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks-metrics
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks
+    helm.sh/chart: memcached-blocks-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+  annotations:
+    prometheus.io/port: '9150'
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: metrics
+      port: 9150
+      targetPort: metrics
+  selector:
+    app.kubernetes.io/name: memcached-blocks
+    app.kubernetes.io/instance: release-name
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: release-name-memcached-blocks
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks
+    helm.sh/chart: memcached-blocks-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  ports:
+    - name: memcache
+      port: 11211
+      targetPort: memcache
+      nodePort: null
+  selector:
+    app.kubernetes.io/name: memcached-blocks
+    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/charts/cortex/templates/alertmanager/alertmanager-svc-headless.yaml
 apiVersion: v1
@@ -100,10 +271,10 @@ metadata:
   name: release-name-cortex-alertmanager-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
   annotations:
@@ -129,10 +300,10 @@ metadata:
   name: release-name-cortex-alertmanager
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
   annotations:
@@ -156,10 +327,10 @@ metadata:
   name: release-name-cortex-compactor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: compactor
   annotations:
@@ -183,10 +354,10 @@ metadata:
   name: release-name-cortex-distributor-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
   annotations:
@@ -212,10 +383,10 @@ metadata:
   name: release-name-cortex-distributor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
   annotations:
@@ -239,10 +410,10 @@ metadata:
   name: release-name-cortex-ingester-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
   annotations:
@@ -267,10 +438,10 @@ metadata:
   name: release-name-cortex-ingester
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
   annotations:
@@ -294,10 +465,10 @@ metadata:
   name: release-name-cortex-querier
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
   annotations:
@@ -321,10 +492,10 @@ metadata:
   name: release-name-cortex-query-frontend-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
   annotations:
@@ -350,10 +521,10 @@ metadata:
   name: release-name-cortex-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
   annotations:
@@ -377,10 +548,10 @@ metadata:
   name: release-name-cortex-ruler
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
   annotations:
@@ -404,10 +575,10 @@ metadata:
   name: release-name-cortex-store-gateway-headless
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
   annotations:
@@ -432,10 +603,10 @@ metadata:
   name: release-name-cortex-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
   annotations:
@@ -459,11 +630,13 @@ metadata:
   name: release-name-cortex-memberlist
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    {}
 spec:
   type: ClusterIP
   clusterIP: None
@@ -476,156 +649,6 @@ spec:
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/part-of: memberlist
----
-# Source: cortex/charts/memcached-blocks-index/templates/metrics-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-index-metrics
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-index
-    helm.sh/chart: memcached-blocks-index-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-  annotations:
-    prometheus.io/port: '9150'
-    prometheus.io/scrape: "true"
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: metrics
-      port: 9150
-      targetPort: metrics
-  selector:
-    app.kubernetes.io/name: memcached-blocks-index
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks-index/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-index
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-index
-    helm.sh/chart: memcached-blocks-index-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: memcache
-      port: 11211
-      targetPort: memcache
-      nodePort: null
-  selector:
-    app.kubernetes.io/name: memcached-blocks-index
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks-metadata/templates/metrics-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-metadata-metrics
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    helm.sh/chart: memcached-blocks-metadata-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-  annotations:
-    prometheus.io/port: '9150'
-    prometheus.io/scrape: "true"
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: metrics
-      port: 9150
-      targetPort: metrics
-  selector:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks-metadata/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-metadata
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    helm.sh/chart: memcached-blocks-metadata-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: memcache
-      port: 11211
-      targetPort: memcache
-      nodePort: null
-  selector:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks/templates/metrics-svc.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks-metrics
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks
-    helm.sh/chart: memcached-blocks-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-  annotations:
-    prometheus.io/port: '9150'
-    prometheus.io/scrape: "true"
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: metrics
-      port: 9150
-      targetPort: metrics
-  selector:
-    app.kubernetes.io/name: memcached-blocks
-    app.kubernetes.io/instance: release-name
----
-# Source: cortex/charts/memcached-blocks/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: release-name-memcached-blocks
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks
-    helm.sh/chart: memcached-blocks-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-  annotations:
-spec:
-  type: ClusterIP
-  sessionAffinity: None
-  ports:
-    - name: memcache
-      port: 11211
-      targetPort: memcache
-      nodePort: null
-  selector:
-    app.kubernetes.io/name: memcached-blocks
-    app.kubernetes.io/instance: release-name
 ---
 # Source: cortex/templates/cortex-alertmanager-headless-kkp.yaml
 # Copyright 2022 The Kubermatic Kubernetes Platform contributors.
@@ -672,10 +695,10 @@ metadata:
   name: release-name-cortex-distributor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: distributor
     app.kubernetes.io/part-of: memberlist
@@ -696,15 +719,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: distributor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -713,7 +736,7 @@ spec:
         []
       containers:
         - name: distributor
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=distributor"
@@ -792,16 +815,16 @@ metadata:
   name: release-name-cortex-querier
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: querier
   annotations:
     {}
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app.kubernetes.io/name: cortex
@@ -815,14 +838,14 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: querier
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -831,7 +854,7 @@ spec:
         []
       containers:
         - name: querier
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=querier"
@@ -926,10 +949,10 @@ metadata:
   name: release-name-cortex-query-frontend
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: query-frontend
   annotations:
@@ -949,14 +972,14 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: query-frontend
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -965,7 +988,7 @@ spec:
         []
       containers:
         - name: query-frontend
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=query-frontend"
@@ -1038,10 +1061,10 @@ metadata:
   name: release-name-cortex-ruler
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ruler
     app.kubernetes.io/part-of: memberlist
@@ -1062,15 +1085,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ruler
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1079,11 +1102,12 @@ spec:
         []
       containers:
         - name: rules
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ruler"
             - "-config.file=/etc/cortex/cortex.yaml"
+            - "-ruler.alertmanager-url=http://_http-metrics._tcp.cortex-alertmanager-headless.default.svc.cluster.local/api/prom/alertmanager/"
             
             - "-blocks-storage.bucket-store.index-cache.backend=memcached"
             - "-blocks-storage.bucket-store.index-cache.memcached.addresses=dns+release-name-memcached-blocks-index.default.svc.cluster.local:11211"
@@ -1091,8 +1115,8 @@ spec:
             - "-blocks-storage.bucket-store.chunks-cache.memcached.addresses=dns+release-name-memcached-blocks.default.svc.cluster.local:11211"
             - "-blocks-storage.bucket-store.metadata-cache.backend=memcached"
             - "-blocks-storage.bucket-store.metadata-cache.memcached.addresses=dns+release-name-memcached-blocks-metadata.default.svc.cluster.local:11211"
-            - "-ruler.storage.s3.access-key-id=$(ACCESS_KEY)"
-            - "-ruler.storage.s3.secret-access-key=$(SECRET_KEY)"
+            - "-ruler-storage.s3.access-key-id=$(ACCESS_KEY)"
+            - "-ruler-storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
             - mountPath: /etc/cortex-runtime-cfg
               name: cortex-runtime-config
@@ -1162,6 +1186,396 @@ spec:
             name: cortex-runtime-config
           name: cortex-runtime-config
 ---
+# Source: cortex/charts/cortex/charts/memcached-blocks-index/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-memcached-blocks-index
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-index
+    helm.sh/chart: memcached-blocks-index-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached-blocks-index
+      app.kubernetes.io/instance: release-name
+  replicas: 2
+  podManagementPolicy: "Parallel"
+  serviceName: release-name-memcached-blocks-index
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached-blocks-index
+        helm.sh/chart: memcached-blocks-index-6.3.12
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        prometheus.io/port: '9150'
+        prometheus.io/scrape: "true"
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: memcached-blocks-index
+                    app.kubernetes.io/instance: release-name
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      containers:
+        - name: memcached
+          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MEMCACHED_PORT_NUMBER
+              value: "11211"
+            - name: MEMCACHED_CACHE_SIZE
+              value: "1024"
+            - name: MEMCACHED_MAX_CONNECTIONS
+              value: "1024"
+            - name: MEMCACHED_THREADS
+              value: "4"
+          ports:
+            - name: memcache
+              containerPort: 11211
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: memcache
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            tcpSocket:
+              port: memcache
+          resources:
+            limits: {}
+            requests:
+              cpu: 5m
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        - name: metrics
+          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          ports:
+            - name: metrics
+              containerPort: 9150
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /metrics
+              port: 9150
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+            httpGet:
+              path: /metrics
+              port: 9150
+          resources:
+            limits: {}
+            requests: {}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks-metadata/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-memcached-blocks-metadata
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks-metadata
+    helm.sh/chart: memcached-blocks-metadata-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached-blocks-metadata
+      app.kubernetes.io/instance: release-name
+  replicas: 2
+  podManagementPolicy: "Parallel"
+  serviceName: release-name-memcached-blocks-metadata
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached-blocks-metadata
+        helm.sh/chart: memcached-blocks-metadata-6.3.12
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        prometheus.io/port: '9150'
+        prometheus.io/scrape: "true"
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: memcached-blocks-metadata
+                    app.kubernetes.io/instance: release-name
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      containers:
+        - name: memcached
+          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MEMCACHED_PORT_NUMBER
+              value: "11211"
+            - name: MEMCACHED_CACHE_SIZE
+              value: "1024"
+            - name: MEMCACHED_MAX_CONNECTIONS
+              value: "1024"
+            - name: MEMCACHED_THREADS
+              value: "4"
+          ports:
+            - name: memcache
+              containerPort: 11211
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: memcache
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            tcpSocket:
+              port: memcache
+          resources:
+            limits: {}
+            requests:
+              cpu: 5m
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        - name: metrics
+          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          ports:
+            - name: metrics
+              containerPort: 9150
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /metrics
+              port: 9150
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+            httpGet:
+              path: /metrics
+              port: 9150
+          resources:
+            limits: {}
+            requests: {}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
+# Source: cortex/charts/cortex/charts/memcached-blocks/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: release-name-memcached-blocks
+  namespace: default
+  labels:
+    app.kubernetes.io/name: memcached-blocks
+    helm.sh/chart: memcached-blocks-6.3.12
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: memcached-blocks
+      app.kubernetes.io/instance: release-name
+  replicas: 2
+  podManagementPolicy: "Parallel"
+  serviceName: release-name-memcached-blocks
+  updateStrategy:
+    rollingUpdate: {}
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: memcached-blocks
+        helm.sh/chart: memcached-blocks-6.3.12
+        app.kubernetes.io/instance: release-name
+        app.kubernetes.io/managed-by: Helm
+      annotations:
+        prometheus.io/port: '9150'
+        prometheus.io/scrape: "true"
+    spec:
+      
+      affinity:
+        podAffinity:
+          
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: memcached-blocks
+                    app.kubernetes.io/instance: release-name
+                topologyKey: kubernetes.io/hostname
+              weight: 1
+        nodeAffinity:
+          
+      securityContext:
+        fsGroup: 1001
+      serviceAccountName: default
+      containers:
+        - name: memcached
+          image: docker.io/bitnami/memcached:1.6.19-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: MEMCACHED_PORT_NUMBER
+              value: "11211"
+            - name: MEMCACHED_CACHE_SIZE
+              value: "1024"
+            - name: MEMCACHED_MAX_CONNECTIONS
+              value: "1024"
+            - name: MEMCACHED_THREADS
+              value: "4"
+          ports:
+            - name: memcache
+              containerPort: 11211
+          livenessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            tcpSocket:
+              port: memcache
+          readinessProbe:
+            failureThreshold: 6
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+            tcpSocket:
+              port: memcache
+          resources:
+            limits: {}
+            requests:
+              cpu: 5m
+              memory: 256Mi
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+        - name: metrics
+          image: docker.io/bitnami/memcached-exporter:0.11.2-debian-11-r0
+          imagePullPolicy: "IfNotPresent"
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1001
+          ports:
+            - name: metrics
+              containerPort: 9150
+          livenessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 5
+            httpGet:
+              path: /metrics
+              port: 9150
+          readinessProbe:
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 3
+            httpGet:
+              path: /metrics
+              port: 9150
+          resources:
+            limits: {}
+            requests: {}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+---
 # Source: cortex/charts/cortex/templates/alertmanager/alertmanager-statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
@@ -1169,10 +1583,10 @@ metadata:
   name: release-name-cortex-alertmanager
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: alertmanager
     app.kubernetes.io/part-of: memberlist
@@ -1202,15 +1616,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1246,13 +1660,13 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: alertmanager
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=alertmanager"
             - "-config.file=/etc/cortex/cortex.yaml"
-            - "-alertmanager.storage.s3.access-key-id=$(ACCESS_KEY)"
-            - "-alertmanager.storage.s3.secret-access-key=$(SECRET_KEY)"
+            - "-alertmanager-storage.s3.access-key-id=$(ACCESS_KEY)"
+            - "-alertmanager-storage.s3.secret-access-key=$(SECRET_KEY)"
           volumeMounts:
             - mountPath: /tmp
               name: storage
@@ -1307,10 +1721,10 @@ metadata:
   name: release-name-cortex-compactor
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: compactor
     app.kubernetes.io/part-of: memberlist
@@ -1340,15 +1754,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: compactor
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1384,7 +1798,7 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: compactor
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=compactor"
@@ -1441,10 +1855,10 @@ metadata:
   name: release-name-cortex-ingester
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: ingester
     app.kubernetes.io/part-of: memberlist
@@ -1475,15 +1889,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: ingester
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1519,7 +1933,7 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: ingester
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=ingester"
@@ -1552,19 +1966,6 @@ spec:
             - name: gossip
               containerPort: 7946
               protocol: TCP
-          startupProbe:
-            failureThreshold: 60
-            httpGet:
-              path: /ready
-              port: http-metrics
-              scheme: HTTP
-            initialDelaySeconds: 120
-            periodSeconds: 30
-          livenessProbe:
-            httpGet:
-              path: /ready
-              port: http-metrics
-              scheme: HTTP
           readinessProbe:
             httpGet:
               path: /ready
@@ -1597,10 +1998,10 @@ metadata:
   name: release-name-cortex-store-gateway
   namespace: default
   labels:
-    helm.sh/chart: cortex-1.7.0
+    helm.sh/chart: cortex-2.1.0
     app.kubernetes.io/name: cortex
     app.kubernetes.io/instance: release-name
-    app.kubernetes.io/version: "v1.13.0"
+    app.kubernetes.io/version: "v1.14.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: store-gateway
     app.kubernetes.io/part-of: memberlist
@@ -1630,15 +2031,15 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: cortex-1.7.0
+        helm.sh/chart: cortex-2.1.0
         app.kubernetes.io/name: cortex
         app.kubernetes.io/instance: release-name
-        app.kubernetes.io/version: "v1.13.0"
+        app.kubernetes.io/version: "v1.14.1"
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/part-of: memberlist
       annotations:
-        checksum/config: db215ef6818194593da13deb83fb6a216f13c7486059c51fa522313d08f66528
+        checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1674,7 +2075,7 @@ spec:
           name: cortex-runtime-config
       containers:
         - name: store-gateway
-          image: "quay.io/cortexproject/cortex:v1.13.0"
+          image: "quay.io/cortexproject/cortex:v1.14.1"
           imagePullPolicy: IfNotPresent
           args:
             - "-target=store-gateway"
@@ -1740,366 +2141,3 @@ spec:
                 secretKeyRef:
                   key: rootPassword
                   name: minio
----
-# Source: cortex/charts/memcached-blocks-index/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: release-name-memcached-blocks-index
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-index
-    helm.sh/chart: memcached-blocks-index-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: memcached-blocks-index
-      app.kubernetes.io/instance: release-name
-  replicas: 2
-  podManagementPolicy: "Parallel"
-  serviceName: release-name-memcached-blocks-index
-  updateStrategy:
-    rollingUpdate: {}
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: memcached-blocks-index
-        helm.sh/chart: memcached-blocks-index-6.3.1
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-      annotations:
-        prometheus.io/port: '9150'
-        prometheus.io/scrape: "true"
-    spec:
-      
-      affinity:
-        podAffinity:
-          
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: memcached-blocks-index
-                    app.kubernetes.io/instance: release-name
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-        nodeAffinity:
-          
-      securityContext:
-        fsGroup: 1001
-      serviceAccountName: default
-      containers:
-        - name: memcached
-          image: docker.io/bitnami/memcached:1.6.17-debian-11-r25
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MEMCACHED_PORT_NUMBER
-              value: "11211"
-          ports:
-            - name: memcache
-              containerPort: 11211
-          livenessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            tcpSocket:
-              port: memcache
-          readinessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
-            tcpSocket:
-              port: memcache
-          resources:
-            limits: {}
-            requests:
-              cpu: 5m
-              memory: 256Mi
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-        - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.10.0-debian-11-r51
-          imagePullPolicy: "IfNotPresent"
-          ports:
-            - name: metrics
-              containerPort: 9150
-          livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            httpGet:
-              path: /metrics
-              port: 9150
-          readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            httpGet:
-              path: /metrics
-              port: 9150
-          resources:
-            limits: {}
-            requests: {}
-      volumes:
-        - name: tmp
-          emptyDir: {}
----
-# Source: cortex/charts/memcached-blocks-metadata/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: release-name-memcached-blocks-metadata
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks-metadata
-    helm.sh/chart: memcached-blocks-metadata-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: memcached-blocks-metadata
-      app.kubernetes.io/instance: release-name
-  replicas: 2
-  podManagementPolicy: "Parallel"
-  serviceName: release-name-memcached-blocks-metadata
-  updateStrategy:
-    rollingUpdate: {}
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: memcached-blocks-metadata
-        helm.sh/chart: memcached-blocks-metadata-6.3.1
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-      annotations:
-        prometheus.io/port: '9150'
-        prometheus.io/scrape: "true"
-    spec:
-      
-      affinity:
-        podAffinity:
-          
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: memcached-blocks-metadata
-                    app.kubernetes.io/instance: release-name
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-        nodeAffinity:
-          
-      securityContext:
-        fsGroup: 1001
-      serviceAccountName: default
-      containers:
-        - name: memcached
-          image: docker.io/bitnami/memcached:1.6.17-debian-11-r25
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MEMCACHED_PORT_NUMBER
-              value: "11211"
-          ports:
-            - name: memcache
-              containerPort: 11211
-          livenessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            tcpSocket:
-              port: memcache
-          readinessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
-            tcpSocket:
-              port: memcache
-          resources:
-            limits: {}
-            requests:
-              cpu: 5m
-              memory: 256Mi
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-        - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.10.0-debian-11-r51
-          imagePullPolicy: "IfNotPresent"
-          ports:
-            - name: metrics
-              containerPort: 9150
-          livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            httpGet:
-              path: /metrics
-              port: 9150
-          readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            httpGet:
-              path: /metrics
-              port: 9150
-          resources:
-            limits: {}
-            requests: {}
-      volumes:
-        - name: tmp
-          emptyDir: {}
----
-# Source: cortex/charts/memcached-blocks/templates/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: release-name-memcached-blocks
-  namespace: default
-  labels:
-    app.kubernetes.io/name: memcached-blocks
-    helm.sh/chart: memcached-blocks-6.3.1
-    app.kubernetes.io/instance: release-name
-    app.kubernetes.io/managed-by: Helm
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: memcached-blocks
-      app.kubernetes.io/instance: release-name
-  replicas: 2
-  podManagementPolicy: "Parallel"
-  serviceName: release-name-memcached-blocks
-  updateStrategy:
-    rollingUpdate: {}
-    type: RollingUpdate
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: memcached-blocks
-        helm.sh/chart: memcached-blocks-6.3.1
-        app.kubernetes.io/instance: release-name
-        app.kubernetes.io/managed-by: Helm
-      annotations:
-        prometheus.io/port: '9150'
-        prometheus.io/scrape: "true"
-    spec:
-      
-      affinity:
-        podAffinity:
-          
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: memcached-blocks
-                    app.kubernetes.io/instance: release-name
-                topologyKey: kubernetes.io/hostname
-              weight: 1
-        nodeAffinity:
-          
-      securityContext:
-        fsGroup: 1001
-      serviceAccountName: default
-      containers:
-        - name: memcached
-          image: docker.io/bitnami/memcached:1.6.17-debian-11-r25
-          imagePullPolicy: "IfNotPresent"
-          securityContext:
-            runAsNonRoot: true
-            runAsUser: 1001
-          env:
-            - name: BITNAMI_DEBUG
-              value: "false"
-            - name: MEMCACHED_PORT_NUMBER
-              value: "11211"
-          ports:
-            - name: memcache
-              containerPort: 11211
-          livenessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 30
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            tcpSocket:
-              port: memcache
-          readinessProbe:
-            failureThreshold: 6
-            initialDelaySeconds: 5
-            periodSeconds: 5
-            successThreshold: 1
-            timeoutSeconds: 3
-            tcpSocket:
-              port: memcache
-          resources:
-            limits: {}
-            requests:
-              cpu: 5m
-              memory: 256Mi
-          volumeMounts:
-            - name: tmp
-              mountPath: /tmp
-        - name: metrics
-          image: docker.io/bitnami/memcached-exporter:0.10.0-debian-11-r51
-          imagePullPolicy: "IfNotPresent"
-          ports:
-            - name: metrics
-              containerPort: 9150
-          livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 5
-            httpGet:
-              path: /metrics
-              port: 9150
-          readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 3
-            httpGet:
-              path: /metrics
-              port: 9150
-          resources:
-            limits: {}
-            requests: {}
-      volumes:
-        - name: tmp
-          emptyDir: {}

--- a/charts/mla/cortex/values.yaml
+++ b/charts/mla/cortex/values.yaml
@@ -82,7 +82,7 @@ cortex:
       query_ingesters_within: 365m
       query_store_after: 360m
     ruler:
-      # This is specifially customized for kubermatic setup so keeping it as is.
+      # This is specifically customized for kubermatic setup so keeping it as is.
       enable_alertmanager_discovery: true
       # Note: This is a KKP-specific headless alertmanager service, used to work around the Cortex helm chart bug in chart versions below v1.0.0
       # alertmanager_url: http://_http-metrics._tcp.cortex-alertmanager-headless-kkp/api/prom/alertmanager/

--- a/charts/mla/cortex/values.yaml
+++ b/charts/mla/cortex/values.yaml
@@ -13,153 +13,50 @@
 # limitations under the License.
 
 cortex:
-  #  Container image settings.
-  #  Since the image is unique for all microservices, so are image settings.
+  # Check master values.yaml which are the default values for Chart version v2.23.8-a
+  # https://github.com/cortexproject/cortex-helm-chart/blob/v2.1.0/values.yaml
 
-  # image:
-  #   repository: quay.io/cortexproject/cortex
-  #   tag: v1.10.0
-  #   pullPolicy: IfNotPresent
-
-  ## Optionally specify an array of imagePullSecrets.
-  ## Secrets must be manually created in the namespace.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  ##
-  # pullSecrets:
-  #   - myRegistrKeySecretName
-
-  # Kubernetes cluster DNS domain
-  clusterDomain: cluster.local
-  tags:
-    blocks-storage-memcached: true
-  ingress:
-    enabled: false
-    annotations:
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-    hosts:
-      - host: chart-example.local
-        paths:
-          - /
-    tls: []
-    #  - secretName: chart-example-tls
-    #    hosts:
-    #      - chart-example.local
-  serviceAccount:
-    create: true
-    name:
-    annotations: {}
-    automountServiceAccountToken: true
-  useExternalConfig: false
-  externalConfigSecretName: 'secret-with-config.yaml'
-  externalConfigVersion: '0'
   config:
     auth_enabled: true
-    api:
-      prometheus_http_prefix: '/prometheus'
-      response_compression_enabled: true
-    ingester:
-      max_transfer_retries: 0
-      lifecycler:
-        join_after: 0s
-        final_sleep: 0s
-        num_tokens: 512
-        ring:
-          replication_factor: 3
-          kvstore:
-            store: memberlist
-            prefix: 'collectors/'
-            consul:
-              host: 'consul:8500'
-              http_client_timeout: '20s'
-              consistent_reads: true
+    # Note: below defaults were changed by cortex from 0.7.0 to 1.7.0. So not keeping old defaults
+    # ingester:
+    #  lifecycler:
+    #     join_after: 0s
+    #     final_sleep: 0s
+
+    #     Note: consul is removed from the setup as per below recommendation.
+    #     Recommendation to remove consul: https://github.com/cortexproject/cortex-helm-chart/blob/v2.1.0/README.md#key-value-store
+    #     ring:
+    #       kvstore:
+    #         consul:
+    #           host: 'consul:8500'
+    #           http_client_timeout: '20s'
+    #           consistent_reads: true
     limits:
-      enforce_metric_name: false
-      reject_old_samples: true
-      reject_old_samples_max_age: 168h
-      max_query_lookback: 168h
+      # Note: below defaults were changed by cortex from 0.7.0 to 1.7.0. So not keeping old defaults in upgrade to helm chart v2.1.0
+      # enforce_metric_name: false
+      
+      # Note: max_query_lookback is limiting query only till 7 days. This is not needed. We should control storage via retention_period. 
+      # Query should be allowed to go back until last of storage.
+      # ref: https://github.com/kubermatic/mla/commit/b49e93289fe013452ba4b4134f9da4ef7ef88df1
+      # max_query_lookback: 168h
+      
+      # Note: below were added for HA setup and stability of the cluster in kubermatic setup. So should be kept.
       accept_ha_samples: true
       max_label_names_per_series: 40
-    schema:
-      configs:
-        - from: 2020-11-01
-          store: cassandra
-          object_store: cassandra
-          schema: v10
-          index:
-            prefix: index_
-            period: 168h
-          chunks:
-            prefix: chunks_
-            period: 168h
-    server:
-      http_listen_port: 8080
-      grpc_listen_port: 9095
-      grpc_server_max_recv_msg_size: 104857600
-      grpc_server_max_send_msg_size: 104857600
-      grpc_server_max_concurrent_streams: 1000
-    ingester_client:
-      grpc_client_config:
-        max_recv_msg_size: 104857600
-        max_send_msg_size: 104857600
-    # See https://github.com/cortexproject/cortex/blob/master/docs/configuration/config-file-reference.md#storage_config
-    storage:
-      engine: blocks
-      cassandra:
-        addresses: # configure cassandra addresses here.
-        keyspace: cortex # configure desired keyspace here.
-        auth: true
-        username: # configure cassandra user here.
-        password: # configure cassandra password here.
-      azure:
-        container_name: # configure azure blob container name here.
-        account_name: # configure azure storage account name here.
-        account_key: # configure azure storage account key here.
-      # aws:
-      #   dynamodb:
-      #     dynamodb_url:
-      #     api_limit:
-      #     throttle_limit:
-      #     metrics:
-      #       url:
-      #       target_queue_length:
-      #       scale_up_factor:
-      #       ignore_throttle_below:
-      #       queue_length_query:
-      #       write_throttle_query:
-      #       write_usage_query:
-      #       read_usage_query:
-      #       read_error_query:
-      #     chunk_gang_size:
-      #     chunk_get_max_parallelism:
-      #   s3:
-      #   bucketnames:
-      #   s3forcepathstyle:
-      index_queries_cache_config:
-        memcached:
-          expiration: 1h
-        memcached_client:
-          timeout: 1s
-    chunk_store:
-      chunk_cache_config:
-        memcached:
-          expiration: 1h
-        memcached_client:
-          timeout: 1s
-    # -- https://cortexmetrics.io/docs/configuration/configuration-file/#store_gateway_config
+    # Note: below defaults were changed by cortex from 0.7.0 to 1.7.0. So not keeping old defaults in upgrade to helm chart v2.1.0
+    # server:
+    #   grpc_server_max_concurrent_streams: 1000
     store_gateway:
+      # Note: Retaining below customization to enable sharding in store_gateway and querier
+      # TODO: sharding makes sense only if we have multiple replicas of store_gateway. but we only have one store_gateway running. So do we really need sharding??
       sharding_enabled: true
       sharding_ring:
         replication_factor: 2
         kvstore:
           store: memberlist
-    table_manager:
-      retention_deletes_enabled: false
-      retention_period: 0s
     distributor:
-      shard_by_all_labels: true
-      pool:
-        health_check_ingesters: true
+      # Note: Retaining below customization to enable accepting ha prometheus metrics
       ha_tracker:
         enable_ha_tracker: true
         # consul is required as ha_tracker does not support memberlist
@@ -171,84 +68,56 @@ cortex:
         kvstore:
           store: memberlist
     memberlist:
-      bind_port: 7946
-      # -- the service name of the memberlist
-      # if using memberlist discovery
+      # TODO: review if we customized below or are defaults from helmchart v1.7.0
+      # This needs to be re-reviewed. There is now a new `memberlist` tag at top level in values.yaml and so may be we can remove the customization.
       join_members:
         - cortex-ingester-headless
       #  - '{{ include "cortex.fullname" $ }}-memberlist'
     querier:
-      active_query_tracker_dir: /data/cortex/querier
+      # Note: below defaults were changed by cortex from 0.7.0 to 1.7.0. So not keeping old defaults in upgrade to helm chart v2.1.0
+      # active_query_tracker_dir: /data/cortex/querier
+
+      # Note: below changes were done specifically in kubermatic config so they are retained.
+      # Ref: https://github.com/kubermatic/mla/commit/b49e93289fe013452ba4b4134f9da4ef7ef88df1
       query_ingesters_within: 365m
-      # -- Comma separated list of store-gateway addresses in DNS Service Discovery
-      # format. This option should is set automatically when using the blocks storage and the
-      # store-gateway sharding is disabled (when enabled, the store-gateway instances
-      # form a ring and addresses are picked from the ring).
-      # @default -- automatic
-      store_gateway_addresses: |-
-        {{ if and (eq .Values.config.storage.engine "blocks") (not .Values.config.store_gateway.sharding_enabled) -}}
-        dns+{{ include "cortex.storeGatewayFullname" $ }}-headless:9095
-        {{- end }}
       query_store_after: 360m
-    query_range:
-      split_queries_by_interval: 24h
-      align_queries_with_step: true
-      cache_results: true
-      results_cache:
-        cache:
-          memcached:
-            expiration: 1h
-          memcached_client:
-            timeout: 1s
     ruler:
+      # This is specifially customized for kubermatic setup so keeping it as is.
       enable_alertmanager_discovery: true
-      # -- Enable the experimental ruler config api.
-      enable_api: true
-      # -- Method to use for backend rule storage (configdb, azure, gcs, s3, swift, local) refer to https://cortexmetrics.io/docs/configuration/configuration-file/#ruler_config
-      storage:
-        type: s3
-        s3:
-          bucketnames: "cortex-ruler"
-          endpoint: "minio:9000"
-          s3forcepathstyle: true
-          insecure: true
-      # This is a KKP-specific headless alertmanager service, used to work around the Cortex helm chart bug in chart versions below v1.0.0
-      alertmanager_url: http://_http-metrics._tcp.cortex-alertmanager-headless-kkp/api/prom/alertmanager/
+      # Note: This is a KKP-specific headless alertmanager service, used to work around the Cortex helm chart bug in chart versions below v1.0.0
+      # alertmanager_url: http://_http-metrics._tcp.cortex-alertmanager-headless-kkp/api/prom/alertmanager/
+      # Note: below setting is kept as we don't want to turn on consul for this ring
       ring:
         kvstore:
           store: memberlist
+    ruler_storage:
+      s3:
+        bucket_name: "cortex-ruler"
+        endpoint: "minio:9000"
+        insecure: true
     runtime_config:
+      # TODO: review if we customized below or are defaults from helmchart v1.7.0 - folder name changed
       file: "/etc/cortex-runtime-cfg/runtime-config.yaml"
       period: "10s"
     alertmanager:
-      # -- Enable the experimental alertmanager config api.
+      # Note: These are customized in kubermatic. Not sure if they are really needed. But will keep them.
       enable_api: true
-      external_url: '/api/prom/alertmanager'
-      # -- Type of backend to use to store alertmanager configs. Supported values are: "configdb", "gcs", "s3", "local". refer to: https://cortexmetrics.io/docs/configuration/configuration-file/#alertmanager_config
-      storage:
-        type: s3
-        s3:
-          bucketnames: "alertmanager"
-          endpoint: "minio:9000"
-          s3forcepathstyle: true
-          insecure: true
       data_dir: /data/cortex/alert-data
-    frontend:
-      #  max_outstanding_per_tenant: 1000
-      log_queries_longer_than: 10s
+    alertmanager_storage:
+      s3:
+        bucket_name: "alertmanager"
+        endpoint: "minio:9000"
+        insecure: true
     compactor:
-      block_deletion_marks_migration_enabled: false
       data_dir: /data/cortex/compactor
-      compaction_interval: 30m
+      # Note: i think there is no need to run compactor every half an hour. Default of 1h is just fine.
+      # compaction_interval: 30m
       sharding_enabled: true
       sharding_ring:
         kvstore:
           store: memberlist
     blocks_storage:
-      backend: s3
       bucket_store:
-        bucket_index:
-          enabled: true
         sync_dir: /data
         ignore_deletion_mark_delay: 1h
       s3:
@@ -264,49 +133,15 @@ cortex:
   runtimeconfigmap:
     # -- If true, a configmap for the `runtime_config` will be created.
     # If false, the configmap _must_ exist already on the cluster or pods will fail to create.
+    # TODO: review if we customized below or are defaults from helmchart v1.7.0
     create: false
-    annotations: {}
-    # -- https://cortexmetrics.io/docs/configuration/arguments/#runtime-configuration-file
-    runtime_config: {}
   alertmanager:
-    enabled: true
     replicas: 2
     statefulSet:
-      ## If true, use a statefulset instead of a deployment for pod management.
-      ## This is useful for using a persistent volume for storing silences between restarts
-      ##
       enabled: true
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
-    resources: {}
-    #  limits:
-    #    cpu: 200m
-    #    memory: 256Mi
-    #  requests:
-    #    cpu: 10m
-    #    memory: 32Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
     extraArgs:
-      alertmanager.storage.s3.access-key-id: $(ACCESS_KEY)
-      alertmanager.storage.s3.secret-access-key: $(SECRET_KEY)
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
+      alertmanager-storage.s3.access-key-id: $(ACCESS_KEY)
+      alertmanager-storage.s3.secret-access-key: $(SECRET_KEY)
     affinity:
       podAntiAffinity:
         preferredDuringSchedulingIgnoredDuringExecution:
@@ -319,123 +154,17 @@ cortex:
                     values:
                       - alertmanager
               topologyKey: "kubernetes.io/hostname"
-    annotations: {}
-    ## DEPRECATED: use persistentVolume.subPath instead
-    persistence:
-      subPath:
     persistentVolume:
-      ## If true and alertmanager.statefulSet.enabled is true,
-      ## Alertmanager will create/use a Persistent Volume Claim
-      ## If false, use emptyDir
-      ##
-      enabled: true
-      ## Alertmanager data Persistent Volume Claim annotations
-      ##
-      annotations: {}
-      ## Alertmanager data Persistent Volume access modes
-      ## Must match those of existing PV or dynamic provisioner
-      ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-      ##
-      accessModes:
-        - ReadWriteOnce
-      ## Alertmanager data Persistent Volume size
-      ##
-      size: 2Gi
-      ## Subdirectory of Alertmanager data Persistent Volume to mount
-      ## Useful if the volume's root directory is not empty
-      ##
-      subPath: ''
-      ## Alertmanager data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
-
       storageClass: "kubermatic-fast"
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    # fsGroup: 10001
-    # runAsGroup: 10001
-    # runAsNonRoot: true
-    # runAsUser: 10001
-
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    ## Tolerations for pod assignment
-    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-    tolerations: []
-    # If not set then a PodDisruptionBudget will not be created
-    podDisruptionBudget:
-      maxUnavailable: 1
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    statefulStrategy:
-      type: RollingUpdate
-    terminationGracePeriodSeconds: 60
-    initContainers: []
-    ## Init containers to be added to the cortex pod.
-    # - name: my-init-container
-    #   image: busybox:latest
-    #   command: ['sh', '-c', 'echo hello']
-
-    extraContainers: []
-    ## Additional containers to be added to the cortex pod.
-    # - name: reverse-proxy
-    #   image: angelbarrera92/basic-auth-reverse-proxy:dev
-    #   args:
-    #     - "serve"
-    #     - "--upstream=http://localhost:3100"
-    #     - "--auth-config=/etc/reverse-proxy-conf/authn.yaml"
-    #   ports:
-    #     - name: http
-    #       containerPort: 11811
-    #       protocol: TCP
-    #   volumeMounts:
-    #     - name: reverse-proxy-auth-config
-    #       mountPath: /etc/reverse-proxy-conf
-
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
           name: cortex-runtime-config
-    ## Additional volumes to the cortex pod.
-    # - name: reverse-proxy-auth-config
-    #   secret:
-    #     secretName: reverse-proxy-auth-config
-
-    ## Extra volume mounts that will be added to the cortex container
     extraVolumeMounts:
       - mountPath: /tmp
         name: storage
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
-    ## Additional ports to the cortex services. Useful to expose extra container ports.
-    # - port: 11811
-    #   protocol: TCP
-    #   name: http
-    #   targetPort: http
-
-    # Extra env variables to pass to the cortex container
     env:
       - name: ACCESS_KEY
         valueFrom:
@@ -447,116 +176,7 @@ cortex:
           secretKeyRef:
             name: minio
             key: rootPassword
-    ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
-    sidecar:
-      image:
-        repository: quay.io/kiwigrid/k8s-sidecar
-        tag: 1.10.7
-        sha: ""
-      imagePullPolicy: IfNotPresent
-      resources: {}
-      #   limits:
-      #     cpu: 100m
-      #     memory: 100Mi
-      #   requests:
-      #     cpu: 50m
-      #     memory: 50Mi
-      # skipTlsVerify Set to true to skip tls verification for kube api calls
-      # skipTlsVerify: true
-      enableUniqueFilenames: false
-      enabled: false
-      label: cortex_alertmanager
-      watchMethod: null
-      labelValue: null
-      folder: /data
-      defaultFolderName: null
-      searchNamespace: null
-      folderAnnotation: null
-      securityContext:
-        runAsUser: 0
   distributor:
-    replicas: 2
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
-    resources: {}
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 100m
-    #    memory: 512Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
-    extraArgs: {}
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/component
-                    operator: In
-                    values:
-                      - distributor
-              topologyKey: 'kubernetes.io/hostname'
-    annotations: {}
-    autoscaling:
-      # -- Creates a HorizontalPodAutoscaler for the distributor pods.
-      enabled: false
-      minReplicas: 2
-      maxReplicas: 30
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 0 # 80
-      # -- Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
-      behavior: {}
-    persistence:
-      subPath:
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    terminationGracePeriodSeconds: 60
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -564,161 +184,34 @@ cortex:
     extraVolumeMounts:
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
-    env: []
   ingester:
-    replicas: 3
     statefulSet:
-      ## If true, use a statefulset instead of a deployment for pod management.
-      ## This is useful when using WAL
-      ##
       enabled: true
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
-    resources: {}
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 100m
-    #    memory: 512Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
     extraArgs:
       blocks-storage.s3.access-key-id: $(ACCESS_KEY)
       blocks-storage.s3.secret-access-key: $(SECRET_KEY)
-    #  log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/component
-                    operator: In
-                    values:
-                      - ingester
-              topologyKey: 'kubernetes.io/hostname'
-    annotations: {}
-    autoscaling:
-      enabled: false
-      minReplicas: 3
-      maxReplicas: 30
-      targetMemoryUtilizationPercentage: 80
-      behavior:
-        scaleDown:
-          # -- see https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down for scaledown details
-          policies:
-            - type: Pods
-              value: 1
-              # set to no less than 2x the maximum between -blocks-storage.bucket-store.sync-interval and -compactor.cleanup-interval
-              periodSeconds: 1800
-          # -- uses metrics from the past 1h to make scaleDown decisions
-          stabilizationWindowSeconds: 3600
-        scaleUp:
-          # -- This default scaleup policy allows adding 1 pod every 30 minutes.
-          # Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
-          policies:
-            - type: Pods
-              value: 1
-              periodSeconds: 1800
-    lifecycle:
-      # -- The /shutdown preStop hook is recommended as part of the ingester
-      # scaledown process, but can be removed to optimize rolling restarts in
-      # instances that will never be scaled down or when using chunks storage
-      # with WAL disabled.
-      # https://cortexmetrics.io/docs/guides/ingesters-scaling-up-and-down/#scaling-down
-      preStop:
-        httpGet:
-          path: "/ingester/shutdown"
-          port: http-metrics
-    ## DEPRECATED: use persistentVolume.subPath instead
-    persistence:
-      subPath:
     persistentVolume:
-      ## If true and ingester.statefulSet.enabled is true,
-      ## Ingester will create/use a Persistent Volume Claim
-      ## If false, use emptyDir
-      ##
-      enabled: true
-      ## Ingester data Persistent Volume Claim annotations
-      ##
-      annotations: {}
-      ## Ingester data Persistent Volume access modes
-      ## Must match those of existing PV or dynamic provisioner
-      ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-      ##
-      accessModes:
-        - ReadWriteOnce
-      ## Ingester data Persistent Volume size
-      ##
+      # TODO: review if we customized below or are defaults from helmchart v1.7.0
       size: 10Gi
-      ## Subdirectory of Ingester data Persistent Volume to mount
-      ## Useful if the volume's root directory is not empty
-      ##
-      subPath: ''
-      ## Ingester data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
-
       storageClass: "kubermatic-fast"
-    startupProbe:
-      # WAL Replay can take a long time. Increasing failureThreshold for ~30 min of time until killed
-      failureThreshold: 60
-      initialDelaySeconds: 120
-      periodSeconds: 30
-      httpGet:
-        path: /ready
-        port: http-metrics
-        scheme: HTTP
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-        scheme: HTTP
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    statefulStrategy:
-      type: RollingUpdate
-    terminationGracePeriodSeconds: 240
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
+
+    # As per latest values.yaml - Startup/liveness probes for ingesters are not recommended.
+    # -- Startup/liveness probes for ingesters are not recommended.
+    #  Ref: https://cortexmetrics.io/docs/guides/running-cortex-on-kubernetes/#take-extra-care-with-ingesters
+    # startupProbe:
+    #   # WAL Replay can take a long time. Increasing failureThreshold for ~30 min of time until killed
+    #   failureThreshold: 60
+    #   initialDelaySeconds: 120
+    #   periodSeconds: 30
+    #   httpGet:
+    #     path: /ready
+    #     port: http-metrics
+    #     scheme: HTTP
+    # livenessProbe:
+    #   httpGet:
+    #     path: /ready
+    #     port: http-metrics
+    #     scheme: HTTP
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -726,7 +219,6 @@ cortex:
     extraVolumeMounts:
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
     env:
       - name: ACCESS_KEY
         valueFrom:
@@ -739,73 +231,13 @@ cortex:
             name: minio
             key: rootPassword
   ruler:
-    enabled: true
-    replicas: 1
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
+    # Note: this is specifically customized in kubermatic. So keeping it that way.
     resources:
       requests:
         cpu: 5m
-    #  limits:
-    #    cpu: 200m
-    #    memory: 256Mi
-    #  requests:
-    #    cpu: 10m
-    #    memory: 32Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
     extraArgs:
-      ruler.storage.s3.access-key-id: $(ACCESS_KEY)
-      ruler.storage.s3.secret-access-key: $(SECRET_KEY)
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
-    affinity: {}
-    annotations: {}
-    persistence:
-      subPath:
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    terminationGracePeriodSeconds: 180
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
+      ruler-storage.s3.access-key-id: $(ACCESS_KEY)
+      ruler-storage.s3.secret-access-key: $(SECRET_KEY)
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -813,7 +245,6 @@ cortex:
     extraVolumeMounts:
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
     env:
       - name: ACCESS_KEY
         valueFrom:
@@ -825,150 +256,14 @@ cortex:
           secretKeyRef:
             name: minio
             key: rootPassword
-    # allow configuring rules via configmap in case you don't want to use the configs db
-    directories: {}
-    # tenant_foo:
-    #   rules1.txt: |
-    #     groups:
-    #       - name: should_fire
-    #         rules:
-    #           - alert: HighPercentageError
-    #             expr: |
-    #               sum(rate({app="foo", env="production"} |= "error" [5m])) by (job)
-    #                 /
-    #               sum(rate({app="foo", env="production"}[5m])) by (job)
-    #                 > 0.05
-    #             for: 10m
-    #             labels:
-    #               severity: warning
-    #             annotations:
-    #               summary: High error rate
-
-    ## Sidecars that collect the configmaps with specified label and stores the included files them into the respective folders
-    sidecar:
-      image:
-        repository: quay.io/kiwigrid/k8s-sidecar
-        tag: 1.10.7
-        sha: ""
-      imagePullPolicy: IfNotPresent
-      resources: {}
-      #   limits:
-      #     cpu: 100m
-      #     memory: 100Mi
-      #   requests:
-      #     cpu: 50m
-      #     memory: 50Mi
-      # skipTlsVerify Set to true to skip tls verification for kube api calls
-      # skipTlsVerify: true
-      enableUniqueFilenames: false
-      enabled: false
-      # label that the configmaps with rules are marked with
-      label: cortex_rules
-      watchMethod: null
-      # value of label that the configmaps with rules are set to
-      labelValue: null
-      # folder in the pod that should hold the collected rules (unless `defaultFolderName` is set)
-      folder: /tmp/rules
-      # The default folder name, it will create a subfolder under the `folder` and put rules in there instead
-      defaultFolderName: null
-      # If specified, the sidecar will search for rules config-maps inside this namespace.
-      # Otherwise the namespace in which the sidecar is running will be used.
-      # It's also possible to specify ALL to search in all namespaces
-      searchNamespace: null
-      # If specified, the sidecar will look for annotation with this name to create folder and put graph here.
-      # You can use this parameter together with `provider.foldersFromFilesStructure`to annotate configmaps and create folder structure.
-      folderAnnotation: null
-      securityContext:
-        runAsUser: 0
-      # running the sidecar will also run as root
-      # provider configuration that lets cortex manage the rules
   querier:
-    replicas: 1
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
+    # Note: this is specifically customized in kubermatic. So keeping it that way.
     resources:
       requests:
         cpu: 5m
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 50m
-    #    memory: 128Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
     extraArgs:
       blocks-storage.s3.access-key-id: $(ACCESS_KEY)
       blocks-storage.s3.secret-access-key: $(SECRET_KEY)
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/component
-                    operator: In
-                    values:
-                      - querier
-              topologyKey: 'kubernetes.io/hostname'
-    annotations: {}
-    autoscaling:
-      # -- Creates a HorizontalPodAutoscaler for the querier pods.
-      enabled: false
-      minReplicas: 2
-      maxReplicas: 30
-      targetCPUUtilizationPercentage: 80
-      targetMemoryUtilizationPercentage: 0 # 80
-      # -- Ref: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-configurable-scaling-behavior
-      behavior: {}
-    persistence:
-      subPath:
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    terminationGracePeriodSeconds: 180
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -976,7 +271,6 @@ cortex:
     extraVolumeMounts:
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
     env:
       - name: ACCESS_KEY
         valueFrom:
@@ -989,81 +283,11 @@ cortex:
             name: minio
             key: rootPassword
   query_frontend:
+    # Note: this is specifically customized in kubermatic. So keeping it that way.
     replicas: 1
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
     resources:
       requests:
         cpu: 5m
-    #  limits:
-    #    cpu: 1
-    #    memory: 256Mi
-    #  requests:
-    #    cpu: 10m
-    #    memory: 32Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
-    extraArgs: {}
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/component
-                    operator: In
-                    values:
-                      - query-frontend
-              topologyKey: 'kubernetes.io/hostname'
-    annotations: {}
-    persistence:
-      subPath:
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    terminationGracePeriodSeconds: 180
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -1071,361 +295,19 @@ cortex:
     extraVolumeMounts:
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
-    env: []
-  table_manager:
-    replicas: 1
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
-    resources: {}
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 10m
-    #    memory: 32Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
-    extraArgs: {}
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: 'http-metrics'
-    nodeSelector: {}
-    affinity: {}
-    annotations: {}
-    persistence:
-      subPath:
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    terminationGracePeriodSeconds: 180
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
-    extraVolumes: []
-    extraVolumeMounts: []
-    extraPorts: []
-    env: []
-  configs:
-    enabled: false
-    replicas: 1
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
-    resources: {}
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 10m
-    #    memory: 32Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
-    extraArgs: {}
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: 'http-metrics'
-    nodeSelector: {}
-    affinity: {}
-    annotations: {}
-    persistence:
-      subPath:
-    startupProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    terminationGracePeriodSeconds: 180
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
-    extraVolumes: []
-    extraVolumeMounts: []
-    extraPorts: []
-    env: []
   nginx:
+    # Note: this is configured specifically in kubermatic so keeping it that way. I am yet to understand why we need nginx.
     enabled: false
-    replicas: 2
-    http_listen_port: 80
-    config:
-      dnsResolver: kube-dns.kube-system.svc.cluster.local
-      ## ref: http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size
-      client_max_body_size: 1M
-      # -- arbitrary snippet to inject in the http { } section of the nginx config
-      httpSnippet: ""
-      # -- arbitrary snippet to inject in the top section of the nginx config
-      mainSnippet: ""
-      # -- arbitrary snippet to inject in the server { } section of the nginx config
-      serverSnippet: ""
-      setHeaders: {}
-      # -- (optional) List of [auth tenants](https://cortexmetrics.io/docs/guides/auth/) to set in the nginx config
-      auth_orgs: []
-      # -- (optional) Name of basic auth secret.
-      # In order to use this option, a secret with htpasswd formatted contents at
-      # the key ".htpasswd" must exist. For example:
-      #
-      #   apiVersion: v1
-      #   kind: Secret
-      #   metadata:
-      #     name: my-secret
-      #     namespace: <same as cortex installation>
-      #   stringData:
-      #     .htpasswd: |
-      #       user1:$apr1$/woC1jnP$KAh0SsVn5qeSMjTtn0E9Q0
-      #       user2:$apr1$QdR8fNLT$vbCEEzDj7LyqCMyNpSoBh/
-      #
-      # Please note that the use of basic auth will not identify organizations
-      # the way X-Scope-OrgID does. Thus, the use of basic auth alone will not
-      # prevent one tenant from viewing the metrics of another. To ensure tenants
-      # are scoped appropriately, explicitly set the `X-Scope-OrgID` header
-      # in the nginx config. Example
-      #   setHeaders:
-      #     X-Scope-Org-Id: $remote_user
-      basicAuthSecretName: ""
-    image:
-      repository: nginx
-      tag: 1.21
-      pullPolicy: IfNotPresent
-    service:
-      type: ClusterIP
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
-    resources: {}
-    #  limits:
-    #    cpu: 100m
-    #    memory: 128Mi
-    #  requests:
-    #    cpu: 10m
-    #    memory: 16Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
-    extraArgs: {}
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: ''
-      prometheus.io/port: 'http-metrics'
-    nodeSelector: {}
-    affinity: {}
-    annotations: {}
-    persistence:
-      subPath:
-    startupProbe:
-      httpGet:
-        path: /healthz
-        port: http-metrics
-      failureThreshold: 10
-    livenessProbe:
-      httpGet:
-        path: /healthz
-        port: http-metrics
-    readinessProbe:
-      httpGet:
-        path: /healthz
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: false
-    strategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxSurge: 0
-        maxUnavailable: 1
-    terminationGracePeriodSeconds: 10
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
-    extraVolumes: []
-    extraVolumeMounts: []
-    extraPorts: []
-    env: []
   store_gateway:
-    replicas: 1
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
     resources:
+      # Note: this is a change is done in Kubermatic side so retaining.
       requests:
         cpu: 5m
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 100m
-    #    memory: 512Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
     extraArgs:
       blocks-storage.s3.access-key-id: $(ACCESS_KEY)
       blocks-storage.s3.secret-access-key: $(SECRET_KEY)
-    # log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/component
-                    operator: In
-                    values:
-                      - store-gateway
-              topologyKey: 'kubernetes.io/hostname'
-    annotations: {}
     persistentVolume:
-      ## If true Store-gateway will create/use a Persistent Volume Claim
-      ## If false, use emptyDir
-      ##
-      enabled: true
-      ## Store-gateway data Persistent Volume Claim annotations
-      ##
-      annotations: {}
-      ## Store-gateway data Persistent Volume access modes
-      ## Must match those of existing PV or dynamic provisioner
-      ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-      ##
-      accessModes:
-        - ReadWriteOnce
-      ## Store-gateway data Persistent Volume size
-      ##
-      size: 2Gi
-      ## Subdirectory of Store-gateway data Persistent Volume to mount
-      ## Useful if the volume's root directory is not empty
-      ##
-      subPath: ''
-      ## Store-gateway data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
-
       storageClass: "kubermatic-fast"
-    startupProbe:
-      # Increasing failureThreshold for ~30 min of time until killed
-      failureThreshold: 60
-      initialDelaySeconds: 120
-      periodSeconds: 30
-      httpGet:
-        path: /ready
-        port: http-metrics
-        scheme: HTTP
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-        scheme: HTTP
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-    terminationGracePeriodSeconds: 240
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -1433,7 +315,6 @@ cortex:
     extraVolumeMounts:
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
     env:
       - name: ACCESS_KEY
         valueFrom:
@@ -1446,111 +327,8 @@ cortex:
             name: minio
             key: rootPassword
   compactor:
-    enabled: true
-    replicas: 1
-    service:
-      annotations: {}
-      labels: {}
-    serviceMonitor:
-      enabled: false
-      additionalLabels: {}
-      relabelings: []
-      metricRelabelings: []
-      # Additional endpoint configuration https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#endpoint
-      extraEndpointSpec: {}
-    resources: {}
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  requests:
-    #    cpu: 100m
-    #    memory: 512Mi
-
-    ## Additional Cortex container arguments, e.g. log level (debug, info, warn, error)
-    extraArgs: {}
-    #  log.level: debug
-
-    ## Pod Labels
-    podLabels: {}
-    ## Pod Annotations
-    podAnnotations:
-      prometheus.io/scrape: 'true'
-      prometheus.io/port: '8080'
-    nodeSelector: {}
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/component
-                    operator: In
-                    values:
-                      - compactor
-              topologyKey: 'kubernetes.io/hostname'
-    annotations: {}
     persistentVolume:
-      ## If true compactor will create/use a Persistent Volume Claim
-      ## If false, use emptyDir
-      ##
-      enabled: true
-      ## compactor data Persistent Volume Claim annotations
-      ##
-      annotations: {}
-      ## compactor data Persistent Volume access modes
-      ## Must match those of existing PV or dynamic provisioner
-      ## Ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-      ##
-      accessModes:
-        - ReadWriteOnce
-      ## compactor data Persistent Volume size
-      ##
-      size: 2Gi
-      ## Subdirectory of compactor data Persistent Volume to mount
-      ## Useful if the volume's root directory is not empty
-      ##
-      subPath: ''
-      ## compactor data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
-
       storageClass: "kubermatic-fast"
-    startupProbe:
-      # Increasing failureThreshold for ~30 min of time until killed
-      failureThreshold: 60
-      initialDelaySeconds: 120
-      periodSeconds: 30
-      httpGet:
-        path: /ready
-        port: http-metrics
-        scheme: HTTP
-    livenessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-        scheme: HTTP
-    readinessProbe:
-      httpGet:
-        path: /ready
-        port: http-metrics
-    securityContext: {}
-    containerSecurityContext:
-      enabled: true
-      readOnlyRootFilesystem: true
-    strategy:
-      type: RollingUpdate
-    terminationGracePeriodSeconds: 240
-    tolerations: []
-    podDisruptionBudget:
-      maxUnavailable: 1
-    initContainers: []
-    extraContainers: []
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -1558,211 +336,21 @@ cortex:
     extraVolumeMounts:
       - mountPath: "/etc/cortex-runtime-cfg"
         name: "cortex-runtime-config"
-    extraPorts: []
-    env: []
-
-# subcharts of cortex chart start here
-# chunk caching
-memcached:
-  enabled: false
-  architecture: "high-availability"
-  replicaCount: 2
-  pdbMinAvailable: 1
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
-  resources: {}
-  #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
-  #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
-  metrics:
+  memcached-blocks-index:
     enabled: true
-  # tolerations: {}
-  # - key: "dedicated"
-  #   operator: "Equal"
-  #   value: "cortex-memcached"
-  #   effect: "NoSchedule"
-  # affinity: {}
-  #   nodeAffinity:
-  #     requiredDuringSchedulingIgnoredDuringExecution:
-  #         nodeSelectorTerms:
-  #         - matchExpressions:
-  #           - key: dedicated
-  #             operator: In
-  #             values:
-  #             - cortex-memcached
-# index read caching
-memcached-index-read:
-  enabled: false
-  architecture: "high-availability"
-  replicaCount: 2
-  # pdbMinAvailable: 1
-  # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
-  resources: {}
-  #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
-  #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
-  metrics:
+    # Note: this is specifically customized in kubermatic. So keeping it that way.
+    resources:
+      requests:
+        cpu: 5m
+  memcached-blocks:
     enabled: true
-  # tolerations: []
-  # - key: "dedicated"
-  #   operator: "Equal"
-  #   value: "cortex-memcached"
-  #   effect: "NoSchedule"
-  # affinity: {}
-  #   nodeAffinity:
-  #     requiredDuringSchedulingIgnoredDuringExecution:
-  #         nodeSelectorTerms:
-  #         - matchExpressions:
-  #           - key: dedicated
-  #             operator: In
-  #             values:
-  #             - cortex-memcached
-# index write caching
-memcached-index-write:
-  enabled: false
-  architecture: "high-availability"
-  replicaCount: 2
-  # dpdbMinAvailable: 1
-  # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
-  resources: {}
-  #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
-  #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
-  metrics:
+    # Note: this is specifically customized in kubermatic. So keeping it that way.
+    resources:
+      requests:
+        cpu: 5m
+  memcached-blocks-metadata:
     enabled: true
-  # tolerations: []
-  # - key: "dedicated"
-  #   operator: "Equal"
-  #   value: "cortex-memcached"
-  #   effect: "NoSchedule"
-  # affinity: {}
-  #   nodeAffinity:
-  #     requiredDuringSchedulingIgnoredDuringExecution:
-  #         nodeSelectorTerms:
-  #         - matchExpressions:
-  #           - key: dedicated
-  #             operator: In
-  #             values:
-  #             - cortex-memcached
-memcached-frontend:
-  enabled: false
-  architecture: "high-availability"
-  replicaCount: 2
-  # dpdbMinAvailable: 1
-  # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
-  resources: {}
-  #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
-  #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
-  metrics:
-    enabled: true
-memcached-blocks-index:
-  # enabled/disabled via the tags.blocks-storage-memcached boolean
-  architecture: "high-availability"
-  replicaCount: 2
-  # dpdbMinAvailable: 1
-  # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
-  resources:
-    requests:
-      cpu: 5m
-  #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
-  #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
-  metrics:
-    enabled: true
-  serviceAccount:
-    create: false
-memcached-blocks:
-  # enabled/disabled via the tags.blocks-storage-memcached boolean
-  architecture: "high-availability"
-  replicaCount: 2
-  # dpdbMinAvailable: 1
-  # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
-  resources:
-    requests:
-      cpu: 5m
-  #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
-  #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
-  metrics:
-    enabled: true
-  serviceAccount:
-    create: false
-memcached-blocks-metadata:
-  # enabled/disabled via the tags.blocks-storage-memcached boolean
-  architecture: "high-availability"
-  replicaCount: 2
-  # dpdbMinAvailable: 1
-  # image: memcached:1.5.7-alpine
-  memcached:
-    maxItemMemory: 3840
-    extraArgs:
-      - -I 32m
-    threads: 32
-  resources:
-    requests:
-      cpu: 5m
-  #  requests:
-  #    memory: 1Gi
-  #    cpu: 10m
-  #  limits:
-  #    memory: 4Gi
-  #    cpu: 1
-  metrics:
-    enabled: true
-  serviceAccount:
-    create: false
-configsdb_postgresql:
-  enabled: false
-  uri:
-  auth:
-    password:
-    existing_secret:
-      name:
-      key:
+    # Note: this is specifically customized in kubermatic. So keeping it that way.
+    resources:
+      requests:
+        cpu: 5m


### PR DESCRIPTION
**What this PR does / why we need it**:
Cortex v1.13.1 used in User-cluster MLA is outdated and is seen to have issues with compactor not starting properly at multiple installations.

Cortex 1.14.1 - provided by cortex helm chart v2.1.0 has seemingly fix the issues compactor had. This PR provide new cortex chart based on upstream cortex chart v2.1.0

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes Partially #12921

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
I have cleaned up the values.yaml of cortex chart to keep ONLY KKP specific overrides. All the default values can be seen in original chart's values.yaml. 

I also have changed some of the values based on new chart's default. These values were present in cortex chart v0.7.0 OR in cortext chart v1.7.0. But in latest chart version the values are different and so it makes sense to let upstream value prevail wherever there is no need of customization. I have left original values commented. I would like to clear out the commented values as well. Either in this PR itself OR in next KKP release.

There are still few TODOs in `values.yaml` which I would like to discuss and then commented them off, if not needed.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
* action required: User-mla Cortex chart upgraded to resolve issues for cortex-compactor and improve stability of user-cluster MLA feature. Few actions are required to be taken to use new upgraded charts:
* Refer to [Upstream helm chart values](https://github.com/cortexproject/cortex-helm-chart/blob/v2.1.0/values.yaml) to see the latest default values.
* Some of the values from earlier `values.yaml` are now incompatible with latest version. They are removed in the `values.yaml` in the current chart. But if you had copied the original values.yaml to customize it further, you may see that `kubermatic-installer` will detect such incompatible options and churn out errors and explain that action that needs to be taken.
* The memcached-* charts are now subcharts of cortex chart so if you provided configuration for `memcached-*` blocks in your `values.yaml` for user-mla, you must move them under `cortex:` block.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
