### PR TITLE
correctly identify defaulted values fields in AppInstalls

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_installation.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation.go
@@ -294,7 +294,7 @@ func (ai *ApplicationInstallationSpec) GetParsedValues() (map[string]interface{}
 	if len(ai.Values.Raw) > 0 && string(ai.Values.Raw) != "{}" && ai.ValuesBlock != "" {
 		return nil, fmt.Errorf("the fields Values and ValuesBlock cannot be used simultaneously. Please delete one of them.")
 	}
-	if len(ai.Values.Raw) > 0 {
+	if len(ai.Values.Raw) > 0 && string(ai.Values.Raw) != "{}" {
 		err := json.Unmarshal(ai.Values.Raw, &values)
 		return values, err
 	}

--- a/pkg/apis/apps.kubermatic/v1/application_installation_test.go
+++ b/pkg/apis/apps.kubermatic/v1/application_installation_test.go
@@ -46,7 +46,7 @@ func TestGetParsedValues(t *testing.T) {
 		},
 		"ValuesBlock set and Values Defaulted": {
 			appIn: ApplicationInstallationSpec{
-				Values:      runtime.RawExtension{},
+				Values:      runtime.RawExtension{Raw: []byte("{}")},
 				ValuesBlock: "not-empty:\n  value",
 			},
 			expResponse: map[string]interface{}{"not-empty": "value"},


### PR DESCRIPTION
**What this PR does / why we need it**:

I mistakenly assumed in the unit tests that "runtime.RawExtension{}" would be the same as the defaulting that k8s apiserver does. But what it actually does is unmarshal it at some point  resulting in the string `{}` to be used instead of it being completely empty. This updates our code and the corresponding test.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes an issue discovered during https://github.com/kubermatic/kubermatic/issues/13096

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
