### PR TITLE
Allow custom tls secret for iap ingress

### DIFF
--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -23,6 +23,7 @@ metadata:
     target: {{ .name }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    {{- if not (.ingress.tlsSecretName) }}
     {{- with $.Values.iap.certIssuer }}
     {{- if eq .kind "ClusterIssuer" }}
     cert-manager.io/cluster-issuer: {{ .name | quote }}
@@ -30,12 +31,17 @@ metadata:
     cert-manager.io/issuer: {{ .name | quote }}
     {{- end }}
     {{- end }}
+    {{- end }}
 {{- if .ingress.annotations }}
 {{ toYaml .ingress.annotations | indent 4 }}
 {{- end }}
 spec:
   tls:
+  {{- if .ingress.tlsSecretName }}
+  - secretName: {{ .ingress.tlsSecretName }}
+  {{- else }}
   - secretName: {{ .name }}-tls
+  {{- end }}
     hosts:
     - {{ .ingress.host | trim }}
   defaultBackend:

--- a/charts/iap/test/test.sh
+++ b/charts/iap/test/test.sh
@@ -1,0 +1,1 @@
+../../../hack/test-chart-rendering.sh

--- a/charts/iap/test/values.custom-tls-secret.yaml
+++ b/charts/iap/test/values.custom-tls-secret.yaml
@@ -1,0 +1,37 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iap:
+  deployments:
+    grafana:
+      name: grafana
+      client_id: grafana
+      client_secret: xxx
+      encryption_key: xxx
+      config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        ## do not route health endpoint through the proxy
+        skip_auth_regex:
+          - '/api/health'
+        ## auto-register users based on their email address
+        ## Grafana is configured to look for the X-Forwarded-Email header
+        pass_user_headers: true
+      upstream_service: grafana.monitoring.svc.cluster.local
+      upstream_port: 3000
+      ingress:
+        host: "grafana.kubermatic.tld"
+        tlsSecretName: "custom-tls"
+        annotations: {}

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -1,0 +1,272 @@
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-grafana-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: Z3JhZmFuYQ==
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-grafana-configmap
+data:
+  config.yaml: |
+    email_domains = ["*"]
+    pass_user_headers = true
+    scope = "groups openid email"
+    skip_auth_regex = ["/api/health"]
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: grafana
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-grafana
+  labels:
+    app: iap
+    target: grafana
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: grafana
+      annotations:
+        checksum/config: 936eab509d15a40f2b18a0897a108817cb8245ddafa2d0aede0f4dc907a2f84f
+        checksum/secrets: a61bd91da5fb2369cbc0ba73e52178417ac106a21ef3621f1f212c7a49665749
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://grafana.monitoring.svc.cluster.local:3000
+        - --cookie-name=grafana_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.yaml
+        envFrom:
+        - secretRef:
+            name: iap-grafana-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 200m
+            memory: 50Mi
+          requests:
+            cpu: 50m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        configMap:
+          name: iap-grafana-configmap
+          items:
+          - key: config.yaml
+            path: config.yaml
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: grafana
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/ingresses.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  tls:
+  - secretName: custom-tls
+    hosts:
+    - grafana.kubermatic.tld
+  defaultBackend:
+    service:
+      name: grafana-iap
+      port:
+        number: 3000
+  rules:
+  - host: grafana.kubermatic.tld
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana-iap
+            port:
+              number: 3000
+---
+# Source: iap/templates/configmaps.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/deployments.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/ingresses.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/pdbs.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/secrets.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/services.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/iap/test/values.example.yaml
+++ b/charts/iap/test/values.example.yaml
@@ -1,0 +1,72 @@
+# Copyright 2021 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iap:
+  deployments:
+    alertmanager:
+      name: alertmanager
+      replicas: 3
+      client_id: alertmanager
+      client_secret: xxx
+      encryption_key: xxx
+      config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        ## example configuration allowing access only to the mygroup from mygithuborg organization
+        github_org: mygithuborg
+        github_team: mygroup
+        ## do not route health endpoint through the proxy
+        skip_auth_regex:
+          - '/-/healthy'
+      upstream_service: alertmanager.monitoring.svc.cluster.local
+      upstream_port: 9093
+      ingress:
+        ## optional name of an existing TLS secret that needs to attached with ingress for this iap deployment.
+        tlsSecretName: ""
+        host: "alertmanager.kubermatic.tld"
+        annotations: {}
+    #
+    grafana:
+      name: grafana
+      client_id: grafana
+      client_secret: xxx
+      encryption_key: xxx
+      config: ## see https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview
+        scope: "groups openid email"
+        email_domains:
+          - '*'
+        ## do not route health endpoint through the proxy
+        skip_auth_regex:
+          - '/api/health'
+        ## auto-register users based on their email address
+        ## Grafana is configured to look for the X-Forwarded-Email header
+        pass_user_headers: true
+      upstream_service: grafana.monitoring.svc.cluster.local
+      upstream_port: 3000
+      ingress:
+        host: "grafana.kubermatic.tld"
+        annotations: {}
+
+  certIssuer:
+    name: letsencrypt-prod
+    kind: ClusterIssuer
+
+  resources:
+    requests:
+      cpu: 25m
+      memory: 25Mi
+    limits:
+      cpu: 100m
+      memory: 50Mi

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -1,0 +1,457 @@
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-alertmanager
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+---
+# Source: iap/templates/pdbs.yaml
+apiVersion: policy/v1
+
+kind: PodDisruptionBudget
+metadata:
+  name: iap-grafana
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-alertmanager-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: YWxlcnRtYW5hZ2Vy
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: iap-grafana-secret
+type: Opaque
+data:
+  OAUTH2_PROXY_CLIENT_ID: Z3JhZmFuYQ==
+  OAUTH2_PROXY_CLIENT_SECRET: eHh4
+  OAUTH2_PROXY_COOKIE_SECRET: eHh4
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-alertmanager-configmap
+data:
+  config.yaml: |
+    email_domains = ["*"]
+    github_org = "mygithuborg"
+    github_team = "mygroup"
+    scope = "groups openid email"
+    skip_auth_regex = ["/-/healthy"]
+---
+# Source: iap/templates/configmaps.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: iap-grafana-configmap
+data:
+  config.yaml: |
+    email_domains = ["*"]
+    pass_user_headers = true
+    scope = "groups openid email"
+    skip_auth_regex = ["/api/health"]
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: alertmanager-iap
+  labels:
+    app: iap
+    target: alertmanager
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: alertmanager
+---
+# Source: iap/templates/services.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+    kind: proxy
+spec:
+  type: ClusterIP
+  ports:
+  - port: 3000
+    name: http
+    protocol: TCP
+    targetPort: http
+  selector:
+    app: iap
+    target: grafana
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-alertmanager
+  labels:
+    app: iap
+    target: alertmanager
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: iap
+      target: alertmanager
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: alertmanager
+      annotations:
+        checksum/config: 9d42d5e5e3115f9e165027dbe538999f504cb248ea530ca85e7edb082741e69d
+        checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://alertmanager.monitoring.svc.cluster.local:9093
+        - --cookie-name=alertmanager_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.yaml
+        envFrom:
+        - secretRef:
+            name: iap-alertmanager-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        configMap:
+          name: iap-alertmanager-configmap
+          items:
+          - key: config.yaml
+            path: config.yaml
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: alertmanager
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/deployments.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: iap-grafana
+  labels:
+    app: iap
+    target: grafana
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: iap
+      target: grafana
+  template:
+    metadata:
+      labels:
+        app: iap
+        target: grafana
+      annotations:
+        checksum/config: 9d42d5e5e3115f9e165027dbe538999f504cb248ea530ca85e7edb082741e69d
+        checksum/secrets: 989d015caf95f5bca21d031b01a46edb1a1319b96503af2d1c8f601c1364d0df
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+        imagePullPolicy: IfNotPresent
+        args:
+        - --provider=oidc
+        - --oidc-issuer-url=https://kubermatic.tld/dex
+        - --http-address=0.0.0.0:3000
+        - --upstream=http://grafana.monitoring.svc.cluster.local:3000
+        - --cookie-name=grafana_oauth2_proxy
+        - --proxy-prefix=/oauth
+        - --ping-path=/oauth/healthy
+        - --silence-ping-logging=true
+        - --reverse-proxy=true
+        - --skip-provider-button=true
+        - --config=/config/config.yaml
+        envFrom:
+        - secretRef:
+            name: iap-grafana-secret
+        ports:
+        - name: http
+          containerPort: 3000
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        readinessProbe:
+          httpGet:
+            path: /oauth/healthy
+            port: http
+          initialDelaySeconds: 3
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 100m
+            memory: 50Mi
+          requests:
+            cpu: 25m
+            memory: 25Mi
+        volumeMounts:
+        - name: config
+          mountPath: /config
+      volumes:
+      - name: config
+        configMap:
+          name: iap-grafana-configmap
+          items:
+          - key: config.yaml
+            path: config.yaml
+      securityContext:
+        fsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      nodeSelector:
+        {}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: iap
+                  target: grafana
+              topologyKey: kubernetes.io/hostname
+            weight: 10
+      tolerations:
+        []
+---
+# Source: iap/templates/ingresses.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: alertmanager-iap
+  labels:
+    app: iap
+    target: alertmanager
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+  - secretName: alertmanager-tls
+    hosts:
+    - alertmanager.kubermatic.tld
+  defaultBackend:
+    service:
+      name: alertmanager-iap
+      port:
+        number: 3000
+  rules:
+  - host: alertmanager.kubermatic.tld
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: alertmanager-iap
+            port:
+              number: 3000
+---
+# Source: iap/templates/ingresses.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: grafana-iap
+  labels:
+    app: iap
+    target: grafana
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+  - secretName: grafana-tls
+    hosts:
+    - grafana.kubermatic.tld
+  defaultBackend:
+    service:
+      name: grafana-iap
+      port:
+        number: 3000
+  rules:
+  - host: grafana.kubermatic.tld
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana-iap
+            port:
+              number: 3000
+---
+# Source: iap/templates/configmaps.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/deployments.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/ingresses.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/pdbs.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/secrets.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# Source: iap/templates/services.yaml
+# Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -54,6 +54,8 @@ iap:
     #   upstream_service: alertmanager.monitoring.svc.cluster.local
     #   upstream_port: 9093
     #   ingress:
+    #     ## (optional) Name of an existing TLS secret to use for the ingress of this iap deployment.
+    #     tlsSecretName: ""
     #     host: "alertmanager.kubermatic.tld"
     #     annotations: {}
     #


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #12961

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
IAP ingresses can be configured to use an existing TLS secret instead of the one generated by the cert-manager.
```

**Documentation**:
<!--
 NONE (no documentation needed for this PR)
-->
```
NONE

```
