### PR TITLE
Ensure that seed level resources for CSI driver are removed

### DIFF
--- a/pkg/resources/csi/deletion.go
+++ b/pkg/resources/csi/deletion.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/kubevirt"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/nutanix"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/vsphere"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(cluster *kubermaticv1.Cluster) []ctrlruntimeclient.Object {
+	resourceList := []ctrlruntimeclient.Object{}
+	ns := cluster.Status.NamespaceName
+
+	switch {
+	case cluster.Spec.Cloud.VSphere != nil:
+		resourceList = vsphere.ResourcesForDeletion(ns)
+	case cluster.Spec.Cloud.VMwareCloudDirector != nil:
+		resourceList = vmwareclouddirector.ResourcesForDeletion(ns)
+	case cluster.Spec.Cloud.Nutanix != nil && cluster.Spec.Cloud.Nutanix.CSI != nil:
+		resourceList = nutanix.ResourcesForDeletion(ns)
+	case cluster.Spec.Cloud.Kubevirt != nil:
+		resourceList = kubevirt.ResourcesForDeletion(ns)
+	}
+	return resourceList
+}

--- a/pkg/resources/csi/kubevirt/deletion.go
+++ b/pkg/resources/csi/kubevirt/deletion.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubevirt
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIControllerName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIConfigMapName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSISecretName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIServiceAccountName,
+				Namespace: namespace,
+			},
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: resources.KubeVirtCSIClusterRoleName,
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIRoleBindingName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/csi/nutanix/deletion.go
+++ b/pkg/resources/csi/nutanix/deletion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nutanix
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSICloudConfigSecretName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/csi/vmwareclouddirector/deletion.go
+++ b/pkg/resources/csi/vmwareclouddirector/deletion.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmwareclouddirector
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.VMwareCloudDirectorCSIControllerName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSICloudConfigSecretName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.VMwareCloudDirectorCSISecretName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.VMwareCloudDirectorCSIServiceAccountName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/csi/vsphere/deletion.go
+++ b/pkg/resources/csi/vsphere/deletion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSICloudConfigSecretName,
+				Namespace: namespace,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a bug where resources deployed in the user cluster namespace on seed, for CSI drivers, were not being removed when the CSI driver was disabled.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug where resources deployed in the user cluster namespace on seed, for CSI drivers, were not being removed when the CSI driver was disabled.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @xrstf @akash-gautam 