### PR TITLE
Fix AWS CCM upgrade

### DIFF
--- a/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
+++ b/pkg/controller/seed-controller-manager/cloud/cloud_controller.go
@@ -191,7 +191,7 @@ func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, clus
 		}
 
 		// reconcile if the lastTime isn't set (= first time init or a forced reconciliation) or too long ago
-		if last.IsZero() || (interval.Duration > 0 && time.Since(last.Time) >= interval.Duration) {
+		if last.IsZero() || (interval.Duration > 0 && time.Since(last.Time) >= interval.Duration) || betterProvider.ClusterNeedsReconciling(cluster) {
 			log.Info("Reconciling cloud provider for cluster")
 
 			// update metrics

--- a/pkg/provider/cloud/aws/provider.go
+++ b/pkg/provider/cloud/aws/provider.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path"
 
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -155,8 +157,11 @@ func (a *AmazonEC2) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermati
 		return fmt.Errorf("updating AWS security group ID is not supported (was %s, updated to %s)", oldSpec.AWS.SecurityGroupID, newSpec.AWS.SecurityGroupID)
 	}
 
-	if oldSpec.AWS.ControlPlaneRoleARN != "" && oldSpec.AWS.ControlPlaneRoleARN != newSpec.AWS.ControlPlaneRoleARN {
-		return fmt.Errorf("updating AWS control plane ARN is not supported (was %s, updated to %s)", oldSpec.AWS.ControlPlaneRoleARN, newSpec.AWS.ControlPlaneRoleARN)
+	// In KKP 2.25, the newly introduced AWS CCM version now requires full ARNs for roles instead of names
+	// only, so the immutability rules for this field are a bit more relaxed and allow to replace the old,
+	// plain role name with a more correct fully qualified ARN. See kubermatic#12936 for more information.
+	if err := validateRoleUpdate(oldSpec.AWS.ControlPlaneRoleARN, newSpec.AWS.ControlPlaneRoleARN); err != nil {
+		return fmt.Errorf("updating AWS control plane ARN is not supported: %w", err)
 	}
 
 	if oldSpec.AWS.InstanceProfileName != "" && oldSpec.AWS.InstanceProfileName != newSpec.AWS.InstanceProfileName {
@@ -164,6 +169,51 @@ func (a *AmazonEC2) ValidateCloudSpecUpdate(_ context.Context, oldSpec kubermati
 	}
 
 	return nil
+}
+
+func validateRoleUpdate(oldValue, newValue string) error {
+	// no changes are made
+	if oldValue == newValue {
+		return nil
+	}
+
+	oldIsARN := arn.IsARN(oldValue)
+	newIsARN := arn.IsARN(newValue)
+
+	// never allow anything but valid ARNs
+	if !newIsARN {
+		return fmt.Errorf("%q is not a valid ARN", newValue)
+	}
+
+	// value is being set the first time
+	if oldValue == "" {
+		return nil
+	}
+
+	// cannot change one ARN into another
+	if oldIsARN && newIsARN {
+		return fmt.Errorf("cannot change role ARN from %q to %q", oldValue, newValue)
+	}
+
+	oldRoleName := getRoleName(oldValue)
+	newRoleName := getRoleName(newValue)
+
+	if oldRoleName != newRoleName {
+		return fmt.Errorf("cannot change role from %q to %q", oldRoleName, newRoleName)
+	}
+
+	return nil
+}
+
+func getRoleName(value string) string {
+	if arn.IsARN(value) {
+		parsed, _ := arn.Parse(value)
+
+		// resource is "role/<name>"
+		return path.Base(parsed.Resource)
+	}
+
+	return value
 }
 
 func (a *AmazonEC2) InitializeCloudProvider(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {

--- a/pkg/provider/cloud/aws/provider.go
+++ b/pkg/provider/cloud/aws/provider.go
@@ -23,6 +23,7 @@ import (
 	"path"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
+
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/provider"
@@ -102,6 +103,16 @@ func (a *AmazonEC2) DefaultCloudSpec(ctx context.Context, spec *kubermaticv1.Clu
 		}
 	}
 	return nil
+}
+
+func (*AmazonEC2) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	awsSpec := cluster.Spec.Cloud.AWS
+	if awsSpec == nil {
+		return false
+	}
+
+	// trigger migration for kubermatic#12936
+	return arn.IsARN(awsSpec.ControlPlaneRoleARN)
 }
 
 // ValidateCloudSpec validates the fields that the user can override while creating

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -213,6 +213,10 @@ func (a *Azure) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Clus
 	return a.reconcileCluster(ctx, cluster, update, true, true)
 }
 
+func (*Azure) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (a *Azure) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, force bool, setTags bool) (*kubermaticv1.Cluster, error) {
 	var err error
 	logger := a.log.With("cluster", cluster.Name)

--- a/pkg/provider/cloud/bringyourown/provider.go
+++ b/pkg/provider/cloud/bringyourown/provider.go
@@ -36,6 +36,10 @@ func (b *bringyourown) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.Clust
 	return nil
 }
 
+func (*bringyourown) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (b *bringyourown) ValidateCloudSpec(_ context.Context, _ kubermaticv1.CloudSpec) error {
 	return nil
 }

--- a/pkg/provider/cloud/edge/provider.go
+++ b/pkg/provider/cloud/edge/provider.go
@@ -36,6 +36,10 @@ func (b *edge) DefaultCloudSpec(_ context.Context, _ *kubermaticv1.ClusterSpec) 
 	return nil
 }
 
+func (*edge) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (b *edge) ValidateCloudSpec(_ context.Context, _ kubermaticv1.CloudSpec) error {
 	return nil
 }

--- a/pkg/provider/cloud/gcp/provider.go
+++ b/pkg/provider/cloud/gcp/provider.go
@@ -76,6 +76,10 @@ func (g *gcp) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluste
 	return g.reconcileCluster(ctx, cluster, update, true, true)
 }
 
+func (*gcp) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (g *gcp) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater, force, setTags bool) (*kubermaticv1.Cluster, error) {
 	var err error
 	if cluster.Spec.Cloud.GCP.Network == "" && cluster.Spec.Cloud.GCP.Subnetwork == "" {

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -102,6 +102,10 @@ func (k *kubevirt) InitializeCloudProvider(ctx context.Context, cluster *kuberma
 	return k.reconcileCluster(ctx, cluster, update)
 }
 
+func (*kubevirt) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (k *kubevirt) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return k.reconcileCluster(ctx, cluster, update)
 }

--- a/pkg/provider/cloud/nutanix/provider.go
+++ b/pkg/provider/cloud/nutanix/provider.go
@@ -72,6 +72,10 @@ func (n *Nutanix) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 	return n.reconcileCluster(ctx, cluster, update, true)
 }
 
+func (*Nutanix) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (n *Nutanix) CleanUpCloudProvider(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	if !kuberneteshelper.HasFinalizer(cluster, categoryCleanupFinalizer) {
 		return cluster, nil

--- a/pkg/provider/cloud/vmwareclouddirector/provider.go
+++ b/pkg/provider/cloud/vmwareclouddirector/provider.go
@@ -103,6 +103,10 @@ func (p *Provider) InitializeCloudProvider(ctx context.Context, cluster *kuberma
 	return p.reconcileCluster(ctx, cluster, update, false)
 }
 
+func (*Provider) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (p *Provider) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	return p.reconcileCluster(ctx, cluster, update, true)
 }

--- a/pkg/provider/cloud/vsphere/provider.go
+++ b/pkg/provider/cloud/vsphere/provider.go
@@ -68,6 +68,10 @@ func (v *VSphere) ReconcileCluster(ctx context.Context, cluster *kubermaticv1.Cl
 	return v.reconcileCluster(ctx, cluster, update)
 }
 
+func (*VSphere) ClusterNeedsReconciling(cluster *kubermaticv1.Cluster) bool {
+	return false
+}
+
 func (v *VSphere) reconcileCluster(ctx context.Context, cluster *kubermaticv1.Cluster, update provider.ClusterUpdater) (*kubermaticv1.Cluster, error) {
 	logger := v.log.With("cluster", cluster.Name)
 	username, password, err := getCredentialsForCluster(cluster.Spec.Cloud, v.secretKeySelector, v.dc)

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -83,6 +83,13 @@ type ReconcilingCloudProvider interface {
 	CloudProvider
 
 	ReconcileCluster(context.Context, *kubermaticv1.Cluster, ClusterUpdater) (*kubermaticv1.Cluster, error)
+
+	// Normally reconciling happens on a regular basis, but the interval between reconciliations can
+	// be quite long if migrations/upgrades need to happen. A cloud provider can implement this to
+	// decide based on the Cluster whether an immediate reconciliation is required. Cloud providers
+	// should be careful and not blindly just "return true" here, as that would defeat the whole
+	// "wait N minutes before doing expensive reconciliation" logic.
+	ClusterNeedsReconciling(*kubermaticv1.Cluster) bool
 }
 
 // ClusterUpdater defines a function to persist an update to a cluster.


### PR DESCRIPTION
**What this PR does / why we need it**:
As noted in #12936, the more recent versions of the AWS CCM require a fully-qualified role ARN. However the KKP cluster webhook forbade changing the role name in the ClusterSpec, making it impossible to properly migrate existing clusters.

This PR relaxes the validation rules a bit to allow going from bare role names to full ARNs.

I also extended the CloudProvider interface to allow them to trigger a reconciliation based on the Cluster object. Otherwise it might take many hours before all AWS clusters have been updated and in the meantime the AWS CCM might crashloop.

**Which issue(s) this PR fixes**:
Fixes #13144

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
