### PR TITLE
improve IPv6 compatibility in etcd-launcher

### DIFF
--- a/cmd/kubermatic-installer/cmd_local.go
+++ b/cmd/kubermatic-installer/cmd_local.go
@@ -448,7 +448,7 @@ func initKindSeedSecret(kubeClient ctrlruntimeclient.Client, logger *logrus.Logg
 		logger.Fatalf("Failed to initialize seed secret: %v", err)
 	}
 	addrRe := regexp.MustCompile(`([ ]*server:) https://127.0.0.1:[0-9]*`)
-	internalKubeconfig := addrRe.ReplaceAllString(string(k), fmt.Sprintf(`$1 https://%v:6443`, ip))
+	internalKubeconfig := addrRe.ReplaceAllString(string(k), fmt.Sprintf(`$1 https://%s`, net.JoinHostPort(ip, "6443")))
 
 	if err := os.WriteFile(internalKubeconfigPath, []byte(internalKubeconfig), 0600); err != nil {
 		logger.Fatalf("failed to write internal kubeconfig: %v", err)

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -92,7 +92,7 @@ func (h HelmTemplate) InstallOrUpgrade(chartLoc string, appDefinition *appskuber
 
 	values, err := applicationInstallation.Spec.GetParsedValues()
 	if err != nil {
-		return util.NoStatusUpdate, fmt.Errorf("failed to unmarshall values: %w", err)
+		return util.NoStatusUpdate, fmt.Errorf("failed to unmarshal values: %w", err)
 	}
 
 	helmRelease, err := helmClient.InstallOrUpgrade(chartLoc, getReleaseName(applicationInstallation), values, *deployOpts, auth)

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller.go
@@ -301,7 +301,7 @@ func (r *Reconciler) parseAppDefDefaultValues(ctx context.Context, cluster *kube
 	if appDef.Spec.DefaultValues != nil {
 		if len(appDef.Spec.DefaultValues.Raw) > 0 {
 			if err := json.Unmarshal(appDef.Spec.DefaultValues.Raw, &values); err != nil {
-				return fmt.Errorf("failed to unmarshall ApplicationDefinition default values: %w", err)
+				return fmt.Errorf("failed to unmarshal ApplicationDefinition default values: %w", err)
 			}
 		}
 	}
@@ -349,11 +349,11 @@ func ApplicationInstallationReconciler(cluster *kubermaticv1.Cluster, overwriteR
 				Duration: 60 * time.Minute, // reconcile the app periodically
 			}
 
-			// Unmarshall existing values
+			// Unmarshal existing values
 			values := make(map[string]any)
 			if len(app.Spec.Values.Raw) > 0 {
 				if err := json.Unmarshal(app.Spec.Values.Raw, &values); err != nil {
-					return app, fmt.Errorf("failed to unmarshall CNI values: %w", err)
+					return app, fmt.Errorf("failed to unmarshal CNI values: %w", err)
 				}
 			}
 

--- a/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/cni-application-installation-controller/controller_test.go
@@ -349,7 +349,7 @@ func getApplicationInstallationValues(userClusterClient ctrlruntimeclient.Client
 	}
 	values := make(map[string]any)
 	if err := json.Unmarshal(app.Spec.Values.Raw, &values); err != nil {
-		return nil, fmt.Errorf("failed to unmarshall CNI values: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal CNI values: %w", err)
 	}
 	return values, nil
 }

--- a/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
+++ b/pkg/controller/seed-controller-manager/initial-application-installation-controller/controller_test.go
@@ -386,7 +386,7 @@ func generateApplication(name string) apiv1.Application {
 	}`), &values)
 
 	if err != nil {
-		panic(fmt.Sprintf("can not unmarshall values: %v", err))
+		panic(fmt.Sprintf("can not unmarshal values: %v", err))
 	}
 
 	return apiv1.Application{

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller.go
@@ -178,7 +178,7 @@ func constraintReconcilerFactory(constraint *kubermaticv1.Constraint) reconcilin
 			}
 
 			// set Match
-			matchMap, err := unmarshallToJSONMap(&constraint.Spec.Match)
+			matchMap, err := unmarshalToJSONMap(&constraint.Spec.Match)
 			if err != nil {
 				return nil, err
 			}
@@ -202,7 +202,7 @@ func constraintReconcilerFactory(constraint *kubermaticv1.Constraint) reconcilin
 	}
 }
 
-func unmarshallToJSONMap(object interface{}) (map[string]interface{}, error) {
+func unmarshalToJSONMap(object interface{}) (map[string]interface{}, error) {
 	raw, err := json.Marshal(object)
 	if err != nil {
 		return nil, fmt.Errorf("error marshalling: %w", err)

--- a/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
+++ b/pkg/controller/user-cluster-controller-manager/constraint-syncer/controller_test.go
@@ -301,9 +301,9 @@ func TestReconcile(t *testing.T) {
 			}
 
 			// get match
-			matchMap, err := unmarshallToJSONMap(tc.expectedConstraint.Spec.Match)
+			matchMap, err := unmarshalToJSONMap(tc.expectedConstraint.Spec.Match)
 			if err != nil {
-				t.Fatalf("failed to unmarshall expected match: %v", err)
+				t.Fatalf("failed to unmarshal expected match: %v", err)
 			}
 			resultMatch, found, err := unstructured.NestedFieldNoCopy(reqLabel.Object, "spec", "match")
 			if err != nil || !found {

--- a/pkg/test/e2e/cilium/cilium_test.go
+++ b/pkg/test/e2e/cilium/cilium_test.go
@@ -252,7 +252,7 @@ func testUserCluster(ctx context.Context, t *testing.T, log *zap.SugaredLogger, 
 
 	log.Info("Testing Hubble relay observe...")
 	err = wait.PollLog(ctx, log, 2*time.Second, 5*time.Minute, func(ctx context.Context) (error, error) {
-		conn, err := grpc.Dial(fmt.Sprintf("%s:%d", nodeIP, 30077), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		conn, err := grpc.Dial(net.JoinHostPort(nodeIP, "30077"), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return fmt.Errorf("failed to dial to Hubble relay: %w", err), nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes the spots I could find by doing `ag --no-filename Sprintf | grep ":[^=]"`, plus a random typo.

Note that there is still

```go
fmt.Sprintf("https://$(POD_NAME).%s.%s.svc.cluster.local:2379,https://$(POD_IP):2379", resources.EtcdServiceName, cluster.Status.NamespaceName),
```

in the codebase, but it's the old etcd command code. Since we already deprecated it in favor of the etcd-launcher, I would say it's fine to say "IPv6 requires the etcd-launcher" because the necessary changes to rewrite the old command are IMHO not worth it.

**Which issue(s) this PR fixes**:
Fixes #13124

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix: Allow IPv6 IPs for etcd-launcher Pods
```

**Documentation**:
```documentation
NONE
```
