### PR TITLE
Fix an error in GetParsedValues when working with k8s-apiserver defaulting

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -291,7 +291,7 @@ func (appInstallation *ApplicationInstallation) SetReadyCondition(installErr err
 // Will return an error if both fields are set.
 func (ai *ApplicationInstallationSpec) GetParsedValues() (map[string]interface{}, error) {
 	values := make(map[string]interface{})
-	if len(ai.Values.Raw) > 0 && ai.ValuesBlock != "" {
+	if len(ai.Values.Raw) > 0 && string(ai.Values.Raw) != "{}" && ai.ValuesBlock != "" {
 		return nil, fmt.Errorf("the fields Values and ValuesBlock cannot be used simultaneously. Please delete one of them.")
 	}
 	if len(ai.Values.Raw) > 0 {

--- a/pkg/apis/apps.kubermatic/v1/application_installation_test.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/apis/apps.kubermatic/v1/application_installation_test.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	http://www.apache.org/licenses/LICENSE-2.0
+    http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 package v1
 
 import (

--- a/pkg/apis/apps.kubermatic/v1/application_installation_test.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation_test.go
@@ -37,29 +37,23 @@ func TestGetParsedValues(t *testing.T) {
 		},
 		"ValuesBlock set": {
 			appIn: ApplicationInstallationSpec{
-				ValuesBlock: `
-not-empty:
-  value`[1:],
+				ValuesBlock: "not-empty:\n  value",
 			},
 			expResponse: map[string]interface{}{"not-empty": "value"},
 			expError:    false,
 		},
 		"ValuesBlock set and Values Defaulted": {
 			appIn: ApplicationInstallationSpec{
-				Values: runtime.RawExtension{},
-				ValuesBlock: `
-not-empty:
-  value`[1:],
+				Values:      runtime.RawExtension{},
+				ValuesBlock: "not-empty:\n  value",
 			},
 			expResponse: map[string]interface{}{"not-empty": "value"},
 			expError:    false,
 		},
 		"Both Values and ValuesBlock set": {
 			appIn: ApplicationInstallationSpec{
-				Values: runtime.RawExtension{Raw: []byte(`{"not-empty":"value"}`)},
-				ValuesBlock: `
-not-empty:
-  value`[1:],
+				Values:      runtime.RawExtension{Raw: []byte(`{"not-empty":"value"}`)},
+				ValuesBlock: "not-empty:\n  value",
 			},
 			expResponse: nil,
 			expError:    true,

--- a/pkg/apis/apps.kubermatic/v1/application_installation_test.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGetParsedValues(t *testing.T) {
+	tt := map[string]struct {
+		appIn       ApplicationInstallationSpec
+		expResponse map[string]interface{}
+		expError    bool
+	}{
+		"Values set": {
+			appIn: ApplicationInstallationSpec{
+				Values: runtime.RawExtension{Raw: []byte(`{"not-empty":"value"}`)},
+			},
+			expResponse: map[string]interface{}{"not-empty": "value"},
+			expError:    false,
+		},
+		"ValuesBlock set": {
+			appIn: ApplicationInstallationSpec{
+				ValuesBlock: `
+not-empty:
+  value`[1:],
+			},
+			expResponse: map[string]interface{}{"not-empty": "value"},
+			expError:    false,
+		},
+		"ValuesBlock set and Values Defaulted": {
+			appIn: ApplicationInstallationSpec{
+				Values: runtime.RawExtension{},
+				ValuesBlock: `
+not-empty:
+  value`[1:],
+			},
+			expResponse: map[string]interface{}{"not-empty": "value"},
+			expError:    false,
+		},
+		"Both Values and ValuesBlock set": {
+			appIn: ApplicationInstallationSpec{
+				Values: runtime.RawExtension{Raw: []byte(`{"not-empty":"value"}`)},
+				ValuesBlock: `
+not-empty:
+  value`[1:],
+			},
+			expResponse: nil,
+			expError:    true,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			res, err := tc.appIn.GetParsedValues()
+			if tc.expError == false && err != nil {
+				t.Errorf("Expected Error to be nil, but got %v", err)
+			}
+			if tc.expError == true && err == nil {
+				t.Errorf("Expected Error to be present, but was nil")
+			}
+			assert.Equal(t, tc.expResponse, res)
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Because the k8s-apiserver code cannot omit the values field, it gets defaulted to `{}` rather than being empty. As a result we need to take this into account when retrieving the values.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

For AppDefs this change is not necessary as we are using a pointer there.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
