### PR TITLE
[release/v2.22] bump metering to v1.0.6

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -56,7 +56,7 @@ const (
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {
-	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.5"))
+	return registry.Must(overwriter(resources.RegistryQuay + "/kubermatic/metering:v1.0.6"))
 }
 
 // ReconcileMeteringResources reconciles the metering related resources.


### PR DESCRIPTION
**What this PR does / why we need it**:
metering v1.0.6 includes a fix for an NPE when a custom CA bundle is used.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update metering to v1.0.6, fixing an error when a custom CA bundle is used.
```

**Documentation**:
```documentation
NONE
```
