### PR TITLE
Set `floating-network-id` in OpenStack cloud-config to provided floating IP pool

### DIFF
--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -131,7 +131,7 @@ func getAllNetworks(netClient *gophercloud.ServiceClient, opts osnetworks.ListOp
 	return allNetworks, nil
 }
 
-func getNetworkByName(netClient *gophercloud.ServiceClient, name string, isExternal bool) (*NetworkWithExternalExt, error) {
+func GetNetworkByName(netClient *gophercloud.ServiceClient, name string, isExternal bool) (*NetworkWithExternalExt, error) {
 	existingNetworks, err := getAllNetworks(netClient, osnetworks.ListOpts{Name: name})
 	if err != nil {
 		return nil, err
@@ -366,7 +366,7 @@ func createUserClusterNetwork(netClient *gophercloud.ServiceClient, clusterName 
 }
 
 func deleteNetworkByName(netClient *gophercloud.ServiceClient, networkName string) error {
-	network, err := getNetworkByName(netClient, networkName, false)
+	network, err := GetNetworkByName(netClient, networkName, false)
 	if err != nil {
 		return fmt.Errorf("failed to get network '%s' by name: %w", networkName, err)
 	}

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -131,7 +131,7 @@ func getAllNetworks(netClient *gophercloud.ServiceClient, opts osnetworks.ListOp
 	return allNetworks, nil
 }
 
-func GetNetworkByName(netClient *gophercloud.ServiceClient, name string, isExternal bool) (*NetworkWithExternalExt, error) {
+func getNetworkByName(netClient *gophercloud.ServiceClient, name string, isExternal bool) (*NetworkWithExternalExt, error) {
 	existingNetworks, err := getAllNetworks(netClient, osnetworks.ListOpts{Name: name})
 	if err != nil {
 		return nil, err
@@ -366,7 +366,7 @@ func createUserClusterNetwork(netClient *gophercloud.ServiceClient, clusterName 
 }
 
 func deleteNetworkByName(netClient *gophercloud.ServiceClient, networkName string) error {
-	network, err := GetNetworkByName(netClient, networkName, false)
+	network, err := getNetworkByName(netClient, networkName, false)
 	if err != nil {
 		return fmt.Errorf("failed to get network '%s' by name: %w", networkName, err)
 	}

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -154,7 +154,7 @@ func GetNetworkByName(netClient *gophercloud.ServiceClient, name string, isExter
 	}
 }
 
-func getExternalNetwork(netClient *gophercloud.ServiceClient) (*NetworkWithExternalExt, error) {
+func getDefaultExternalNetwork(netClient *gophercloud.ServiceClient) (*NetworkWithExternalExt, error) {
 	existingNetworks, err := getAllNetworks(netClient, osnetworks.ListOpts{})
 	if err != nil {
 		return nil, err

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -221,19 +221,18 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 	}
 
 	// Reconciling the external Network (the floating IP pool used for machines and LBs)
-	if force {
-		if cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
-			cluster, err = reconcileExtNetwork(ctx, netClient, cluster, update)
-			if err != nil {
-				return nil, err
-			}
-		} else {
-			cluster, err = fetchExtNetwork(ctx, netClient, cluster, update)
-			if err != nil {
-				return nil, err
-			}
+	if force || cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
+		cluster, err = reconcileExtNetwork(ctx, netClient, cluster, update)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		cluster, err = fetchExtNetwork(ctx, netClient, cluster, update)
+		if err != nil {
+			return nil, err
 		}
 	}
+
 	// Reconciling the Network
 	if force || cluster.Spec.Cloud.Openstack.Network == "" {
 		cluster, err = reconcileNetwork(ctx, netClient, cluster, update)

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -91,7 +91,7 @@ func NewCloudProvider(
 		dc:                dc.Spec.Openstack,
 		secretKeySelector: secretKeyGetter,
 		caBundle:          caBundle,
-		getClientFunc:     GetNetClientForCluster,
+		getClientFunc:     getNetClientForCluster,
 	}, nil
 }
 
@@ -138,7 +138,7 @@ func (os *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 	}
 
 	if spec.Openstack.Network != "" {
-		network, err := GetNetworkByName(netClient, spec.Openstack.Network, false)
+		network, err := getNetworkByName(netClient, spec.Openstack.Network, false)
 		if err != nil {
 			return fmt.Errorf("failed to get network %q: %w", spec.Openstack.Network, err)
 		}
@@ -153,7 +153,7 @@ func (os *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 	}
 
 	if spec.Openstack.FloatingIPPool != "" {
-		_, err := GetNetworkByName(netClient, spec.Openstack.FloatingIPPool, true)
+		_, err := getNetworkByName(netClient, spec.Openstack.FloatingIPPool, true)
 		if err != nil {
 			return fmt.Errorf("failed to get floating ip pool %q: %w", spec.Openstack.FloatingIPPool, err)
 		}
@@ -238,7 +238,7 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 			return nil, fmt.Errorf("failed to update cluster floating IP pool: %w", err)
 		}
 	} else {
-		extNetwork, err := GetNetworkByName(netClient, cluster.Spec.Cloud.Openstack.FloatingIPPool, true)
+		extNetwork, err := getNetworkByName(netClient, cluster.Spec.Cloud.Openstack.FloatingIPPool, true)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external network by name: %w", err)
 		}
@@ -894,7 +894,7 @@ func (os *Provider) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermati
 	return nil
 }
 
-func GetNetClientForCluster(ctx context.Context, cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error) {
+func getNetClientForCluster(ctx context.Context, cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error) {
 	creds, err := GetCredentialsForCluster(cluster, secretKeySelector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -88,7 +88,7 @@ func NewCloudProvider(
 		dc:                dc.Spec.Openstack,
 		secretKeySelector: secretKeyGetter,
 		caBundle:          caBundle,
-		getClientFunc:     getNetClientForCluster,
+		getClientFunc:     GetNetClientForCluster,
 	}, nil
 }
 
@@ -135,7 +135,7 @@ func (os *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 	}
 
 	if spec.Openstack.Network != "" {
-		network, err := getNetworkByName(netClient, spec.Openstack.Network, false)
+		network, err := GetNetworkByName(netClient, spec.Openstack.Network, false)
 		if err != nil {
 			return fmt.Errorf("failed to get network %q: %w", spec.Openstack.Network, err)
 		}
@@ -150,7 +150,7 @@ func (os *Provider) ValidateCloudSpec(ctx context.Context, spec kubermaticv1.Clo
 	}
 
 	if spec.Openstack.FloatingIPPool != "" {
-		_, err := getNetworkByName(netClient, spec.Openstack.FloatingIPPool, true)
+		_, err := GetNetworkByName(netClient, spec.Openstack.FloatingIPPool, true)
 		if err != nil {
 			return fmt.Errorf("failed to get floating ip pool %q: %w", spec.Openstack.FloatingIPPool, err)
 		}
@@ -245,6 +245,7 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 			return nil, err
 		}
 	}
+
 	// Reconciling the subnets. All machines will live in one dedicated subnet.
 	if force || cluster.Spec.Cloud.Openstack.SubnetID == "" || cluster.Spec.Cloud.Openstack.IPv6SubnetID == "" {
 		network, err := getNetworkByName(netClient, cluster.Spec.Cloud.Openstack.Network, false)
@@ -870,7 +871,7 @@ func (os *Provider) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermati
 	return nil
 }
 
-func getNetClientForCluster(ctx context.Context, cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error) {
+func GetNetClientForCluster(ctx context.Context, cluster kubermaticv1.CloudSpec, dc *kubermaticv1.DatacenterSpecOpenstack, secretKeySelector provider.SecretKeySelectorValueFunc, caBundle *x509.CertPool) (*gophercloud.ServiceClient, error) {
 	creds, err := GetCredentialsForCluster(cluster, secretKeySelector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get credentials: %w", err)

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -111,6 +111,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 						RouterCleanupFinalizer,
 						RouterSubnetLinkCleanupFinalizer,
 					},
+					Annotations: map[string]string{
+						FloatingIPPoolIDAnnotation: ostesting.ExternalNetwork.ID,
+					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
@@ -164,6 +167,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 						RouterCleanupFinalizer,
 						RouterSubnetLinkCleanupFinalizer,
 						RouterIPv6SubnetLinkCleanupFinalizer,
+					},
+					Annotations: map[string]string{
+						FloatingIPPoolIDAnnotation: ostesting.ExternalNetwork.ID,
 					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
@@ -230,6 +236,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 			wantCluster: kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "cluster-xyz",
+					Annotations: map[string]string{
+						FloatingIPPoolIDAnnotation: ostesting.ExternalNetwork.ID,
+					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
@@ -291,6 +300,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 						RouterCleanupFinalizer,
 						RouterSubnetLinkCleanupFinalizer,
 					},
+					Annotations: map[string]string{
+						FloatingIPPoolIDAnnotation: ostesting.ExternalNetwork.ID,
+					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
@@ -348,6 +360,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 						RouterCleanupFinalizer,
 						RouterSubnetLinkCleanupFinalizer,
 					},
+					Annotations: map[string]string{
+						FloatingIPPoolIDAnnotation: ostesting.ExternalNetwork.ID,
+					},
 				},
 				Spec: kubermaticv1.ClusterSpec{
 					ClusterNetwork: kubermaticv1.ClusterNetworkingConfig{
@@ -402,6 +417,9 @@ func TestInitializeCloudProvider(t *testing.T) {
 						SecurityGroupCleanupFinalizer,
 						RouterCleanupFinalizer,
 						RouterSubnetLinkCleanupFinalizer,
+					},
+					Annotations: map[string]string{
+						FloatingIPPoolIDAnnotation: ostesting.ExternalNetwork.ID,
 					},
 				},
 				Spec: kubermaticv1.ClusterSpec{

--- a/pkg/resources/cloudconfig/cloudconfig.go
+++ b/pkg/resources/cloudconfig/cloudconfig.go
@@ -124,6 +124,7 @@ func CloudConfig(
 			LoadBalancer: openstack.LoadBalancerOpts{
 				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
 				UseOctavia:           useOctavia,
+				FloatingNetworkID:    cluster.Spec.Cloud.Openstack.FloatingIPPool,
 			},
 			Version: cluster.Status.Versions.ControlPlane.String(),
 		}

--- a/pkg/resources/cloudconfig/cloudconfig.go
+++ b/pkg/resources/cloudconfig/cloudconfig.go
@@ -30,6 +30,7 @@ import (
 	vsphere "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gcp"
+	openstackprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/openstack"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudconfig/openstack"
 )
@@ -104,6 +105,7 @@ func CloudConfig(
 		if cluster.Spec.Cloud.Openstack.UseOctavia != nil {
 			useOctavia = cluster.Spec.Cloud.Openstack.UseOctavia
 		}
+
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
 				AuthURL:                     dc.Spec.Openstack.AuthURL,

--- a/pkg/resources/cloudconfig/cloudconfig.go
+++ b/pkg/resources/cloudconfig/cloudconfig.go
@@ -106,10 +106,6 @@ func CloudConfig(
 			useOctavia = cluster.Spec.Cloud.Openstack.UseOctavia
 		}
 
-		if cluster.Annotations[openstackprovider.FloatingIPPoolIDAnnotation] == "" {
-			return "", fmt.Errorf("failed to read floating IP pool ID from %s", openstackprovider.FloatingIPPoolIDAnnotation)
-		}
-
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
 				AuthURL:                     dc.Spec.Openstack.AuthURL,
@@ -141,6 +137,12 @@ func CloudConfig(
 
 		if cluster.Spec.Cloud.Openstack.IngressHostnameSuffix != nil {
 			openstackCloudConfig.LoadBalancer.IngressHostnameSuffix = cluster.Spec.Cloud.Openstack.IngressHostnameSuffix
+		}
+
+		// we won't throw an error here for backwards compatibility and instead simply not set
+		// the floating-ip-pool-id field if the annotation is not there.
+		if cluster.Annotations[openstackprovider.FloatingIPPoolIDAnnotation] != "" {
+			openstackCloudConfig.LoadBalancer.FloatingNetworkID = cluster.Annotations[openstackprovider.FloatingIPPoolIDAnnotation]
 		}
 
 		cloudConfig, err = openstack.CloudConfigToString(openstackCloudConfig)

--- a/pkg/resources/cloudconfig/cloudconfig.go
+++ b/pkg/resources/cloudconfig/cloudconfig.go
@@ -106,6 +106,10 @@ func CloudConfig(
 			useOctavia = cluster.Spec.Cloud.Openstack.UseOctavia
 		}
 
+		if cluster.Annotations[openstackprovider.FloatingIPPoolIDAnnotation] == "" {
+			return "", fmt.Errorf("failed to read floating IP pool ID from %s", openstackprovider.FloatingIPPoolIDAnnotation)
+		}
+
 		openstackCloudConfig := &openstack.CloudConfig{
 			Global: openstack.GlobalOpts{
 				AuthURL:                     dc.Spec.Openstack.AuthURL,
@@ -126,7 +130,7 @@ func CloudConfig(
 			LoadBalancer: openstack.LoadBalancerOpts{
 				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
 				UseOctavia:           useOctavia,
-				FloatingNetworkID:    cluster.Spec.Cloud.Openstack.FloatingIPPool,
+				FloatingNetworkID:    cluster.Annotations[openstackprovider.FloatingIPPoolIDAnnotation],
 			},
 			Version: cluster.Status.Versions.ControlPlane.String(),
 		}

--- a/pkg/resources/cloudconfig/cloudconfig.go
+++ b/pkg/resources/cloudconfig/cloudconfig.go
@@ -126,7 +126,6 @@ func CloudConfig(
 			LoadBalancer: openstack.LoadBalancerOpts{
 				ManageSecurityGroups: manageSecurityGroups == nil || *manageSecurityGroups,
 				UseOctavia:           useOctavia,
-				FloatingNetworkID:    cluster.Annotations[openstackprovider.FloatingIPPoolIDAnnotation],
 			},
 			Version: cluster.Status.Versions.ControlPlane.String(),
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This hopefully addresses #12905 - seems that we have missed setting an explicit floating network in the cloud-config passed to the CCM. That is fine when your OpenStack setup only has a single external network (like the one we are testing against), but becomes problematic if there are multiple.

It seems to be sensible to default to the same external network that is used for node floating IPs because we know that the router connection has to be there. If people want to use other networks, they have the option to set the `loadbalancer.openstack.org/floating-network-id` annotation on their `Service` objects.

This PR works by storing the external network ID in an annotation to basically "cache" it between the cloud provider reconciling loop and the cloud-config Secret generator, which doesn't have access to cloud resources directly, so it cannot resolve the external network name given in the cloud spec to the ID that the OpenStack cloud-config needs.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12905

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Explicitly configure OpenStack CCM with floating IP pool configured for user cluster instead of defaulting to first external network available
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
