### PR TITLE
Update KubeLB to v0.6.0-rc.0

### DIFF
--- a/pkg/ee/kubelb/controller.go
+++ b/pkg/ee/kubelb/controller.go
@@ -304,10 +304,11 @@ func (r *reconciler) createOrUpdateKubeLBUserClusterResources(ctx context.Contex
 }
 
 func (r *reconciler) createOrUpdateKubeLBSeedClusterResources(ctx context.Context, cluster *kubermaticv1.Cluster, kubeLBManagementClient ctrlruntimeclient.Client, kubeconfig []byte, dc kubermaticv1.Datacenter) error {
-	namespace := cluster.Status.NamespaceName
+	seedNamespace := cluster.Status.NamespaceName
+	tenantNamespace := fmt.Sprintf(kubelbresources.TenantNamespacePattern, cluster.Name)
 
 	// Generate kubeconfig secret.
-	tenantKubeconfig, err := r.generateKubeconfig(ctx, kubeLBManagementClient, namespace, string(kubeconfig))
+	tenantKubeconfig, err := r.generateKubeconfig(ctx, kubeLBManagementClient, tenantNamespace, string(kubeconfig))
 	if err != nil {
 		return fmt.Errorf("failed to generate kubeconfig: %w", err)
 	}
@@ -317,7 +318,7 @@ func (r *reconciler) createOrUpdateKubeLBSeedClusterResources(ctx context.Contex
 	}
 
 	// Create kubeconfig secret in the user cluster namespace.
-	if err := reconciling.ReconcileSecrets(ctx, secretReconcilers, namespace, r.Client); err != nil {
+	if err := reconciling.ReconcileSecrets(ctx, secretReconcilers, seedNamespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile kubeLB tenant kubeconfig secret: %w", err)
 	}
 
@@ -326,7 +327,7 @@ func (r *reconciler) createOrUpdateKubeLBSeedClusterResources(ctx context.Contex
 		kubelbseedresources.ServiceAccountReconciler(),
 	}
 
-	if err := reconciling.ReconcileServiceAccounts(ctx, saReconcilers, namespace, r.Client); err != nil {
+	if err := reconciling.ReconcileServiceAccounts(ctx, saReconcilers, seedNamespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile service account: %w", err)
 	}
 
@@ -334,7 +335,7 @@ func (r *reconciler) createOrUpdateKubeLBSeedClusterResources(ctx context.Contex
 	deploymentReconcilers := []reconciling.NamedDeploymentReconcilerFactory{
 		kubelbseedresources.DeploymentReconciler(kubelbseedresources.NewKubeLBData(ctx, cluster, r, r.overwriteRegistry, dc)),
 	}
-	if err := reconciling.ReconcileDeployments(ctx, deploymentReconcilers, namespace, r.Client); err != nil {
+	if err := reconciling.ReconcileDeployments(ctx, deploymentReconcilers, seedNamespace, r.Client); err != nil {
 		return fmt.Errorf("failed to reconcile the Deployments: %w", err)
 	}
 

--- a/pkg/ee/kubelb/resources/seed-cluster/deployment.go
+++ b/pkg/ee/kubelb/resources/seed-cluster/deployment.go
@@ -61,7 +61,7 @@ var (
 
 const (
 	imageName = "kubelb-ccm-ee"
-	imageTag  = "fd09a9ee6da0271a4a3a0a039b8e98bfc0423b6b"
+	imageTag  = "v0.6.0-rc.0"
 )
 
 type kubeLBData interface {


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating KubeLB to https://github.com/kubermatic/kubelb-ee/releases/tag/v0.6.0-rc.0 and fixing a bug where wrong namespace was being used for fetching the SA token from the KubeLB management cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @xmudrii 