### PR TITLE
Persist comments in Application's values fields - non breaking

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -408,6 +408,9 @@ func createExampleApplicationInstallation() *appskubermaticv1.ApplicationInstall
 				Version: "1.2.3",
 			},
 			Values: runtime.RawExtension{Raw: []byte(`{ "commonLabels": {"owner": "somebody"}}`)},
+			ValuesBlock: `
+commonLabels:
+  owner: somebody`[1:],
 		},
 	}
 }

--- a/docs/zz_generated.applicationInstallation.ce.yaml
+++ b/docs/zz_generated.applicationInstallation.ce.yaml
@@ -30,3 +30,7 @@ spec:
   values:
     commonLabels:
       owner: somebody
+  # ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+  valuesBlock: |-
+    commonLabels:
+      owner: somebody

--- a/docs/zz_generated.applicationInstallation.ce.yaml
+++ b/docs/zz_generated.applicationInstallation.ce.yaml
@@ -25,7 +25,8 @@ spec:
     # Name is the namespace to deploy the Application into.
     # Should be a valid lowercase RFC1123 domain name
     name: my-namespace
-  # Values describe overrides for manifest-rendering. It's a free yaml field.
+  # Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved.
+  # Deprecated: Use ValuesBlock instead.
   values:
     commonLabels:
       owner: somebody

--- a/docs/zz_generated.applicationInstallation.ce.yaml
+++ b/docs/zz_generated.applicationInstallation.ce.yaml
@@ -25,12 +25,12 @@ spec:
     # Name is the namespace to deploy the Application into.
     # Should be a valid lowercase RFC1123 domain name
     name: my-namespace
-  # Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved.
+  # Values specify values overrides that are passed to helm templating. Comments are not preserved.
   # Deprecated: Use ValuesBlock instead.
   values:
     commonLabels:
       owner: somebody
-  # ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+  # ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
   valuesBlock: |-
     commonLabels:
       owner: somebody

--- a/docs/zz_generated.applicationInstallation.ee.yaml
+++ b/docs/zz_generated.applicationInstallation.ee.yaml
@@ -30,3 +30,7 @@ spec:
   values:
     commonLabels:
       owner: somebody
+  # ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+  valuesBlock: |-
+    commonLabels:
+      owner: somebody

--- a/docs/zz_generated.applicationInstallation.ee.yaml
+++ b/docs/zz_generated.applicationInstallation.ee.yaml
@@ -25,7 +25,8 @@ spec:
     # Name is the namespace to deploy the Application into.
     # Should be a valid lowercase RFC1123 domain name
     name: my-namespace
-  # Values describe overrides for manifest-rendering. It's a free yaml field.
+  # Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved.
+  # Deprecated: Use ValuesBlock instead.
   values:
     commonLabels:
       owner: somebody

--- a/docs/zz_generated.applicationInstallation.ee.yaml
+++ b/docs/zz_generated.applicationInstallation.ee.yaml
@@ -25,12 +25,12 @@ spec:
     # Name is the namespace to deploy the Application into.
     # Should be a valid lowercase RFC1123 domain name
     name: my-namespace
-  # Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved.
+  # Values specify values overrides that are passed to helm templating. Comments are not preserved.
   # Deprecated: Use ValuesBlock instead.
   values:
     commonLabels:
       owner: somebody
-  # ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+  # ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
   valuesBlock: |-
     commonLabels:
       owner: somebody

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -161,7 +161,7 @@ type ApplicationSpec struct {
 	// Deprecated: Use ValuesBlock instead
 	Values json.RawMessage `json:"values,omitempty"`
 
-	// Values describe overrides for manifest-rendering. Preserves yaml comments.
+	// ValuesBlock describe overrides for manifest-rendering. Preserves yaml comments.
 	ValuesBlock string `json:"valuesBlock,omitempty"`
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -157,11 +157,11 @@ type ApplicationSpec struct {
 	// ApplicationRef is a reference to identify which Application should be deployed
 	ApplicationRef ApplicationRef `json:"applicationRef"`
 
-	// Values describe overrides for manifest-rendering
+	// Values specify values overrides that are passed to helm templating. Comments are not preserved.
 	// Deprecated: Use ValuesBlock instead
 	Values json.RawMessage `json:"values,omitempty"`
 
-	// ValuesBlock describe overrides for manifest-rendering. Preserves yaml comments.
+	// ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
 	ValuesBlock string `json:"valuesBlock,omitempty"`
 }
 

--- a/pkg/api/v1/types.go
+++ b/pkg/api/v1/types.go
@@ -158,7 +158,11 @@ type ApplicationSpec struct {
 	ApplicationRef ApplicationRef `json:"applicationRef"`
 
 	// Values describe overrides for manifest-rendering
+	// Deprecated: Use ValuesBlock instead
 	Values json.RawMessage `json:"values,omitempty"`
+
+	// Values describe overrides for manifest-rendering. Preserves yaml comments.
+	ValuesBlock string `json:"valuesBlock,omitempty"`
 }
 
 type NamespaceSpec struct {

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"fmt"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -192,8 +194,14 @@ type ApplicationDefinitionSpec struct {
 	Method TemplateMethod `json:"method"`
 
 	// DefaultValues describe overrides for manifest-rendering in UI when creating an application.
+	// Deprecated: use DefaultValuesBlock instead
 	// +kubebuilder:pruning:PreserveUnknownFields
 	DefaultValues *runtime.RawExtension `json:"defaultValues,omitempty"`
+
+	// DefaultValuesBlock describe overrides for manifest-rendering in UI when creating an application.
+	// Preserves yaml comments.
+	// +kubebuilder:pruning:PreserveUnknownFields
+	DefaultValuesBlock string `json:"defaultValuesBlock,omitempty"`
 
 	// DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.
 	// These settings can be overridden in applicationInstallation.
@@ -235,4 +243,20 @@ type ApplicationDefinitionList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []ApplicationDefinition `json:"items"`
+}
+
+// GetDefaultValues parses the values either from the Values or ValuesBlock field.
+// Will return an error if both fields are set.
+// Will return nil if none of the fields are set.
+func (ad *ApplicationDefinitionSpec) GetDefaultValues() ([]byte, error) {
+	if ad.DefaultValues != nil && len(ad.DefaultValues.Raw) > 0 && ad.DefaultValuesBlock != "" {
+		return nil, fmt.Errorf("The fields DefaultValues and DefaultValuesBlock cannot be used simultaneously. Please delete one of them.")
+	}
+	if ad.DefaultValues != nil && len(ad.DefaultValues.Raw) > 0 {
+		return ad.DefaultValues.Raw, nil
+	}
+	if ad.DefaultValuesBlock != "" {
+		return []byte(ad.DefaultValuesBlock), nil
+	}
+	return nil, nil
 }

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -193,12 +193,12 @@ type ApplicationDefinitionSpec struct {
 	// Method used to install the application
 	Method TemplateMethod `json:"method"`
 
-	// DefaultValues describe overrides for manifest-rendering in UI when creating an application.
+	// DefaultValues specify values overrides for manifest-rendering in UI when creating an application. Comments are not preserved.
 	// Deprecated: use DefaultValuesBlock instead
 	// +kubebuilder:pruning:PreserveUnknownFields
 	DefaultValues *runtime.RawExtension `json:"defaultValues,omitempty"`
 
-	// DefaultValuesBlock describe overrides for manifest-rendering in UI when creating an application.
+	// DefaultValuesBlock specify values overrides for manifest-rendering in UI when creating an application. Comments not preserved.
 	// Preserves yaml comments.
 	DefaultValuesBlock string `json:"defaultValuesBlock,omitempty"`
 

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -249,7 +249,7 @@ type ApplicationDefinitionList struct {
 // Will return nil if none of the fields are set.
 func (ad *ApplicationDefinitionSpec) GetDefaultValues() ([]byte, error) {
 	if ad.DefaultValues != nil && len(ad.DefaultValues.Raw) > 0 && ad.DefaultValuesBlock != "" {
-		return nil, fmt.Errorf("The fields DefaultValues and DefaultValuesBlock cannot be used simultaneously. Please delete one of them.")
+		return nil, fmt.Errorf("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously. Please delete one of them.")
 	}
 	if ad.DefaultValues != nil && len(ad.DefaultValues.Raw) > 0 {
 		return ad.DefaultValues.Raw, nil

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -200,7 +200,6 @@ type ApplicationDefinitionSpec struct {
 
 	// DefaultValuesBlock describe overrides for manifest-rendering in UI when creating an application.
 	// Preserves yaml comments.
-	// +kubebuilder:pruning:PreserveUnknownFields
 	DefaultValuesBlock string `json:"defaultValuesBlock,omitempty"`
 
 	// DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.

--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -292,7 +292,7 @@ func (appInstallation *ApplicationInstallation) SetReadyCondition(installErr err
 func (ai *ApplicationInstallationSpec) GetParsedValues() (map[string]interface{}, error) {
 	values := make(map[string]interface{})
 	if len(ai.Values.Raw) > 0 && ai.ValuesBlock != "" {
-		return nil, fmt.Errorf("The fields Values and ValuesBlock cannot be used simultaneously. Please delete one of them.")
+		return nil, fmt.Errorf("the fields Values and ValuesBlock cannot be used simultaneously. Please delete one of them.")
 	}
 	if len(ai.Values.Raw) > 0 {
 		err := json.Unmarshal(ai.Values.Raw, &values)

--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -21,11 +21,11 @@ import (
 	"fmt"
 
 	"helm.sh/helm/v3/pkg/release"
-	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -69,13 +69,13 @@ type ApplicationInstallationSpec struct {
 	// ApplicationRef is a reference to identify which Application should be deployed
 	ApplicationRef ApplicationRef `json:"applicationRef"`
 
-	// Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved.
+	// Values specify values overrides that are passed to helm templating. Comments are not preserved.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// Deprecated: Use ValuesBlock instead.
 	Values runtime.RawExtension `json:"values,omitempty"`
 	// As kubebuilder does not support interface{} as a type, deferring json decoding, seems to be our best option (see https://github.com/kubernetes-sigs/controller-tools/issues/294#issuecomment-518379253)
 
-	// ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+	// ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
 	ValuesBlock string `json:"valuesBlock,omitempty"`
 
 	// ReconciliationInterval is the interval at which to force the reconciliation of the application. By default, Applications are only reconciled

--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -17,7 +17,11 @@ limitations under the License.
 package v1
 
 import (
+	"encoding/json"
+	"fmt"
+
 	"helm.sh/helm/v3/pkg/release"
+	"sigs.k8s.io/yaml"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,10 +69,14 @@ type ApplicationInstallationSpec struct {
 	// ApplicationRef is a reference to identify which Application should be deployed
 	ApplicationRef ApplicationRef `json:"applicationRef"`
 
-	// Values describe overrides for manifest-rendering. It's a free yaml field.
+	// Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved.
 	// +kubebuilder:pruning:PreserveUnknownFields
+	// Deprecated: Use ValuesBlock instead.
 	Values runtime.RawExtension `json:"values,omitempty"`
 	// As kubebuilder does not support interface{} as a type, deferring json decoding, seems to be our best option (see https://github.com/kubernetes-sigs/controller-tools/issues/294#issuecomment-518379253)
+
+	// ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+	ValuesBlock string `json:"valuesBlock,omitempty"`
 
 	// ReconciliationInterval is the interval at which to force the reconciliation of the application. By default, Applications are only reconciled
 	// on changes on spec, annotations, or the parent application definition. Meaning that if the user manually deletes the workload
@@ -277,4 +285,19 @@ func (appInstallation *ApplicationInstallation) SetReadyCondition(installErr err
 		appInstallation.SetCondition(Ready, corev1.ConditionTrue, "InstallationSuccessful", "application successfully installed or upgraded")
 		appInstallation.Status.Failures = 0
 	}
+}
+
+// GetParsedValues parses the values either from the Values or ValuesBlock field.
+// Will return an error if both fields are set.
+func (ai *ApplicationInstallationSpec) GetParsedValues() (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+	if len(ai.Values.Raw) > 0 && ai.ValuesBlock != "" {
+		return nil, fmt.Errorf("The fields Values and ValuesBlock cannot be used simultaneously. Please delete one of them.")
+	}
+	if len(ai.Values.Raw) > 0 {
+		err := json.Unmarshal(ai.Values.Raw, &values)
+		return values, err
+	}
+	err := yaml.Unmarshal([]byte(ai.ValuesBlock), &values)
+	return values, err
 }

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"path"
 
@@ -91,11 +90,9 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, appDefinition *appskuber
 		return util.NoStatusUpdate, err
 	}
 
-	values := make(map[string]interface{})
-	if len(applicationInstallation.Spec.Values.Raw) > 0 {
-		if err := json.Unmarshal(applicationInstallation.Spec.Values.Raw, &values); err != nil {
-			return util.NoStatusUpdate, fmt.Errorf("failed to unmarshall values: %w", err)
-		}
+	values, err := applicationInstallation.Spec.GetParsedValues()
+	if err != nil {
+		return util.NoStatusUpdate, fmt.Errorf("failed to unmarshall values: %w", err)
 	}
 
 	helmRelease, err := helmClient.InstallOrUpgrade(chartLoc, getReleaseName(applicationInstallation), values, *deployOpts, auth)

--- a/pkg/applications/providers/template/helm_integration_test.go
+++ b/pkg/applications/providers/template/helm_integration_test.go
@@ -84,7 +84,7 @@ func TestHelmProvider(t *testing.T) {
 			name: "when an application is created with no values, it should install app with default values",
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
-				app := createApplicationInstallation(testNs, nil, nil)
+				app := createApplicationInstallation(testNs, nil, "", nil)
 
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, test.DefaultData, test.DefaultVersionLabel, 1, false)
 			},
@@ -94,7 +94,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				customCmData := map[string]string{"hello": "world", "a": "b"}
-				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), nil)
+				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), "", nil)
 
 				appendDefaultValues(customCmData, test.DefaultData) // its check that object values are merged with default object values
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, customCmData, test.DefaultVersionLabel, 1, false)
@@ -106,7 +106,7 @@ func TestHelmProvider(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				// its check that scalar values overwrite default  scalar values
 				customVersionLabel := "1.2.3"
-				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.VersionLabelKey, customVersionLabel), nil)
+				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.VersionLabelKey, customVersionLabel), "", nil)
 
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, test.DefaultData, customVersionLabel, 1, false)
 			},
@@ -116,7 +116,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				customCmData := map[string]string{"hello": "world", "a": "b"}
-				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), nil)
+				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), "", nil)
 
 				appendDefaultValues(customCmData, test.DefaultData)
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, customCmData, test.DefaultVersionLabel, 1, false)
@@ -133,7 +133,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
 				customCmData := map[string]string{"hello": "world", "a": "b"}
-				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), nil)
+				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.CmDataKey, customCmData), "", nil)
 
 				appendDefaultValues(customCmData, test.DefaultData)
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, customCmData, test.DefaultVersionLabel, 1, false)
@@ -173,7 +173,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				chartFullPath := createChartWithDependency(t, registryUrl)
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
-				app := createApplicationInstallation(testNs, nil, nil)
+				app := createApplicationInstallation(testNs, nil, "", nil)
 
 				app.Status.ApplicationVersion.Template.DependencyCredentials = &appskubermaticv1.DependencyCredentials{HelmCredentials: &appskubermaticv1.HelmCredentials{RegistryConfigFile: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{Name: "registry-secret"},
@@ -202,7 +202,7 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				chartFullPath := createChartWithDependency(t, registryUrl)
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
-				app := createApplicationInstallation(testNs, nil, nil)
+				app := createApplicationInstallation(testNs, nil, "", nil)
 
 				template := HelmTemplate{
 					Ctx:             context.Background(),
@@ -227,7 +227,7 @@ func TestHelmProvider(t *testing.T) {
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: true, Timeout: metav1.Duration{Duration: 5 * time.Second}, Atomic: false}}
 
 				// Create an application that deploy a LB service that will never get public ip -> helm release will not be be successful.
-				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.DeploySvcKey, true), deployOpts)
+				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.DeploySvcKey, true), "", deployOpts)
 
 				template := HelmTemplate{
 					Ctx:             context.Background(),
@@ -264,7 +264,7 @@ func TestHelmProvider(t *testing.T) {
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: true, Timeout: metav1.Duration{Duration: 5 * time.Second}, Atomic: false}}
 
 				// Create an application that deploy a LB service that will never get public ip -> helm release will not be be successful.
-				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.DeploySvcKey, true), nil)
+				app := createApplicationInstallation(testNs, toHelmRawValues(t, test.DeploySvcKey, true), "", nil)
 
 				template := HelmTemplate{
 					Ctx:             context.Background(),
@@ -299,9 +299,18 @@ func TestHelmProvider(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				deployOpts := &appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Wait: false, Timeout: metav1.Duration{Duration: 0}, Atomic: false, EnableDNS: true}}
 				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
-				app := createApplicationInstallation(testNs, nil, deployOpts)
+				app := createApplicationInstallation(testNs, nil, "", deployOpts)
 
 				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, test.DefaultData, test.DefaultVersionLabel, 1, true)
+			},
+		},
+		{
+			name: "when an application is created with valuesBlock, it is installed with values from valuesBlock",
+			testFunc: func(t *testing.T) {
+				testNs := test.CreateNamespaceWithCleanup(t, ctx, client)
+				app := createApplicationInstallation(testNs, nil, "key: value", nil)
+
+				installOrUpgradeTest(t, ctx, client, testNs, app, exampleChartLoc, test.DefaultData, test.DefaultVersionLabel, 1, false)
 			},
 		},
 	}
@@ -330,7 +339,7 @@ func installOrUpgradeTest(t *testing.T, ctx context.Context, client ctrlruntimec
 	test.CheckConfigMap(t, ctx, client, testNs, expectedData, expectedVersionLabel, enableDns)
 	assertStatusIsUpdated(t, app, statusUpdater, expectedVersion)
 }
-func createApplicationInstallation(testNs *corev1.Namespace, rawValues []byte, deployOpts *appskubermaticv1.DeployOptions) *appskubermaticv1.ApplicationInstallation {
+func createApplicationInstallation(testNs *corev1.Namespace, rawValues []byte, rawValuesBlock string, deployOpts *appskubermaticv1.DeployOptions) *appskubermaticv1.ApplicationInstallation {
 	app := &appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "default",
@@ -362,6 +371,11 @@ func createApplicationInstallation(testNs *corev1.Namespace, rawValues []byte, d
 	if rawValues != nil {
 		app.Spec.Values.Raw = rawValues
 	}
+
+	if rawValuesBlock != "" {
+		app.Spec.ValuesBlock = rawValuesBlock
+	}
+
 	return app
 }
 

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller.go
@@ -212,7 +212,8 @@ func (r *Reconciler) createInitialApplicationInstallations(ctx context.Context, 
 				Name:    application.Spec.ApplicationRef.Name,
 				Version: application.Spec.ApplicationRef.Version,
 			},
-			Values: runtime.RawExtension{Raw: application.Spec.Values},
+			Values:      runtime.RawExtension{Raw: application.Spec.Values},
+			ValuesBlock: application.Spec.ValuesBlock,
 		},
 	}
 

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -60,7 +60,6 @@ spec:
                 defaultValuesBlock:
                   description: DefaultValuesBlock describe overrides for manifest-rendering in UI when creating an application. Preserves yaml comments.
                   type: string
-                  x-kubernetes-preserve-unknown-fields: true
                 description:
                   description: Description of the application. what is its purpose
                   type: string

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -54,8 +54,12 @@ spec:
                       type: object
                   type: object
                 defaultValues:
-                  description: DefaultValues describe overrides for manifest-rendering in UI when creating an application.
+                  description: 'DefaultValues describe overrides for manifest-rendering in UI when creating an application. Deprecated: use DefaultValuesBlock instead'
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                defaultValuesBlock:
+                  description: DefaultValuesBlock describe overrides for manifest-rendering in UI when creating an application. Preserves yaml comments.
+                  type: string
                   x-kubernetes-preserve-unknown-fields: true
                 description:
                   description: Description of the application. what is its purpose

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -54,11 +54,11 @@ spec:
                       type: object
                   type: object
                 defaultValues:
-                  description: 'DefaultValues describe overrides for manifest-rendering in UI when creating an application. Deprecated: use DefaultValuesBlock instead'
+                  description: 'DefaultValues specify values overrides for manifest-rendering in UI when creating an application. Comments are not preserved. Deprecated: use DefaultValuesBlock instead'
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 defaultValuesBlock:
-                  description: DefaultValuesBlock describe overrides for manifest-rendering in UI when creating an application. Preserves yaml comments.
+                  description: DefaultValuesBlock specify values overrides for manifest-rendering in UI when creating an application. Comments not preserved. Preserves yaml comments.
                   type: string
                 description:
                   description: Description of the application. what is its purpose

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -98,9 +98,12 @@ spec:
                   description: "ReconciliationInterval is the interval at which to force the reconciliation of the application. By default, Applications are only reconciled on changes on spec, annotations, or the parent application definition. Meaning that if the user manually deletes the workload deployed by the application, nothing will happen until the application CR change. \n Setting a value greater than zero force reconciliation even if no changes occurred on application CR. Setting a value equal to 0 disables the force reconciliation of the application (default behavior). Setting this too low can cause a heavy load and may disrupt your application workload depending on the template method."
                   type: string
                 values:
-                  description: Values describe overrides for manifest-rendering. It's a free yaml field.
+                  description: 'Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved. Deprecated: Use ValuesBlock instead.'
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                valuesBlock:
+                  description: ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+                  type: string
               required:
                 - applicationRef
                 - namespace

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationinstallations.yaml
@@ -98,11 +98,11 @@ spec:
                   description: "ReconciliationInterval is the interval at which to force the reconciliation of the application. By default, Applications are only reconciled on changes on spec, annotations, or the parent application definition. Meaning that if the user manually deletes the workload deployed by the application, nothing will happen until the application CR change. \n Setting a value greater than zero force reconciliation even if no changes occurred on application CR. Setting a value equal to 0 disables the force reconciliation of the application (default behavior). Setting this too low can cause a heavy load and may disrupt your application workload depending on the template method."
                   type: string
                 values:
-                  description: 'Values describe overrides for manifest-rendering. It is a free yaml field; comments are not preserved. Deprecated: Use ValuesBlock instead.'
+                  description: 'Values specify values overrides that are passed to helm templating. Comments are not preserved. Deprecated: Use ValuesBlock instead.'
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 valuesBlock:
-                  description: ValuesBlock describes overrides for manifest-rendering. It is a free yaml field, which preserves comments.
+                  description: ValuesBlock specifies values overrides that are passed to helm templating. Comments are preserved.
                   type: string
               required:
                 - applicationRef

--- a/pkg/install/images/application_definitions.go
+++ b/pkg/install/images/application_definitions.go
@@ -79,9 +79,13 @@ func getImagesFromApplicationDefinition(logger logrus.FieldLogger, helmClient he
 
 	// if DefaultValues is provided, use it as values file
 	valuesFile := ""
-	if appDef.Spec.DefaultValues != nil {
+	values, err := appDef.Spec.GetDefaultValues()
+	if err != nil {
+		return nil, err
+	}
+	if values != nil {
 		valuesFile = path.Join(tmpDir, "values.yaml")
-		err = os.WriteFile(valuesFile, appDef.Spec.DefaultValues.Raw, 0644)
+		err = os.WriteFile(valuesFile, values, 0644)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create values file: %w", err)
 		}

--- a/pkg/validation/application_definition.go
+++ b/pkg/validation/application_definition.go
@@ -21,6 +21,7 @@ import (
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/validation/openapi"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
@@ -34,6 +35,7 @@ func ValidateApplicationDefinitionSpec(ad appskubermaticv1.ApplicationDefinition
 	allErrs = append(allErrs, ValidateApplicationDefinitionWithOpenAPI(ad, parentFieldPath)...)
 	allErrs = append(allErrs, ValidateApplicationVersions(ad.Spec.Versions, parentFieldPath.Child("spec"))...)
 	allErrs = append(allErrs, ValidateDeployOpts(ad.Spec.DefaultDeployOptions, parentFieldPath.Child("spec.defaultDeployOptions"))...)
+	allErrs = append(allErrs, ValidateApplicationValues(ad.Spec, parentFieldPath.Child("spec"))...)
 	return allErrs
 }
 
@@ -174,6 +176,24 @@ func ValidateApplicationDefinitionWithOpenAPI(ad appskubermaticv1.ApplicationDef
 		return allErrs
 	}
 	allErrs = append(allErrs, validation.ValidateCustomResource(parentFieldPath, ad, v)...)
+
+	return allErrs
+}
+
+func ValidateApplicationValues(spec appskubermaticv1.ApplicationDefinitionSpec, parentFieldPath *field.Path) []*field.Error {
+	allErrs := field.ErrorList{}
+
+	if spec.DefaultValues != nil && len(spec.DefaultValues.Raw) > 0 && spec.DefaultValuesBlock != "" {
+		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("defaultValues"), "Only defaultValues or defaultValuesBlock can be set, but not both simultaneously"))
+		allErrs = append(allErrs, field.Forbidden(parentFieldPath.Child("defaultValuesBlock"), "Only defaultValues or defaultValuesBlock can be set, but not both simultaneously"))
+	}
+
+	// we need to verify that the defaultValuesBlock is valid yaml as it is a free-text string
+	if spec.DefaultValuesBlock != "" {
+		if err := yaml.Unmarshal([]byte(spec.DefaultValuesBlock), struct{}{}); err != nil {
+			allErrs = append(allErrs, field.TypeInvalid(parentFieldPath.Child("defaultValues"), nil, fmt.Sprintf("invalid yaml %v", err)))
+		}
+	}
 
 	return allErrs
 }

--- a/pkg/validation/application_definition.go
+++ b/pkg/validation/application_definition.go
@@ -21,11 +21,11 @@ import (
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/validation/openapi"
-	"sigs.k8s.io/yaml"
 
 	"k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
 	apimachineryvalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/yaml"
 )
 
 func ValidateApplicationDefinitionSpec(ad appskubermaticv1.ApplicationDefinition) field.ErrorList {

--- a/pkg/validation/application_installation.go
+++ b/pkg/validation/application_installation.go
@@ -69,6 +69,13 @@ func ValidateApplicationInstallationSpec(ctx context.Context, client ctrlruntime
 		}
 	}
 	allErrs = append(allErrs, ValidateDeployOpts(spec.DeployOptions, specPath.Child("deployOptions"))...)
+
+	// Ensure that not both values and ValuesBlock fields are set simultaneously
+	if len(ai.Spec.Values.Raw) > 0 && ai.Spec.ValuesBlock != "" {
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("values"), "Only values or valuesBlock can be set, but not both simultaneously"))
+		allErrs = append(allErrs, field.Forbidden(specPath.Child("valuesBlock"), "Only values or valuesBlock can be set, but not both simultaneously"))
+	}
+
 	return allErrs
 }
 

--- a/pkg/validation/application_installation_test.go
+++ b/pkg/validation/application_installation_test.go
@@ -186,6 +186,17 @@ func TestValidateApplicationInstallationSpec(t *testing.T) {
 				}(),
 			}, expectedError: `[spec.reconciliationInterval: Invalid value: "-10ns": should be a positive value, or zero to disable]`,
 		},
+		{
+			name: "Create ApplicationInstallation Failure - Both values and valuesBlock are set",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.Values = runtime.RawExtension{Raw: []byte("key: value")}
+					spec.ValuesBlock = "key: value"
+					return *spec
+				}(),
+			}, expectedError: `[spec.values: Forbidden: Only values or valuesBlock can be set, but not both simultaneously spec.valuesBlock: Forbidden: Only values or valuesBlock can be set, but not both simultaneously]`,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR allows a user to have comments in the values section of their Applications. It differs from the original implementation in https://github.com/kubermatic/kubermatic/pull/13053 by introducing separate fields

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12941

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature

**Special notes for your reviewer**:

* I could not find a distinct coding style for accessors for such a case, so I implemented them directly on the appinstall and appdef spec and according to usage by th consumers. Feel free to suggest suitable alternatives if need be
* the Appdefs require some additional nil checking, because they are implemented as a runtime.RawExtension pointer rather than the actual struct (as it is done in AppInstalls)

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Comments are now persisted in the values section of ApplicationDefinitions and ApplicationInstallations when using the new defaultValuesBlock and valuesBlock fields respectively
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1619
```
