### PR TITLE
[release/v2.24] Add support for Kubernetes v1.26.13, v1.27.10, v1.28.6

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -458,7 +458,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.27.6
+    default: v1.27.10
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -550,9 +550,12 @@ spec:
       - v1.26.4
       - v1.26.6
       - v1.26.9
+      - v1.26.13
       - v1.27.3
       - v1.27.6
+      - v1.27.10
       - v1.28.2
+      - v1.28.6
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -458,7 +458,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.27.6
+    default: v1.27.10
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -550,9 +550,12 @@ spec:
       - v1.26.4
       - v1.26.6
       - v1.26.9
+      - v1.26.13
       - v1.27.3
       - v1.27.6
+      - v1.27.10
       - v1.28.2
+      - v1.28.6
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -217,7 +217,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.27.6"),
+		Default: semver.NewSemverOrDie("v1.27.10"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -231,11 +231,14 @@ var (
 			newSemver("v1.26.4"),
 			newSemver("v1.26.6"),
 			newSemver("v1.26.9"),
+			newSemver("v1.26.13"),
 			// Kubernetes 1.27
 			newSemver("v1.27.3"),
 			newSemver("v1.27.6"),
+			newSemver("v1.27.10"),
 			// Kubernetes 1.28
 			newSemver("v1.28.2"),
+			newSemver("v1.28.6"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.26 =======


### PR DESCRIPTION
**What this PR does / why we need it**:

What it says on the title. Also sets the default to v1.27.10.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add support for Kubernetes v1.26.13, v1.27.10, v1.28.6 and set default version to v1.27.10
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
