### PR TITLE
kubelb: update name of the tenant namespace

### DIFF
--- a/pkg/ee/kubelb/cleanup.go
+++ b/pkg/ee/kubelb/cleanup.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubelbresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources"
 	kubelbmanagementresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/kubelb-cluster"
 	kubelbseedresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/seed-cluster"
 	kubelbuserclusterresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/user-cluster"
@@ -80,7 +81,8 @@ func (r *reconciler) ensureKubeLBManagementClusterResourcesAreRemoved(ctx contex
 		return err
 	}
 
-	for _, resource := range kubelbmanagementresources.ResourcesForDeletion(cluster.Status.NamespaceName) {
+	namespace := fmt.Sprintf(kubelbresources.TenantNamespacePattern, cluster.Name)
+	for _, resource := range kubelbmanagementresources.ResourcesForDeletion(namespace) {
 		err := kubeLBManagementClient.Delete(ctx, resource)
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure kubeLB resources are removed/not present on kubelb management cluster: %w", err)

--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -37,6 +37,7 @@ import (
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
+	kubelbresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources"
 	kubelbmanagementresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/kubelb-cluster"
 	kubelbseedresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/seed-cluster"
 	kubelbuserclusterresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources/user-cluster"
@@ -213,7 +214,7 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *kubermaticv1.Cluste
 }
 
 func (r *reconciler) createOrUpdateKubeLBManagementClusterResources(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster) error {
-	namespace := cluster.Status.NamespaceName
+	namespace := fmt.Sprintf(kubelbresources.TenantNamespacePattern, cluster.Name)
 
 	// Create namespace; which is equivalent to registering the tenant.
 	nsReconcilers := []reconciling.NamedNamespaceReconcilerFactory{

--- a/pkg/ee/kubelb/resources/resources.go
+++ b/pkg/ee/kubelb/resources/resources.go
@@ -1,0 +1,27 @@
+//go:build ee
+
+/*
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2024 Kubermatic GmbH
+
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+   END OF TERMS AND CONDITIONS
+*/
+
+package resources
+
+const TenantNamespacePattern = "tenant-%s"

--- a/pkg/ee/kubelb/resources/seed-cluster/deployment.go
+++ b/pkg/ee/kubelb/resources/seed-cluster/deployment.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kubelbresources "k8c.io/kubermatic/v2/pkg/ee/kubelb/resources"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -201,7 +202,7 @@ func getFlags(name string, kubelb *kubermaticv1.KubeLBDatacenterSettings) []stri
 		"-health-probe-bind-address", "0.0.0.0:8085",
 		"-metrics-addr", "0.0.0.0:8082",
 		"-leader-election-namespace", metav1.NamespaceSystem,
-		"-cluster-name", fmt.Sprintf("cluster-%s", name),
+		"-cluster-name", fmt.Sprintf(kubelbresources.TenantNamespacePattern, name),
 	}
 
 	if kubelb != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
The prefix for the tenant namespaces created in the management cluster has been updated from `cluster-` to `tenant-`.  This is required for a special case where our customers want to use the seed cluster as the KubeLB management cluster. Since KKP also creates the namespace `cluster-$ID` for each cluster, it results in a conflict and a race condition between KKP and KubeLB to remove the namespace.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind design

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
[ACTION REQUIRED] KubeLB: The prefix for the tenant namespaces created in the management cluster has been updated from `cluster-` to `tenant-`. The tenants will be migrated automatically to the new namespace, load balancers, and services. The load balancer IPs need to be rotated and previous namespace cleaned up.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @moadqassem 
/milestone KKP 2.25
