### PR TITLE
[release/v2.24] Ensure that seed level resources for CSI driver are removed

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -595,7 +595,7 @@ func (r *Reconciler) ensureRoleBindings(ctx context.Context, c *kubermaticv1.Clu
 	namedRoleBindingReconcilerFactorys := []reconciling.NamedRoleBindingReconcilerFactory{
 		usercluster.RoleBindingReconciler,
 	}
-	if c.Spec.DisableCSIDriver {
+	if !c.Spec.DisableCSIDriver {
 		namedRoleBindingReconcilerFactorys = append(namedRoleBindingReconcilerFactorys, csi.RoleBindingsReconcilers(c)...)
 	}
 
@@ -615,7 +615,7 @@ func (r *Reconciler) ensureClusterRoles(ctx context.Context, c *kubermaticv1.Clu
 		userclusterwebhook.ClusterRole(),
 	}
 
-	if c.Spec.DisableCSIDriver {
+	if !c.Spec.DisableCSIDriver {
 		namedClusterRoleReconcilerFactorys = append(namedClusterRoleReconcilerFactorys, csi.ClusterRolesReconcilers(c)...)
 	}
 
@@ -704,7 +704,7 @@ func GetConfigMapReconcilers(data *resources.TemplateData) []reconciling.NamedCo
 		apiserver.AdmissionControlReconciler(data),
 		apiserver.CABundleReconciler(data),
 	}
-	if data.Cluster().Spec.DisableCSIDriver {
+	if !data.Cluster().Spec.DisableCSIDriver {
 		creators = append(creators, csi.ConfigMapsReconcilers(data)...)
 	}
 

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -202,6 +202,12 @@ func (r *Reconciler) ensureResourcesAreDeployed(ctx context.Context, cluster *ku
 		}
 	}
 
+	if cluster.Spec.DisableCSIDriver {
+		if err := r.ensureCSIDriverResourcesAreRemoved(ctx, data); err != nil {
+			return nil, err
+		}
+	}
+
 	// Ensure that encryption-at-rest is completely removed when no longer enabled or active
 	if !cluster.IsEncryptionEnabled() && !cluster.IsEncryptionActive() {
 		if err := r.ensureEncryptionConfigurationIsRemoved(ctx, data); err != nil {
@@ -382,7 +388,10 @@ func GetDeploymentReconcilers(data *resources.TemplateData, enableAPIserverOIDCA
 		usercluster.DeploymentReconciler(data),
 		userclusterwebhook.DeploymentReconciler(data),
 	}
-	deployments = append(deployments, csi.DeploymentsReconcilers(data)...)
+
+	if !data.Cluster().Spec.DisableCSIDriver {
+		deployments = append(deployments, csi.DeploymentsReconcilers(data)...)
+	}
 
 	if data.Cluster().Spec.IsKubernetesDashboardEnabled() {
 		deployments = append(deployments, kubernetesdashboard.DeploymentReconciler(data))
@@ -456,7 +465,10 @@ func (r *Reconciler) GetSecretReconcilers(ctx context.Context, data *resources.T
 		apiserver.TokenUsersReconciler(data),
 		resources.ViewerKubeconfigReconciler(data),
 	}
-	creators = append(creators, csi.SecretsReconcilers(ctx, data)...)
+
+	if !data.Cluster().Spec.DisableCSIDriver {
+		creators = append(creators, csi.SecretsReconcilers(ctx, data)...)
+	}
 
 	if data.Cluster().Spec.IsKubernetesDashboardEnabled() {
 		creators = append(creators,
@@ -536,7 +548,9 @@ func (r *Reconciler) ensureServiceAccounts(ctx context.Context, c *kubermaticv1.
 		machinecontroller.WebhookServiceAccountReconciler,
 		userclusterwebhook.ServiceAccountReconciler,
 	}
-	namedServiceAccountReconcilerFactorys = append(namedServiceAccountReconcilerFactorys, csi.ServiceAccountReconcilers(c)...)
+	if !c.Spec.DisableCSIDriver {
+		namedServiceAccountReconcilerFactorys = append(namedServiceAccountReconcilerFactorys, csi.ServiceAccountReconcilers(c)...)
+	}
 
 	if c.Spec.IsOperatingSystemManagerEnabled() {
 		namedServiceAccountReconcilerFactorys = append(namedServiceAccountReconcilerFactorys, operatingsystemmanager.ServiceAccountReconciler)
@@ -581,7 +595,9 @@ func (r *Reconciler) ensureRoleBindings(ctx context.Context, c *kubermaticv1.Clu
 	namedRoleBindingReconcilerFactorys := []reconciling.NamedRoleBindingReconcilerFactory{
 		usercluster.RoleBindingReconciler,
 	}
-	namedRoleBindingReconcilerFactorys = append(namedRoleBindingReconcilerFactorys, csi.RoleBindingsReconcilers(c)...)
+	if c.Spec.DisableCSIDriver {
+		namedRoleBindingReconcilerFactorys = append(namedRoleBindingReconcilerFactorys, csi.RoleBindingsReconcilers(c)...)
+	}
 
 	if c.Spec.ExposeStrategy == kubermaticv1.ExposeStrategyLoadBalancer {
 		namedRoleBindingReconcilerFactorys = append(namedRoleBindingReconcilerFactorys, nodeportproxy.RoleBindingReconciler)
@@ -599,7 +615,9 @@ func (r *Reconciler) ensureClusterRoles(ctx context.Context, c *kubermaticv1.Clu
 		userclusterwebhook.ClusterRole(),
 	}
 
-	namedClusterRoleReconcilerFactorys = append(namedClusterRoleReconcilerFactorys, csi.ClusterRolesReconcilers(c)...)
+	if c.Spec.DisableCSIDriver {
+		namedClusterRoleReconcilerFactorys = append(namedClusterRoleReconcilerFactorys, csi.ClusterRolesReconcilers(c)...)
+	}
 
 	if err := reconciling.ReconcileClusterRoles(ctx, namedClusterRoleReconcilerFactorys, "", r.Client); err != nil {
 		return fmt.Errorf("failed to ensure Cluster Roles: %w", err)
@@ -686,7 +704,9 @@ func GetConfigMapReconcilers(data *resources.TemplateData) []reconciling.NamedCo
 		apiserver.AdmissionControlReconciler(data),
 		apiserver.CABundleReconciler(data),
 	}
-	creators = append(creators, csi.ConfigMapsReconcilers(data)...)
+	if data.Cluster().Spec.DisableCSIDriver {
+		creators = append(creators, csi.ConfigMapsReconcilers(data)...)
+	}
 
 	if data.IsKonnectivityEnabled() {
 		creators = append(creators, apiserver.EgressSelectorConfigReconciler())
@@ -840,6 +860,16 @@ func (r *Reconciler) ensureKubernetesDashboardResourcesAreRemoved(ctx context.Co
 		err := r.Client.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure kubernetes-dashboard resources are removed/not present: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) ensureCSIDriverResourcesAreRemoved(ctx context.Context, data *resources.TemplateData) error {
+	for _, resource := range csi.ResourcesForDeletion(data.Cluster()) {
+		err := r.Client.Delete(ctx, resource)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to ensure CSI driver resources are removed/not present: %w", err)
 		}
 	}
 	return nil

--- a/pkg/resources/csi/deletion.go
+++ b/pkg/resources/csi/deletion.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package csi
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/kubevirt"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/nutanix"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/vmwareclouddirector"
+	"k8c.io/kubermatic/v2/pkg/resources/csi/vsphere"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(cluster *kubermaticv1.Cluster) []ctrlruntimeclient.Object {
+	resourceList := []ctrlruntimeclient.Object{}
+	ns := cluster.Status.NamespaceName
+
+	switch {
+	case cluster.Spec.Cloud.VSphere != nil:
+		resourceList = vsphere.ResourcesForDeletion(ns)
+	case cluster.Spec.Cloud.VMwareCloudDirector != nil:
+		resourceList = vmwareclouddirector.ResourcesForDeletion(ns)
+	case cluster.Spec.Cloud.Nutanix != nil && cluster.Spec.Cloud.Nutanix.CSI != nil:
+		resourceList = nutanix.ResourcesForDeletion(ns)
+	case cluster.Spec.Cloud.Kubevirt != nil:
+		resourceList = kubevirt.ResourcesForDeletion(ns)
+	}
+	return resourceList
+}

--- a/pkg/resources/csi/kubevirt/deletion.go
+++ b/pkg/resources/csi/kubevirt/deletion.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubevirt
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIControllerName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIConfigMapName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSISecretName,
+				Namespace: namespace,
+			},
+		},
+		&corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIServiceAccountName,
+				Namespace: namespace,
+			},
+		},
+		&rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: resources.KubeVirtCSIClusterRoleName,
+			},
+		},
+		&rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.KubeVirtCSIRoleBindingName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/csi/nutanix/deletion.go
+++ b/pkg/resources/csi/nutanix/deletion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nutanix
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSICloudConfigSecretName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/csi/vmwareclouddirector/deletion.go
+++ b/pkg/resources/csi/vmwareclouddirector/deletion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vmwareclouddirector
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSICloudConfigSecretName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/resources/csi/vsphere/deletion.go
+++ b/pkg/resources/csi/vsphere/deletion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSICloudConfigSecretName,
+				Namespace: namespace,
+			},
+		},
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Manual backport of #13045 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug where resources deployed in the user cluster namespace on seed, for CSI drivers, were not being removed when the CSI driver was disabled.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @xrstf 