### PR TITLE
[release/v2.22] update version matrix for EKS/AKS (#12962)

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -515,25 +515,26 @@ spec:
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.24
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
-          - v1.25
-          - v1.24
-          - v1.23
+          - v1.28
+          - v1.27
+          - v1.26
       eks:
         # Default is the default version to offer users.
-        default: v1.24
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.28
+          - v1.27
+          - v1.26
+          - v1.25
           - v1.24
-          - v1.23
-          - v1.22
-          - v1.21
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -515,25 +515,26 @@ spec:
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.24
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
-          - v1.25
-          - v1.24
-          - v1.23
+          - v1.28
+          - v1.27
+          - v1.26
       eks:
         # Default is the default version to offer users.
-        default: v1.24
+        default: v1.28
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.28
+          - v1.27
+          - v1.26
+          - v1.25
           - v1.24
-          - v1.23
-          - v1.22
-          - v1.21
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -363,23 +363,24 @@ var (
 	eksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-		Default: semver.NewSemverOrDie("v1.24"),
+		Default: semver.NewSemverOrDie("v1.28"),
 		Versions: []semver.Semver{
+			newSemver("v1.28"),
+			newSemver("v1.27"),
+			newSemver("v1.26"),
+			newSemver("v1.25"),
 			newSemver("v1.24"),
-			newSemver("v1.23"),
-			newSemver("v1.22"),
-			newSemver("v1.21"),
 		},
 	}
 
 	aksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
-		Default: semver.NewSemverOrDie("v1.24"),
+		Default: semver.NewSemverOrDie("v1.28"),
 		Versions: []semver.Semver{
-			newSemver("v1.25"),
-			newSemver("v1.24"),
-			newSemver("v1.23"),
+			newSemver("v1.28"),
+			newSemver("v1.27"),
+			newSemver("v1.26"),
 		},
 	}
 

--- a/pkg/resources/reconciling/zz_generated_reconcile.go
+++ b/pkg/resources/reconciling/zz_generated_reconcile.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual cherrypick because we neglected to keep the AKS/EKS versions up-to-date in older release branches.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update EKS/AKS version matrix to only include Kubernetes versions supported by those managed offerings. For  AKS 1.26-1.28 are supported, for EKS 1.24 to 1.28. The default for newly created external clusters is now 1.28.
```

**Documentation**:
```documentation
NONE
```
