### PR TITLE
Fixed broken tags link for Feb 2024 KKP patch releases

### DIFF
--- a/docs/changelogs/CHANGELOG-2.22.md
+++ b/docs/changelogs/CHANGELOG-2.22.md
@@ -15,7 +15,7 @@
 - [v2.22.12](#v22212)
 - [v2.22.13](#v22213)
 
-## [2.22.13](https://github.com/kubermatic/kubermatic/releases/tag/2.22.13)
+## [v2.22.13](https://github.com/kubermatic/kubermatic/releases/tag/v2.22.13)
 
 ### Updates
 

--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -13,7 +13,7 @@
 - [v2.23.10](#v22310)
 - [v2.23.11](#v22311)
 
-## [2.23.11](https://github.com/kubermatic/kubermatic/releases/tag/2.23.11)
+## [v2.23.11](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.11)
 
 ### Bugfixes
 

--- a/docs/changelogs/CHANGELOG-2.24.md
+++ b/docs/changelogs/CHANGELOG-2.24.md
@@ -5,7 +5,7 @@
 - [v2.24.2](#v2242)
 - [v2.24.3](#v2243)
 
-## [2.24.3](https://github.com/kubermatic/kubermatic/releases/tag/2.24.3)
+## [v2.24.3](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.3)
 
 ### Bugfixes
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixed the broken link to the tags.. Added prefix `v` to the versions

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
