### PR TITLE
Evictable pods & gentle label/annotation handling

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -59,6 +59,7 @@ aws-ebs-csi-driver:
 	  --set 'controller.k8sTagClusterId=\{{ "{{ .Cluster.Name }}" }}' \
 	  --set 'node.securityContext.seccompProfile.type=RuntimeDefault' \
 	  --set 'controller.securityContext.seccompProfile.type=RuntimeDefault' \
+	  --set 'controller.podAnnotations.cluster-autoscaler\.kubernetes\.io/safe-to-evict-local-volumes=socket-dir' \
 	  --api-versions 'policy/v1/PodDisruptionBudget' \
 	  --skip-tests \
 	  >> $(OUTPUT_FILE)

--- a/addons/Makefile
+++ b/addons/Makefile
@@ -25,7 +25,7 @@ hubble:
 	helm repo update
 	cat hubble/_header.txt > $(OUTPUT_FILE)
 	helm template cilium cilium/cilium \
-	  --version 1.12.2 \
+	  --version 1.12.13 \
 	  --namespace kube-system \
 	  --values values-hubble.yaml \
 	  >> $(OUTPUT_FILE)

--- a/addons/csi/aws-ebs/driver.yaml
+++ b/addons/csi/aws-ebs/driver.yaml
@@ -590,6 +590,8 @@ spec:
         app.kubernetes.io/version: "1.26.0"
         app.kubernetes.io/component: csi-driver
         app.kubernetes.io/managed-by: Helm
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
     spec:
       nodeSelector:
         kubernetes.io/os: linux

--- a/addons/csi/azure-disk/csi-azuredisk-controller.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-controller.yaml
@@ -19,6 +19,7 @@
 # - removal of tolerations
 # - set spec.replicas=1 since leader elections are configured
 # - mount cloud-config instead of using host path
+# - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
@@ -53,6 +54,8 @@ spec:
     metadata:
       labels:
         app: csi-azuredisk-controller
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
     spec:
       hostNetwork: true
       serviceAccountName: csi-azuredisk-controller-sa

--- a/addons/csi/azure-file/csi-azurefile-controller.yaml
+++ b/addons/csi/azure-file/csi-azurefile-controller.yaml
@@ -20,6 +20,7 @@
 # - removal of tolerations
 # - add security context
 # - mount cloud-config for credentials
+# - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
@@ -54,6 +55,8 @@ spec:
     metadata:
       labels:
         app: csi-azurefile-controller
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
     spec:
       hostNetwork: true  # only required for MSI enabled cluster
       serviceAccountName: csi-azurefile-controller-sa

--- a/addons/csi/digitalocean/csi-driver.yaml
+++ b/addons/csi/digitalocean/csi-driver.yaml
@@ -19,6 +19,7 @@
 # - add a securityContext
 # - add a dedicated secret for csi driver
 # - StorageClasses and VolumeSnapshotClasses have been moved to the default-storage-class addon
+# - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 
 {{ if eq .Cluster.CloudProviderName "digitalocean" }}
 
@@ -67,6 +68,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: csi-do-plugin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       labels:
         app: csi-do-controller
         role: csi-do

--- a/addons/csi/gcp/driver.yaml
+++ b/addons/csi/gcp/driver.yaml
@@ -483,6 +483,8 @@ spec:
       app: gcp-compute-persistent-disk-csi-driver
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:

--- a/addons/csi/hetzner/hcloud-csi.yaml
+++ b/addons/csi/hetzner/hcloud-csi.yaml
@@ -18,6 +18,7 @@
 # modifications:
 # - seccomp profile in DaemonSet hcloud-csi-node
 # - seccomp profile in Deployment hcloud-csi-controller
+# - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "hetzner" }}
@@ -313,6 +314,8 @@ spec:
         app.kubernetes.io/instance: hcloud-csi
         app.kubernetes.io/component: controller
         app: hcloud-csi-controller
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
     spec:
       serviceAccountName: hcloud-csi-controller
       securityContext:

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -22,6 +22,7 @@
 #  - add KKP CABundle
 #  - load cloud-config
 #  - add NetworkPolicy
+#  - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 #
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
@@ -60,6 +61,8 @@ spec:
     metadata:
       labels:
         app: csi-cinder-controllerplugin
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
     spec:
       serviceAccount: csi-cinder-controller-sa
       securityContext:

--- a/addons/csi/vsphere/csi-migration-webhook.yaml
+++ b/addons/csi/vsphere/csi-migration-webhook.yaml
@@ -75,6 +75,8 @@ spec:
       labels:
         app: csi-migration-webhook
         role: csi-migration-webhook
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
     spec:
       serviceAccountName: csi-migration-webhook
       containers:

--- a/addons/csi/vsphere/vsphere-csi-driver.yaml
+++ b/addons/csi/vsphere/vsphere-csi-driver.yaml
@@ -24,6 +24,7 @@
 #   - remove node selector for operator
 #   - set "improved-volume-topology": "false"
 #   - set "improved-csi-idempotency": "false"
+#   - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "vsphere" }}
@@ -237,6 +238,8 @@ spec:
       labels:
         app: vsphere-csi-controller
         role: vsphere-csi
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
     spec:
       priorityClassName: system-cluster-critical # Guarantees scheduling for critical system pods
       affinity:

--- a/addons/gcp-csi-driver-kustomization.yaml
+++ b/addons/gcp-csi-driver-kustomization.yaml
@@ -37,3 +37,10 @@ patches:
             type: RuntimeDefault
     target:
       kind: Deployment
+  - patch: |-
+      - op: add
+        path: /spec/template/metadata/annotations
+        value:
+          cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+    target:
+      kind: Deployment

--- a/addons/hubble/_header.txt
+++ b/addons/hubble/_header.txt
@@ -16,4 +16,6 @@
 # Run `make hubble` instead.
 
 {{ if eq .Cluster.CNIPlugin.Type "cilium" }}
-{{ if eq .Cluster.CNIPlugin.Version "v1.12" }}
+{{ if or (eq .Cluster.CNIPlugin.Version "v1.12") (hasPrefix "1.13" .Cluster.CNIPlugin.Version) }}
+# NOTE: 1.13 above allows proper uninstallation by the addon-controller by migration to Applications infra for Cilium CNI as of 1.13
+# We rely on KKP webhooks to make sure the migration is allowed only by upgrade from 1.12 to 1.13

--- a/addons/hubble/hubble_v1.12.yaml
+++ b/addons/hubble/hubble_v1.12.yaml
@@ -19,7 +19,6 @@
 {{ if or (eq .Cluster.CNIPlugin.Version "v1.12") (hasPrefix "1.13" .Cluster.CNIPlugin.Version) }}
 # NOTE: 1.13 above allows proper uninstallation by the addon-controller by migration to Applications infra for Cilium CNI as of 1.13
 # We rely on KKP webhooks to make sure the migration is allowed only by upgrade from 1.12 to 1.13
-
 ---
 # Source: cilium/templates/hubble-relay/serviceaccount.yaml
 apiVersion: v1
@@ -53,10 +52,10 @@ data:
     cluster-name: default
     peer-service: "hubble-peer.kube-system.svc.cluster.local:443"
     listen-address: :4245
-    dial-timeout: 
-    retry-timeout: 
-    sort-buffer-len-max: 
-    sort-buffer-drain-timeout: 
+    dial-timeout:
+    retry-timeout:
+    sort-buffer-len-max:
+    sort-buffer-drain-timeout:
     tls-client-cert-file: /var/lib/hubble-relay/tls/client.crt
     tls-client-key-file: /var/lib/hubble-relay/tls/client.key
     tls-hubble-server-ca-files: /var/lib/hubble-relay/tls/hubble-server-ca.crt
@@ -210,24 +209,6 @@ spec:
       port: 80
       targetPort: 8081
 ---
-# Source: cilium/templates/hubble/peer-service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: hubble-peer
-  namespace: kube-system
-  labels:
-    k8s-app: cilium
-spec:
-  selector:
-    k8s-app: cilium
-  ports:
-  - name: peer-service
-    port: 443
-    protocol: TCP
-    targetPort: 4244
-  internalTrafficPolicy: Local
----
 # Source: cilium/templates/hubble-relay/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -329,6 +310,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
       labels:
         k8s-app: hubble-ui
     spec:
@@ -348,11 +330,11 @@ spec:
         - name: http
           containerPort: 8081
         volumeMounts:
-          - name: hubble-ui-nginx-conf
-            mountPath: /etc/nginx/conf.d/default.conf
-            subPath: nginx.conf
-          - name: tmp-dir
-            mountPath: /tmp
+        - name: hubble-ui-nginx-conf
+          mountPath: /etc/nginx/conf.d/default.conf
+          subPath: nginx.conf
+        - name: tmp-dir
+          mountPath: /tmp
         terminationMessagePolicy: FallbackToLogsOnError
       - name: backend
         image: "{{ Image "quay.io/cilium/hubble-ui-backend:v0.11.0@sha256:14c04d11f78da5c363f88592abae8d2ecee3cbe009f443ef11df6ac5f692d839" }}"
@@ -381,7 +363,7 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: hubble-generate-certs-394f790584
+  name: hubble-generate-certs-c26869f410
   namespace: kube-system
   labels:
     k8s-app: hubble-generate-certs
@@ -458,5 +440,24 @@ spec:
           automountServiceAccountToken: true
           restartPolicy: OnFailure
       ttlSecondsAfterFinished: 1800
+---
+# Source: cilium/templates/hubble/peer-service.yaml
+# NOTE: missing if chart rendered with "agent: false"
+apiVersion: v1
+kind: Service
+metadata:
+  name: hubble-peer
+  namespace: kube-system
+  labels:
+    k8s-app: cilium
+spec:
+  selector:
+    k8s-app: cilium
+  ports:
+  - name: peer-service
+    port: 443
+    protocol: TCP
+    targetPort: 4244
+  internalTrafficPolicy: Local
 {{ end }}
 {{ end }}

--- a/addons/kube-state-metrics/pdb.yaml
+++ b/addons/kube-state-metrics/pdb.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-state-metrics

--- a/addons/values-hubble.yaml
+++ b/addons/values-hubble.yaml
@@ -26,6 +26,8 @@ hubble:
     enabled: true
   ui:
     enabled: true
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp-dir
 
 kubeProxyReplacement: strict
 agent: false

--- a/charts/backup/velero/templates/daemonset.yaml
+++ b/charts/backup/velero/templates/daemonset.yaml
@@ -31,6 +31,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: node-agent
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: scratch
     spec:
       containers:
       - name: node-agent

--- a/charts/backup/velero/templates/deployment.yaml
+++ b/charts/backup/velero/templates/deployment.yaml
@@ -33,6 +33,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "8085"
         kubermatic.io/chart: velero
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: plugins,scratch
 {{- with .Values.velero.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}

--- a/charts/minio/templates/deployment.yaml
+++ b/charts/minio/templates/deployment.yaml
@@ -31,6 +31,7 @@ spec:
         prometheus.io/port: "9000"
         prometheus.io/metrics_path: /minio/prometheus/metrics
         kubermatic.io/chart: minio
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: minio-backup
         {{- if .Values.minio.backup.enabled }}
         backup.velero.io/backup-volumes: minio-backup
         pre.hook.backup.velero.io/container: backup

--- a/charts/minio/test/enable-ingress.yaml.out
+++ b/charts/minio/test/enable-ingress.yaml.out
@@ -144,6 +144,7 @@ spec:
         prometheus.io/port: "9000"
         prometheus.io/metrics_path: /minio/prometheus/metrics
         kubermatic.io/chart: minio
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: minio-backup
         backup.velero.io/backup-volumes: minio-backup
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: 60m

--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -144,6 +144,7 @@ spec:
         prometheus.io/port: "9000"
         prometheus.io/metrics_path: /minio/prometheus/metrics
         kubermatic.io/chart: minio
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: minio-backup
         backup.velero.io/backup-volumes: minio-backup
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: 60m

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -145,6 +145,7 @@ spec:
         prometheus.io/port: "9000"
         prometheus.io/metrics_path: /minio/prometheus/metrics
         kubermatic.io/chart: minio
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: minio-backup
         backup.velero.io/backup-volumes: minio-backup
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: 60m

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -145,6 +145,7 @@ spec:
         prometheus.io/port: "9000"
         prometheus.io/metrics_path: /minio/prometheus/metrics
         kubermatic.io/chart: minio
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: minio-backup
         backup.velero.io/backup-volumes: minio-backup
         pre.hook.backup.velero.io/container: backup
         pre.hook.backup.velero.io/timeout: 60m

--- a/charts/mla/consul/test/config.yaml.out
+++ b/charts/mla/consul/test/config.yaml.out
@@ -265,6 +265,8 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         "consul.hashicorp.com/config-checksum": 0c3eb6ce33226c599419e7286c447e31765e9161fa21076f45af5b3036ae838f
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "extra-config"
+        
     spec:
       affinity:
         podAntiAffinity:

--- a/charts/mla/consul/test/default.yaml.out
+++ b/charts/mla/consul/test/default.yaml.out
@@ -265,6 +265,8 @@ spec:
       annotations:
         "consul.hashicorp.com/connect-inject": "false"
         "consul.hashicorp.com/config-checksum": 0c3eb6ce33226c599419e7286c447e31765e9161fa21076f45af5b3036ae838f
+        "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "extra-config"
+        
     spec:
       affinity:
         podAntiAffinity:

--- a/charts/mla/consul/values.yaml
+++ b/charts/mla/consul/values.yaml
@@ -635,7 +635,8 @@ consul:
     # ```
     #
     # @type: string
-    annotations: null
+    annotations: |
+      "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": "extra-config"
     # Server service properties.
     service:
       # Annotations to apply to the server service.
@@ -1451,7 +1452,7 @@ consul:
     # which can lead to hangs. In these environments it is recommend to use "Ignore" instead.
     # This setting can be safely disabled by setting to "Ignore".
     failurePolicy: "Fail"
-    # Selector for restricting the webhook to only specific namespaces. 
+    # Selector for restricting the webhook to only specific namespaces.
     # Use with `connectInject.default: true` to automatically inject all pods in namespaces that match the selector. This should be set to a multiline string.
     # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-namespaceselector
     # for more details.

--- a/charts/mla/cortex/test/config.yaml.out
+++ b/charts/mla/cortex/test/config.yaml.out
@@ -728,6 +728,7 @@ spec:
         app.kubernetes.io/part-of: memberlist
       annotations:
         checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -846,6 +847,7 @@ spec:
         app.kubernetes.io/component: querier
       annotations:
         checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1094,6 +1096,7 @@ spec:
         app.kubernetes.io/part-of: memberlist
       annotations:
         checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage,tmp
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1216,6 +1219,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: '9150'
         prometheus.io/scrape: "true"
     spec:
@@ -1346,6 +1350,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: '9150'
         prometheus.io/scrape: "true"
     spec:
@@ -1476,6 +1481,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: '9150'
         prometheus.io/scrape: "true"
     spec:

--- a/charts/mla/cortex/test/default.yaml.out
+++ b/charts/mla/cortex/test/default.yaml.out
@@ -728,6 +728,7 @@ spec:
         app.kubernetes.io/part-of: memberlist
       annotations:
         checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -846,6 +847,7 @@ spec:
         app.kubernetes.io/component: querier
       annotations:
         checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1094,6 +1096,7 @@ spec:
         app.kubernetes.io/part-of: memberlist
       annotations:
         checksum/config: 911b5b6fe52178872afd166bae86cf360898db35141c02e32be23c24954673df
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage,tmp
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
     spec:
@@ -1216,6 +1219,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: '9150'
         prometheus.io/scrape: "true"
     spec:
@@ -1346,6 +1350,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: '9150'
         prometheus.io/scrape: "true"
     spec:
@@ -1476,6 +1481,7 @@ spec:
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/managed-by: Helm
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
         prometheus.io/port: '9150'
         prometheus.io/scrape: "true"
     spec:

--- a/charts/mla/cortex/values.yaml
+++ b/charts/mla/cortex/values.yaml
@@ -35,12 +35,12 @@ cortex:
     limits:
       # Note: below defaults were changed by cortex from 0.7.0 to 1.7.0. So not keeping old defaults in upgrade to helm chart v2.1.0
       # enforce_metric_name: false
-      
-      # Note: max_query_lookback is limiting query only till 7 days. This is not needed. We should control storage via retention_period. 
+
+      # Note: max_query_lookback is limiting query only till 7 days. This is not needed. We should control storage via retention_period.
       # Query should be allowed to go back until last of storage.
       # ref: https://github.com/kubermatic/mla/commit/b49e93289fe013452ba4b4134f9da4ef7ef88df1
       # max_query_lookback: 168h
-      
+
       # Note: below were added for HA setup and stability of the cluster in kubermatic setup. So should be kept.
       accept_ha_samples: true
       max_label_names_per_series: 40
@@ -177,6 +177,8 @@ cortex:
             name: minio
             key: rootPassword
   distributor:
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -238,6 +240,8 @@ cortex:
     extraArgs:
       ruler-storage.s3.access-key-id: $(ACCESS_KEY)
       ruler-storage.s3.secret-access-key: $(SECRET_KEY)
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage,tmp
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -264,6 +268,8 @@ cortex:
     extraArgs:
       blocks-storage.s3.access-key-id: $(ACCESS_KEY)
       blocks-storage.s3.secret-access-key: $(SECRET_KEY)
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: storage
     extraVolumes:
       - name: cortex-runtime-config
         configMap:
@@ -338,18 +344,24 @@ cortex:
         name: "cortex-runtime-config"
   memcached-blocks-index:
     enabled: true
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     # Note: this is specifically customized in kubermatic. So keeping it that way.
     resources:
       requests:
         cpu: 5m
   memcached-blocks:
     enabled: true
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     # Note: this is specifically customized in kubermatic. So keeping it that way.
     resources:
       requests:
         cpu: 5m
   memcached-blocks-metadata:
     enabled: true
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     # Note: this is specifically customized in kubermatic. So keeping it that way.
     resources:
       requests:

--- a/charts/mla/loki-distributed/test/config.yaml.out
+++ b/charts/mla/loki-distributed/test/config.yaml.out
@@ -891,6 +891,7 @@ spec:
     metadata:
       annotations:
         checksum/config: c1c01847f718c05c33ebbe772556d082801a709e80b7b986ec56f5dd1b5fcb48
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data,tmp
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
       labels:
@@ -1015,6 +1016,7 @@ spec:
     metadata:
       annotations:
         checksum/config: c1c01847f718c05c33ebbe772556d082801a709e80b7b986ec56f5dd1b5fcb48
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
       labels:
@@ -1135,6 +1137,7 @@ spec:
     metadata:
       annotations:
         checksum/config: c1c01847f718c05c33ebbe772556d082801a709e80b7b986ec56f5dd1b5fcb48
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data,temp
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
       labels:

--- a/charts/mla/loki-distributed/test/default.yaml.out
+++ b/charts/mla/loki-distributed/test/default.yaml.out
@@ -891,6 +891,7 @@ spec:
     metadata:
       annotations:
         checksum/config: c1c01847f718c05c33ebbe772556d082801a709e80b7b986ec56f5dd1b5fcb48
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data,tmp
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
       labels:
@@ -1015,6 +1016,7 @@ spec:
     metadata:
       annotations:
         checksum/config: c1c01847f718c05c33ebbe772556d082801a709e80b7b986ec56f5dd1b5fcb48
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
       labels:
@@ -1135,6 +1137,7 @@ spec:
     metadata:
       annotations:
         checksum/config: c1c01847f718c05c33ebbe772556d082801a709e80b7b986ec56f5dd1b5fcb48
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data,temp
         prometheus.io/port: "3100"
         prometheus.io/scrape: "true"
       labels:

--- a/charts/mla/loki-distributed/values.yaml
+++ b/charts/mla/loki-distributed/values.yaml
@@ -115,6 +115,7 @@ loki-distributed:
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "3100"
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
     extraArgs:
       - -s3.access-key-id=$(rootUser)
       - -s3.secret-access-key=$(rootPassword)
@@ -128,6 +129,7 @@ loki-distributed:
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "3100"
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data,temp
     extraArgs:
       - -s3.access-key-id=$(rootUser)
       - -s3.secret-access-key=$(rootPassword)
@@ -139,6 +141,7 @@ loki-distributed:
     podAnnotations:
       prometheus.io/scrape: "true"
       prometheus.io/port: "3100"
+      cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data,tmp
     extraArgs:
       - -ruler.storage.s3.access-key-id=$(rootUser)
       - -ruler.storage.s3.secret-access-key=$(rootPassword)

--- a/charts/monitoring/grafana/templates/deployment.yaml
+++ b/charts/monitoring/grafana/templates/deployment.yaml
@@ -29,6 +29,7 @@ spec:
         app: grafana
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps.yaml") . | sha256sum }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: grafana-storage,grafana-datasources
     spec:
       {{- if .Values.grafana.imagePullSecrets }}
       imagePullSecrets: {{- toYaml .Values.grafana.imagePullSecrets | nindent 8 }}

--- a/charts/monitoring/karma/templates/deployment.yaml
+++ b/charts/monitoring/karma/templates/deployment.yaml
@@ -34,6 +34,7 @@ spec:
       annotations:
         fluentbit.io/parser: json_iso
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") $ | sha1sum }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: shared-config
     spec:
       serviceAccountName: '{{ template "name" .}}'
       {{- if .Values.karma.imagePullSecrets }}

--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -38,6 +38,7 @@ spec:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9090'
         kubermatic.io/chart: prometheus
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: backup
         {{- if .Values.prometheus.backup.enabled }}
         backup.velero.io/backup-volumes: backup
         pre.hook.backup.velero.io/container: backup

--- a/charts/s3-exporter/templates/pdb.yaml
+++ b/charts/s3-exporter/templates/pdb.yaml
@@ -1,0 +1,24 @@
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: s3-exporter
+  namespace: {{ .Release.Namespace }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: s3-exporter

--- a/pkg/controller/operator/common/vpa/recommender.go
+++ b/pkg/controller/operator/common/vpa/recommender.go
@@ -27,7 +27,9 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
 
@@ -108,6 +110,19 @@ func RecommenderDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, 
 			}
 
 			return d, nil
+		}
+	}
+}
+
+func RecommenderPDBReconciler() reconciling.NamedPodDisruptionBudgetReconcilerFactory {
+	maxUnavailable := intstr.FromInt(1)
+	return func() (string, reconciling.PodDisruptionBudgetReconciler) {
+		return RecommenderName, func(pdb *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, error) {
+			pdb.Spec.MaxUnavailable = &maxUnavailable
+			pdb.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: appPodLabels(RecommenderName),
+			}
+			return pdb, nil
 		}
 	}
 }

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -588,7 +588,7 @@ func (r *Reconciler) reconcileDeployments(ctx context.Context, cfg *kubermaticv1
 			vpa.AdmissionControllerDeploymentReconciler(cfg, r.versions),
 		}
 
-		// no ownership because these resources are most likely in a different namespace than Kubermatic
+		// no ownership because these resources are not in the kubermatic namespace
 		if err := reconciling.ReconcileDeployments(ctx, creators, metav1.NamespaceSystem, client, volumeLabelModifier); err != nil {
 			return fmt.Errorf("failed to reconcile VPA Deployments: %w", err)
 		}
@@ -626,6 +626,19 @@ func (r *Reconciler) reconcilePodDisruptionBudgets(ctx context.Context, cfg *kub
 		return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %w", err)
 	}
 
+	if cfg.Spec.FeatureGates[features.VerticalPodAutoscaler] {
+		creators = append(creators,
+			vpa.RecommenderPDBReconciler(),
+			vpa.UpdaterPDBReconciler(),
+			vpa.AdmissionControllerPDBReconciler(),
+		)
+
+		// no ownership because these resources are not in the kubermatic namespace
+		if err := reconciling.ReconcilePodDisruptionBudgets(ctx, creators, metav1.NamespaceSystem, client); err != nil {
+			return fmt.Errorf("failed to reconcile PodDisruptionBudgets: %w", err)
+		}
+	}
+
 	return nil
 }
 
@@ -658,7 +671,7 @@ func (r *Reconciler) reconcileServices(ctx context.Context, cfg *kubermaticv1.Ku
 			vpa.AdmissionControllerServiceReconciler(),
 		}
 
-		// no ownership because these resources are most likely in a different namespace than Kubermatic
+		// no ownership because these resources are not in the kubermatic namespace
 		if err := reconciling.ReconcileServices(ctx, creators, metav1.NamespaceSystem, client); err != nil {
 			return fmt.Errorf("failed to reconcile VPA Services: %w", err)
 		}

--- a/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_test.go
@@ -364,7 +364,6 @@ func (k KCMDeploymentConfig) Create(td *resources.TemplateData) *appsv1.Deployme
 		},
 		Status: k.Status,
 	}
-	wrappedPodSpec, _ := apiserver.IsRunningWrapper(td, d.Spec.Template.Spec, sets.New(resources.ControllerManagerDeploymentName))
-	d.Spec.Template.Spec = *wrappedPodSpec
+	d.Spec.Template, _ = apiserver.IsRunningWrapper(td, d.Spec.Template, sets.New(resources.ControllerManagerDeploymentName))
 	return &d
 }

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/mla/monitoring-agent/deployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -82,7 +83,12 @@ func DeploymentReconciler(overrides *corev1.ResourceRequirements, replicas *int3
 			if replicas != nil {
 				deployment.Spec.Replicas = replicas
 			}
-			deployment.Spec.Template.ObjectMeta.Labels = controllerLabels
+
+			kubernetes.EnsureLabels(&deployment.Spec.Template, controllerLabels)
+			kubernetes.EnsureAnnotations(&deployment.Spec.Template, map[string]string{
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: storageVolumeName,
+			})
+
 			deployment.Spec.Template.Spec.ServiceAccountName = resources.MLAMonitoringAgentServiceAccountName
 			deployment.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 				RunAsUser:    ptr.To[int64](65534),

--- a/pkg/ee/kubelb/resources/seed-cluster/deployment.go
+++ b/pkg/ee/kubelb/resources/seed-cluster/deployment.go
@@ -91,11 +91,10 @@ func DeploymentReconciler(data kubeLBData) reconciling.NamedDeploymentReconciler
 				return nil, err
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, deployment.Spec.Template.Spec, sets.New(resources.KubeLBDeploymentName))
+			deployment.Spec.Template, err = apiserver.IsRunningWrapper(data, deployment.Spec.Template, sets.New(resources.KubeLBDeploymentName))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			deployment.Spec.Template.Spec = *wrappedPodSpec
 
 			return deployment, nil
 		}

--- a/pkg/kubernetes/helper.go
+++ b/pkg/kubernetes/helper.go
@@ -395,6 +395,34 @@ func EnsureLabels(o metav1.Object, toEnsure map[string]string) {
 	o.SetLabels(labels)
 }
 
+func EnsureAnnotations(o metav1.Object, toEnsure map[string]string) {
+	annotations := o.GetAnnotations()
+
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	for key, value := range toEnsure {
+		annotations[key] = value
+	}
+	o.SetAnnotations(annotations)
+}
+
+func EnsureAnnotationContains(o metav1.Object, annotation string, separator string, toEnsure ...string) {
+	values := sets.New[string]()
+
+	existing, ok := o.GetAnnotations()[annotation]
+	if ok {
+		parts := strings.Split(existing, separator)
+		values.Insert(parts...)
+	}
+
+	values.Insert(toEnsure...)
+
+	EnsureAnnotations(o, map[string]string{
+		annotation: strings.Join(sets.List(values), separator),
+	})
+}
+
 type SeedClientMap map[string]ctrlruntimeclient.Client
 
 type SeedVisitorFunc func(seedName string, seedClient ctrlruntimeclient.Client, log *zap.SugaredLogger) error

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -97,12 +97,16 @@ func DeploymentReconciler(data *resources.TemplateData, enableOIDCAuthentication
 
 			address := data.Cluster().Status.Address
 
+			// these volumes should not block the autoscaler from evicting the pod
+			safeToEvictVolumes := []string{resources.AuditLogVolumeName, resources.KonnectivityUDS}
+
 			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 				Labels: podLabels,
 				Annotations: map[string]string{
-					"prometheus.io/scrape_with_kube_cert": "true",
-					"prometheus.io/path":                  "/metrics",
-					"prometheus.io/port":                  fmt.Sprint(address.Port),
+					"prometheus.io/scrape_with_kube_cert":                   "true",
+					"prometheus.io/path":                                    "/metrics",
+					"prometheus.io/port":                                    fmt.Sprint(address.Port),
+					resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: strings.Join(safeToEvictVolumes, ","),
 				},
 			}
 

--- a/pkg/resources/apiserver/is-running.go
+++ b/pkg/resources/apiserver/is-running.go
@@ -20,10 +20,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	httpproberapi "k8c.io/kubermatic/v2/cmd/http-prober/api"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
@@ -58,18 +58,7 @@ func IsRunningWrapper(data isRunningInitContainerData, specTemplate corev1.PodTe
 
 	// add the temp volume to the list of non-blocking volumes
 	annotation := resources.ClusterAutoscalerSafeToEvictVolumesAnnotation
-	safeVolumes := sets.New(emptyDirVolumeName)
-
-	existing, ok := specTemplate.Annotations[annotation]
-	if ok {
-		parts := strings.Split(existing, ",")
-		safeVolumes.Insert(parts...)
-	}
-
-	if specTemplate.Annotations == nil {
-		specTemplate.Annotations = map[string]string{}
-	}
-	specTemplate.Annotations[annotation] = strings.Join(sets.List(safeVolumes), ",")
+	kubernetes.EnsureAnnotationContains(&specTemplate, annotation, ",", emptyDirVolumeName)
 
 	return specTemplate, nil
 }

--- a/pkg/resources/apiserver/service.go
+++ b/pkg/resources/apiserver/service.go
@@ -63,9 +63,7 @@ func ServiceReconciler(exposeStrategy kubermaticv1.ExposeStrategy, externalURL s
 				return nil, fmt.Errorf("unsupported expose strategy: %q", exposeStrategy)
 			}
 
-			se.Spec.Selector = map[string]string{
-				resources.AppLabelKey: name,
-			}
+			se.Spec.Selector = resources.BaseAppLabels(name, nil)
 
 			if len(se.Spec.Ports) == 0 {
 				se.Spec.Ports = []corev1.ServicePort{

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -28,7 +29,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
@@ -53,22 +53,14 @@ var (
 func azureDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return AzureCCMDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = AzureCCMDeploymentName
-			dep.Labels = resources.BaseAppLabels(AzureCCMDeploymentName, nil)
 			dep.Spec.Replicas = resources.Int32(1)
 
-			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(OpenstackCCMDeploymentName, nil),
-			}
-
-			podLabels, err := data.GetPodTemplateLabels(OpenstackCCMDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
+			podLabels, err := data.GetPodTemplateLabels(AzureCCMDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
 				return nil, err
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
 				resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/cloudcontroller/deployment.go
+++ b/pkg/resources/cloudcontroller/deployment.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/vpnsidecar"
@@ -28,6 +29,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -93,6 +95,13 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 				modified, err := creator(dep)
 				if err != nil {
 					return nil, err
+				}
+
+				baseLabels := resources.BaseAppLabels(name, nil)
+				kubernetes.EnsureLabels(modified, baseLabels)
+
+				modified.Spec.Selector = &metav1.LabelSelector{
+					MatchLabels: baseLabels,
 				}
 
 				containerNames := sets.New(ccmContainerName)

--- a/pkg/resources/cloudcontroller/deployment.go
+++ b/pkg/resources/cloudcontroller/deployment.go
@@ -108,11 +108,10 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 					containerNames.Insert(openvpnSidecar.Name)
 				}
 
-				wrappedPodSpec, err := apiserver.IsRunningWrapper(data, modified.Spec.Template.Spec, containerNames)
+				modified.Spec.Template, err = apiserver.IsRunningWrapper(data, modified.Spec.Template, containerNames)
 				if err != nil {
 					return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 				}
-				modified.Spec.Template.Spec = *wrappedPodSpec
 
 				return modified, nil
 			}

--- a/pkg/resources/cloudcontroller/digitalocean.go
+++ b/pkg/resources/cloudcontroller/digitalocean.go
@@ -19,6 +19,7 @@ package cloudcontroller
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -27,7 +28,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -51,22 +51,14 @@ var (
 func digitalOceanDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return DigitalOceanCCMDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = DigitalOceanCCMDeploymentName
-			dep.Labels = resources.BaseAppLabels(DigitalOceanCCMDeploymentName, nil)
 			dep.Spec.Replicas = resources.Int32(1)
-
-			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(DigitalOceanCCMDeploymentName, nil),
-			}
 
 			podLabels, err := data.GetPodTemplateLabels(DigitalOceanCCMDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
 				return nil, err
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
 				resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/cloudcontroller/gcp.go
+++ b/pkg/resources/cloudcontroller/gcp.go
@@ -69,6 +69,9 @@ func gcpDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDepl
 			}
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "scratch",
+			})
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
 				resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/cloudcontroller/gcp.go
+++ b/pkg/resources/cloudcontroller/gcp.go
@@ -19,6 +19,7 @@ package cloudcontroller
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -27,7 +28,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
@@ -61,22 +61,14 @@ var (
 func gcpDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return GCPCCMDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Labels = resources.BaseAppLabels(GCPCCMDeploymentName, nil)
-
 			dep.Spec.Replicas = resources.Int32(1)
-
-			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(GCPCCMDeploymentName, nil),
-			}
 
 			podLabels, err := data.GetPodTemplateLabels(GCPCCMDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
 				return nil, err
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
 				resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/cloudcontroller/kubevirt.go
+++ b/pkg/resources/cloudcontroller/kubevirt.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -27,7 +28,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -52,23 +52,14 @@ var (
 func kubevirtDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return KubeVirtCCMDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = KubeVirtCCMDeploymentName
-			dep.Labels = resources.BaseAppLabels(KubeVirtCCMDeploymentName, nil)
-
 			dep.Spec.Replicas = resources.Int32(1)
-
-			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(KubeVirtCCMDeploymentName, nil),
-			}
 
 			podLabels, err := data.GetPodTemplateLabels(KubeVirtCCMDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
 				return nil, err
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
 				resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/cloudcontroller/openstack.go
+++ b/pkg/resources/cloudcontroller/openstack.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -28,7 +29,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -52,23 +52,14 @@ var (
 func openStackDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return OpenstackCCMDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = OpenstackCCMDeploymentName
-			dep.Labels = resources.BaseAppLabels(OpenstackCCMDeploymentName, nil)
-
 			dep.Spec.Replicas = resources.Int32(1)
-
-			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(OpenstackCCMDeploymentName, nil),
-			}
 
 			podLabels, err := data.GetPodTemplateLabels(OpenstackCCMDeploymentName, dep.Spec.Template.Spec.Volumes, nil)
 			if err != nil {
 				return nil, err
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
 				resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -18,6 +18,7 @@ package cloudcontroller
 
 import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/semver"
@@ -26,7 +27,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -50,13 +50,6 @@ var (
 func vsphereDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return VSphereCCMDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = VSphereCCMDeploymentName
-			dep.Labels = resources.BaseAppLabels(VSphereCCMDeploymentName, nil)
-
-			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(VSphereCCMDeploymentName, nil),
-			}
-
 			podLabels, err := data.GetPodTemplateLabels(VSphereCCMDeploymentName, dep.Spec.Template.Spec.Volumes, map[string]string{
 				"component": "cloud-controller-manager",
 				"tier":      "control-plane",
@@ -64,9 +57,8 @@ func vsphereDeploymentReconciler(data *resources.TemplateData) reconciling.Named
 			if err != nil {
 				return nil, err
 			}
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err =
 				resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -198,11 +198,10 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -23,6 +23,7 @@ import (
 	semverlib "github.com/Masterminds/semver/v3"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudconfig"
@@ -60,8 +61,8 @@ const (
 func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.ControllerManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = resources.ControllerManagerDeploymentName
-			dep.Labels = resources.BaseAppLabels(name, nil)
+			baseLabels := resources.BaseAppLabels(name, nil)
+			kubernetes.EnsureLabels(dep, baseLabels)
 
 			version := data.Cluster().Status.Versions.ControllerManager.Semver()
 
@@ -76,7 +77,7 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 			}
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(name, nil),
+				MatchLabels: baseLabels,
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
@@ -102,14 +103,12 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 				return nil, err
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-				Annotations: map[string]string{
-					"prometheus.io/path":                  "/metrics",
-					"prometheus.io/scrape_with_kube_cert": "true",
-					"prometheus.io/port":                  "10257",
-				},
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				"prometheus.io/path":                  "/metrics",
+				"prometheus.io/scrape_with_kube_cert": "true",
+				"prometheus.io/port":                  "10257",
+			})
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)
 			if err != nil {

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -115,6 +115,10 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 			}
 
 			kubernetes.EnsureLabels(&set.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&set.Spec.Template, map[string]string{
+				// these volumes should not block the autoscaler from evicting the pod
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "launcher",
+			})
 
 			etcdEnv := []corev1.EnvVar{
 				{

--- a/pkg/resources/konnectivity/proxyservice.go
+++ b/pkg/resources/konnectivity/proxyservice.go
@@ -33,9 +33,8 @@ import (
 func ServiceReconciler(exposeStrategy kubermaticv1.ExposeStrategy, externalURL string) reconciling.NamedServiceReconcilerFactory {
 	return func() (string, reconciling.ServiceReconciler) {
 		return resources.KonnectivityProxyServiceName, func(se *corev1.Service) (*corev1.Service, error) {
-			se.Spec.Selector = map[string]string{
-				resources.AppLabelKey: "apiserver", // because konnectivity proxy runs in sidecar in apiserver pod
-			}
+			// because konnectivity proxy runs in sidecar in apiserver pod
+			se.Spec.Selector = resources.BaseAppLabels(resources.ApiserverDeploymentName, nil)
 
 			if se.Annotations == nil {
 				se.Annotations = make(map[string]string)

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -102,11 +102,10 @@ func DeploymentReconciler(data kubernetesDashboardData) reconciling.NamedDeploym
 			}
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -132,11 +132,10 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -81,11 +81,10 @@ func DeploymentReconciler(data machinecontrollerData) reconciling.NamedDeploymen
 			if err != nil {
 				return nil, err
 			}
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, deployment.Spec.Template.Spec, sets.New(Name), "cluster.k8s.io,v1alpha1,machines,kube-system")
+			deployment.Spec.Template, err = apiserver.IsRunningWrapper(data, deployment.Spec.Template, sets.New(Name), "cluster.k8s.io,v1alpha1,machines,kube-system")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			deployment.Spec.Template.Spec = *wrappedPodSpec
 
 			return deployment, nil
 		}

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -175,11 +175,10 @@ func WebhookDeploymentReconciler(data machinecontrollerData) reconciling.NamedDe
 
 			dep.Spec.Template.Spec.ServiceAccountName = webhookServiceAccountName
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(Name), "Machine,cluster.k8s.io/v1alpha1")
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(Name), "Machine,cluster.k8s.io/v1alpha1")
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -206,11 +206,10 @@ func DeploymentReconciler(data metricsServerData) reconciling.NamedDeploymentRec
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/servingcerthelper"
@@ -88,12 +89,12 @@ func TLSServingCertSecretReconciler(caGetter servingcerthelper.CAGetter) reconci
 func DeploymentReconciler(data metricsServerData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.MetricsServerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = resources.MetricsServerDeploymentName
-			dep.Labels = resources.BaseAppLabels(name, nil)
+			baseLabels := resources.BaseAppLabels(name, nil)
+			kubernetes.EnsureLabels(dep, baseLabels)
 
 			dep.Spec.Replicas = resources.Int32(2)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(name, nil),
+				MatchLabels: baseLabels,
 			}
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 
@@ -103,9 +104,7 @@ func DeploymentReconciler(data metricsServerData) reconciling.NamedDeploymentRec
 				return nil, fmt.Errorf("failed to create pod labels: %w", err)
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 
 			dep.Spec.Template.Spec.Volumes = volumes
 

--- a/pkg/resources/metrics-server/service.go
+++ b/pkg/resources/metrics-server/service.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metricsserver
 
 import (
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -28,11 +29,10 @@ import (
 func ServiceReconciler() reconciling.NamedServiceReconcilerFactory {
 	return func() (string, reconciling.ServiceReconciler) {
 		return resources.MetricsServerServiceName, func(se *corev1.Service) (*corev1.Service, error) {
-			se.Name = resources.MetricsServerServiceName
-			labels := resources.BaseAppLabels(name, nil)
-			se.Labels = labels
+			baseLabels := resources.BaseAppLabels(name, nil)
+			kubernetes.EnsureLabels(se, baseLabels)
 
-			se.Spec.Selector = labels
+			se.Spec.Selector = baseLabels
 			se.Spec.Ports = []corev1.ServicePort{
 				{
 					Port:       443,

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -212,6 +212,11 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 			}
 
 			kubernetes.EnsureLabels(&d.Spec.Template, baseLabels)
+			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
+				// these volumes should not block the autoscaler from evicting the pod
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: volumeMountNameEnvoyConfig,
+			})
+
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 			}

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -202,12 +203,15 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 	volumeMountNameEnvoyConfig := "envoy-config"
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.NodePortProxyEnvoyDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d.Name = resources.NodePortProxyEnvoyDeploymentName
-			d.Labels = resources.BaseAppLabels(envoyAppLabelValue, nil)
+			baseLabels := resources.BaseAppLabels(envoyAppLabelValue, nil)
+			kubernetes.EnsureLabels(d, baseLabels)
+
 			d.Spec.Replicas = resources.Int32(2)
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(envoyAppLabelValue, nil)}
-			d.Spec.Template.Labels = resources.BaseAppLabels(envoyAppLabelValue, nil)
+				MatchLabels: baseLabels,
+			}
+
+			kubernetes.EnsureLabels(&d.Spec.Template, baseLabels)
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
 				{Name: resources.ImagePullSecretName},
 			}

--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -112,6 +112,8 @@ func DeploymentReconciler(data openVPNDeploymentReconcilerData) reconciling.Name
 				"prometheus.io/path":   "/metrics",
 				"prometheus.io/port":   fmt.Sprintf("%d", exporterPort),
 				"prometheus.io/scrape": "true",
+				// these volumes should not block the autoscaler from evicting the pod
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "openvpn-status",
 			})
 
 			_, podNet, err := net.ParseCIDR(data.Cluster().Spec.ClusterNetwork.Pods.CIDRBlocks[0])

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -26,6 +26,7 @@ import (
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -98,12 +99,12 @@ func DeploymentReconciler(data operatingSystemManagerData) reconciling.NamedDepl
 func DeploymentReconcilerWithoutInitWrapper(data operatingSystemManagerData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.OperatingSystemManagerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = resources.OperatingSystemManagerDeploymentName
-			dep.Labels = resources.BaseAppLabels(Name, nil)
+			baseLabels := resources.BaseAppLabels(Name, nil)
+			kubernetes.EnsureLabels(dep, baseLabels)
 
 			dep.Spec.Replicas = resources.Int32(1)
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(Name, nil),
+				MatchLabels: baseLabels,
 			}
 
 			volumes := []corev1.Volume{getKubeconfigVolume()}
@@ -114,14 +115,12 @@ func DeploymentReconcilerWithoutInitWrapper(data operatingSystemManagerData) rec
 				return nil, fmt.Errorf("failed to create pod labels: %w", err)
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-				Annotations: map[string]string{
-					"prometheus.io/scrape": "true",
-					"prometheus.io/path":   "/metrics",
-					"prometheus.io/port":   "8080",
-				},
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/path":   "/metrics",
+				"prometheus.io/port":   "8080",
+			})
 
 			clusterDNSIP := resources.NodeLocalDNSCacheAddress
 			if !data.NodeLocalDNSCacheEnabled() {

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -83,11 +83,10 @@ func DeploymentReconciler(data operatingSystemManagerData) reconciling.NamedDepl
 				return nil, err
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, deployment.Spec.Template.Spec, sets.New(Name))
+			deployment.Spec.Template, err = apiserver.IsRunningWrapper(data, deployment.Spec.Template, sets.New(Name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			deployment.Spec.Template.Spec = *wrappedPodSpec
 
 			return deployment, nil
 		}

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -162,11 +162,10 @@ func WebhookDeploymentReconciler(data operatingSystemManagerData) reconciling.Na
 				return nil, fmt.Errorf("failed to set resource requirements: %w", err)
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(Name))
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(Name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/prometheus/federation_service.go
+++ b/pkg/resources/prometheus/federation_service.go
@@ -28,16 +28,15 @@ import (
 func ServiceReconciler(data *resources.TemplateData) reconciling.NamedServiceReconcilerFactory {
 	return func() (string, reconciling.ServiceReconciler) {
 		return name, func(se *corev1.Service) (*corev1.Service, error) {
-			se.Name = name
-			se.Labels = resources.BaseAppLabels(name, nil)
-			// We need to set cluster: user for the ServiceMonitor which federates metrics8
-			se.Labels["cluster"] = "user"
+			se.Labels = resources.BaseAppLabels(name, map[string]string{
+				// We need to set cluster: user for the ServiceMonitor which federates metrics
+				"cluster": "user",
+			})
 
 			se.Spec.ClusterIP = "None"
-			se.Spec.Selector = map[string]string{
-				resources.AppLabelKey: "prometheus",
-				"cluster":             data.Cluster().Name,
-			}
+			se.Spec.Selector = resources.BaseAppLabels("prometheus", map[string]string{
+				"cluster": data.Cluster().Name,
+			})
 			se.Spec.Ports = []corev1.ServicePort{
 				{
 					Name:       "web",

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -83,6 +83,10 @@ func StatefulSetReconciler(data *resources.TemplateData) reconciling.NamedStatef
 			}
 
 			kubernetes.EnsureLabels(&set.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&set.Spec.Template, map[string]string{
+				// these volumes should not block the autoscaler from evicting the pod
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: volumeDataName,
+			})
 
 			set.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 			set.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -19,6 +19,7 @@ package prometheus
 import (
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -64,12 +65,12 @@ func StatefulSetReconciler(data *resources.TemplateData) reconciling.NamedStatef
 				set = &appsv1.StatefulSet{}
 			}
 
-			set.Name = resources.PrometheusStatefulSetName
-
 			requiredBaseLabels := map[string]string{"cluster": data.Cluster().Name}
-			set.Labels = resources.BaseAppLabels(name, requiredBaseLabels)
+			baseLabels := resources.BaseAppLabels(name, requiredBaseLabels)
+
+			kubernetes.EnsureLabels(set, baseLabels)
 			set.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(name, requiredBaseLabels),
+				MatchLabels: baseLabels,
 			}
 
 			set.Spec.Replicas = resources.Int32(1)
@@ -81,9 +82,8 @@ func StatefulSetReconciler(data *resources.TemplateData) reconciling.NamedStatef
 				return nil, fmt.Errorf("failed to create pod labels: %w", err)
 			}
 
-			set.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-			}
+			kubernetes.EnsureLabels(&set.Spec.Template, podLabels)
+
 			set.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyAlways
 			set.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 				FSGroup:      resources.Int64(2000),

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -441,6 +441,13 @@ const (
 	// TopologyKeyZone defines the topology key for the node's cloud provider zone.
 	TopologyKeyZone = "topology.kubernetes.io/zone"
 
+	// ClusterAutoscalerSafeToEvictVolumesAnnotation is an annotation that contains a comma-separated
+	// list of hostPath/emptyDir volumes that should not block the pod from being evicted by the
+	// cluster-autoscaler.
+	// See https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node
+	// for more information.
+	ClusterAutoscalerSafeToEvictVolumesAnnotation = "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes"
+
 	// MachineCRDName defines the CRD name for machine objects.
 	MachineCRDName = "machines.cluster.k8s.io"
 	// MachineSetCRDName defines the CRD name for machineset objects.

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -179,11 +179,10 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 
 			dep.Spec.Template.Spec.Affinity = resources.HostnameAntiAffinity(name, kubermaticv1.AntiAffinityTypePreferred)
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(name))
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(name))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: aws-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: aws-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: aws-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -10,13 +10,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openstack-cloud-controller-manager
+      app: azure-cloud-controller-manager
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
-        app: openstack-cloud-controller-manager
+        app: azure-cloud-controller-manager
         cluster: de-test-01
     spec:
       automountServiceAccountToken: false

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -10,13 +10,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openstack-cloud-controller-manager
+      app: azure-cloud-controller-manager
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
-        app: openstack-cloud-controller-manager
+        app: azure-cloud-controller-manager
         cluster: de-test-01
     spec:
       automountServiceAccountToken: false

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -10,13 +10,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openstack-cloud-controller-manager
+      app: azure-cloud-controller-manager
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
-        app: openstack-cloud-controller-manager
+        app: azure-cloud-controller-manager
         cluster: de-test-01
     spec:
       automountServiceAccountToken: false

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: digitalocean-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: digitalocean-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: digitalocean-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,scratch
       creationTimestamp: null
       labels:
         app: gcp-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,scratch
       creationTimestamp: null
       labels:
         app: gcp-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,scratch
       creationTimestamp: null
       labels:
         app: gcp-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: openstack-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: openstack-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: openstack-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-csi-controller.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       creationTimestamp: null
       labels:
         app: csi-controller

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-csi-controller.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       creationTimestamp: null
       labels:
         app: csi-controller

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-csi-controller.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
       creationTimestamp: null
       labels:
         app: csi-controller

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -13,6 +13,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: vsphere-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -13,6 +13,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: vsphere-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: metrics-server

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-openvpn-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-openvpn-server-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-openvpn-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-openvpn-server.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: openvpn-status
         prometheus.io/path: /metrics
         prometheus.io/port: "9176"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
@@ -14,6 +14,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler.yaml
@@ -15,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
@@ -19,6 +19,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
@@ -2,6 +2,8 @@
 
 metadata:
   creationTimestamp: null
+  labels:
+    app: usercluster-webhook
   name: usercluster-webhook
   namespace: cluster-de-test-01
 spec:
@@ -13,6 +15,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -13,6 +13,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
       creationTimestamp: null
       labels:
         app: vsphere-cloud-controller-manager

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd-externalCloudProvider.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-etcd.yaml
@@ -14,6 +14,8 @@ spec:
   serviceName: etcd
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: launcher
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus.yaml
@@ -16,6 +16,8 @@ spec:
   serviceName: ""
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -201,11 +201,10 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 				},
 			}
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, d.Spec.Template.Spec, sets.New(resources.UserClusterControllerDeploymentName))
+			d.Spec.Template, err = apiserver.IsRunningWrapper(data, d.Spec.Template, sets.New(resources.UserClusterControllerDeploymentName))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			d.Spec.Template.Spec = *wrappedPodSpec
 
 			return d, nil
 		}

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -62,30 +63,26 @@ type webhookData interface {
 	GetEnvVars() ([]corev1.EnvVar, error)
 }
 
-func webhookPodLabels() map[string]string {
-	return map[string]string{
-		resources.AppLabelKey: resources.UserClusterWebhookDeploymentName,
-	}
-}
-
 // DeploymentReconciler returns the function to create and update the user cluster webhook deployment.
 func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.UserClusterWebhookDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
-			d.Name = resources.UserClusterWebhookDeploymentName
+			baseLabels := resources.BaseAppLabels(resources.UserClusterWebhookDeploymentName, nil)
+			kubernetes.EnsureLabels(d, baseLabels)
+
 			d.Spec.Replicas = ptr.To[int32](1)
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: webhookPodLabels(),
+				MatchLabels: baseLabels,
 			}
 			d.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}
 			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
-			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
-			d.Spec.Template.Annotations = map[string]string{
+			kubernetes.EnsureLabels(&d.Spec.Template, baseLabels)
+			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/port":   "8080",
 				"fluentbit.io/parser":  "json_iso",
-			}
+			})
 
 			projectID, ok := data.Cluster().Labels[kubermaticv1.ProjectIDLabelKey]
 			if !ok {

--- a/pkg/resources/usercluster-webhook/service.go
+++ b/pkg/resources/usercluster-webhook/service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -33,13 +34,11 @@ import (
 func ServiceReconciler() reconciling.NamedServiceReconcilerFactory {
 	return func() (string, reconciling.ServiceReconciler) {
 		return resources.UserClusterWebhookServiceName, func(se *corev1.Service) (*corev1.Service, error) {
-			se.Name = resources.UserClusterWebhookServiceName
-			se.Labels = resources.BaseAppLabels(resources.UserClusterWebhookServiceName, nil)
+			baseLabels := resources.BaseAppLabels(resources.UserClusterWebhookServiceName, nil)
+			kubernetes.EnsureLabels(se, baseLabels)
 
 			se.Spec.Type = corev1.ServiceTypeClusterIP
-			se.Spec.Selector = map[string]string{
-				resources.AppLabelKey: resources.UserClusterWebhookDeploymentName,
-			}
+			se.Spec.Selector = resources.BaseAppLabels(resources.UserClusterWebhookDeploymentName, nil)
 			se.Spec.Ports = []corev1.ServicePort{
 				{
 					Name:       "seed",

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -25,6 +25,7 @@ import (
 	providerconfig "github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/apiserver"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -84,8 +85,8 @@ type userclusterControllerData interface {
 func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return resources.UserClusterControllerDeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
-			dep.Name = resources.UserClusterControllerDeploymentName
-			dep.Labels = resources.BaseAppLabels(resources.UserClusterControllerDeploymentName, nil)
+			baseLabels := resources.BaseAppLabels(resources.UserClusterControllerDeploymentName, nil)
+			kubernetes.EnsureLabels(dep, baseLabels)
 
 			dep.Spec.Replicas = resources.Int32(1)
 
@@ -94,7 +95,7 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 			}
 
 			dep.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: resources.BaseAppLabels(resources.UserClusterControllerDeploymentName, nil),
+				MatchLabels: baseLabels,
 			}
 			dep.Spec.Strategy.Type = appsv1.RollingUpdateDeploymentStrategyType
 			dep.Spec.Strategy.RollingUpdate = &appsv1.RollingUpdateDeployment{
@@ -117,14 +118,12 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 				return nil, fmt.Errorf("failed to create pod labels: %w", err)
 			}
 
-			dep.Spec.Template.ObjectMeta = metav1.ObjectMeta{
-				Labels: podLabels,
-				Annotations: map[string]string{
-					"prometheus.io/scrape": "true",
-					"prometheus.io/path":   "/metrics",
-					"prometheus.io/port":   "8085",
-				},
-			}
+			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				"prometheus.io/scrape": "true",
+				"prometheus.io/path":   "/metrics",
+				"prometheus.io/port":   "8085",
+			})
 
 			dep.Spec.Template.Spec.Volumes = volumes
 

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -304,11 +304,10 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 			}
 			dep.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
-			wrappedPodSpec, err := apiserver.IsRunningWrapper(data, dep.Spec.Template.Spec, sets.New(resources.UserClusterControllerContainerName))
+			dep.Spec.Template, err = apiserver.IsRunningWrapper(data, dep.Spec.Template, sets.New(resources.UserClusterControllerContainerName))
 			if err != nil {
 				return nil, fmt.Errorf("failed to add apiserver.IsRunningWrapper: %w", err)
 			}
-			dep.Spec.Template.Spec = *wrappedPodSpec
 
 			return dep, nil
 		}

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -123,6 +123,8 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 				"prometheus.io/scrape": "true",
 				"prometheus.io/path":   "/metrics",
 				"prometheus.io/port":   "8085",
+				// these volumes should not block the autoscaler from evicting the pod
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: resources.ApplicationCacheVolumeName,
 			})
 
 			dep.Spec.Template.Spec.Volumes = volumes


### PR DESCRIPTION
**What this PR does / why we need it**:
The Cluster-Autoscaler does not evict Pods that use non-memory emptyDirs, unless they have a special annotation (see [here](https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/FAQ.md#what-types-of-pods-can-prevent-ca-from-removing-a-node)). This PR is meant to add this special annotation to all Pods (i.e. PodTemplateSpecs in Deployments, StatefulSets) that make use of emptyDirs. This applies to both our own Helm charts, as well as addons and all the Go code that reconciles such resources.

In the process of doing this I was coming from the "I could have tested this on a KKP dev system, if only KKP let me manually patch the pod templates *grrrrr*" standpoint, and so I changed the reconciling code to not overwrite all the labels/annotations in the pod template, but to only merge the required ones into the existing ones.

Also there was a fun bug in the Azure CCM code, which accidentally used openstack labels. A harmless bug,as there can never be both openstack and azure CCMs in the same cluster namespace, but still fun. To prevent such mistakes and to slim down the code a bit, the labelling of CCM deployments is now mostly taken care of by the wrapper code.

The S3 exporter was also blocking the cluster-autoscaler because pods in the kube-system namespace are treated differently. To allow it to be evictable, a PDB has to be provided. The same applies to the Vertical Pod Autoscaler (VPA).

NB: Setting `.Name` or `.Namespace` is _never_ required or useful in our reconciling framework. I removed some leftovers from older code.

**What type of PR is this?**
/kind feature
/kind design

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Improve compatibility with cluster-autoscaler 1.27.1+: Pods using temporary volumes are now marked as evictable.
```

**Documentation**:
```documentation
NONE
```
