### PR TITLE
fix go-restful dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -184,7 +184,7 @@ require (
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/emicklei/go-restful/v3 v3.11.1 // indirect
+	github.com/emicklei/go-restful/v3 v3.11.2 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.0.2 // indirect
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -358,8 +358,8 @@ github.com/elazarl/goproxy v0.0.0-20230808193330-2592e75ae04a/go.mod h1:Ro8st/El
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.15.0+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful/v3 v3.11.1 h1:S+9bSbua1z3FgCnV0KKOSSZ3mDthb5NyEPL5gEpCvyk=
-github.com/emicklei/go-restful/v3 v3.11.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
+github.com/emicklei/go-restful/v3 v3.11.2 h1:1onLa9DcsMYO9P+CXaL0dStDqQ2EHHXLiz+BtnqkLAU=
+github.com/emicklei/go-restful/v3 v3.11.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=
 github.com/emirpasic/gods v1.18.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
**What this PR does / why we need it**:
It seems the v3.11.1 tag was moved, cause our Athens cache says

```
INFO[12:47PM]: github.com/emicklei/go-restful/v3@v3.11.1: verifying module: checksum mismatch
        downloaded: h1:PZ8lyY5omynnq9Y2BHKmNqkC3AnPMES2e2bg7slcfzw=
        sum.golang.org: h1:S+9bSbua1z3FgCnV0KKOSSZ3mDthb5NyEPL5gEpCvyk=

SECURITY ERROR
This download does NOT match the one reported by the checksum server.
The bits may have been replaced on the origin server, or an attacker may
have intercepted the download attempt.

For more information, see 'go help module-auth'.
        http-method=GET http-path=/github.com/emicklei/go-restful/v3/@v/v3.11.1.mod kind=Not Found module= operation=download.VersionModuleHandler ops=[download.VersionModuleHandler pool.GoMod protocol.GoMod protocol.processDownload stash.Pool stasher.Stash stasher.fetchModule goGetFetcher.Fetch module.downloadModule] request-id=5de8aa7a-43fe-46b2-8a6c-5e3d2afe27b8 version=
INFO[12:47PM]: incoming request http-method=GET http-path=/github.com/emicklei/go-restful/v3/@v/v3.11.1.mod http-status=404 request-id=5de8aa7a-43fe-46b2-8a6c-5e3d2afe27b8
```

It seems the author then thankfully tagged a new v3.11.2 on the same commit:

![2024-02-21T13-54-11](https://github.com/kubermatic/kubermatic/assets/127499/bdd662d8-24e3-4cba-91bc-35ad832f8032)

/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
