### PR TITLE
VCD: Move CSI controller to seed cluster

### DIFF
--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -15,7 +15,7 @@
 presubmits:
   - name: pre-kubermatic-e2e-vmware-cloud-director-ubuntu-1.29
     decorate: true
-    run_if_changed: "(pkg/provider/cloud/vmwareclouddirector)"
+    run_if_changed: "(addons/csi/vmware-cloud-director/|pkg/provider/cloud/vmwareclouddirector|pkg/resources/csi/vmwareclouddirector)"
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
     labels:
       preset-vcloud-director: "true"

--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -112,6 +112,43 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 ---
+# external resizer
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-binding
+subjects:
+  - kind: ServiceAccount
+    name: csi-vcd-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -160,13 +197,26 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-resizer
+          image: {{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.4.0" }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=30s"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "IfNotPresent"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: vcd-csi-plugin
           securityContext:
             privileged: true
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.5.0" }}
+          image: {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.6.0" }}
           imagePullPolicy: IfNotPresent
           command:
             - /opt/vcloud/bin/cloud-director-named-disk-csi-driver

--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -107,41 +107,4 @@ roleRef:
   name: csi-provisioner-role
   apiGroup: rbac.authorization.k8s.io
 
----
-# external resizer
-kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-resizer-role
-rules:
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumes"]
-    verbs: ["get", "list", "watch", "update", "patch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: [""]
-    resources: ["persistentvolumeclaims/status"]
-    verbs: ["update", "patch"]
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
-
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: csi-resizer-binding
-subjects:
-  - kind: User
-    name: kubermatic:vcloud-csi
-    namespace: kube-system
-roleRef:
-  kind: ClusterRole
-  name: csi-resizer-role
-  apiGroup: rbac.authorization.k8s.io
-
 {{ end }}

--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -21,12 +21,6 @@
 # - remove affinity
 
 {{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: csi-vcd-controller-sa
-  namespace: kube-system
 
 ---
 # external attacher
@@ -57,8 +51,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-attacher-binding
 subjects:
-  - kind: ServiceAccount
-    name: csi-vcd-controller-sa
+  - kind: User
+    name: kubermatic:vcloud-csi
     namespace: kube-system
 roleRef:
   kind: ClusterRole
@@ -103,8 +97,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-provisioner-binding
 subjects:
-  - kind: ServiceAccount
-    name: csi-vcd-controller-sa
+  - kind: User
+    name: kubermatic:vcloud-csi
     namespace: kube-system
 roleRef:
   kind: ClusterRole
@@ -140,133 +134,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: csi-resizer-binding
 subjects:
-  - kind: ServiceAccount
-    name: csi-vcd-controller-sa
+  - kind: User
+    name: kubermatic:vcloud-csi
     namespace: kube-system
 roleRef:
   kind: ClusterRole
   name: csi-resizer-role
   apiGroup: rbac.authorization.k8s.io
-
----
-kind: Deployment
-apiVersion: apps/v1
-metadata:
-  name: csi-vcd-controllerplugin
-  namespace: kube-system
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: csi-vcd-controllerplugin
-  template:
-    metadata:
-      labels:
-        app: csi-vcd-controllerplugin
-    spec:
-      serviceAccount: csi-vcd-controller-sa
-      dnsPolicy: Default
-      securityContext:
-        seccompProfile:
-          type: RuntimeDefault
-      containers:
-        - name: csi-attacher
-          image: {{ Image "registry.k8s.io/sig-storage/csi-attacher:v3.2.1" }}
-          imagePullPolicy: IfNotPresent
-          args:
-            - --csi-address=$(ADDRESS)
-            - --timeout=180s
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-provisioner
-          image: {{ Image "registry.k8s.io/sig-storage/csi-provisioner:v2.2.2" }}
-          imagePullPolicy: IfNotPresent
-          args:
-            - --csi-address=$(ADDRESS)
-            - --default-fstype=ext4
-            - --timeout=300s
-            - --v=5
-          env:
-            - name: ADDRESS
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: csi-resizer
-          image: {{ Image "registry.k8s.io/sig-storage/csi-resizer:v1.4.0" }}
-          args:
-            - "--csi-address=$(ADDRESS)"
-            - "--timeout=30s"
-            - "--v=5"
-          env:
-            - name: ADDRESS
-              value: /var/lib/csi/sockets/pluginproxy/csi.sock
-          imagePullPolicy: "IfNotPresent"
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-        - name: vcd-csi-plugin
-          securityContext:
-            privileged: true
-            capabilities:
-              add: ["SYS_ADMIN"]
-            allowPrivilegeEscalation: true
-          image: {{ Image "projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.6.0" }}
-          imagePullPolicy: IfNotPresent
-          command:
-            - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
-            - --cloud-config=/etc/kubernetes/vcloud/vcloud-csi-config.yaml
-            - --endpoint=$(CSI_ENDPOINT)
-            - --upgrade-rde
-            - --v=5
-          env:
-            - name: NODE_ID
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-            - name: CSI_ENDPOINT
-              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
-          volumeMounts:
-            - name: socket-dir
-              mountPath: /var/lib/csi/sockets/pluginproxy/
-            - name: pods-probe-dir
-              mountPath: /dev
-              mountPropagation: HostToContainer
-            - name: pv-dir
-              mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
-              mountPropagation: "Bidirectional"
-            - name: vcloud-csi-config-volume
-              mountPath: /etc/kubernetes/vcloud
-            - name: vcloud-basic-auth-volume
-              mountPath: /etc/kubernetes/vcloud/basic-auth
-      tolerations:
-        - key: "CriticalAddonsOnly"
-          operator: "Exists"
-        - key: node-role.kubernetes.io/control-plane
-          effect: NoSchedule
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
-      volumes:
-        - name: socket-dir
-          emptyDir: {}
-        - name: pods-probe-dir
-          hostPath:
-            path: /dev
-            type: Directory
-        - name: pv-dir
-          hostPath:
-            path: /var/lib/kubelet/plugins/kubernetes.io/csi
-            type: DirectoryOrCreate
-        - name: vcloud-csi-config-volume
-          configMap:
-            name: vcloud-csi-configmap
-        - name: vcloud-basic-auth-volume
-          secret:
-            secretName: vcloud-basic-auth
 
 {{ end }}

--- a/addons/csi/vmware-cloud-director/csi-controller.yaml
+++ b/addons/csi/vmware-cloud-director/csi-controller.yaml
@@ -19,6 +19,8 @@
 # - image source includes registry templating
 # - add a securityContext
 # - remove affinity
+# - use `kubermatic:vcloud-csi` user instead of service account
+# - remove deployment for CSI controller; it has been moved from user cluster to seed cluster
 
 {{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
 

--- a/hack/versions.yaml
+++ b/hack/versions.yaml
@@ -79,6 +79,13 @@ products:
           package: k8c.io/kubermatic/v2/pkg/resources/csi/kubevirt
           constant: csiVersion
 
+  - name: VMware Cloud Director CSI
+    source: https://github.com/vmware/cloud-director-named-disk-csi-driver
+    occurrences:
+      - goConstant:
+          package: k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector
+          constant: csiVersion
+
   - name: CoreDNS
     source: https://github.com/kubernetes/kubernetes
     occurrences:

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -450,6 +450,7 @@ func (r *Reconciler) GetSecretReconcilers(ctx context.Context, data *resources.T
 		resources.GetInternalKubeconfigReconciler(namespace, resources.KubeStateMetricsKubeconfigSecretName, resources.KubeStateMetricsCertUsername, nil, data, r.log),
 		resources.GetInternalKubeconfigReconciler(namespace, resources.InternalUserClusterAdminKubeconfigSecretName, resources.InternalUserClusterAdminKubeconfigCertUsername, []string{"system:masters"}, data, r.log),
 		resources.GetInternalKubeconfigReconciler(namespace, resources.ClusterAutoscalerKubeconfigSecretName, resources.ClusterAutoscalerCertUsername, nil, data, r.log),
+		resources.GetInternalKubeconfigReconciler(namespace, resources.VMwareCloudDirectorCSIKubeconfigSecretName, resources.VMwareCloudDirectorCSICertUsername, nil, data, r.log),
 		resources.AdminKubeconfigReconciler(data),
 		apiserver.TokenViewerReconciler(),
 		apiserver.TokenUsersReconciler(data),

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -66,7 +66,6 @@ import (
 	"k8c.io/reconciler/pkg/reconciling"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -290,12 +289,6 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 
 	if !data.kubernetesDashboardEnabled {
 		if err := r.ensureKubernetesDashboardResourcesAreRemoved(ctx); err != nil {
-			return err
-		}
-	}
-
-	if cluster.Spec.Cloud.VMwareCloudDirector != nil {
-		if err := r.ensureOrphanedVMwareCloudDirectorCSIResourcesAreRemoved(ctx); err != nil {
 			return err
 		}
 	}
@@ -1410,35 +1403,6 @@ func (r *reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Co
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure Kubernetes Dashboard resources are removed/not present: %w", err)
 		}
-	}
-	return nil
-}
-
-func (r *reconciler) ensureOrphanedVMwareCloudDirectorCSIResourcesAreRemoved(ctx context.Context) error {
-	// Remove the Deployment of CSI driver from user cluster
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "csi-vcd-controllerplugin",
-			Namespace: metav1.NamespaceSystem,
-		},
-	}
-
-	err := r.Client.Delete(ctx, deployment)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to ensure that the VCD CSI driver deployment is removed/not present: %w", err)
-	}
-
-	// Remove the service account of CSI driver from user cluster
-	serviceAccount := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "csi-vcd-controller-sa",
-			Namespace: metav1.NamespaceSystem,
-		},
-	}
-
-	err = r.Client.Delete(ctx, serviceAccount)
-	if err != nil && !apierrors.IsNotFound(err) {
-		return fmt.Errorf("failed to ensure that the VCD CSI driver service account is removed/not present: %w", err)
 	}
 	return nil
 }

--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -574,13 +574,13 @@ func getDigitalOceanResourceRequirements(ctx context.Context, userClient ctrlrun
 func getVMwareCloudDirectorResourceRequirements(ctx context.Context, userClient ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {
 	rawConfig, err := vmwareclouddirectortypes.GetConfig(*config)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get vmwareclouddirector raw config: %w", err)
+		return nil, fmt.Errorf("failed to get VMware Cloud Director raw config: %w", err)
 	}
 
 	var totalCPUCores int64
 	switch {
 	case rawConfig.CPUs == 0:
-		return nil, fmt.Errorf("found invalid value of vmwareclouddirector \"cpus\" from machine config, %v", rawConfig.CPUs)
+		return nil, fmt.Errorf("found invalid value of VMware Cloud Director \"cpus\" from machine config, %v", rawConfig.CPUs)
 	case rawConfig.CPUCores != 0:
 		totalCPUCores = rawConfig.CPUs * rawConfig.CPUCores
 	default:

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -58,6 +58,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/defaulting"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
 	metricsserver "k8c.io/kubermatic/v2/pkg/resources/metrics-server"
 	"k8c.io/kubermatic/v2/pkg/resources/operatingsystemmanager"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -418,6 +419,7 @@ func getImagesFromReconcilers(log logrus.FieldLogger, templateData *resources.Te
 	deploymentReconcilers = append(deploymentReconcilers, operatingsystemmanager.DeploymentReconciler(templateData))
 	deploymentReconcilers = append(deploymentReconcilers, k8sdashboard.DeploymentReconciler(templateData.RewriteImage))
 	deploymentReconcilers = append(deploymentReconcilers, gatekeeper.ControllerDeploymentReconciler(false, templateData.RewriteImage, nil))
+	deploymentReconcilers = append(deploymentReconcilers, vmwareclouddirector.ControllerDeploymentReconciler(templateData))
 
 	if templateData.Cluster().Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
 		deploymentReconcilers = append(deploymentReconcilers, cloudcontroller.DeploymentReconciler(templateData))
@@ -632,6 +634,7 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		resources.KubeVirtCSISecretName,
 		resources.KubeVirtInfraSecretName,
 		resources.GoogleServiceAccountSecretName,
+		resources.VMwareCloudDirectorCSIKubeconfigSecretName,
 	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -635,6 +635,8 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		resources.KubeVirtInfraSecretName,
 		resources.GoogleServiceAccountSecretName,
 		resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+		resources.CSICloudConfigSecretName,
+		resources.VMwareCloudDirectorCSISecretName,
 	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{

--- a/pkg/resources/csi/deployment.go
+++ b/pkg/resources/csi/deployment.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/csi/kubevirt"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
 	"k8c.io/reconciler/pkg/reconciling"
 )
 
@@ -29,6 +30,8 @@ func DeploymentsReconcilers(data *resources.TemplateData) []reconciling.NamedDep
 	switch {
 	case data.Cluster().Spec.Cloud.Kubevirt != nil:
 		creatorGetters = kubevirt.DeploymentsReconcilers(data)
+	case data.Cluster().Spec.Cloud.VMwareCloudDirector != nil:
+		creatorGetters = vmwareclouddirector.DeploymentsReconcilers(data)
 	}
 
 	return creatorGetters

--- a/pkg/resources/csi/rbac.go
+++ b/pkg/resources/csi/rbac.go
@@ -19,6 +19,7 @@ package csi
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources/csi/kubevirt"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
 	"k8c.io/reconciler/pkg/reconciling"
 )
 
@@ -29,6 +30,8 @@ func ServiceAccountReconcilers(cluster *kubermaticv1.Cluster) []reconciling.Name
 	switch {
 	case cluster.Spec.Cloud.Kubevirt != nil:
 		creatorGetters = append(creatorGetters, kubevirt.ServiceAccountsReconcilers(cluster)...)
+	case cluster.Spec.Cloud.VMwareCloudDirector != nil:
+		creatorGetters = append(creatorGetters, vmwareclouddirector.ServiceAccountsReconcilers(cluster)...)
 	}
 
 	return creatorGetters

--- a/pkg/resources/csi/vmwareclouddirector/deployment.go
+++ b/pkg/resources/csi/vmwareclouddirector/deployment.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Original source: https://github.com/vmware/cloud-director-named-disk-csi-driver/blob/1.5.0/manifests/csi-controller.yaml
+
+package vmwareclouddirector
+
+import (
+	"fmt"
+
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
+	"k8c.io/reconciler/pkg/reconciling"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	csiVersion = "1.5.0"
+)
+
+var (
+	hostPathType            = corev1.HostPathDirectoryOrCreate
+	mountPropagationHostToC = corev1.MountPropagationHostToContainer
+)
+
+// DeploymentsReconcilers returns the CSI controller Deployments for VMware Cloud Director.
+func DeploymentsReconcilers(data *resources.TemplateData) []reconciling.NamedDeploymentReconcilerFactory {
+	creators := []reconciling.NamedDeploymentReconcilerFactory{
+		ControllerDeploymentReconciler(data),
+	}
+	return creators
+}
+
+// ControllerDeploymentReconciler returns the CSI controller Deployment for VMware Cloud Director.
+func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
+	return func() (name string, create reconciling.DeploymentReconciler) {
+		return resources.VMwareCloudDirectorCSIControllerName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			volumes := []corev1.Volume{
+				{
+					Name: "socket-dir",
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+				{
+					Name: "pods-probe-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/dev",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: "pv-dir",
+					VolumeSource: corev1.VolumeSource{
+						HostPath: &corev1.HostPathVolumeSource{
+							Path: "/var/lib/kubelet/plugins/kubernetes.io/csi",
+							Type: &hostPathType,
+						},
+					},
+				},
+				{
+					Name: resources.CSICloudConfigSecretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: resources.CSICloudConfigSecretName,
+						},
+					},
+				},
+				{
+					Name: "vcloud-basic-auth-volume",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: resources.VMwareCloudDirectorCSISecretName,
+						},
+					},
+				},
+				{
+					Name: resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+						},
+					},
+				},
+			}
+			dep.Name = resources.OperatingSystemManagerDeploymentName
+			dep.Labels = resources.BaseAppLabels(resources.VMwareCloudDirectorCSIControllerName, nil)
+
+			dep.Spec.Replicas = resources.Int32(1)
+			dep.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: resources.BaseAppLabels(resources.VMwareCloudDirectorCSIControllerName, nil),
+			}
+			dep.Spec.Template.Spec.Volumes = volumes
+
+			podLabels, err := data.GetPodTemplateLabels(resources.VMwareCloudDirectorCSIControllerName, volumes, nil)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create pod labels: %w", err)
+			}
+
+			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
+				Labels: podLabels,
+			}
+			dep.Spec.Template.Spec.ServiceAccountName = resources.VMwareCloudDirectorCSIServiceAccountName
+			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
+			if err != nil {
+				return nil, err
+			}
+
+			dep.Spec.Template.Spec.Containers = []corev1.Container{
+				{
+					Name:            "csi-attacher",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Image:           registry.Must(data.RewriteImage("registry.k8s.io/sig-storage/csi-attacher:v4.3.0")),
+					Args: []string{
+						"--csi-address=$(ADDRESS)",
+						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+						"--timeout=180s",
+						"--v=5",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ADDRESS",
+							Value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "socket-dir",
+							MountPath: "/var/lib/csi/sockets/pluginproxy/",
+						},
+						{
+							Name:      resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
+					},
+				},
+				{
+					Name:            "csi-provisioner",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Image:           registry.Must(data.RewriteImage("registry.k8s.io/sig-storage/csi-provisioner:v2.2.2")),
+					Args: []string{
+						"--csi-address=$(ADDRESS)",
+						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+						"--default-fstype=ext4",
+						"--timeout=300s",
+						"--v=5",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ADDRESS",
+							Value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "socket-dir",
+							MountPath: "/var/lib/csi/sockets/pluginproxy/",
+						},
+						{
+							Name:      resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
+					},
+				},
+				{
+					Name:            "csi-resizer",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Image:           registry.Must(data.RewriteImage("registry.k8s.io/sig-storage/csi-resizer:v1.4.0")),
+					Args: []string{
+						"--csi-address=$(ADDRESS)",
+						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
+						"--timeout=30s",
+						"--v=5",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "ADDRESS",
+							Value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "socket-dir",
+							MountPath: "/var/lib/csi/sockets/pluginproxy/",
+						},
+						{
+							Name:      resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+							MountPath: "/etc/kubernetes/kubeconfig",
+							ReadOnly:  true,
+						},
+					},
+				},
+				{
+					Name:            "vcd-csi-plugin",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Image:           registry.Must(data.RewriteImage("projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:" + csiVersion)),
+					Command:         []string{"/opt/vcloud/bin/cloud-director-named-disk-csi-driver"},
+					Args: []string{
+						"--endpoint=$(CSI_ENDPOINT)",
+						"--cloud-config=/etc/kubernetes/vcloud/config",
+						"--upgrade-rde",
+						"--v=5",
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name:  "CSI_ENDPOINT",
+							Value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+						},
+						{
+							Name: "NODE_ID",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									FieldPath: "spec.nodeName",
+								},
+							},
+						},
+					},
+					VolumeMounts: []corev1.VolumeMount{
+						{
+							Name:      "socket-dir",
+							MountPath: "/var/lib/csi/sockets/pluginproxy/",
+						},
+						{
+							Name:             "pods-probe-dir",
+							MountPath:        "/dev",
+							MountPropagation: &mountPropagationHostToC,
+						},
+						{
+							Name:             "pv-dir",
+							MountPath:        "/var/lib/kubelet/plugins/kubernetes.io/csi",
+							MountPropagation: &mountPropagationHostToC,
+						},
+						{
+							Name:      resources.CSICloudConfigSecretName,
+							MountPath: "/etc/kubernetes/vcloud",
+						},
+						{
+							Name:      "vcloud-basic-auth-volume",
+							MountPath: "/etc/kubernetes/vcloud/basic-auth",
+						},
+					},
+				},
+			}
+			return dep, nil
+		}
+	}
+}

--- a/pkg/resources/csi/vmwareclouddirector/deployment.go
+++ b/pkg/resources/csi/vmwareclouddirector/deployment.go
@@ -218,7 +218,6 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 					Args: []string{
 						"--endpoint=$(CSI_ENDPOINT)",
 						"--cloud-config=/etc/kubernetes/vcloud/config",
-						"--upgrade-rde",
 						"--v=5",
 					},
 					Env: []corev1.EnvVar{

--- a/pkg/resources/csi/vmwareclouddirector/deployment.go
+++ b/pkg/resources/csi/vmwareclouddirector/deployment.go
@@ -27,6 +27,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -152,6 +153,16 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 							ReadOnly:  true,
 						},
 					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("24Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
+						},
+					},
 				},
 				{
 					Name:            "csi-provisioner",
@@ -181,32 +192,14 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 							ReadOnly:  true,
 						},
 					},
-				},
-				{
-					Name:            "csi-resizer",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Image:           registry.Must(data.RewriteImage("registry.k8s.io/sig-storage/csi-resizer:v1.4.0")),
-					Args: []string{
-						"--csi-address=$(ADDRESS)",
-						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
-						"--timeout=30s",
-						"--v=5",
-					},
-					Env: []corev1.EnvVar{
-						{
-							Name:  "ADDRESS",
-							Value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("24Mi"),
 						},
-					},
-					VolumeMounts: []corev1.VolumeMount{
-						{
-							Name:      "socket-dir",
-							MountPath: "/var/lib/csi/sockets/pluginproxy/",
-						},
-						{
-							Name:      resources.VMwareCloudDirectorCSIKubeconfigSecretName,
-							MountPath: "/etc/kubernetes/kubeconfig",
-							ReadOnly:  true,
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("100m"),
+							corev1.ResourceMemory: resource.MustParse("64Mi"),
 						},
 					},
 				},
@@ -256,6 +249,16 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 						{
 							Name:      "vcloud-basic-auth-volume",
 							MountPath: "/etc/kubernetes/vcloud/basic-auth",
+						},
+					},
+					Resources: corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("10m"),
+							corev1.ResourceMemory: resource.MustParse("24Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("200m"),
+							corev1.ResourceMemory: resource.MustParse("128Mi"),
 						},
 					},
 				},

--- a/pkg/resources/csi/vmwareclouddirector/rbac.go
+++ b/pkg/resources/csi/vmwareclouddirector/rbac.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmwareclouddirector
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/reconciler/pkg/reconciling"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ServiceAccountsReconcilers returns the CSI serviceaccounts.
+func ServiceAccountsReconcilers(c *kubermaticv1.Cluster) []reconciling.NamedServiceAccountReconcilerFactory {
+	creators := []reconciling.NamedServiceAccountReconcilerFactory{
+		ControllerServiceAccountReconciler(c),
+	}
+	return creators
+}
+
+// ControllerServiceAccountReconciler returns the CSI serviceaccount.
+func ControllerServiceAccountReconciler(c *kubermaticv1.Cluster) reconciling.NamedServiceAccountReconcilerFactory {
+	return func() (name string, create reconciling.ServiceAccountReconciler) {
+		return resources.VMwareCloudDirectorCSIServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
+			sa.Labels = resources.BaseAppLabels(resources.VMwareCloudDirectorCSIServiceAccountName, nil)
+			sa.Name = resources.VMwareCloudDirectorCSIServiceAccountName
+			sa.Namespace = c.Status.NamespaceName
+			return sa, nil
+		}
+	}
+}

--- a/pkg/resources/csi/vmwareclouddirector/secret.go
+++ b/pkg/resources/csi/vmwareclouddirector/secret.go
@@ -32,7 +32,7 @@ func SecretsReconcilers(data *resources.TemplateData) []reconciling.NamedSecretR
 	return creators
 }
 
-// CloudConfigSecretNameReconciler returns the CSI secrets for vmwareclouddirector cloud config.
+// CloudConfigSecretNameReconciler returns the CSI secrets for VMware Cloud Director cloud config.
 func cloudConfigSecretNameReconciler(data *resources.TemplateData) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
 		return resources.CSICloudConfigSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
@@ -58,7 +58,7 @@ func cloudConfigSecretNameReconciler(data *resources.TemplateData) reconciling.N
 	}
 }
 
-// BasicAuthSecretNameReconciler returns the CSI secrets for vmwareclouddirector.
+// BasicAuthSecretNameReconciler returns the CSI secrets for VMware Cloud Director.
 func basicAuthSecretNameReconciler(data *resources.TemplateData) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
 		return resources.VMwareCloudDirectorCSISecretName, func(s *corev1.Secret) (*corev1.Secret, error) {

--- a/pkg/resources/csi/vmwareclouddirector/secret.go
+++ b/pkg/resources/csi/vmwareclouddirector/secret.go
@@ -26,17 +26,18 @@ import (
 // Secretsreators returns the CSI secrets for KubeVirt.
 func SecretsReconcilers(data *resources.TemplateData) []reconciling.NamedSecretReconcilerFactory {
 	creators := []reconciling.NamedSecretReconcilerFactory{
-		CloudConfigSecretNameReconciler(data),
+		cloudConfigSecretNameReconciler(data),
+		basicAuthSecretNameReconciler(data),
 	}
 	return creators
 }
 
-// CloudConfigSecretNameReconciler returns the CSI secrets for vmwareclouddirector.
-func CloudConfigSecretNameReconciler(data *resources.TemplateData) reconciling.NamedSecretReconcilerFactory {
+// CloudConfigSecretNameReconciler returns the CSI secrets for vmwareclouddirector cloud config.
+func cloudConfigSecretNameReconciler(data *resources.TemplateData) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return resources.CSICloudConfigSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
-			if cm.Data == nil {
-				cm.Data = map[string][]byte{}
+		return resources.CSICloudConfigSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
+			if s.Data == nil {
+				s.Data = map[string][]byte{}
 			}
 
 			credentials, err := resources.GetCredentials(data)
@@ -49,10 +50,35 @@ func CloudConfigSecretNameReconciler(data *resources.TemplateData) reconciling.N
 				return nil, err
 			}
 
-			cm.Labels = resources.BaseAppLabels(resources.CSICloudConfigSecretName, nil)
-			cm.Data[resources.CloudConfigKey] = []byte(vcdCloudConfig)
+			s.Labels = resources.BaseAppLabels(resources.CSICloudConfigSecretName, nil)
+			s.Data[resources.CloudConfigKey] = []byte(vcdCloudConfig)
 
-			return cm, nil
+			return s, nil
+		}
+	}
+}
+
+// BasicAuthSecretNameReconciler returns the CSI secrets for vmwareclouddirector.
+func basicAuthSecretNameReconciler(data *resources.TemplateData) reconciling.NamedSecretReconcilerFactory {
+	return func() (string, reconciling.SecretReconciler) {
+		return resources.VMwareCloudDirectorCSISecretName, func(s *corev1.Secret) (*corev1.Secret, error) {
+			if s.Data == nil {
+				s.Data = map[string][]byte{}
+			}
+			s.Labels = resources.BaseAppLabels(resources.VMwareCloudDirectorCSISecretName, nil)
+
+			credentials, err := resources.GetCredentials(data)
+			if err != nil {
+				return nil, err
+			}
+
+			if credentials.VMwareCloudDirector.APIToken != "" {
+				s.Data["refreshToken"] = []byte(credentials.VMwareCloudDirector.APIToken)
+			} else {
+				s.Data["username"] = []byte(credentials.VMwareCloudDirector.Username)
+				s.Data["password"] = []byte(credentials.VMwareCloudDirector.Password)
+			}
+			return s, nil
 		}
 	}
 }

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -507,6 +507,18 @@ const (
 	// KubeVirtCSIRoleBindingName is the name of the deployment of the CSI controller.
 	KubeVirtCSIRoleBindingName = "csi-controller"
 
+	// VMwareCloudDirectorCSIControllerName is the name of the deployment of the CSI controller.
+	VMwareCloudDirectorCSIControllerName = "csi-controller"
+	// VMwareCloudDirectorCSISecretName is the name for the secret containing the credentials for VMware Cloud Director.
+	VMwareCloudDirectorCSISecretName = "vcloud-basic-auth"
+	// VMwareCloudDirectorCSIConfigmapName is the name for the configmap containing the configmap for VMware Cloud Director CSI driver.
+	VMwareCloudDirectorCSIConfigmapName = "vcloud-csi-configmap"
+	// VMwareCloudDirectorCSIServiceAccountName is the name of the service account of the CSI controller.
+	VMwareCloudDirectorCSIServiceAccountName = "vcloud-csi"
+	// VMwareCloudDirectorCertUsername is the name of the user coming from kubeconfig cert.
+	VMwareCloudDirectorCSICertUsername = "kubermatic:vcloud-csi"
+	// VMwareCloudDirectorCSIKubeconfigSecretName is the name for the secret containing the kubeconfig used by the osm.
+	VMwareCloudDirectorCSIKubeconfigSecretName = "vcloud-csi-kubeconfig"
 	// DefaultNodePortRange is a Kubernetes cluster's default nodeport range.
 	DefaultNodePortRange = "30000-32767"
 )

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-csi-controller.yaml
@@ -1,0 +1,143 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: csi-controller
+  name: csi-controller
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: csi-controller
+        cloud-config-csi-secret-revision: "123456"
+        cluster: de-test-01
+        vcloud-basic-auth-secret-revision: "123456"
+        vcloud-csi-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --timeout=180s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --default-fstype=ext4
+        - --timeout=300s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --cloud-config=/etc/kubernetes/vcloud/config
+        - --v=5
+        command:
+        - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.5.0
+        imagePullPolicy: IfNotPresent
+        name: vcd-csi-plugin
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /dev
+          mountPropagation: HostToContainer
+          name: pods-probe-dir
+        - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+          mountPropagation: HostToContainer
+          name: pv-dir
+        - mountPath: /etc/kubernetes/vcloud
+          name: cloud-config-csi
+        - mountPath: /etc/kubernetes/vcloud/basic-auth
+          name: vcloud-basic-auth-volume
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      serviceAccountName: vcloud-csi
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - hostPath:
+          path: /dev
+          type: DirectoryOrCreate
+        name: pods-probe-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/kubernetes.io/csi
+          type: DirectoryOrCreate
+        name: pv-dir
+      - name: cloud-config-csi
+        secret:
+          secretName: cloud-config-csi
+      - name: vcloud-basic-auth-volume
+        secret:
+          secretName: vcloud-basic-auth
+      - name: vcloud-csi-kubeconfig
+        secret:
+          secretName: vcloud-csi-kubeconfig
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-csi-controller.yaml
@@ -1,0 +1,143 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: csi-controller
+  name: csi-controller
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: csi-controller
+        cloud-config-csi-secret-revision: "123456"
+        cluster: de-test-01
+        vcloud-basic-auth-secret-revision: "123456"
+        vcloud-csi-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --timeout=180s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --default-fstype=ext4
+        - --timeout=300s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --cloud-config=/etc/kubernetes/vcloud/config
+        - --v=5
+        command:
+        - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.5.0
+        imagePullPolicy: IfNotPresent
+        name: vcd-csi-plugin
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /dev
+          mountPropagation: HostToContainer
+          name: pods-probe-dir
+        - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+          mountPropagation: HostToContainer
+          name: pv-dir
+        - mountPath: /etc/kubernetes/vcloud
+          name: cloud-config-csi
+        - mountPath: /etc/kubernetes/vcloud/basic-auth
+          name: vcloud-basic-auth-volume
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      serviceAccountName: vcloud-csi
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - hostPath:
+          path: /dev
+          type: DirectoryOrCreate
+        name: pods-probe-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/kubernetes.io/csi
+          type: DirectoryOrCreate
+        name: pv-dir
+      - name: cloud-config-csi
+        secret:
+          secretName: cloud-config-csi
+      - name: vcloud-basic-auth-volume
+        secret:
+          secretName: vcloud-basic-auth
+      - name: vcloud-csi-kubeconfig
+        secret:
+          secretName: vcloud-csi-kubeconfig
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-csi-controller.yaml
@@ -1,0 +1,143 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: csi-controller
+  name: csi-controller
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: csi-controller
+        cloud-config-csi-secret-revision: "123456"
+        cluster: de-test-01
+        vcloud-basic-auth-secret-revision: "123456"
+        vcloud-csi-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --timeout=180s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --default-fstype=ext4
+        - --timeout=300s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --cloud-config=/etc/kubernetes/vcloud/config
+        - --v=5
+        command:
+        - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.5.0
+        imagePullPolicy: IfNotPresent
+        name: vcd-csi-plugin
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /dev
+          mountPropagation: HostToContainer
+          name: pods-probe-dir
+        - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+          mountPropagation: HostToContainer
+          name: pv-dir
+        - mountPath: /etc/kubernetes/vcloud
+          name: cloud-config-csi
+        - mountPath: /etc/kubernetes/vcloud/basic-auth
+          name: vcloud-basic-auth-volume
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      serviceAccountName: vcloud-csi
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - hostPath:
+          path: /dev
+          type: DirectoryOrCreate
+        name: pods-probe-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/kubernetes.io/csi
+          type: DirectoryOrCreate
+        name: pv-dir
+      - name: cloud-config-csi
+        secret:
+          secretName: cloud-config-csi
+      - name: vcloud-basic-auth-volume
+        secret:
+          secretName: vcloud-basic-auth
+      - name: vcloud-csi-kubeconfig
+        secret:
+          secretName: vcloud-csi-kubeconfig
+status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-csi-controller.yaml
@@ -1,0 +1,143 @@
+# This file has been generated, DO NOT EDIT.
+
+metadata:
+  creationTimestamp: null
+  labels:
+    app: csi-controller
+  name: csi-controller
+  namespace: cluster-de-test-01
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: csi-controller
+  strategy: {}
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: csi-controller
+        cloud-config-csi-secret-revision: "123456"
+        cluster: de-test-01
+        vcloud-basic-auth-secret-revision: "123456"
+        vcloud-csi-kubeconfig-secret-revision: "123456"
+    spec:
+      containers:
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --timeout=180s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-attacher:v4.3.0
+        imagePullPolicy: IfNotPresent
+        name: csi-attacher
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --csi-address=$(ADDRESS)
+        - --kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig
+        - --default-fstype=ext4
+        - --timeout=300s
+        - --v=5
+        env:
+        - name: ADDRESS
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        image: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+        imagePullPolicy: IfNotPresent
+        name: csi-provisioner
+        resources:
+          limits:
+            cpu: 100m
+            memory: 64Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /etc/kubernetes/kubeconfig
+          name: vcloud-csi-kubeconfig
+          readOnly: true
+      - args:
+        - --endpoint=$(CSI_ENDPOINT)
+        - --cloud-config=/etc/kubernetes/vcloud/config
+        - --v=5
+        command:
+        - /opt/vcloud/bin/cloud-director-named-disk-csi-driver
+        env:
+        - name: CSI_ENDPOINT
+          value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+        - name: NODE_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        image: projects.registry.vmware.com/vmware-cloud-director/cloud-director-named-disk-csi-driver:1.5.0
+        imagePullPolicy: IfNotPresent
+        name: vcd-csi-plugin
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 24Mi
+        volumeMounts:
+        - mountPath: /var/lib/csi/sockets/pluginproxy/
+          name: socket-dir
+        - mountPath: /dev
+          mountPropagation: HostToContainer
+          name: pods-probe-dir
+        - mountPath: /var/lib/kubelet/plugins/kubernetes.io/csi
+          mountPropagation: HostToContainer
+          name: pv-dir
+        - mountPath: /etc/kubernetes/vcloud
+          name: cloud-config-csi
+        - mountPath: /etc/kubernetes/vcloud/basic-auth
+          name: vcloud-basic-auth-volume
+      dnsConfig:
+        nameservers:
+        - 192.0.2.14
+        options:
+        - name: ndots
+          value: "5"
+        searches:
+        - kube-system.svc.cluster.local
+        - svc.cluster.local
+        - cluster.local
+      dnsPolicy: None
+      serviceAccountName: vcloud-csi
+      volumes:
+      - emptyDir: {}
+        name: socket-dir
+      - hostPath:
+          path: /dev
+          type: DirectoryOrCreate
+        name: pods-probe-dir
+      - hostPath:
+          path: /var/lib/kubelet/plugins/kubernetes.io/csi
+          type: DirectoryOrCreate
+        name: pv-dir
+      - name: cloud-config-csi
+        secret:
+          secretName: cloud-config-csi
+      - name: vcloud-basic-auth-volume
+        secret:
+          secretName: vcloud-basic-auth
+      - name: vcloud-csi-kubeconfig
+        secret:
+          secretName: vcloud-csi-kubeconfig
+status: {}

--- a/pkg/resources/test/load_files_test.go
+++ b/pkg/resources/test/load_files_test.go
@@ -637,6 +637,27 @@ func TestLoadFiles(t *testing.T) {
 									Namespace:       cluster.Status.NamespaceName,
 								},
 							},
+							&corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									ResourceVersion: "123456",
+									Name:            resources.CSICloudConfigSecretName,
+									Namespace:       cluster.Status.NamespaceName,
+								},
+							},
+							&corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									ResourceVersion: "123456",
+									Name:            resources.VMwareCloudDirectorCSISecretName,
+									Namespace:       cluster.Status.NamespaceName,
+								},
+							},
+							&corev1.Secret{
+								ObjectMeta: metav1.ObjectMeta{
+									ResourceVersion: "123456",
+									Name:            resources.VMwareCloudDirectorCSIKubeconfigSecretName,
+									Namespace:       cluster.Status.NamespaceName,
+								},
+							},
 							&corev1.ConfigMap{
 								ObjectMeta: metav1.ObjectMeta{
 									ResourceVersion: "123456",


### PR DESCRIPTION
**What this PR does / why we need it**:
For VCD, this PR moves the CSI controller plugin to the user cluster namespace in the seed cluster. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Towards https://github.com/kubermatic/kubermatic/issues/11985, fixes #13021 

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:
**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
VMware Cloud Director: Move CSI controller to seed cluster
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
