### PR TITLE
Update AppInstall validation to handle k8s apiserver defaulting

### DIFF
--- a/pkg/defaulting/application_installation.go
+++ b/pkg/defaulting/application_installation.go
@@ -27,6 +27,7 @@ const DefaultHelmTimeout = 5 * time.Minute
 
 func DefaultApplicationInstallation(appInstall *appskubermaticv1.ApplicationInstallation) error {
 	DefaultDeployOpts(appInstall.Spec.DeployOptions)
+	DefaultOmittedValues(&appInstall.Spec)
 	return nil
 }
 
@@ -40,5 +41,16 @@ func DefaultDeployOpts(deployOpts *appskubermaticv1.DeployOptions) {
 		if deployOpts.Helm.Wait && deployOpts.Helm.Timeout.Duration == 0 {
 			deployOpts.Helm.Timeout.Duration = DefaultHelmTimeout
 		}
+	}
+}
+
+// DefaultOmittedValues defaults the values field to "{}" if it was not explicitly set.
+// Defaulting the field on our end allows users to omit the field in case they are not
+// using it or making use of the newer ValuesBlock field.
+// Without this defaulting, the k8s-apiserver complains that the field cannot be null.
+// This is most likely due to the fact that Values is of type runtime.RawExtension.
+func DefaultOmittedValues(spec *appskubermaticv1.ApplicationInstallationSpec) {
+	if len(spec.Values.Raw) == 0 {
+		spec.Values.Raw = []byte("{}")
 	}
 }

--- a/pkg/defaulting/application_installation_test.go
+++ b/pkg/defaulting/application_installation_test.go
@@ -27,6 +27,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/validation"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestDefaultApplicationInstallation(t *testing.T) {
@@ -44,56 +45,68 @@ func TestDefaultApplicationInstallation(t *testing.T) {
 	}{
 		{
 			name:        "test no mutation - deployOpts is nil",
-			appInstall:  getApplicationInstallation(nil),
-			expectedApp: getApplicationInstallation(nil),
+			appInstall:  getApplicationInstallation(nil, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(nil, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test no mutation - deployOpts.Helm is nil",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{}, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test no mutation - deployOpts.Helm is all filled",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 1}}}, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test no mutation - deployOpts.Helm is all filled (atomic=false)",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: 1}}}, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test no mutation - deployOpts.Helm is all filled (atomic=false, wait= false, timeout = 0)",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: false, Timeout: metav1.Duration{Duration: 0}}}, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test mutation - deployOpts.Helm atomic =true --> wait and timeout should be defaulted",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true}}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true}}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test mutation - deployOpts.Helm atomic =true  and wait= true -->  timeout should be defaulted",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true}}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true}}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test mutation - deployOpts.Helm atomic =false  and wait= true -->  timeout should be defaulted",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true}}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true}}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: false, Wait: true, Timeout: metav1.Duration{Duration: defaulting.DefaultHelmTimeout}}}, runtime.RawExtension{Raw: []byte(" ")}),
 			wantErr:     false,
 		},
 		{
 			name:        "test mutation - deployOpts.Helm atomic =true and timeout=10  --> wait should be defaulted",
-			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Timeout: metav1.Duration{Duration: 10}}}),
-			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 10}}}),
+			appInstall:  getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Timeout: metav1.Duration{Duration: 10}}}, runtime.RawExtension{Raw: []byte(" ")}),
+			expectedApp: getApplicationInstallation(&appskubermaticv1.DeployOptions{Helm: &appskubermaticv1.HelmDeployOptions{Atomic: true, Wait: true, Timeout: metav1.Duration{Duration: 10}}}, runtime.RawExtension{Raw: []byte(" ")}),
+			wantErr:     false,
+		},
+		{
+			name:        "test mutation - values set --> existing values should not be overwritten",
+			appInstall:  getApplicationInstallation(nil, runtime.RawExtension{Raw: []byte(`{ "commonLabels": {"owner": "somebody"}}`)}),
+			expectedApp: getApplicationInstallation(nil, runtime.RawExtension{Raw: []byte(`{ "commonLabels": {"owner": "somebody"}}`)}),
+			wantErr:     false,
+		},
+		{
+			name:        "test mutation - values omitted --> values should be defaulted",
+			appInstall:  getApplicationInstallation(nil, runtime.RawExtension{}), // we cannot use nil here, but empty runtime.RawExtension does the trick
+			expectedApp: getApplicationInstallation(nil, runtime.RawExtension{Raw: []byte(`{}`)}),
 			wantErr:     false,
 		},
 	}
@@ -116,7 +129,7 @@ func TestDefaultApplicationInstallation(t *testing.T) {
 	}
 }
 
-func getApplicationInstallation(deployOpts *appskubermaticv1.DeployOptions) *appskubermaticv1.ApplicationInstallation {
+func getApplicationInstallation(deployOpts *appskubermaticv1.DeployOptions, values runtime.RawExtension) *appskubermaticv1.ApplicationInstallation {
 	return &appskubermaticv1.ApplicationInstallation{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "app-1",
@@ -131,6 +144,7 @@ func getApplicationInstallation(deployOpts *appskubermaticv1.DeployOptions) *app
 				Version: "v1.0.0",
 			},
 			DeployOptions: deployOpts,
+			Values:        values,
 		},
 	}
 }

--- a/pkg/validation/application_installation.go
+++ b/pkg/validation/application_installation.go
@@ -70,8 +70,11 @@ func ValidateApplicationInstallationSpec(ctx context.Context, client ctrlruntime
 	}
 	allErrs = append(allErrs, ValidateDeployOpts(spec.DeployOptions, specPath.Child("deployOptions"))...)
 
-	// Ensure that not both values and ValuesBlock fields are set simultaneously
-	if len(ai.Spec.Values.Raw) > 0 && ai.Spec.ValuesBlock != "" {
+	// Ensure that not both Values and ValuesBlock fields are set simultaneously.
+	// The values.Raw != "{}" is required because Values is of type runtime.Rawextension, which
+	// means it has the x-kubernetes-preserve-unknown-fields set to true, which in turn means that
+	// its null value when applied through the k8s-api is "{}" and not an empty byteslice.
+	if len(ai.Spec.Values.Raw) > 0 && string(ai.Spec.Values.Raw) != "{}" && ai.Spec.ValuesBlock != "" {
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("values"), "Only values or valuesBlock can be set, but not both simultaneously"))
 		allErrs = append(allErrs, field.Forbidden(specPath.Child("valuesBlock"), "Only values or valuesBlock can be set, but not both simultaneously"))
 	}

--- a/pkg/validation/application_installation_test.go
+++ b/pkg/validation/application_installation_test.go
@@ -197,6 +197,17 @@ func TestValidateApplicationInstallationSpec(t *testing.T) {
 				}(),
 			}, expectedError: `[spec.values: Forbidden: Only values or valuesBlock can be set, but not both simultaneously spec.valuesBlock: Forbidden: Only values or valuesBlock can be set, but not both simultaneously]`,
 		},
+		{
+			name: "Create ApplicationInstallation Success - ValuesBlock set and Values in default empty",
+			ai: &appskubermaticv1.ApplicationInstallation{
+				Spec: func() appskubermaticv1.ApplicationInstallationSpec {
+					spec := ai.Spec.DeepCopy()
+					spec.Values = runtime.RawExtension{Raw: []byte("{}")} // Raw.Runtime Extension gets defaulted to '{}' when set through k8s-api
+					spec.ValuesBlock = "key: value"
+					return *spec
+				}(),
+			}, expectedError: `[]`,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/webhook/application/applicationinstallation/mutation/mutation_test.go
+++ b/pkg/webhook/application/applicationinstallation/mutation/mutation_test.go
@@ -119,7 +119,7 @@ func TestHandle(t *testing.T) {
 			name: "Delete applicationInstallation should not generate path",
 			req: webhook.AdmissionRequest{
 				AdmissionRequest: admissionv1.AdmissionRequest{
-					Operation: admissionv1.Create,
+					Operation: admissionv1.Delete,
 					RequestKind: &metav1.GroupVersionKind{
 						Group:   appskubermaticv1.GroupName,
 						Version: appskubermaticv1.GroupVersion,


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes two issues:
1. Before the validation would always fail if you want to use valuesBlock, because values cannot be empty and if you set both values and valuesBlock the validation failed
2. The values field could not be omitted, it would always at least need to be specified as `values: {}`. With this the defaulting now takes over that job.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
For the CNI defaultApps, existing checks do not need to be adjusted, because there we unmarshal the values into a map and then also check again if the map itself is not empty
https://github.com/kubermatic/kubermatic/blob/c1efb1b1b6f42d66ecf902132f7c7fd586de21f6/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go#L353-L363

For AppDef the issue does not exist because the defaultValues field is a pointer to runtime.Rawextension and not the struct itself

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
4. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
