### PR TITLE
Fix error check when deleting cluster backup resources.

### DIFF
--- a/pkg/ee/cluster-backup/controller.go
+++ b/pkg/ee/cluster-backup/controller.go
@@ -48,6 +48,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
@@ -305,7 +306,8 @@ func (r *reconciler) undeployClusterBackupUserClusterResources(ctx context.Conte
 	}
 
 	for _, resource := range userClusterResources {
-		if err := userClusterClient.Delete(ctx, resource); err != nil && !apierrors.IsNotFound(err) {
+		// skip err if resource doesn't exist or if the API for it doesn't exist
+		if err := userClusterClient.Delete(ctx, resource); err != nil && !(apierrors.IsNotFound(err) || meta.IsNoMatchError(err)) {
 			return fmt.Errorf("failed to delete cluster backup user-cluster resource: %w", err)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The Cluster Backup reconciler returns an unnecessary error when deleting backup components due to missing API/CRD definition. This PR checks the returned error and skips it.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
