### PR TITLE
add VMWare Cloud Provider Disk Size Nil handle

### DIFF
--- a/pkg/ee/validation/machine/providers.go
+++ b/pkg/ee/validation/machine/providers.go
@@ -26,6 +26,7 @@ package machine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -124,7 +125,7 @@ func GetMachineResourceUsage(ctx context.Context, userClient ctrlruntimeclient.C
 	case types.CloudProviderDigitalocean:
 		quotaUsage, err = getDigitalOceanResourceRequirements(ctx, userClient, config)
 	case types.CloudProviderVMwareCloudDirector:
-		quotaUsage, err = getVMwareCloudDirectorResourceRequirements(ctx, userClient, config)
+		quotaUsage, err = GetVMwareCloudDirectorResourceRequirements(ctx, userClient, config)
 	case types.CloudProviderAnexia:
 		quotaUsage, err = getAnexiaResourceRequirements(ctx, userClient, config)
 	case types.CloudProviderEquinixMetal, types.CloudProviderPacket:
@@ -571,7 +572,7 @@ func getDigitalOceanResourceRequirements(ctx context.Context, userClient ctrlrun
 	return NewResourceDetailsFromCapacity(capacity)
 }
 
-func getVMwareCloudDirectorResourceRequirements(ctx context.Context, userClient ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {
+func GetVMwareCloudDirectorResourceRequirements(ctx context.Context, userClient ctrlruntimeclient.Client, config *types.Config) (*ResourceDetails, error) {
 	rawConfig, err := vmwareclouddirectortypes.GetConfig(*config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get VMware Cloud Director raw config: %w", err)
@@ -592,6 +593,10 @@ func getVMwareCloudDirectorResourceRequirements(ctx context.Context, userClient 
 
 	if err := capacity.WithMemory(int(rawConfig.MemoryMB), "M"); err != nil {
 		return nil, fmt.Errorf("failed to parse memory size: %w", err)
+	}
+
+	if rawConfig.DiskSizeGB == nil {
+		return nil, errors.New("DiskSizeGB cannot be nil")
 	}
 
 	if err := capacity.WithStorage(int(*rawConfig.DiskSizeGB), "G"); err != nil {

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -34,16 +34,11 @@ import (
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockCtrlRuntimeClient is a mock implementation of ctrlruntimeclient.Client
 type MockCtrlRuntimeClient struct {
 	ctrlruntimeclient.Client
-	// Add fields to simulate internal state or return values here
 }
 
-// Implement methods of ctrlruntimeclient.Client that your function calls
-
 func TestGetVMwareCloudDirectorResourceRequirements(t *testing.T) {
-	// Example test case for successful path
 	testCases := []struct {
 		name        string
 		config      *types.Config

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -1,25 +1,25 @@
 //go:build ee
 
 /*
-		Kubermatic Enterprise Read-Only License
-		       Version 1.0 ("KERO-1.0”)
-		   Copyright © 2022 Kubermatic GmbH
+                  Kubermatic Enterprise Read-Only License
+                         Version 1.0 ("KERO-1.0”)
+                     Copyright © 2022 Kubermatic GmbH
 
-	 1. You may only view, read and display for studying purposes the source
-	    code of the software licensed under this license, and, to the extent
-	    explicitly provided under this license, the binary code.
-	 2. Any use of the software which exceeds the foregoing right, including,
-	    without limitation, its execution, compilation, copying, modification
-	    and distribution, is expressly prohibited.
-	 3. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
-	    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-	    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-	    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-	    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-	    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-	    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+   1.	You may only view, read and display for studying purposes the source
+      code of the software licensed under this license, and, to the extent
+      explicitly provided under this license, the binary code.
+   2.	Any use of the software which exceeds the foregoing right, including,
+      without limitation, its execution, compilation, copying, modification
+      and distribution, is expressly prohibited.
+   3.	THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+      IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+      CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+      TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+      SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-END OF TERMS AND CONDITIONS
+   END OF TERMS AND CONDITIONS
 */
 
 package machine

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -1,0 +1,81 @@
+package machine_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	vmwareclouddirectortypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vmwareclouddirector/types"
+	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+	"k8c.io/kubermatic/v2/pkg/ee/validation/machine"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// MockCtrlRuntimeClient is a mock implementation of ctrlruntimeclient.Client
+type MockCtrlRuntimeClient struct {
+	ctrlruntimeclient.Client
+	// Add fields to simulate internal state or return values here
+}
+
+// Implement methods of ctrlruntimeclient.Client that your function calls
+
+func TestGetVMwareCloudDirectorResourceRequirements(t *testing.T) {
+	// Example test case for successful path
+	testCases := []struct {
+		name        string
+		config      *types.Config
+		expectedErr bool
+	}{
+		{
+			name: "valid VMware configuration",
+			config: &types.Config{
+				CloudProvider:     types.CloudProviderVMwareCloudDirector,
+				CloudProviderSpec: genFakeVMWareSpec(4, 2048, 20),
+			},
+			expectedErr: false,
+		},
+		{
+			name: "Should fail with DiskSize not defined",
+			config: &types.Config{
+				CloudProvider:     types.CloudProviderVMwareCloudDirector,
+				CloudProviderSpec: genFakeVMWareSpec(4, 2048, 0),
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClient := &MockCtrlRuntimeClient{}
+			_, err := machine.GetVMwareCloudDirectorResourceRequirements(context.Background(), mockClient, tc.config)
+			if err != nil {
+				if !tc.expectedErr {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+
+			if err == nil && tc.expectedErr {
+				t.Fatal("expected error, got none")
+			}
+		})
+	}
+}
+
+func genFakeVMWareSpec(cpu, ram, disk int64) runtime.RawExtension {
+	var diskSize *int64
+
+	if disk != 0 {
+		diskSize = new(int64)
+		*diskSize = disk
+	}
+	vmwareconfig := &vmwareclouddirectortypes.RawConfig{
+		CPUs:       cpu,
+		MemoryMB:   ram,
+		DiskSizeGB: diskSize,
+	}
+	rawBytes, _ := json.Marshal(vmwareconfig)
+	return runtime.RawExtension{
+		Raw: rawBytes,
+	}
+}

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -21,6 +21,7 @@
 
 END OF TERMS AND CONDITIONS
 */
+
 package machine
 
 import (
@@ -30,6 +31,7 @@ import (
 
 	vmwareclouddirectortypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vmwareclouddirector/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -21,7 +21,7 @@
 
 END OF TERMS AND CONDITIONS
 */
-package machine_test
+package machine
 
 import (
 	"context"
@@ -30,7 +30,6 @@ import (
 
 	vmwareclouddirectortypes "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vmwareclouddirector/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
-	"k8c.io/kubermatic/v2/pkg/ee/validation/machine"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -71,7 +70,7 @@ func TestGetVMwareCloudDirectorResourceRequirements(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			mockClient := &MockCtrlRuntimeClient{}
-			_, err := machine.GetVMwareCloudDirectorResourceRequirements(context.Background(), mockClient, tc.config)
+			_, err := getVMwareCloudDirectorResourceRequirements(context.Background(), mockClient, tc.config)
 			if err != nil {
 				if !tc.expectedErr {
 					t.Fatalf("unexpected error: %v", err)

--- a/pkg/ee/validation/machine/providers_test.go
+++ b/pkg/ee/validation/machine/providers_test.go
@@ -1,3 +1,26 @@
+//go:build ee
+
+/*
+		Kubermatic Enterprise Read-Only License
+		       Version 1.0 ("KERO-1.0”)
+		   Copyright © 2022 Kubermatic GmbH
+
+	 1. You may only view, read and display for studying purposes the source
+	    code of the software licensed under this license, and, to the extent
+	    explicitly provided under this license, the binary code.
+	 2. Any use of the software which exceeds the foregoing right, including,
+	    without limitation, its execution, compilation, copying, modification
+	    and distribution, is expressly prohibited.
+	 3. THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+	    EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+	    IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+	    CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+	    TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+	    SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+END OF TERMS AND CONDITIONS
+*/
 package machine_test
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
When I tried to test ClusterTemplate for VMWare Cloud Provider from [sig-cs-infra](https://github.com/kubermatic/sig-cs-infra/blob/main/latest.snapshots.k8c.io/settings/cluster-templates/sig-vcloud.yaml). I figure out that in this template don't define a DiskSize. When We apply it and use it without DiskSize we will get a panic error.


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

This PR handles the DiskSize nil value and adds a unit test for providers resource requirements (Mainly testing VMWare Provider)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
