### PR TITLE
update k8s patch releases, update EKS/AKS support matrix

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -452,26 +452,27 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.28.6
+    default: v1.28.7
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.28
+        default: v1.29
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.29
           - v1.28
           - v1.27
-          - v1.26
       eks:
         # Default is the default version to offer users.
-        default: v1.28
+        default: v1.29
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.29
           - v1.28
           - v1.27
           - v1.26
@@ -543,11 +544,14 @@ spec:
       - v1.27.3
       - v1.27.6
       - v1.27.10
+      - v1.27.11
       - v1.28.2
       - v1.28.5
       - v1.28.6
+      - v1.28.7
       - v1.29.0
       - v1.29.1
+      - v1.29.2
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -452,26 +452,27 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.28.6
+    default: v1.28.7
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.28
+        default: v1.29
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.29
           - v1.28
           - v1.27
-          - v1.26
       eks:
         # Default is the default version to offer users.
-        default: v1.28
+        default: v1.29
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.29
           - v1.28
           - v1.27
           - v1.26
@@ -543,11 +544,14 @@ spec:
       - v1.27.3
       - v1.27.6
       - v1.27.10
+      - v1.27.11
       - v1.28.2
       - v1.28.5
       - v1.28.6
+      - v1.28.7
       - v1.29.0
       - v1.29.1
+      - v1.29.2
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -217,7 +217,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.28.6"),
+		Default: semver.NewSemverOrDie("v1.28.7"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -230,13 +230,16 @@ var (
 			newSemver("v1.27.3"),
 			newSemver("v1.27.6"),
 			newSemver("v1.27.10"),
+			newSemver("v1.27.11"),
 			// Kubernetes 1.28
 			newSemver("v1.28.2"),
 			newSemver("v1.28.5"),
 			newSemver("v1.28.6"),
+			newSemver("v1.28.7"),
 			// Kubernetes 1.29
 			newSemver("v1.29.0"),
 			newSemver("v1.29.1"),
+			newSemver("v1.29.2"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.27 =======
@@ -320,8 +323,9 @@ var (
 	eksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-		Default: semver.NewSemverOrDie("v1.28"),
+		Default: semver.NewSemverOrDie("v1.29"),
 		Versions: []semver.Semver{
+			newSemver("v1.29"),
 			newSemver("v1.28"),
 			newSemver("v1.27"),
 			newSemver("v1.26"),
@@ -333,11 +337,11 @@ var (
 	aksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
-		Default: semver.NewSemverOrDie("v1.28"),
+		Default: semver.NewSemverOrDie("v1.29"),
 		Versions: []semver.Semver{
+			newSemver("v1.29"),
 			newSemver("v1.28"),
 			newSemver("v1.27"),
-			newSemver("v1.26"),
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This

* adds the newly released Kubernetes patch releases
* adds 1.29 for EKS according to the [docs](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#available-versions)
* adds 1.29, which is in preview on AKS right now but scheduled for GA in March 2024. Likewise, this PR removes 1.26 which will be removed in March: https://learn.microsoft.com/en-us/azure/aks/supported-kubernetes-versions?tabs=azure-cli#aks-kubernetes-release-calendar

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add 1.29.2/1.28.7/1.27.11 to the list of supported Kubernetes releases.
Add 1.29 to the list of supported EKS versions.
Add 1.29 / remove 1.26 from the list of supported AKS versions.
```

**Documentation**:
```documentation
NONE
```
