### PR TITLE
raise memory limit for envoy-agent DaemonSet

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -37,11 +37,11 @@ var (
 	defaultResourceRequirements = map[string]*corev1.ResourceRequirements{
 		resources.EnvoyAgentDaemonSetName: {
 			Requests: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("32Mi"),
-				corev1.ResourceCPU:    resource.MustParse("50m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceCPU:    resource.MustParse("100m"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceMemory: resource.MustParse("64Mi"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
 				corev1.ResourceCPU:    resource.MustParse("1"),
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Even in our small scale test cluster with 7 nodes, envoy-agent is already consuming 32MB, half of the limit. With larger clusters this can apparently rise quickly (according to the linked issue).

I searched around but could not find any recent documentation or official example manifests that give guidance on resource constraints, so I took the only thing I found: Kelsey Hightower's example from 7 years ago: https://github.com/kelseyhightower/kubernetes-envoy-sds/blob/master/daemonsets/envoy.yaml -- but fear not, our Envoy is from 2021, so the manifests are only 4 years older than our Envoy version.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13095

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Raise memory limit on envoy-agent from 64Mi to 512Mi to support larger user clusters.
```

**Documentation**:
```documentation
NONE
```
