### PR TITLE
Disable the deployment of machine controller when edge provider is used

### DIFF
--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -24,7 +24,7 @@ CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.22-node-18-2 containerize ./hac
 echodate "Running codespell..."
 
 codespell \
-  --skip .git,_build,_dist,vendor,go.mod,go.sum,.typos.toml,*.jpg,*.jpeg,*.png,*.woff,*.woff2,*.pem,./charts/cert-manager/crd,./charts/backup/velero/crd,./charts/oauth/test,./addons/multus/crds.yaml,./charts/local-kubevirt/crds \
+  --skip .git,_build,_dist,vendor,go.mod,go.sum,.typos.toml,*.jpg,*.jpeg,*.png,*.woff,*.woff2,*.pem,./charts/cert-manager/crd,./charts/backup/velero/crd,./charts/oauth/test,./addons/multus/crds.yaml,./charts/local-kubevirt/crds,./pkg/ee/default-application-catalog/applicationdefinitions \
   --ignore-words .codespell.exclude \
   --check-filenames \
   --check-hidden

--- a/pkg/install/stack/usercluster-mla/validation.go
+++ b/pkg/install/stack/usercluster-mla/validation.go
@@ -195,6 +195,20 @@ func validateHelmValues(helmValues *yamled.Document, opt stack.DeployOptions) []
 		}
 	}
 
+	// loki
+
+	if helmValues.Has(yamled.Path{"loki-distributed", "ingester", "persistence", "size"}) ||
+		helmValues.Has(yamled.Path{"loki-distributed", "ingester", "persistence", "storageClass"}) &&
+			!helmValues.Has(yamled.Path{"loki-distributed", "ingester", "persistence", "claims"}) {
+		failures = append(failures, fmt.Errorf("Please use loki-distributed.ingester.persistence.claims to configure persistence in the Loki Ingester"))
+	}
+
+	if helmValues.Has(yamled.Path{"loki-distributed", "compactor", "persistence", "size"}) ||
+		helmValues.Has(yamled.Path{"loki-distributed", "compactor", "persistence", "storageClass"}) &&
+			!helmValues.Has(yamled.Path{"loki-distributed", "compactor", "persistence", "claims"}) {
+		failures = append(failures, fmt.Errorf("Please use loki-distributed.compactor.persistence.claims to configure persistence in the Loki Ingester"))
+	}
+
 	return failures
 }
 

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -57,7 +57,7 @@ var (
 
 const (
 	Name = "operating-system-manager"
-	Tag  = "87dae0183459127da1c27a82e8caa361ed5c19ca"
+	Tag  = "29ee9d78677d8cde84ff3a46a9c5a9b9b761025f"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
@@ -60,7 +60,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
@@ -45,7 +45,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
@@ -81,7 +81,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
@@ -39,7 +39,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
@@ -40,7 +40,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
@@ -52,7 +52,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:87dae0183459127da1c27a82e8caa361ed5c19ca
+        image: quay.io/kubermatic/operating-system-manager:29ee9d78677d8cde84ff3a46a9c5a9b9b761025f
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
When Edge provider is used, there is no to deploy and resources that are relevant to machine controller since there is no need to reconcile machines. Thus, this PR removes machine controller and its resources. The other provider that also doesn't need machine controller is BYO. However, we don't know how users are using in general and they might be using a custom machine controller(custom image) that can be deployed with it.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
none
```
