### PR TITLE
renamed restic command to node-agent due to velero upstream changes

### DIFF
--- a/charts/backup/velero/templates/daemonset.yaml
+++ b/charts/backup/velero/templates/daemonset.yaml
@@ -16,32 +16,31 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: restic
+  name: node-agent
   labels:
-    app.kubernetes.io/name: restic
+    app.kubernetes.io/name: node-agent
     app.kubernetes.io/version: '{{ .Values.velero.image.tag }}'
     app.kubernetes.io/managed-by: helm
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: restic
+      app.kubernetes.io/name: node-agent
   updateStrategy:
     type: RollingUpdate
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: restic
+        app.kubernetes.io/name: node-agent
     spec:
       containers:
-      - name: restic
+      - name: node-agent
         image: '{{ .Values.velero.image.repository }}:{{ .Values.velero.image.tag }}'
         imagePullPolicy: {{ .Values.velero.image.pullPolicy }}
         command:
         - /velero
         args:
-        - restic
+        - node-agent
         - server
-        - --uploader-type=restic
         {{- if .Values.velero.credentials.azure }}
         envFrom:
         - secretRef:


### PR DESCRIPTION
**What this PR does / why we need it**: Velero changed restic integration in v0.10 version due to this, velero restic integration has not been working after velero was upgraded to v0.10 (KKP 2.23). This PR makes minimal changes as suggested in [velero release notes of v0.10](https://velero.io/docs/v1.10/upgrade-to-1.10/#instructions) and in the [latest velero helm chart](https://github.com/vmware-tanzu/helm-charts/blob/main/charts/velero/templates/node-agent-daemonset.yaml#L96-L111)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore
/kind bug

**Special notes for your reviewer**:
There is a [upstream velero helmchart](https://github.com/vmware-tanzu/helm-charts/tree/main/charts/velero) and we should consider switching to the same instead of our own.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
action required: if you use `velero.restic.deploy: true`, you will see new daemonset `node-agent` running in `velero` namespace. You might need to remove existing daemonset named `restic` manually.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
