### PR TITLE
Exclude some KKP resources when Edge provider is used 

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -808,12 +808,19 @@ func (r *Reconciler) ensureCronJobs(ctx context.Context, c *kubermaticv1.Cluster
 
 func (r *Reconciler) ensureVerticalPodAutoscalers(ctx context.Context, c *kubermaticv1.Cluster, data *resources.TemplateData) error {
 	controlPlaneDeploymentNames := []string{
-		resources.MachineControllerDeploymentName,
-		resources.MachineControllerWebhookDeploymentName,
 		resources.ApiserverDeploymentName,
 		resources.ControllerManagerDeploymentName,
 		resources.SchedulerDeploymentName,
 	}
+
+	// machine controller is not deployed for the edge clusters
+	if c.Spec.Cloud.Edge == nil {
+		controlPlaneDeploymentNames = append(controlPlaneDeploymentNames,
+			resources.MachineControllerDeploymentName,
+			resources.MachineControllerWebhookDeploymentName,
+		)
+	}
+
 	if !data.IsKonnectivityEnabled() {
 		controlPlaneDeploymentNames = append(controlPlaneDeploymentNames,
 			resources.OpenVPNServerDeploymentName,


### PR DESCRIPTION
**What this PR does / why we need it**:
When the edge provider is used machine controller and its underlying resources are not needed(e.g: some webhooks). In addition to that, we should not check for the deployment of machine controller during VPA reconciliation, otherwise seed controller manager will keep logging out some errors regarding VPA not being installed due to the fact of missing some deployments.
 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
Some other PRs will follow to address the machine controller health checks when edge provider is used.
**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
None
```
