### PR TITLE
charts: bump local-kubevirt to v1.1.1 and cdi to 1.58.1

### DIFF
--- a/charts/local-kubevirt/Chart.yaml
+++ b/charts/local-kubevirt/Chart.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: kubevirt
-version: v1.1.0
-appVersion: v1.1.0
+version: v1.1.1
+appVersion: v1.1.1
 description: KubeVirt chart for KKP local installation 
 keywords:
   - kubermatic

--- a/charts/local-kubevirt/crds/customresourcedefinition-cdis.cdi.kubevirt.io.yaml
+++ b/charts/local-kubevirt/crds/customresourcedefinition-cdis.cdi.kubevirt.io.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
+++ b/charts/local-kubevirt/crds/customresourcedefinition-kubevirts.kubevirt.io.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -477,6 +477,9 @@ spec:
                         binding:
                           additionalProperties:
                             properties:
+                              domainAttachmentType:
+                                description: 'DomainAttachmentType is a standard domain network attachment method kubevirt supports. Supported values: "tap". The standard domain attachment can be used instead or in addition to the sidecarImage. version: 1alphav1'
+                                type: string
                               networkAttachmentDefinition:
                                 description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object. Format: <name>, <namespace>/<name>. If namespace is not specified, VMI namespace is assumed. version: 1alphav1'
                                 type: string
@@ -2350,6 +2353,9 @@ spec:
                         binding:
                           additionalProperties:
                             properties:
+                              domainAttachmentType:
+                                description: 'DomainAttachmentType is a standard domain network attachment method kubevirt supports. Supported values: "tap". The standard domain attachment can be used instead or in addition to the sidecarImage. version: 1alphav1'
+                                type: string
                               networkAttachmentDefinition:
                                 description: 'NetworkAttachmentDefinition references to a NetworkAttachmentDefinition CR object. Format: <name>, <namespace>/<name>. If namespace is not specified, VMI namespace is assumed. version: 1alphav1'
                                 type: string

--- a/charts/local-kubevirt/templates/cdi-cr.yaml
+++ b/charts/local-kubevirt/templates/cdi-cr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/clusterrole-cdi-operator-cluster.yaml
+++ b/charts/local-kubevirt/templates/clusterrole-cdi-operator-cluster.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/clusterrole-kubevirt-operator.yaml
+++ b/charts/local-kubevirt/templates/clusterrole-kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1011,6 +1011,13 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - kubevirt.io
+    resources:
+      - kubevirts
+    verbs:
+      - get
+      - list
   - apiGroups:
       - subresources.kubevirt.io
     resources:

--- a/charts/local-kubevirt/templates/clusterrole-kubevirt.io-operator.yaml
+++ b/charts/local-kubevirt/templates/clusterrole-kubevirt.io-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/clusterrolebinding-cdi-operator.yaml
+++ b/charts/local-kubevirt/templates/clusterrolebinding-cdi-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/clusterrolebinding-kubevirt-operator.yaml
+++ b/charts/local-kubevirt/templates/clusterrolebinding-kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/deployment-cdi-operator.yaml
+++ b/charts/local-kubevirt/templates/deployment-cdi-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,25 +40,25 @@ spec:
             - name: DEPLOY_CLUSTER_RESOURCES
               value: "true"
             - name: OPERATOR_VERSION
-              value: v1.58.0
+              value: v1.58.1
             - name: CONTROLLER_IMAGE
-              value: quay.io/kubevirt/cdi-controller:v1.58.0
+              value: quay.io/kubevirt/cdi-controller:v1.58.1
             - name: IMPORTER_IMAGE
-              value: quay.io/kubevirt/cdi-importer:v1.58.0
+              value: quay.io/kubevirt/cdi-importer:v1.58.1
             - name: CLONER_IMAGE
-              value: quay.io/kubevirt/cdi-cloner:v1.58.0
+              value: quay.io/kubevirt/cdi-cloner:v1.58.1
             - name: APISERVER_IMAGE
-              value: quay.io/kubevirt/cdi-apiserver:v1.58.0
+              value: quay.io/kubevirt/cdi-apiserver:v1.58.1
             - name: UPLOAD_SERVER_IMAGE
-              value: quay.io/kubevirt/cdi-uploadserver:v1.58.0
+              value: quay.io/kubevirt/cdi-uploadserver:v1.58.1
             - name: UPLOAD_PROXY_IMAGE
-              value: quay.io/kubevirt/cdi-uploadproxy:v1.58.0
+              value: quay.io/kubevirt/cdi-uploadproxy:v1.58.1
             - name: VERBOSITY
               value: "1"
             - name: PULL_POLICY
               value: IfNotPresent
             - name: MONITORING_NAMESPACE
-          image: quay.io/kubevirt/cdi-operator:v1.58.0
+          image: quay.io/kubevirt/cdi-operator:v1.58.1
           imagePullPolicy: IfNotPresent
           name: cdi-operator
           ports:

--- a/charts/local-kubevirt/templates/deployment-virt-operator.yaml
+++ b/charts/local-kubevirt/templates/deployment-virt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,14 +56,14 @@ spec:
             - virt-operator
           env:
             - name: VIRT_OPERATOR_IMAGE
-              value: quay.io/kubevirt/virt-operator:v1.1.0
+              value: quay.io/kubevirt/virt-operator:v1.1.1
             - name: WATCH_NAMESPACE
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.annotations['olm.targetNamespaces']
             - name: KUBEVIRT_VERSION
-              value: v1.1.0
-          image: quay.io/kubevirt/virt-operator:v1.1.0
+              value: v1.1.1
+          image: quay.io/kubevirt/virt-operator:v1.1.1
           imagePullPolicy: IfNotPresent
           name: virt-operator
           ports:

--- a/charts/local-kubevirt/templates/kubevirt-cr.yaml
+++ b/charts/local-kubevirt/templates/kubevirt-cr.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/priorityclass-kubevirt-cluster-critical.yaml
+++ b/charts/local-kubevirt/templates/priorityclass-kubevirt-cluster-critical.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/role-cdi-operator.yaml
+++ b/charts/local-kubevirt/templates/role-cdi-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/role-kubevirt-operator.yaml
+++ b/charts/local-kubevirt/templates/role-kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/rolebinding-cdi-operator.yaml
+++ b/charts/local-kubevirt/templates/rolebinding-cdi-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/rolebinding-kubevirt-operator-rolebinding.yaml
+++ b/charts/local-kubevirt/templates/rolebinding-kubevirt-operator-rolebinding.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/serviceaccount-cdi-operator.yaml
+++ b/charts/local-kubevirt/templates/serviceaccount-cdi-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/templates/serviceaccount-kubevirt-operator.yaml
+++ b/charts/local-kubevirt/templates/serviceaccount-kubevirt-operator.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/charts/local-kubevirt/values.yaml
+++ b/charts/local-kubevirt/values.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
**What this PR does / why we need it**:
there appear to be no breaking changes:
* https://github.com/kubevirt/kubevirt/releases/tag/v1.1.1
* https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.58.1

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
kubermatic-installer: update local KubeVirt chart to v1.1.1 and CDI to 1.58.1
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
