### PR TITLE
charts/kubermatic-operator: ability to configure environment variables

### DIFF
--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -64,6 +64,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- with .Values.kubermaticOperator.extraEnv }}
+        {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - name: metrics
           containerPort: 8085

--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         {{- with .Values.kubermaticOperator.extraEnv }}
-        {{- toYaml . | nindent 10 }}
+        {{- toYaml . | nindent 8 }}
         {{- end }}
         ports:
         - name: metrics

--- a/charts/kubermatic-operator/values.yaml
+++ b/charts/kubermatic-operator/values.yaml
@@ -33,3 +33,8 @@ kubermaticOperator:
     limits:
       cpu: 500m
       memory: 512Mi
+
+  # Additional environment variables to pass to the kubermatic-operator pod.
+  extraEnv: []
+  # - name: KEY
+  #   value: 'value'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding support to configure environment variables for the Kubermatic operator pod. Since `POD_NAMESPACE` is a mandatory environment variable, I have resorted to providing "extra" env variables instead of the ability to override it completely.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
charts/kubermatic-operator: ability to configure environment variables for the kubermatic-operator pod
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
