### PR TITLE
Example command to generate secrets now works on macOS by default

### DIFF
--- a/charts/kubermatic.example.ce.yaml
+++ b/charts/kubermatic.example.ce.yaml
@@ -53,6 +53,6 @@ spec:
 
     # these need to be randomly generated. Those can be generated on the
     # shell using:
-    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    # cat /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c32
     issuerCookieKey: <a-random-key>
     serviceAccountKey: <another-random-key>

--- a/charts/kubermatic.example.ee.yaml
+++ b/charts/kubermatic.example.ee.yaml
@@ -63,6 +63,6 @@ spec:
 
     # these need to be randomly generated. Those can be generated on the
     # shell using:
-    # cat /dev/urandom | tr -dc A-Za-z0-9 | head -c32
+    # cat /dev/urandom | base64 | tr -dc 'A-Za-z0-9' | head -c32
     issuerCookieKey: <a-random-key>
     serviceAccountKey: <another-random-key>


### PR DESCRIPTION
**What this PR does / why we need it**:
We got a report that the command in our examples is not working with macOS. Indeed, I can report that with the "stock" `tr` on macOS, this doesn't work:

```sh
$  cat /dev/urandom | /usr/bin/tr -dc A-Za-z0-9 | head -c32
tr: Illegal byte sequence
```

This was shadowed on my macOS system because I have GNU coreutils installed, but not everyone does.

We were gracefully provided an alternative command that works both on Linux and stock macOS which incorporates `base64` into the pipe. This PR updates our example file to that new command which works on both Linux and macOS as far as my testing showed.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Examples now include command to generate secrets that works on vanilla macOS
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1605
```
