### PR TITLE
Bump to Metering 1.2.1

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -499,6 +499,8 @@ spec:
     # ReportConfigurations is a map of report configuration definitions.
     reports:
       weekly:
+        # Format is the file format of the generated report, one of "csv" or "json" (defaults to "csv").
+        format: ""
         # Interval defines the number of days consulted in the metering report.
         # Ignored when `Monthly` is set to true
         interval: 7

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -505,6 +505,8 @@ spec:
     # ReportConfigurations is a map of report configuration definitions.
     reports:
       weekly:
+        # Format is the file format of the generated report, one of "csv" or "json" (defaults to "csv").
+        format: ""
         # Interval defines the number of days consulted in the metering report.
         # Ignored when `Monthly` is set to true
         interval: 7

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -932,6 +932,15 @@ type MeteringConfiguration struct {
 	ReportConfigurations map[string]MeteringReportConfiguration `json:"reports,omitempty"`
 }
 
+// MeteringReportFormat maps directly to the values supported by the kubermatic-metering tool.
+// +kubebuilder:validation:Enum=csv;json
+type MeteringReportFormat string
+
+const (
+	MeteringReportFormatCSV  MeteringReportFormat = "csv"
+	MeteringReportFormatJSON MeteringReportFormat = "json"
+)
+
 type MeteringReportConfiguration struct {
 	// +kubebuilder:default:=`0 1 * * 6`
 
@@ -962,6 +971,10 @@ type MeteringReportConfiguration struct {
 
 	// Types of reports to generate. Available report types are cluster and namespace. By default, all types of reports are generated.
 	Types []string `json:"type,omitempty"`
+
+	// Format is the file format of the generated report, one of "csv" or "json" (defaults to "csv").
+	// +kubebuilder:default=csv
+	Format MeteringReportFormat `json:"format,omitempty"`
 }
 
 // OIDCProviderConfiguration allows to configure OIDC provider at the Seed level. If set, it overwrites the OIDC configuration from the KubermaticConfiguration.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -2153,6 +2153,13 @@ spec:
                     reports:
                       additionalProperties:
                         properties:
+                          format:
+                            default: csv
+                            description: Format is the file format of the generated report, one of "csv" or "json" (defaults to "csv").
+                            enum:
+                              - csv
+                              - json
+                            type: string
                           interval:
                             default: 7
                             description: |-

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -53,6 +53,10 @@ func CronJobReconciler(reportName string, mrc kubermaticv1.MeteringReportConfigu
 			args = append(args, fmt.Sprintf("--output-dir=%s", reportName))
 			args = append(args, fmt.Sprintf("--output-prefix=%s", seed.Name))
 
+			if mrc.Format != "" {
+				args = append(args, fmt.Sprintf("--output-format=%s", mrc.Format))
+			}
+
 			if mrc.Monthly {
 				args = append(args, "--last-month")
 			} else {

--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -73,7 +73,7 @@ func prometheusStatefulSet(getRegistry registry.ImageRewriter, seed *kubermaticv
 				{
 					Name:            Name,
 					Image:           getPrometheusImage(getRegistry),
-					ImagePullPolicy: "IfNotPresent",
+					ImagePullPolicy: corev1.PullIfNotPresent,
 					Args: []string{
 						fmt.Sprintf("--storage.tsdb.retention.time=%dd", seed.Spec.Metering.RetentionDays),
 						"--config.file=/etc/config/prometheus.yml",

--- a/pkg/ee/metering/reconcile.go
+++ b/pkg/ee/metering/reconcile.go
@@ -52,7 +52,7 @@ import (
 
 const (
 	meteringName    = "metering"
-	meteringVersion = "v1.1.2"
+	meteringVersion = "v1.2.1"
 )
 
 func getMeteringImage(overwriter registry.ImageRewriter) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Metering v1.2.1 adds JSON support, new columns, nonroot runtime and updated dependencies. This PR makes the reporting format configurable in KKP and bumps the used metering version.

The new columns are added at the _end_ of the CSV files, so I do not think this is a breaking change. Because of that I would also like to backport this PR into 2.25, the changes in 1.2.1 are just too good to keep them from users for 6 more months.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update Metering to v1.2.1.
- Add `format` to metering report configuration, allowing to generate JSON files instead of CSV.
- Add `cloud-provider`, `datacenter` and `cluster-owner` columns to the generated metering reports.
```

**Documentation**:
```documentation
NONE
```
