### PR TITLE
Fix DefaultValues Wording

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -193,13 +193,12 @@ type ApplicationDefinitionSpec struct {
 	// Method used to install the application
 	Method TemplateMethod `json:"method"`
 
-	// DefaultValues specify values overrides for manifest-rendering in UI when creating an application. Comments are not preserved.
+	// DefaultValues specify default values for the UI which are passed to helm templating when creating an application. Comments are not preserved.
 	// Deprecated: use DefaultValuesBlock instead
 	// +kubebuilder:pruning:PreserveUnknownFields
 	DefaultValues *runtime.RawExtension `json:"defaultValues,omitempty"`
 
-	// DefaultValuesBlock specify values overrides for manifest-rendering in UI when creating an application. Comments not preserved.
-	// Preserves yaml comments.
+	// DefaultValuesBlock specifies default values for the UI which are passed to helm templating when creating an application. Comments are preserved.
 	DefaultValuesBlock string `json:"defaultValuesBlock,omitempty"`
 
 	// DefaultDeployOptions holds the settings specific to the templating method used to deploy the application.

--- a/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
+++ b/pkg/crd/k8c.io/apps.kubermatic.k8c.io_applicationdefinitions.yaml
@@ -54,11 +54,11 @@ spec:
                       type: object
                   type: object
                 defaultValues:
-                  description: 'DefaultValues specify values overrides for manifest-rendering in UI when creating an application. Comments are not preserved. Deprecated: use DefaultValuesBlock instead'
+                  description: 'DefaultValues specify default values for the UI which are passed to helm templating when creating an application. Comments are not preserved. Deprecated: use DefaultValuesBlock instead'
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
                 defaultValuesBlock:
-                  description: DefaultValuesBlock specify values overrides for manifest-rendering in UI when creating an application. Comments not preserved. Preserves yaml comments.
+                  description: DefaultValuesBlock specifies default values for the UI which are passed to helm templating when creating an application. Comments are preserved.
                   type: string
                 description:
                   description: Description of the application. what is its purpose


### PR DESCRIPTION
**What this PR does / why we need it**:

Small but important wording change. For defaultValues the comments are of course preserved!

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
