### PR TITLE
bump Konnectivity versions

### DIFF
--- a/pkg/resources/konnectivity/sidecar.go
+++ b/pkg/resources/konnectivity/sidecar.go
@@ -133,17 +133,17 @@ func ProxySidecar(data *resources.TemplateData, serverCount int32) (*corev1.Cont
 func NetworkProxyVersion(clusterVersion semver.Semver) string {
 	// https://github.com/kubernetes-sigs/apiserver-network-proxy#releases
 	switch clusterVersion.MajorMinor() {
-	case "1.24":
-		fallthrough
 	case "1.25":
 		fallthrough
 	case "1.26":
 		return "v0.0.37"
 	case "1.27":
-		return "v0.1.2"
+		return "v0.1.6"
 	case "1.28":
+		return "v0.28.3"
+	case "1.29":
 		fallthrough
 	default:
-		return "v0.1.4"
+		return "v0.29.0"
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Too late for #12936, but now the latest Konnectivity images are available, so this PR should be seen as a follow-up to #12936. In absence of a changelog, I went through the upstream git log and could not find any CLI changes in the sidecar.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
No release note because this is just a mini PR that was created to save CI time. We also do not individually document each CCM/CSI version bump with a release note.

```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
