### PR TITLE
Conformance Tester: add flatcar to supported OS list for GCP and VCD

### DIFF
--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -145,6 +145,49 @@ presubmits:
             limits:
               memory: 6Gi
 
+  - name: pre-kubermatic-e2e-gcp-flatcar-1.29
+    decorate: true
+    always_run: false
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-gce: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.29"
+            - name: PROVIDER
+              value: "gcp"
+            - name: DISTRIBUTIONS
+              value: flatcar
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi
   - name: pre-kubermatic-e2e-gcp-offline
     decorate: true
     clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -56,3 +56,47 @@ presubmits:
               cpu: 3.5
             limits:
               memory: 6Gi
+
+  - name: pre-kubermatic-e2e-vmware-cloud-director-flatcar-1.29
+    decorate: true
+    always_run: false
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-vcloud-director: "true"
+      preset-vault: "true"
+      preset-docker-mirror: "true"
+      preset-docker-pull: "true"
+      preset-docker-push: "true"
+      preset-repo-ssh: "true"
+      preset-e2e-ssh: "true"
+      preset-kubeconfig-ci: "true"
+      preset-kind-volume-mounts: "true"
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.22-node-18-kind-0.22-5
+          env:
+            - name: KUBERMATIC_EDITION
+              value: ee
+            - name: RELEASES_TO_TEST
+              value: "1.29"
+            - name: PROVIDER
+              value: "vmwareclouddirector"
+            - name: DISTRIBUTIONS
+              value: flatcar
+            - name: SERVICE_ACCOUNT_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: e2e-ci
+                  key: serviceAccountSigningKey
+          command:
+            - "./hack/ci/run-e2e-tests.sh"
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3.5
+            limits:
+              memory: 6Gi

--- a/cmd/conformance-tester/pkg/scenarios/google.go
+++ b/cmd/conformance-tester/pkg/scenarios/google.go
@@ -37,6 +37,7 @@ type googleScenario struct {
 func (s *googleScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
 	return sets.New[providerconfig.OperatingSystem](
 		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemFlatcar,
 	)
 }
 

--- a/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
+++ b/cmd/conformance-tester/pkg/scenarios/vmware_cloud_director.go
@@ -46,6 +46,7 @@ type vmwareCloudDirectorScenario struct {
 func (s *vmwareCloudDirectorScenario) compatibleOperatingSystems() sets.Set[providerconfig.OperatingSystem] {
 	return sets.New[providerconfig.OperatingSystem](
 		providerconfig.OperatingSystemUbuntu,
+		providerconfig.OperatingSystemFlatcar,
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Both GCP and VCD now support flatcar; updating the compatibility matrix for conformance tester accordingly.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
For reference https://github.com/kubermatic/kubermatic/issues/13158

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/cc @Skarlso