### PR TITLE
bump metering to v1.1.2

### DIFF
--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -53,7 +53,7 @@ import (
 
 const (
 	meteringName    = "metering"
-	meteringVersion = "v1.1.1"
+	meteringVersion = "v1.1.2"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
metering v1.1.2 includes a fix for an NPE when a custom CA bundle is used.

This PR can be backported easily into 2.24. For 2.22/2.23 I opened dedicated PRs already: #13011 and #13012

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update metering to v1.1.2, fixing an error when a custom CA bundle is used.
```

**Documentation**:
```documentation
NONE
```
