### PR TITLE
node-local-dns: cleanup tolerations

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/node-local-dns/deamonset.go
@@ -85,8 +85,6 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 				},
 			}
 
-			patchTolerations(&ds.Spec.Template.Spec)
-
 			hostPathType := corev1.HostPathFileOrCreate
 			ds.Spec.Template.Spec.Containers = []corev1.Container{
 				{
@@ -199,27 +197,5 @@ func DaemonSetReconciler(imageRewriter registry.ImageRewriter) reconciling.Named
 
 			return ds, nil
 		}
-	}
-}
-
-// patchTolerations ensures that a toleration for the CriticalAddonsOnly taint
-// exists, but pays attention to not overwrite any potential changes the user
-// has made.
-func patchTolerations(podSpec *corev1.PodSpec) {
-	exists := false
-	defaultTolerationKey := "CriticalAddonsOnly"
-
-	for _, toleration := range podSpec.Tolerations {
-		if toleration.Key == defaultTolerationKey {
-			exists = true
-			break
-		}
-	}
-
-	if !exists {
-		podSpec.Tolerations = append(podSpec.Tolerations, corev1.Toleration{
-			Key:      defaultTolerationKey,
-			Operator: corev1.TolerationOpExists,
-		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Cleanup that removes patchTolerations() from NLDNS daemonset reconciliation.

AFAICS:

* current main sets the tolerations to a fixed set that doesn't contain a "CriticalAddonsOnly" toleration, then calls patchTolerations(), which will always just add a key="CriticalAddonsOnly"/operator=Exists toleration, so this could just be appended to the fixet set (after line 85), but then the tolerations already in the set tolerate more anyway, so the CriticalAddonsOnly toleration doesn't really do anything.

* alternatively the CriticalAddonsOnly toleration might be desired, in which case more changes are needed

related PRs:

* https://github.com/kubermatic/kubermatic/pull/7466

* https://github.com/kubermatic/kubermatic/pull/8425

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind cleanup

**Special notes for your reviewer**:

I didn't test this specific PR, but our fork's version of the daemonset is very similar and I tested that.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove CriticalAddonsOnly toleration from node-local-dns DaemonSet as it has more general tolerations configured
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
