### PR TITLE
[release/v2.24] Azure CCM upgrade for KKP 2.24

### DIFF
--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -138,7 +138,7 @@ func AzureCCMVersion(version semver.Semver) (string, error) {
 	case v128:
 		fallthrough
 	default:
-		return "1.28.0", nil
+		return "1.28.5", nil
 	}
 }
 

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -38,7 +38,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.0
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.5
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Azure CCM version is upgraded to work around Azure CCM issue https://github.com/kubernetes-sigs/cloud-provider-azure/issues/4823

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13168

**What type of PR is this?**
/kind bug
/kind chore
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:
This fix is needed only for v2.24 as v2.25 already uses new version of Azure CCM.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Azure CCM component version to v1.28.5 for user clusters with Kubernetes v1.28 from v1.28.0 address few LoadBalancer related issues found in some customer implementations.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
