### PR TITLE
bump telemetry client to 0.5

### DIFF
--- a/charts/telemetry/Chart.yaml
+++ b/charts/telemetry/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v1
 name: telemetry
 description: A Helm chart to install Kubermatic telemetry agents
 version: v9.9.9-dev
-appVersion: v0.4.1
+appVersion: v0.5.0
 keywords:
   - telemetry
 maintainers:

--- a/charts/telemetry/values.yaml
+++ b/charts/telemetry/values.yaml
@@ -23,17 +23,17 @@ telemetry:
   kubermaticAgent:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.4.1"
+      tag: "v0.5.0"
 
   kubernetesAgent:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.4.1"
+      tag: "v0.5.0"
 
   reporter:
     image:
       repository: quay.io/kubermatic/telemetry-agent
-      tag: "v0.4.1"
+      tag: "v0.5.0"
 
   resources:
     limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Telemetry 0.5 is updated to KKP 2.24, Kube 1.28 and now ships with a distroless container image.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update telemetry to v0.5.0, now shipping with a distroless image
```

**Documentation**:
```documentation
NONE
```
