### PR TITLE
[release/v2.23] fix panic if no KubeVirt DNS config was set (#12933)

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -197,7 +197,7 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 							DNSConfig:                    &corev1.PodDNSConfig{},
 							Images:                       kubermaticv1.KubeVirtImageSources{HTTP: &kubevirtHTTPSource},
 							EnableDefaultNetworkPolicies: pointer.Bool(true),
-							CustomNetworkPolicies: []*kubermaticv1.CustomNetworkPolicy{
+							CustomNetworkPolicies: []kubermaticv1.CustomNetworkPolicy{
 								{
 									Name: "deny-ingress",
 									Spec: networkingv1.NetworkPolicySpec{

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -720,7 +720,7 @@ type DatacenterSpecKubevirt struct {
 
 	// Optional: CustomNetworkPolicies allows to add some extra custom NetworkPolicies, that are deployed
 	// in the dedicated infra KubeVirt cluster. They are added to the defaults.
-	CustomNetworkPolicies []*CustomNetworkPolicy `json:"customNetworkPolicies,omitempty"`
+	CustomNetworkPolicies []CustomNetworkPolicy `json:"customNetworkPolicies,omitempty"`
 
 	// Images represents standard VM Image sources.
 	Images KubeVirtImageSources `json:"images,omitempty"`

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -2171,13 +2171,9 @@ func (in *DatacenterSpecKubevirt) DeepCopyInto(out *DatacenterSpecKubevirt) {
 	}
 	if in.CustomNetworkPolicies != nil {
 		in, out := &in.CustomNetworkPolicies, &out.CustomNetworkPolicies
-		*out = make([]*CustomNetworkPolicy, len(*in))
+		*out = make([]CustomNetworkPolicy, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(CustomNetworkPolicy)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	in.Images.DeepCopyInto(&out.Images)


### PR DESCRIPTION
**What this PR does / why we need it**:
This backports #12933.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix panic if no KubeVirt DNS config was set in the datacenter.
```

**Documentation**:
```documentation
NONE
```
