### PR TITLE
Undeploy user-cluster resources when Cluster Backup is disabled

### DIFF
--- a/pkg/ee/cluster-backup/resources/user-cluster/cluster_backup.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/cluster_backup.go
@@ -40,11 +40,11 @@ import (
 )
 
 const (
-	clusterRoleBindingName = "velero"
+	ClusterRoleBindingName = "velero"
 	clusterBackupAppName   = "velero"
-	defaultBSLName         = "default-cluster-backup-bsl"
+	DefaultBSLName         = "default-cluster-backup-bsl"
 
-	cloudCredentialsSecretName           = "velero-cloud-credentials"
+	CloudCredentialsSecretName           = "velero-cloud-credentials"
 	defaultCloudCredentialsSecretKeyName = "cloud"
 
 	version       = "v1.12.0"
@@ -83,7 +83,7 @@ func ServiceAccountReconciler() reconciling.NamedServiceAccountReconcilerFactory
 // ClusterRoleBindingReconciler creates the clusterrolebinding for velero on the user cluster.
 func ClusterRoleBindingReconciler() reconciling.NamedClusterRoleBindingReconcilerFactory {
 	return func() (string, reconciling.ClusterRoleBindingReconciler) {
-		return clusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
+		return ClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.Labels = resources.BaseAppLabels(clusterBackupAppName, nil)
 			crb.RoleRef = rbacv1.RoleRef{
 				// too wide but probably needed to be able to do backups and restore.
@@ -106,7 +106,7 @@ func ClusterRoleBindingReconciler() reconciling.NamedClusterRoleBindingReconcile
 // BSLReconciler creates the default BackupStorage location is created for velero.
 func BSLReconciler(ctx context.Context, cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBackupStorageLocation) kkpreconciling.NamedBackupStorageLocationReconcilerFactory {
 	return func() (string, kkpreconciling.BackupStorageLocationReconciler) {
-		return defaultBSLName, func(bsl *velerov1.BackupStorageLocation) (*velerov1.BackupStorageLocation, error) {
+		return DefaultBSLName, func(bsl *velerov1.BackupStorageLocation) (*velerov1.BackupStorageLocation, error) {
 			projectID, ok := cluster.Labels[kubermaticv1.ProjectIDLabelKey]
 			if !ok {
 				return nil, fmt.Errorf("cluster ProjectID label is not set")

--- a/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
@@ -36,18 +36,18 @@ import (
 )
 
 const (
-	clusterBackupName                 = "velero-cluster-backup"
+	DeploymentName                    = "velero"
 	clusterbackupKubeConfigSecretName = "velero-kubeconfig"
 )
 
 // DeploymentReconciler creates the velero deployment in the user cluster namespace.
 func DeploymentReconciler() reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
-		return clusterBackupName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Labels = resources.BaseAppLabels(clusterBackupName, nil)
+		return DeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
+			dep.Labels = resources.BaseAppLabels(DeploymentName, nil)
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(clusterBackupName, nil),
+				MatchLabels: resources.BaseAppLabels(DeploymentName, nil),
 			}
 			dep.Spec.Replicas = resources.Int32(1)
 
@@ -57,7 +57,7 @@ func DeploymentReconciler() reconciling.NamedDeploymentReconcilerFactory {
 			volumeMounts := getVolumeMounts()
 
 			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: resources.BaseAppLabels(clusterBackupName, nil),
+				Labels: resources.BaseAppLabels(DeploymentName, nil),
 				Annotations: map[string]string{
 					"prometheus.io/path":   "/metrics",
 					"prometheus.io/port":   "8085",

--- a/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
@@ -137,7 +137,7 @@ func getVolumeMounts() []corev1.VolumeMount {
 			MountPath: "/scratch",
 		},
 		{
-			Name:      cloudCredentialsSecretName,
+			Name:      CloudCredentialsSecretName,
 			MountPath: "/credentials",
 		},
 	}
@@ -163,8 +163,8 @@ func getVolumes() []corev1.Volume {
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 		},
 		{
-			Name:         cloudCredentialsSecretName,
-			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: cloudCredentialsSecretName}},
+			Name:         CloudCredentialsSecretName,
+			VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: CloudCredentialsSecretName}},
 		},
 	}
 	return vs

--- a/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
@@ -97,8 +97,8 @@ func DaemonSetReconciler() reconciling.NamedDaemonSetReconcilerFactory {
 						VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 					},
 					{
-						Name:         cloudCredentialsSecretName,
-						VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: cloudCredentialsSecretName}},
+						Name:         CloudCredentialsSecretName,
+						VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: CloudCredentialsSecretName}},
 					},
 				},
 				RestartPolicy:                 corev1.RestartPolicyAlways,
@@ -166,7 +166,7 @@ func getContainers() []corev1.Container {
 					MountPath: "/scratch",
 				},
 				{
-					Name:      cloudCredentialsSecretName,
+					Name:      CloudCredentialsSecretName,
 					MountPath: "/credentials",
 				},
 			},

--- a/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
@@ -38,12 +38,12 @@ import (
 )
 
 const (
-	daemonSetName = "node-agent"
+	DaemonSetName = "node-agent"
 )
 
 var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
-		daemonSetName: {
+		DaemonSetName: {
 			Requests: corev1.ResourceList{
 				corev1.ResourceMemory: resource.MustParse("256Mi"),
 				corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -57,26 +57,26 @@ var (
 
 	// the "name" label is required here. it's used by Velero to detect the daemonset pods on the nodes, if it's not there Velero will partiallyFail to do the backup: https://github.com/vmware-tanzu/velero/blob/b30a679e5b1c2cbd9021e1301580f2359ef981bf/pkg/nodeagent/node_agent.go#L84
 	veleroAddionalLabels = map[string]string{
-		"app.kubernetes.io/name": daemonSetName,
-		"name":                   daemonSetName,
+		"app.kubernetes.io/name": DaemonSetName,
+		"name":                   DaemonSetName,
 	}
 )
 
 // DaemonSetReconciler returns the function to create and update the Velero node-agent DaemonSet.
 func DaemonSetReconciler() reconciling.NamedDaemonSetReconcilerFactory {
 	return func() (string, reconciling.DaemonSetReconciler) {
-		return daemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
+		return DaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
 			ds.Namespace = resources.ClusterBackupNamespaceName
-			ds.Labels = resources.BaseAppLabels(daemonSetName, map[string]string{"component": "velero"})
+			ds.Labels = resources.BaseAppLabels(DaemonSetName, map[string]string{"component": "velero"})
 
 			ds.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(daemonSetName,
+				MatchLabels: resources.BaseAppLabels(DaemonSetName,
 					veleroAddionalLabels),
 			}
 
 			// has to be the same as the selector
 			ds.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: resources.BaseAppLabels(daemonSetName,
+				Labels: resources.BaseAppLabels(DaemonSetName,
 					veleroAddionalLabels),
 			}
 
@@ -123,7 +123,7 @@ func DaemonSetReconciler() reconciling.NamedDaemonSetReconcilerFactory {
 func getContainers() []corev1.Container {
 	return []corev1.Container{
 		{
-			Name:  daemonSetName,
+			Name:  DaemonSetName,
 			Image: fmt.Sprintf("velero/velero:%s", version), ImagePullPolicy: corev1.PullIfNotPresent,
 			Command: []string{
 				"/velero",

--- a/pkg/ee/cluster-backup/resources/user-cluster/secret.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/secret.go
@@ -43,7 +43,7 @@ import (
 // SecretReconciler returns a function to create the Secret containing the backup destination credentials.
 func SecretReconciler(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBackupStorageLocation) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return cloudCredentialsSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
+		return CloudCredentialsSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
 			refName := cbsl.Spec.Credential.Name
 			refNamespace := resources.KubermaticNamespace
 


### PR DESCRIPTION
**What this PR does / why we need it**:
When Cluster Backup is disabled, related user-cluster resources should be removed.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
