### PR TITLE
Set up OIDC network policy with different ingress controllers

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -105,6 +105,8 @@ spec:
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.
     domain: example.com
+    # NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
+    namespaceOverride: ""
   # MasterController configures the master-controller-manager.
   masterController:
     # DebugLog enables more verbose logging.

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -105,7 +105,7 @@ spec:
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.
     domain: example.com
-    # NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
+    # NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.
     namespaceOverride: ""
   # MasterController configures the master-controller-manager.
   masterController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -105,6 +105,8 @@ spec:
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.
     domain: example.com
+    # NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
+    namespaceOverride: ""
   # MasterController configures the master-controller-manager.
   masterController:
     # DebugLog enables more verbose logging.

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -105,7 +105,7 @@ spec:
     # Domain is the base domain where the dashboard shall be available. Even with
     # a disabled Ingress, this must always be a valid hostname.
     domain: example.com
-    # NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
+    # NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.
     namespaceOverride: ""
   # MasterController configures the master-controller-manager.
   masterController:

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -331,7 +331,7 @@ type KubermaticIngressConfiguration struct {
 	// ingress controller.
 	ClassName string `json:"className,omitempty"`
 
-	// NamespaceOverride need to be set if the another ingress-controller is used than nginx-ingress-controller shipped with KKP.
+	// NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
 	NamespaceOverride string `json:"namespaceOverride,omitempty"`
 
 	// Disable will prevent an Ingress from being created at all. This is mostly useful

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -331,7 +331,7 @@ type KubermaticIngressConfiguration struct {
 	// ingress controller.
 	ClassName string `json:"className,omitempty"`
 
-	// NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
+	// NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.
 	NamespaceOverride string `json:"namespaceOverride,omitempty"`
 
 	// Disable will prevent an Ingress from being created at all. This is mostly useful

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -331,6 +331,9 @@ type KubermaticIngressConfiguration struct {
 	// ingress controller.
 	ClassName string `json:"className,omitempty"`
 
+	// NamespaceOverride need to be set if the another ingress-controller is used than nginx-ingress-controller shipped with KKP.
+	NamespaceOverride string `json:"namespaceOverride,omitempty"`
+
 	// Disable will prevent an Ingress from being created at all. This is mostly useful
 	// during testing. If the Ingress is disabled, the CertificateIssuer setting can also
 	// be left empty, as no Certificate resource will be created.

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -29,7 +29,6 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
-	kubermaticmaster "k8c.io/kubermatic/v2/pkg/install/stack/kubermatic-master"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubernetesprovider "k8c.io/kubermatic/v2/pkg/provider/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
@@ -693,18 +692,7 @@ func (r *Reconciler) ensureNetworkPolicies(ctx context.Context, c *kubermaticv1.
 			if err != nil {
 				return fmt.Errorf("failed to resolve OIDC issuer URL %q: %w", issuerURL, err)
 			}
-
-			ingressNsLabels := map[string]string{
-				corev1.LabelMetadataName: kubermaticmaster.NginxIngressControllerNamespace,
-			}
-
-			if cfg.Spec.Ingress.NamespaceOverride != "" {
-				ingressNsLabels = map[string]string{
-					corev1.LabelMetadataName: cfg.Spec.Ingress.NamespaceOverride,
-				}
-			}
-
-			namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.OIDCIssuerAllowReconciler(ipList, ingressNsLabels))
+			namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, apiserver.OIDCIssuerAllowReconciler(ipList, cfg.Spec.Ingress.NamespaceOverride))
 		}
 
 		apiIPs, err := r.fetchKubernetesServiceIPList(ctx, resolverCtx)

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -176,7 +176,7 @@ spec:
                       description: Domain is the base domain where the dashboard shall be available. Even with a disabled Ingress, this must always be a valid hostname.
                       type: string
                     namespaceOverride:
-                      description: NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
+                      description: NamespaceOverride need to be set if a different ingress-controller is used than the KKP default one.
                       type: string
                   required:
                     - domain

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -175,6 +175,9 @@ spec:
                     domain:
                       description: Domain is the base domain where the dashboard shall be available. Even with a disabled Ingress, this must always be a valid hostname.
                       type: string
+                    namespaceOverride:
+                      description: NamespaceOverride need to be set if a different ingress-controller is used then the KKP default one.
+                      type: string
                   required:
                     - domain
                   type: object


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes 
- https://github.com/kubermatic/kubermatic/issues/13117

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix OIDC network policy, by allowing to set NamespaceOverride to specify where the ingress controller is deployed.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
TBD
```
