### PR TITLE
Add provider incompatibility for in-tree providers with Kubernetes >= 1.29

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -500,6 +500,14 @@ spec:
         operation: UPGRADE
         provider: openstack
         version: '>= 1.26.0'
+      - condition: inTreeProvider
+        operation: CREATE
+        provider: ""
+        version: '>= 1.29.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: ""
+        version: '>= 1.29.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -500,6 +500,14 @@ spec:
         operation: UPGRADE
         provider: openstack
         version: '>= 1.26.0'
+      - condition: inTreeProvider
+        operation: CREATE
+        provider: ""
+        version: '>= 1.29.0'
+      - condition: inTreeProvider
+        operation: UPGRADE
+        provider: ""
+        version: '>= 1.29.0'
     # Updates is a list of available and automatic upgrades.
     # All 'to' versions must be configured in the version list for this orchestrator.
     # Each update may optionally be configured to be 'automatic: true', in which case the

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -299,6 +299,21 @@ var (
 				Condition: kubermaticv1.InTreeCloudProviderCondition,
 				Operation: kubermaticv1.UpdateOperation,
 			},
+			// In-tree cloud providers have been fully removed in Kubernetes 1.29.
+			// Thus, no in-tree provider is available anymore, and no cluster with in-tree CCM
+			// can be upgraded to 1.29.
+			{
+				Provider:  "",
+				Version:   ">= 1.29.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.CreateOperation,
+			},
+			{
+				Provider:  "",
+				Version:   ">= 1.29.0",
+				Condition: kubermaticv1.InTreeCloudProviderCondition,
+				Operation: kubermaticv1.UpdateOperation,
+			},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

@xrstf says all in-tree providers have been removed with Kubernetes 1.29. Upstream PR is [kubernetes/kubernetes#117503](https://github.com/kubernetes/kubernetes/pull/117503), so I'm adding a provider incompatibility for _all_ providers that prevent using in-tree providers with Kubernetes 1.29.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
