### PR TITLE
Add `HasCCM` method to check if a provider comes with a CCM

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -291,29 +291,6 @@ func (c ClusterSpec) IsKubeLBEnabled() bool {
 	return c.KubeLB != nil && c.KubeLB.Enabled
 }
 
-// GetVersionConditions returns a kubermaticv1.ConditionType list that should be used when checking
-// for available versions in a VersionManager instance.
-func (c ClusterSpec) GetVersionConditions() []ConditionType {
-	conditions := []ConditionType{}
-
-	// we will not return the external/internal provider condition for providers that do not
-	// have a CCM.
-	if c.HasCCM() {
-		if c.Features[ClusterFeatureExternalCloudProvider] {
-			conditions = append(conditions, ExternalCloudProviderCondition)
-		} else {
-			conditions = append(conditions, InTreeCloudProviderCondition)
-		}
-	}
-
-	return conditions
-}
-
-// HasCCM returns whether there _is_ a CCM (internal or external) to be deployed.
-func (c ClusterSpec) HasCCM() bool {
-	return c.Cloud.AWS != nil || c.Cloud.Azure != nil || c.Cloud.Openstack != nil || c.Cloud.Hetzner != nil || c.Cloud.GCP != nil || c.Cloud.Anexia != nil || c.Cloud.VSphere != nil || c.Cloud.Kubevirt != nil || c.Cloud.Digitalocean != nil
-}
-
 // CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.
 type CNIPluginSettings struct {
 	// Type is the CNI plugin type to be used.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -312,7 +312,6 @@ func (c ClusterSpec) GetVersionConditions() []ConditionType {
 // HasCCM returns whether there _is_ a CCM (internal or external) to be deployed.
 func (c ClusterSpec) HasCCM() bool {
 	return c.Cloud.AWS != nil || c.Cloud.Azure != nil || c.Cloud.Openstack != nil || c.Cloud.Hetzner != nil || c.Cloud.GCP != nil || c.Cloud.Anexia != nil || c.Cloud.VSphere != nil || c.Cloud.Kubevirt != nil || c.Cloud.Digitalocean != nil
-
 }
 
 // CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.

--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -296,13 +296,23 @@ func (c ClusterSpec) IsKubeLBEnabled() bool {
 func (c ClusterSpec) GetVersionConditions() []ConditionType {
 	conditions := []ConditionType{}
 
-	if c.Features[ClusterFeatureExternalCloudProvider] {
-		conditions = append(conditions, ExternalCloudProviderCondition)
-	} else {
-		conditions = append(conditions, InTreeCloudProviderCondition)
+	// we will not return the external/internal provider condition for providers that do not
+	// have a CCM.
+	if c.HasCCM() {
+		if c.Features[ClusterFeatureExternalCloudProvider] {
+			conditions = append(conditions, ExternalCloudProviderCondition)
+		} else {
+			conditions = append(conditions, InTreeCloudProviderCondition)
+		}
 	}
 
 	return conditions
+}
+
+// HasCCM returns whether there _is_ a CCM (internal or external) to be deployed.
+func (c ClusterSpec) HasCCM() bool {
+	return c.Cloud.AWS != nil || c.Cloud.Azure != nil || c.Cloud.Openstack != nil || c.Cloud.Hetzner != nil || c.Cloud.GCP != nil || c.Cloud.Anexia != nil || c.Cloud.VSphere != nil || c.Cloud.Kubevirt != nil || c.Cloud.Digitalocean != nil
+
 }
 
 // CNIPluginSettings contains the spec of the CNI plugin used by the Cluster.

--- a/pkg/controller/seed-controller-manager/update-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/update-controller/controller.go
@@ -29,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/version"
+	clusterversion "k8c.io/kubermatic/v2/pkg/version/cluster"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -491,7 +492,7 @@ func hasOwnerRefToAny(obj ctrlruntimeclient.Object, ownerKind string, ownerNames
 }
 
 func getNextApiServerVersion(ctx context.Context, config *kubermaticv1.KubermaticConfiguration, cluster *kubermaticv1.Cluster) (*semver.Semver, error) {
-	updateConditions := cluster.Spec.GetVersionConditions()
+	updateConditions := clusterversion.GetVersionConditions(&cluster.Spec)
 	updateManager := version.NewFromConfiguration(config)
 	currentVersion := cluster.Status.Versions.Apiserver.Semver()
 	targetVersion := cluster.Spec.Version.Semver()

--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -37,6 +37,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/version"
+	clusterversion "k8c.io/kubermatic/v2/pkg/version/cluster"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -318,7 +319,7 @@ func ValidateVersion(spec *kubermaticv1.ClusterSpec, versionManager *version.Man
 		err           error
 	)
 
-	conditions := spec.GetVersionConditions()
+	conditions := clusterversion.GetVersionConditions(spec)
 
 	// if a current version is passed, we are doing a version upgrade.
 	if currentVersion != nil {

--- a/pkg/validation/cluster_test.go
+++ b/pkg/validation/cluster_test.go
@@ -1228,6 +1228,7 @@ func TestValidateVersion(t *testing.T) {
 				Version: semver.Semver("1.3.0"),
 				Cloud: kubermaticv1.CloudSpec{
 					ProviderName: string(kubermaticv1.OpenstackCloudProvider),
+					Openstack:    &kubermaticv1.OpenstackCloudSpec{},
 				},
 			},
 			versionManager: version.New(
@@ -1257,6 +1258,7 @@ func TestValidateVersion(t *testing.T) {
 				Version: semver.Semver("1.3.0"),
 				Cloud: kubermaticv1.CloudSpec{
 					ProviderName: string(kubermaticv1.OpenstackCloudProvider),
+					Openstack:    &kubermaticv1.OpenstackCloudSpec{},
 				},
 			},
 			versionManager: version.New(
@@ -1295,7 +1297,7 @@ func TestValidateVersion(t *testing.T) {
 			err := ValidateVersion(test.spec, test.versionManager, test.currentVersion, nil)
 
 			if (err == nil) != test.valid {
-				t.Errorf("Extected err to be %v, got %v", test.valid, err)
+				t.Errorf("Extected err == nil to be %v, got err: %v", test.valid, err)
 			}
 		})
 	}

--- a/pkg/version/cluster/cluster.go
+++ b/pkg/version/cluster/cluster.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/cloudcontroller"
+)
+
+// GetVersionConditions returns a kubermaticv1.ConditionType list that should be used when checking
+// for available versions in a VersionManager instance.
+func GetVersionConditions(spec *kubermaticv1.ClusterSpec) []kubermaticv1.ConditionType {
+	conditions := []kubermaticv1.ConditionType{}
+
+	// we will not return the external/internal provider condition for providers that do not
+	// have a CCM.
+	if cloudcontroller.HasCCM(spec) {
+		if spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] {
+			conditions = append(conditions, kubermaticv1.ExternalCloudProviderCondition)
+		} else {
+			conditions = append(conditions, kubermaticv1.InTreeCloudProviderCondition)
+		}
+	}
+
+	return conditions
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow-up to #13043. We don't want to allow any provider to use in-tree providers with Kubernetes 1.29 because all of that code got removed. However, the in-tree provider condition is _always_ added if external CCM is not configured. Some providers do not have a provider implementation though, so they shouldn't get the in-tree provider condition attached to them.

In addition, I'm wrapping the cloud controller deployment reconciler in the new `HasCCM` method to make sure that people implementing new CCMs see this method and make sure it's updated.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
