### PR TITLE
fix: exclude test folders from chart archive

### DIFF
--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -246,6 +246,7 @@ for buildTarget in $RELEASE_PLATFORMS; do
     --transform='flags=r;s|charts/values.example.mla.yaml|examples/values.example.mla.yaml|' \
     --transform='flags=r;s|charts/kubermatic.example.ce.yaml|examples/kubermatic.example.yaml|' \
     --transform='flags=r;s|charts/seed.example.yaml|examples/seed.example.yaml|' \
+    --exclude='*/test' \
     _build/kubermatic-installer* \
     charts/backup \
     charts/cert-manager \
@@ -286,6 +287,7 @@ for buildTarget in $RELEASE_PLATFORMS; do
     --transform='flags=r;s|charts/kubermatic.example.ee.yaml|examples/kubermatic.example.yaml|' \
     --transform='flags=r;s|charts/seed.example.yaml|examples/seed.example.yaml|' \
     --transform='flags=r;s|pkg/ee/LICENSE|LICENSE.ee|' \
+    --exclude='*/test' \
     _build/kubermatic-installer* \
     charts/backup \
     charts/cert-manager \


### PR DESCRIPTION
**What this PR does / why we need it**:

Excludes test folders which contain symlinks that break once the archive is untarred.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/13142

**What type of PR is this?**
/kind bug

**Special notes for your reviewer**:

Does this PR introduce a user-facing change? Then add your Release Note here:

```release-notes
Exclude `test` folders which contain symlinks that break once the archive is untarred.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
