### PR TITLE
Remove 1.25 from AKS versions (EOL on January 14th)

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -471,7 +471,6 @@ spec:
           - v1.28
           - v1.27
           - v1.26
-          - v1.25
       eks:
         # Default is the default version to offer users.
         default: v1.28

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -471,7 +471,6 @@ spec:
           - v1.28
           - v1.27
           - v1.26
-          - v1.25
       eks:
         # Default is the default version to offer users.
         default: v1.28

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -338,7 +338,6 @@ var (
 			newSemver("v1.28"),
 			newSemver("v1.27"),
 			newSemver("v1.26"),
-			newSemver("v1.25"),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli says 1.25 is soon going away.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Remove 1.25 from list of supported versions on AKS (EOL on January 14th)
```

**Documentation**:
```documentation
NONE
```
