### PR TITLE
[release/v2.24]Fix logic for checking CSI driver usage

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -70,8 +70,8 @@ const (
 	migratedVsphereCSIAddon   = "kubermatic.k8c.io/migrated-vsphere-csi-addon"
 	csiAddonStorageClassLabel = "kubermatic-addon=csi"
 	CSIAddonName              = "csi"
-
-	yes = "yes"
+	pvMigrationAnnotation     = "pv.kubernetes.io/migrated-to"
+	yes                       = "yes"
 )
 
 // KubeconfigProvider provides functionality to get a clusters admin kubeconfig.
@@ -881,8 +881,14 @@ func (r *Reconciler) pvsForProvisioner(ctx context.Context, cluster *kubermaticv
 		return pvsForProvisioner, fmt.Errorf("failed to get the list of PVs having %v as provisioner : %w", provisionerName, err)
 	}
 	for i := 0; i < len(pvList.Items); i++ {
-		if pvList.Items[i].Spec.CSI.Driver == provisionerName {
-			pvsForProvisioner = append(pvsForProvisioner, pvList.Items[i].Name)
+		if pvList.Items[i].Spec.CSI != nil {
+			if pvList.Items[i].Spec.CSI.Driver == provisionerName {
+				pvsForProvisioner = append(pvsForProvisioner, pvList.Items[i].Name)
+			}
+		} else {
+			if pvList.Items[i].ObjectMeta.Annotations[pvMigrationAnnotation] == provisionerName {
+				pvsForProvisioner = append(pvsForProvisioner, pvList.Items[i].Name)
+			}
 		}
 	}
 	return pvsForProvisioner, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
While checking if the CSI driver created by the CSI addon is in use or not we didn't include logic for volumes created by the in-tree provisioner & later migrated to CSI.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13119

**What type of PR is this?**
Add one of the following kinds:
/kind bug

**Special notes for your reviewer**:
Manual backport of #13122

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->

```release-note
Fix the panic of the seed controller manager while checking CSI addon usage for user clusters, when a user cluster has PVs which were migrated from the in-tree provisioner to the CSI provisioner.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
