### PR TITLE
Update example base domain to kkp.example.com

### DIFF
--- a/charts/kubermatic.example.ce.yaml
+++ b/charts/kubermatic.example.ce.yaml
@@ -24,7 +24,7 @@ spec:
     # a disabled Ingress, this must always be a valid hostname.
     # this domain must match what you configured as dex.ingress.host
     # in the values.yaml
-    domain: cluster.example.dev
+    domain: kkp.example.com
     certificateIssuer:
       # APIGroup is the group for the resource being referenced.
       # If APIGroup is not specified, the specified Kind must be in the core API group.
@@ -44,7 +44,7 @@ spec:
     issuerClientID: kubermaticIssuer
     # When using letsencrypt-prod replace with "false"
     skipTokenIssuerTLSVerify: true
-    tokenIssuer: https://cluster.example.dev/dex
+    tokenIssuer: https://kkp.example.com/dex
 
     # This must match the secret configured for the kubermaticIssuer client from
     # the dex clients in values.yaml.

--- a/charts/kubermatic.example.ee.yaml
+++ b/charts/kubermatic.example.ee.yaml
@@ -34,7 +34,7 @@ spec:
     # a disabled Ingress, this must always be a valid hostname.
     # this domain must match what you configured as dex.ingress.host
     # in the values.yaml
-    domain: cluster.example.dev
+    domain: kkp.example.com
     certificateIssuer:
       # APIGroup is the group for the resource being referenced.
       # If APIGroup is not specified, the specified Kind must be in the core API group.
@@ -54,7 +54,7 @@ spec:
     issuerClientID: kubermaticIssuer
     # When using letsencrypt-prod replace with "false"
     skipTokenIssuerTLSVerify: true
-    tokenIssuer: https://cluster.example.dev/dex
+    tokenIssuer: https://kkp.example.com/dex
 
     # This must match the secret configured for the kubermaticIssuer client from
     # the dex clients in values.yaml.

--- a/charts/oauth/test/values.example.ce.yaml.out
+++ b/charts/oauth/test/values.example.ce.yaml.out
@@ -268,7 +268,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
-        checksum/config: d05f0723557402cffb219d4b52616a7fcfe59d82acc8bb7a75485cd3dd17a758
+        checksum/config: 2f2f2cf8ac475c122c30a0628af7671747766cdad171d2f87a37daa26ecb84b3
         checksum/secrets: 14780be2ecc3df3e4c622bcd96f0e8b79630d685e9580d082ed178d50f62d78a
     spec:
       serviceAccountName: dex

--- a/charts/oauth/test/values.example.ce.yaml.out
+++ b/charts/oauth/test/values.example.ce.yaml.out
@@ -102,7 +102,7 @@ metadata:
   name: dex
 data:
   config.yaml: |
-    issuer: "https://cluster.example.dev/dex"
+    issuer: "https://kkp.example.com/dex"
     oauth2:
       skipApprovalScreen: true
       responseTypes:
@@ -130,15 +130,15 @@ data:
 
     staticClients:
       - RedirectURIs:
-        - https://cluster.example.dev
-        - https://cluster.example.dev/projects
+        - https://kkp.example.com
+        - https://kkp.example.com/projects
         id: kubermatic
         name: Kubermatic
         secret: <a-random-key>
       - RedirectURIs:
-        - https://cluster.example.dev/api/v1/kubeconfig
-        - https://cluster.example.dev/api/v2/kubeconfig/secret
-        - https://cluster.example.dev/api/v2/dashboard/login
+        - https://kkp.example.com/api/v1/kubeconfig
+        - https://kkp.example.com/api/v2/kubeconfig/secret
+        - https://kkp.example.com/api/v2/dashboard/login
         id: kubermaticIssuer
         name: Kubermatic OIDC Issuer
         secret: <a-random-key>
@@ -352,14 +352,14 @@ spec:
   tls:
   - secretName: dex-tls
     hosts:
-    - cluster.example.dev
+    - kkp.example.com
   defaultBackend:
     service:
       name: dex
       port:
         number: 5556
   rules:
-  - host: cluster.example.dev
+  - host: kkp.example.com
     http:
       paths:
       - path: /dex

--- a/charts/oauth/test/values.example.ee.yaml.out
+++ b/charts/oauth/test/values.example.ee.yaml.out
@@ -268,7 +268,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '5558'
         kubermatic.io/chart: oauth
-        checksum/config: d05f0723557402cffb219d4b52616a7fcfe59d82acc8bb7a75485cd3dd17a758
+        checksum/config: 2f2f2cf8ac475c122c30a0628af7671747766cdad171d2f87a37daa26ecb84b3
         checksum/secrets: 14780be2ecc3df3e4c622bcd96f0e8b79630d685e9580d082ed178d50f62d78a
     spec:
       serviceAccountName: dex

--- a/charts/oauth/test/values.example.ee.yaml.out
+++ b/charts/oauth/test/values.example.ee.yaml.out
@@ -102,7 +102,7 @@ metadata:
   name: dex
 data:
   config.yaml: |
-    issuer: "https://cluster.example.dev/dex"
+    issuer: "https://kkp.example.com/dex"
     oauth2:
       skipApprovalScreen: true
       responseTypes:
@@ -130,15 +130,15 @@ data:
 
     staticClients:
       - RedirectURIs:
-        - https://cluster.example.dev
-        - https://cluster.example.dev/projects
+        - https://kkp.example.com
+        - https://kkp.example.com/projects
         id: kubermatic
         name: Kubermatic
         secret: <a-random-key>
       - RedirectURIs:
-        - https://cluster.example.dev/api/v1/kubeconfig
-        - https://cluster.example.dev/api/v2/kubeconfig/secret
-        - https://cluster.example.dev/api/v2/dashboard/login
+        - https://kkp.example.com/api/v1/kubeconfig
+        - https://kkp.example.com/api/v2/kubeconfig/secret
+        - https://kkp.example.com/api/v2/dashboard/login
         id: kubermaticIssuer
         name: Kubermatic OIDC Issuer
         secret: <a-random-key>
@@ -352,14 +352,14 @@ spec:
   tls:
   - secretName: dex-tls
     hosts:
-    - cluster.example.dev
+    - kkp.example.com
   defaultBackend:
     service:
       name: dex
       port:
         number: 5556
   rules:
-  - host: cluster.example.dev
+  - host: kkp.example.com
     http:
       paths:
       - path: /dex

--- a/charts/values.example.ce.yaml
+++ b/charts/values.example.ce.yaml
@@ -16,7 +16,7 @@
 dex:
   ingress:
     # configure your base domain, under which the Kubermatic dashboard shall be available
-    host: cluster.example.dev
+    host: kkp.example.com
 
   clients:
   # The "kubermatic" client is used for logging into the Kubermatic dashboard. It always
@@ -29,8 +29,8 @@ dex:
     secret: <a-random-key>
     RedirectURIs:
     # ensure the URLs below use the dex.ingress.host configured above
-    - https://cluster.example.dev
-    - https://cluster.example.dev/projects
+    - https://kkp.example.com
+    - https://kkp.example.com/projects
 
   # The "kubermaticIssuer" client is used for providing OIDC access to User Clusters.
   # This configuration is optional, used if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting.
@@ -43,9 +43,9 @@ dex:
     secret: <a-random-key>
     RedirectURIs:
       # ensure the URLs below use the dex.ingress.host configured above
-      - https://cluster.example.dev/api/v1/kubeconfig
-      - https://cluster.example.dev/api/v2/kubeconfig/secret
-      - https://cluster.example.dev/api/v2/dashboard/login
+      - https://kkp.example.com/api/v1/kubeconfig
+      - https://kkp.example.com/api/v2/kubeconfig/secret
+      - https://kkp.example.com/api/v2/dashboard/login
 
   # Depending on your chosen login method, you need to configure either an OAuth provider like
   # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`

--- a/charts/values.example.ee.yaml
+++ b/charts/values.example.ee.yaml
@@ -16,7 +16,7 @@
 dex:
   ingress:
     # configure your base domain, under which the Kubermatic dashboard shall be available
-    host: cluster.example.dev
+    host: kkp.example.com
 
   clients:
   # The "kubermatic" client is used for logging into the Kubermatic dashboard. It always
@@ -29,8 +29,8 @@ dex:
     secret: <a-random-key>
     RedirectURIs:
     # ensure the URLs below use the dex.ingress.host configured above
-    - https://cluster.example.dev
-    - https://cluster.example.dev/projects
+    - https://kkp.example.com
+    - https://kkp.example.com/projects
 
     # The "kubermaticIssuer" client is used for providing OIDC access to User Clusters.
     # This configuration is optional, used if the "enableOIDCKubeconfig: true" option is used in KubermaticSetting.
@@ -43,9 +43,9 @@ dex:
     secret: <a-random-key>
     RedirectURIs:
       # ensure the URLs below use the dex.ingress.host configured above
-      - https://cluster.example.dev/api/v1/kubeconfig
-      - https://cluster.example.dev/api/v2/kubeconfig/secret
-      - https://cluster.example.dev/api/v2/dashboard/login
+      - https://kkp.example.com/api/v1/kubeconfig
+      - https://kkp.example.com/api/v2/kubeconfig/secret
+      - https://kkp.example.com/api/v2/dashboard/login
 
   # Depending on your chosen login method, you need to configure either an OAuth provider like
   # Google or GitHub, or configure a set of static passwords. Check the `charts/oauth/values.yaml`


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the example base domain (from `cluster.example.dev` to `kkp.example.com`) in the bundled KKP configuration and values files, plus test values.yaml files.
Since found that `kkp.example.com` is been set in most of the charts values.yaml and sounds more closure to the KKP itself. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1632
```
