### PR TITLE
add version labels to deployments managed by controllers

### DIFF
--- a/pkg/controller/operator/common/util.go
+++ b/pkg/controller/operator/common/util.go
@@ -179,6 +179,28 @@ func VolumeRevisionLabelsModifierFactory(ctx context.Context, client ctrlruntime
 	}
 }
 
+// VersionLabelModifierFactory adds the version label for Deployments and their corresponding pods.
+func VersionLabelModifierFactory(version string) reconciling.ObjectModifier {
+	return func(create reconciling.ObjectReconciler) reconciling.ObjectReconciler {
+		return func(existing ctrlruntimeclient.Object) (ctrlruntimeclient.Object, error) {
+			obj, err := create(existing)
+			if err != nil {
+				return obj, err
+			}
+
+			deployment, ok := obj.(*appsv1.Deployment)
+			if !ok {
+				return obj, nil
+			}
+
+			deployment.ObjectMeta.Labels[resources.VersionLabel] = version
+			deployment.Spec.Template.Labels[resources.VersionLabel] = version
+
+			return obj, nil
+		}
+	}
+}
+
 func createSecretData(s *corev1.Secret, data map[string]string) *corev1.Secret {
 	if s.Data == nil {
 		s.Data = make(map[string][]byte)

--- a/pkg/controller/operator/common/util.go
+++ b/pkg/controller/operator/common/util.go
@@ -190,9 +190,12 @@ func VersionLabelModifierFactory(version string) reconciling.ObjectModifier {
 
 			deployment, ok := obj.(*appsv1.Deployment)
 			if !ok {
-				return obj, nil
+				return obj, fmt.Errorf("VersionLabelModifier is only implemented for deployments, not %T", obj)
 			}
 
+			if deployment.ObjectMeta.Labels == nil {
+				deployment.ObjectMeta.Labels = make(map[string]string)
+			}
 			deployment.ObjectMeta.Labels[resources.VersionLabel] = version
 			deployment.Spec.Template.Labels[resources.VersionLabel] = version
 

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -342,6 +342,7 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, config *kubermati
 	modifiers := []reconciling.ObjectModifier{
 		common.OwnershipModifierFactory(config, r.scheme),
 		common.VolumeRevisionLabelsModifierFactory(ctx, r.Client),
+		common.VersionLabelModifierFactory(r.versions.Kubermatic),
 	}
 	// add the image pull secret wrapper only when an image pull secret is
 	// provided

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -569,6 +569,7 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, cfg *kubermaticv1
 	modifiers := []reconciling.ObjectModifier{
 		common.OwnershipModifierFactory(seed, r.scheme),
 		volumeLabelModifier,
+		common.VersionLabelModifierFactory(r.versions.Kubermatic),
 	}
 	// add the image pull secret wrapper only when an image pull secret is
 	// provided


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the version label to all deployments and pods that are owned by our controllers. This is required for a different task which needs this label to be in place to determine the currently deployed version of a component.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind cleanup

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
