### PR TITLE
[mla] fix minio values file errors

### DIFF
--- a/charts/mla/minio/Chart.yaml
+++ b/charts/mla/minio/Chart.yaml
@@ -16,7 +16,7 @@ apiVersion: v2
 description: High Performance, Kubernetes Native Object Storage
 name: minio
 version: v9.9.9-dev
-appVersion: RELEASE.2022-09-17T00-09-45Z
+appVersion: RELEASE.2023-04-28T18-11-17Z
 keywords:
   - storage
   - object-storage

--- a/charts/mla/minio/test/config.yaml.out
+++ b/charts/mla/minio/test/config.yaml.out
@@ -484,10 +484,7 @@ metadata:
     heritage: Helm
 spec:
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 0
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/mla/minio/test/default.yaml.out
+++ b/charts/mla/minio/test/default.yaml.out
@@ -484,10 +484,7 @@ metadata:
     heritage: Helm
 spec:
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 100%
-      maxUnavailable: 0
+    type: Recreate
   replicas: 1
   selector:
     matchLabels:

--- a/charts/mla/minio/values.yaml
+++ b/charts/mla/minio/values.yaml
@@ -40,7 +40,7 @@ minio:
   ## Additional arguments to pass to minio binary
   extraArgs: []
   ## Update strategy for Deployments
-  DeploymentUpdate:
+  deploymentUpdate:
     type: Recreate
     maxUnavailable: 0
     maxSurge: 100%


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a missed change in the updated minio chart.
Field `deploymentUpdate` starts now with a lowercase `d` which made the rollout strategy configuration be not respected by the chart. As such, rolling update of the deployment halts because it's usually not possible to have the same PVC mounted to two pods.
This PR restores the previous configuration of `Recreate`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
