### PR TITLE
Fix default application upgrade issue

### DIFF
--- a/pkg/ee/default-application-catalog/applicationdefinitions/argocd-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/argocd-app.yaml
@@ -30,6 +30,13 @@ spec:
         source:
           helm:
             chartName: argo-cd
+            chartVersion: 5.5.12
+            url: https://argoproj.github.io/argo-helm
+      version: v2.4.14
+    - template:
+        source:
+          helm:
+            chartName: argo-cd
             chartVersion: 6.0.0
             url: https://argoproj.github.io/argo-helm
       version: v2.10.0

--- a/pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/cert-manager-app.yaml
@@ -30,6 +30,13 @@ spec:
       source:
         helm:
           chartName: cert-manager
+          chartVersion: v1.12.3
+          url: https://charts.jetstack.io
+    version: v1.12.3
+  - template:
+      source:
+        helm:
+          chartName: cert-manager
           chartVersion: v1.14.1
           url: https://charts.jetstack.io
     version: v1.14.1

--- a/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/falco-app.yaml
@@ -30,6 +30,13 @@ spec:
       source:
         helm:
           chartName: falco
+          chartVersion: 3.5.0
+          url: https://falcosecurity.github.io/charts
+    version: 0.35.1
+  - template:
+      source:
+        helm:
+          chartName: falco
           chartVersion: 4.1.1
           url: https://falcosecurity.github.io/charts
     version: 0.37.0

--- a/pkg/ee/default-application-catalog/applicationdefinitions/flux2-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/flux2-app.yaml
@@ -30,6 +30,13 @@ spec:
       source:
         helm:
           chartName: flux2
+          chartVersion: 2.9.2
+          url: https://fluxcd-community.github.io/helm-charts
+    version: 2.0.1
+  - template:
+      source:
+        helm:
+          chartName: flux2
           chartVersion: 2.12.2
           url: https://fluxcd-community.github.io/helm-charts
     version: 2.2.2

--- a/pkg/ee/default-application-catalog/applicationdefinitions/metallb-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/metallb-app.yaml
@@ -30,6 +30,13 @@ spec:
       source:
         helm:
           chartName: metallb
+          chartVersion: 0.13.10
+          url: https://metallb.github.io/metallb
+    version: v0.13.10
+  - template:
+      source:
+        helm:
+          chartName: metallb
           chartVersion: 0.14.3
           url: https://metallb.github.io/metallb
     version: v0.14.3

--- a/pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/nginx-app.yaml
@@ -30,6 +30,13 @@ spec:
       source:
         helm:
           chartName: ingress-nginx
+          chartVersion: 4.7.1
+          url: https://kubernetes.github.io/ingress-nginx
+    version: 1.8.1
+  - template:
+      source:
+        helm:
+          chartName: ingress-nginx
           chartVersion: 4.9.1
           url: https://kubernetes.github.io/ingress-nginx
     version: 1.9.6

--- a/pkg/ee/default-application-catalog/applicationdefinitions/trivy-operator-app.yaml
+++ b/pkg/ee/default-application-catalog/applicationdefinitions/trivy-operator-app.yaml
@@ -30,6 +30,13 @@ spec:
       source:
         helm:
           chartName: trivy-operator
+          chartVersion: 0.15.1
+          url: https://aquasecurity.github.io/helm-charts/
+    version: 0.15.1
+  - template:
+      source:
+        helm:
+          chartName: trivy-operator
           chartVersion: 0.20.5
           url: https://aquasecurity.github.io/helm-charts/
     version: 0.18.4


### PR DESCRIPTION
**What this PR does / why we need it**:
Retain the default applications version from previous minor KKP 2.24.x release to avoid accidental removal/deletion of the deployed applications during the KKP 2.25.x upgrade process. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes # https://github.com/kubermatic/kubermatic/issues/13143

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
