### PR TITLE
Fix CCM images

### DIFF
--- a/addons/azure-cloud-node-manager/cloud-node-manager.yaml
+++ b/addons/azure-cloud-node-manager/cloud-node-manager.yaml
@@ -18,19 +18,19 @@
 {{ if eq .Cluster.CloudProviderName "azure" }}
 {{ $version := "UNSUPPORTED" }}
 {{ if eq .Cluster.MajorMinorVersion "1.25" }}
-{{ $version = "v1.25.23" }}
+{{ $version = "v1.25.24" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.26" }}
-{{ $version = "v1.26.18" }}
+{{ $version = "v1.26.19" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.27" }}
-{{ $version = "v1.27.12"}}
+{{ $version = "v1.27.13" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.28" }}
-{{ $version = "v1.28.4"}}
+{{ $version = "v1.28.5" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.29" }}
-{{ $version = "v1.28.4"}}
+{{ $version = "v1.29.0" }}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 apiVersion: v1

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -128,17 +128,17 @@ func AzureCCMVersion(version semver.Semver) (string, error) {
 	// https://github.com/kubernetes-sigs/cloud-provider-azure/releases
 	switch version.MajorMinor() {
 	case v125:
-		return "1.25.23", nil
+		return "1.25.24", nil
 	case v126:
-		return "1.26.18", nil
+		return "1.26.19", nil
 	case v127:
-		return "1.27.12", nil
+		return "1.27.13", nil
 	case v128:
-		fallthrough
+		return "1.28.5", nil
 	case v129:
 		fallthrough
 	default:
-		return "1.28.4", nil
+		return "1.29.0", nil
 	}
 }
 

--- a/pkg/resources/cloudcontroller/digitalocean.go
+++ b/pkg/resources/cloudcontroller/digitalocean.go
@@ -151,6 +151,6 @@ func DigitaloceanCCMVersion(version semver.Semver) string {
 		fallthrough
 	default:
 		// This should always be the latest version.
-		return "v0.1.45"
+		return "v0.1.46"
 	}
 }

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	HetznerCCMDeploymentName = "hcloud-cloud-controller-manager"
-	hetznerCCMVersion        = "v1.17.2" // https://github.com/hetznercloud/hcloud-cloud-controller-manager#versioning-policy
+	hetznerCCMVersion        = "v1.19.0" // https://github.com/hetznercloud/hcloud-cloud-controller-manager#versioning-policy
 )
 
 var (
@@ -92,14 +92,6 @@ func hetznerDeploymentReconciler(data *resources.TemplateData) reconciling.Named
 					},
 					Env: append(
 						getEnvVars(),
-						corev1.EnvVar{
-							Name: "NODE_NAME",
-							ValueFrom: &corev1.EnvVarSource{
-								FieldRef: &corev1.ObjectFieldSelector{
-									FieldPath: "spec.nodeName",
-								},
-							},
-						},
 						corev1.EnvVar{
 							Name: "HCLOUD_TOKEN",
 							ValueFrom: &corev1.EnvVarSource{

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -130,13 +130,13 @@ func OpenStackCCMTag(version semver.Semver) (string, error) {
 	case v125:
 		return "v1.25.6", nil
 	case v126:
-		return "v1.26.5", nil
+		return "v1.26.4", nil
 	case v127:
-		return "v1.27.6", nil
+		return "v1.27.3", nil
 	case v128:
-		fallthrough
-	case v129:
 		return "v1.28.1", nil
+	case v129:
+		return "v1.29.0", nil
 	default:
 		return "", fmt.Errorf("%v is not yet supported", version)
 	}

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -132,10 +132,10 @@ func VSphereCCMVersion(version semver.Semver) string {
 	case v127:
 		return "1.27.0"
 	case v128:
-		fallthrough
+		return "1.28.0"
 	case v129:
 		fallthrough
 	default:
-		return "1.28.0"
+		return "1.29.0"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.26.18
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.26.19
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.27.12
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.27.13
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.4
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.5
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.4
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.29.0
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.46
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.46
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.46
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -43,7 +43,7 @@ spec:
               name: cloud-credentials
         - name: REGION
           value: fra1
-        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.45
+        image: docker.io/digitalocean/digitalocean-cloud-controller-manager:v0.1.46
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.5
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.26.4
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.27.6
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.27.3
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.28.1
+        image: registry.k8s.io/provider-os/openstack-cloud-controller-manager:v1.29.0
         name: cloud-controller-manager
         resources:
           limits:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.28.0
+        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.29.0
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Once again, I got confused by the weird tagging syntax "those CCM repos" use, where the tag `openstack-controller-manager-1.2.3` does not mean the CCM has this version, but the _Helm chart_ has that version...

This PR fixes the Openstack images and also bumps all remaining CCMs to their latest versions. And this time and forever now, I checked the registry explicitly.

Hetzner CCM 1.19 removed the NODE_NAME env var, as it was unused already.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
