### PR TITLE
Add openstack reconcile cluster function

### DIFF
--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -202,7 +202,7 @@ func deleteSecurityGroup(netClient *gophercloud.ServiceClient, sgName string) er
 }
 
 type createKubermaticSecurityGroupRequest struct {
-	clusterName    string
+	secGroupName   string
 	ipv4Rules      bool
 	ipv6Rules      bool
 	nodePortsCIDRs kubermaticv1.NetworkRanges
@@ -211,8 +211,7 @@ type createKubermaticSecurityGroupRequest struct {
 }
 
 func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req createKubermaticSecurityGroupRequest) (string, error) {
-	secGroupName := resourceNamePrefix + req.clusterName
-	secGroups, err := getSecurityGroups(netClient, ossecuritygroups.ListOpts{Name: secGroupName})
+	secGroups, err := getSecurityGroups(netClient, ossecuritygroups.ListOpts{Name: req.secGroupName})
 	if err != nil {
 		return "", fmt.Errorf("failed to get security groups: %w", err)
 	}
@@ -221,7 +220,7 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req cre
 	switch len(secGroups) {
 	case 0:
 		gres := ossecuritygroups.Create(netClient, ossecuritygroups.CreateOpts{
-			Name:        secGroupName,
+			Name:        req.secGroupName,
 			Description: "Contains security rules for the Kubernetes worker nodes",
 		})
 		if gres.Err != nil {
@@ -236,7 +235,7 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req cre
 		securityGroupID = secGroups[0].ID
 	default:
 		return "", fmt.Errorf("there are already %d security groups with name %q, dont know which one to use",
-			len(secGroups), secGroupName)
+			len(secGroups), req.secGroupName)
 	}
 
 	var rules []ossecuritygrouprules.CreateOpts
@@ -351,7 +350,7 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req cre
 		}
 	}
 
-	return secGroupName, nil
+	return req.secGroupName, nil
 }
 
 func createKubermaticNetwork(netClient *gophercloud.ServiceClient, clusterName string) (*osnetworks.Network, error) {

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -56,6 +56,49 @@ const (
 	resourceNamePrefix = "kubernetes-"
 )
 
+func getRouterByName(netClient *gophercloud.ServiceClient, name string) (*osrouters.Router, error) {
+	routers, err := getAllRouters(netClient, osrouters.ListOpts{Name: name})
+	if err != nil {
+		return nil, err
+	}
+	switch len(routers) {
+	case 1:
+		return &routers[0], nil
+	case 0:
+		return nil, fmt.Errorf("router with name '%s' not found", name)
+	default:
+		return nil, fmt.Errorf("found %d router for name '%s', expected exactly one", len(routers), name)
+	}
+}
+
+func getRouterByID(netClient *gophercloud.ServiceClient, id string) (*osrouters.Router, error) {
+	routers, err := getAllRouters(netClient, osrouters.ListOpts{ID: id})
+	if err != nil {
+		return nil, err
+	}
+	switch len(routers) {
+	case 1:
+		return &routers[0], nil
+	case 0:
+		return nil, fmt.Errorf("router with ID '%s' not found", id)
+	default:
+		return nil, fmt.Errorf("found %d router for ID '%s', expected exactly one", len(routers), id)
+	}
+}
+
+func getAllRouters(netClient *gophercloud.ServiceClient, listOpts osrouters.ListOpts) ([]osrouters.Router, error) {
+	allPages, err := osrouters.List(netClient, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	allRouters, err := osrouters.ExtractRouters(allPages)
+	if err != nil {
+		return nil, err
+	}
+	return allRouters, nil
+}
+
 func getSecurityGroups(netClient *gophercloud.ServiceClient, opts ossecuritygroups.ListOpts) ([]ossecuritygroups.SecGroup, error) {
 	page, err := ossecuritygroups.List(netClient, opts).AllPages()
 	if err != nil {
@@ -447,6 +490,54 @@ func getSubnetPoolByName(netClient *gophercloud.ServiceClient, name string) (*su
 	default:
 		return nil, fmt.Errorf("found %d subnet pools for name '%s', expected exactly one", len(pools), name)
 	}
+}
+
+func getSubnetByID(netClient *gophercloud.ServiceClient, id string) (*ossubnets.Subnet, error) {
+	listOpts := ossubnets.ListOpts{
+		ID: id,
+	}
+	allSubnets, err := getAllSubnets(netClient, listOpts)
+	if err != nil {
+		return nil, err
+	}
+	switch len(allSubnets) {
+	case 1:
+		return &allSubnets[0], nil
+	case 0:
+		return nil, fmt.Errorf("subnet pool named '%s' not found", id)
+	default:
+		return nil, fmt.Errorf("found %d subnet pools for id '%s', expected exactly one", len(allSubnets), id)
+	}
+}
+
+func getSubnetByName(netClient *gophercloud.ServiceClient, name string) (*ossubnets.Subnet, error) {
+	listOpts := ossubnets.ListOpts{
+		Name: name,
+	}
+	allSubnets, err := getAllSubnets(netClient, listOpts)
+	if err != nil {
+		return nil, err
+	}
+	switch len(allSubnets) {
+	case 1:
+		return &allSubnets[0], nil
+	case 0:
+		return nil, fmt.Errorf("subnet pool named '%s' not found", name)
+	default:
+		return nil, fmt.Errorf("found %d subnet pools for id '%s', expected exactly one", len(allSubnets), name)
+	}
+}
+
+func getAllSubnets(netClient *gophercloud.ServiceClient, listOpts ossubnets.ListOpts) ([]ossubnets.Subnet, error) {
+	allPages, err := ossubnets.List(netClient, listOpts).AllPages()
+	if err != nil {
+		return nil, err
+	}
+	allSubnets, err := ossubnets.ExtractSubnets(allPages)
+	if err != nil {
+		return nil, err
+	}
+	return allSubnets, nil
 }
 
 func getAllSubnetPools(netClient *gophercloud.ServiceClient, listOpts subnetpools.ListOpts) ([]subnetpools.SubnetPool, error) {

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -67,7 +67,7 @@ func getRouterByName(netClient *gophercloud.ServiceClient, name string) (*osrout
 	case 0:
 		return nil, fmt.Errorf("router with name '%s' not found", name)
 	default:
-		return nil, fmt.Errorf("found %d router for name '%s', expected exactly one", len(routers), name)
+		return nil, fmt.Errorf("found %d routers for name '%s', expected exactly one", len(routers), name)
 	}
 }
 
@@ -82,7 +82,7 @@ func getRouterByID(netClient *gophercloud.ServiceClient, id string) (*osrouters.
 	case 0:
 		return nil, fmt.Errorf("router with ID '%s' not found", id)
 	default:
-		return nil, fmt.Errorf("found %d router for ID '%s', expected exactly one", len(routers), id)
+		return nil, fmt.Errorf("found %d routers for ID '%s', expected exactly one", len(routers), id)
 	}
 }
 
@@ -353,7 +353,7 @@ func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req cre
 	return req.secGroupName, nil
 }
 
-func createKubermaticNetwork(netClient *gophercloud.ServiceClient, clusterName string) (*osnetworks.Network, error) {
+func createUserClusterNetwork(netClient *gophercloud.ServiceClient, clusterName string) (*osnetworks.Network, error) {
 	iTrue := true
 	res := osnetworks.Create(netClient, osnetworks.CreateOpts{
 		Name:         resourceNamePrefix + clusterName,
@@ -505,7 +505,7 @@ func getSubnetByID(netClient *gophercloud.ServiceClient, id string) (*ossubnets.
 	case 0:
 		return nil, fmt.Errorf("subnet with id '%s' not found", id)
 	default:
-		return nil, fmt.Errorf("found %d subnet for id '%s', expected exactly one", len(allSubnets), id)
+		return nil, fmt.Errorf("found %d subnets for id '%s', expected exactly one", len(allSubnets), id)
 	}
 }
 
@@ -523,7 +523,7 @@ func getSubnetByName(netClient *gophercloud.ServiceClient, name string) (*ossubn
 	case 0:
 		return nil, fmt.Errorf("subnet named '%s' not found", name)
 	default:
-		return nil, fmt.Errorf("found %d subnet for name '%s', expected exactly one", len(allSubnets), name)
+		return nil, fmt.Errorf("found %d subnets for name '%s', expected exactly one", len(allSubnets), name)
 	}
 }
 

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -201,7 +201,7 @@ func deleteSecurityGroup(netClient *gophercloud.ServiceClient, sgName string) er
 	return nil
 }
 
-type createKubermaticSecurityGroupRequest struct {
+type createSecurityGroupRequest struct {
 	secGroupName   string
 	ipv4Rules      bool
 	ipv6Rules      bool
@@ -210,7 +210,7 @@ type createKubermaticSecurityGroupRequest struct {
 	highPort       int
 }
 
-func createKubermaticSecurityGroup(netClient *gophercloud.ServiceClient, req createKubermaticSecurityGroupRequest) (string, error) {
+func createSecurityGroup(netClient *gophercloud.ServiceClient, req createSecurityGroupRequest) (string, error) {
 	secGroups, err := getSecurityGroups(netClient, ossecuritygroups.ListOpts{Name: req.secGroupName})
 	if err != nil {
 		return "", fmt.Errorf("failed to get security groups: %w", err)
@@ -394,7 +394,7 @@ func deleteRouter(netClient *gophercloud.ServiceClient, routerID string) error {
 	return res.ExtractErr()
 }
 
-func createKubermaticSubnet(netClient *gophercloud.ServiceClient, clusterName, networkID string, dnsServers []string) (*ossubnets.Subnet, error) {
+func createSubnet(netClient *gophercloud.ServiceClient, clusterName, networkID string, dnsServers []string) (*ossubnets.Subnet, error) {
 	iTrue := true
 	subnetOpts := ossubnets.CreateOpts{
 		Name:       resourceNamePrefix + clusterName,
@@ -424,7 +424,7 @@ func createKubermaticSubnet(netClient *gophercloud.ServiceClient, clusterName, n
 	return res.Extract()
 }
 
-func createKubermaticIPv6Subnet(netClient *gophercloud.ServiceClient, clusterName, networkID, subnetPoolName string, dnsServers []string) (*ossubnets.Subnet, error) {
+func createIPv6Subnet(netClient *gophercloud.ServiceClient, clusterName, networkID, subnetPoolName string, dnsServers []string) (*ossubnets.Subnet, error) {
 	subnetOpts := ossubnets.CreateOpts{
 		Name:            resourceNamePrefix + clusterName + "-ipv6",
 		NetworkID:       networkID,
@@ -551,7 +551,7 @@ func getAllSubnetPools(netClient *gophercloud.ServiceClient, listOpts subnetpool
 	return allSubnetPools, nil
 }
 
-func createKubermaticRouter(netClient *gophercloud.ServiceClient, clusterName, extNetworkName string) (*osrouters.Router, error) {
+func createRouter(netClient *gophercloud.ServiceClient, clusterName, extNetworkName string) (*osrouters.Router, error) {
 	extNetwork, err := getNetworkByName(netClient, extNetworkName, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get external network %q: %w", extNetworkName, err)

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -504,9 +504,9 @@ func getSubnetByID(netClient *gophercloud.ServiceClient, id string) (*ossubnets.
 	case 1:
 		return &allSubnets[0], nil
 	case 0:
-		return nil, fmt.Errorf("subnet pool named '%s' not found", id)
+		return nil, fmt.Errorf("subnet with id '%s' not found", id)
 	default:
-		return nil, fmt.Errorf("found %d subnet pools for id '%s', expected exactly one", len(allSubnets), id)
+		return nil, fmt.Errorf("found %d subnet for id '%s', expected exactly one", len(allSubnets), id)
 	}
 }
 
@@ -522,9 +522,9 @@ func getSubnetByName(netClient *gophercloud.ServiceClient, name string) (*ossubn
 	case 1:
 		return &allSubnets[0], nil
 	case 0:
-		return nil, fmt.Errorf("subnet pool named '%s' not found", name)
+		return nil, fmt.Errorf("subnet named '%s' not found", name)
 	default:
-		return nil, fmt.Errorf("found %d subnet pools for id '%s', expected exactly one", len(allSubnets), name)
+		return nil, fmt.Errorf("found %d subnet for name '%s', expected exactly one", len(allSubnets), name)
 	}
 }
 

--- a/pkg/provider/cloud/openstack/helper.go
+++ b/pkg/provider/cloud/openstack/helper.go
@@ -57,7 +57,7 @@ const (
 )
 
 func getRouterByName(netClient *gophercloud.ServiceClient, name string) (*osrouters.Router, error) {
-	routers, err := getAllRouters(netClient, osrouters.ListOpts{Name: name})
+	routers, err := listRouters(netClient, osrouters.ListOpts{Name: name})
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +72,7 @@ func getRouterByName(netClient *gophercloud.ServiceClient, name string) (*osrout
 }
 
 func getRouterByID(netClient *gophercloud.ServiceClient, id string) (*osrouters.Router, error) {
-	routers, err := getAllRouters(netClient, osrouters.ListOpts{ID: id})
+	routers, err := listRouters(netClient, osrouters.ListOpts{ID: id})
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +86,7 @@ func getRouterByID(netClient *gophercloud.ServiceClient, id string) (*osrouters.
 	}
 }
 
-func getAllRouters(netClient *gophercloud.ServiceClient, listOpts osrouters.ListOpts) ([]osrouters.Router, error) {
+func listRouters(netClient *gophercloud.ServiceClient, listOpts osrouters.ListOpts) ([]osrouters.Router, error) {
 	allPages, err := osrouters.List(netClient, listOpts).AllPages()
 	if err != nil {
 		return nil, err

--- a/pkg/provider/cloud/openstack/internal/testing/fixtures.go
+++ b/pkg/provider/cloud/openstack/internal/testing/fixtures.go
@@ -19,6 +19,7 @@ package testing
 import (
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/external"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/networks"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/subnets"
 )
 
 // IDs used when a new resource is created.
@@ -56,4 +57,8 @@ var ExternalNetwork = Network{
 
 var InternalNetwork = Network{
 	Network: networks.Network{Name: "kubernetes-cluster-xyz", ID: NetworkID},
+}
+
+var SubnetTest = Subnet{
+	Subnet: subnets.Subnet{ID: SubnetID, Name: "kubernetes-cluster-xyz"},
 }

--- a/pkg/provider/cloud/openstack/internal/testing/simulator.go
+++ b/pkg/provider/cloud/openstack/internal/testing/simulator.go
@@ -199,7 +199,9 @@ func (s *SecGroupRule) SubResources() []ResourceBuilder {
 	return nil
 }
 
-type Subnet subnets.Subnet
+type Subnet struct {
+	subnets.Subnet
+}
 
 func (s Subnet) GetID() string {
 	return s.ID

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -217,7 +217,7 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 		return nil, err
 	}
 
-	if !force || cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
+	if  cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
 		extNetwork, err := getExternalNetwork(netClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external network: %w", err)

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -217,7 +217,7 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 		return nil, err
 	}
 
-	if cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
+	if !force || cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
 		extNetwork, err := getExternalNetwork(netClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external network: %w", err)

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -217,7 +217,7 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 		return nil, err
 	}
 
-	if  cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
+	if cluster.Spec.Cloud.Openstack.FloatingIPPool == "" {
 		extNetwork, err := getExternalNetwork(netClient)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get external network: %w", err)

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -331,7 +331,7 @@ func reconcileSecurityGroup(ctx context.Context, netClient *gophercloud.ServiceC
 	ipv4Network := cluster.IsIPv4Only() || cluster.IsDualStack()
 	ipv6Network := cluster.IsIPv6Only() || cluster.IsDualStack()
 
-	req := createKubermaticSecurityGroupRequest{
+	req := createSecurityGroupRequest{
 		secGroupName: securityGroup,
 		ipv4Rules:    ipv4Network,
 		ipv6Rules:    ipv6Network,
@@ -341,7 +341,7 @@ func reconcileSecurityGroup(ctx context.Context, netClient *gophercloud.ServiceC
 
 	req.nodePortsCIDRs = resources.GetNodePortsAllowedIPRanges(cluster, cluster.Spec.Cloud.Openstack.NodePortsAllowedIPRanges, cluster.Spec.Cloud.Openstack.NodePortsAllowedIPRange)
 
-	secGroupName, err := createKubermaticSecurityGroup(netClient, req)
+	secGroupName, err := createSecurityGroup(netClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the user cluster security group: %w", err)
 	}
@@ -389,7 +389,7 @@ func reconcileIPv6Subnet(ctx context.Context, netClient *gophercloud.ServiceClie
 		}
 		// At this point, either the SubnetID was empty, or the specified subnet was not found by ID or name
 		// Proceed to create a new subnet
-		subnet, err = createKubermaticIPv6Subnet(netClient, cluster.Name, network, cluster.Spec.Cloud.Openstack.IPv6SubnetPool, dnservers)
+		subnet, err = createIPv6Subnet(netClient, cluster.Name, network, cluster.Spec.Cloud.Openstack.IPv6SubnetPool, dnservers)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create the IPv6 subnet: %w", err)
 		}
@@ -440,7 +440,7 @@ func reconcileIPv4Subnet(ctx context.Context, netClient *gophercloud.ServiceClie
 		}
 		// At this point, either the SubnetID was empty, or the specified subnet was not found by ID or name
 		// Proceed to create a new subnet
-		subnet, err = createKubermaticSubnet(netClient, cluster.Name, network, dnservers)
+		subnet, err = createSubnet(netClient, cluster.Name, network, dnservers)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create the kubermatic IPv4 subnet: %w", err)
 		}
@@ -517,7 +517,7 @@ func reconcileRouter(ctx context.Context, netClient *gophercloud.ServiceClient, 
 		return cluster, nil
 	}
 	// Router not found by name, create a new router
-	router, err = createKubermaticRouter(netClient, cluster.Name, cluster.Spec.Cloud.Openstack.FloatingIPPool)
+	router, err = createRouter(netClient, cluster.Name, cluster.Spec.Cloud.Openstack.FloatingIPPool)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create a new router: %w", err)
 	}

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -245,7 +245,7 @@ func (os *Provider) reconcileCluster(ctx context.Context, cluster *kubermaticv1.
 			return nil, err
 		}
 	}
-	// Reconciling the subnets.All machines will live in one dedicated subnet.
+	// Reconciling the subnets. All machines will live in one dedicated subnet.
 	if force || cluster.Spec.Cloud.Openstack.SubnetID == "" || cluster.Spec.Cloud.Openstack.IPv6SubnetID == "" {
 		network, err := getNetworkByName(netClient, cluster.Spec.Cloud.Openstack.Network, false)
 		if err != nil {
@@ -290,7 +290,7 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 		networkName = cluster.Name
 	}
 
-	newNetwork, err := createKubermaticNetwork(netClient, networkName)
+	newNetwork, err := createUserClusterNetwork(netClient, networkName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create the kubermatic network: %w", err)
 	}
@@ -343,7 +343,7 @@ func reconcileSecurityGroup(ctx context.Context, netClient *gophercloud.ServiceC
 
 	secGroupName, err := createKubermaticSecurityGroup(netClient, req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create the kubermatic security group: %w", err)
+		return nil, fmt.Errorf("failed to create the user cluster security group: %w", err)
 	}
 	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kubernetes.AddFinalizer(cluster, SecurityGroupCleanupFinalizer)
@@ -383,7 +383,7 @@ func reconcileIPv6Subnet(ctx context.Context, netClient *gophercloud.ServiceClie
 				cluster.Spec.Cloud.Openstack.IPv6SubnetID = subnet.ID
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to update IPv6 subnet to the cluster:: %w", err)
+				return nil, fmt.Errorf("failed to update IPv6 subnet to the cluster: %w", err)
 			}
 			return cluster, nil
 		}
@@ -434,7 +434,7 @@ func reconcileIPv4Subnet(ctx context.Context, netClient *gophercloud.ServiceClie
 				cluster.Spec.Cloud.Openstack.SubnetID = subnet.ID
 			})
 			if err != nil {
-				return nil, fmt.Errorf("failed to update IPv4 subnet to the cluster:: %w", err)
+				return nil, fmt.Errorf("failed to update IPv4 subnet to the cluster: %w", err)
 			}
 			return cluster, nil
 		}
@@ -451,7 +451,7 @@ func reconcileIPv4Subnet(ctx context.Context, netClient *gophercloud.ServiceClie
 			cluster.Spec.Cloud.Openstack.SubnetID = subnet.ID
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to update IPv4 subnet to the cluster:: %w", err)
+			return nil, fmt.Errorf("failed to update IPv4 subnet to the cluster: %w", err)
 		}
 	}
 	return cluster, nil
@@ -563,10 +563,10 @@ func linkSubnetToRouter(netClient *gophercloud.ServiceClient, cluster *kubermati
 	ipAttached = err == nil && router != ""
 	if !ipAttached {
 		_, err := attachSubnetToRouter(netClient, subnetID, routerID)
-		kubernetes.AddFinalizer(cluster, finalizer)
 		if err != nil {
 			return err
 		}
+		kubernetes.AddFinalizer(cluster, finalizer)
 	}
 	return nil
 }

--- a/pkg/provider/cloud/openstack/provider_test.go
+++ b/pkg/provider/cloud/openstack/provider_test.go
@@ -222,6 +222,7 @@ func TestInitializeCloudProvider(t *testing.T) {
 			resources: []ostesting.Resource{
 				&ostesting.ExternalNetwork,
 				&ostesting.InternalNetwork,
+				&ostesting.SubnetTest,
 				&ostesting.Router{
 					ID: ostesting.RouterID,
 				},
@@ -337,6 +338,7 @@ func TestInitializeCloudProvider(t *testing.T) {
 			resources: []ostesting.Resource{
 				&ostesting.ExternalNetwork,
 				&ostesting.InternalNetwork,
+				&ostesting.SubnetTest,
 			},
 			wantCluster: kubermaticv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Reconcile Cluster for Openstack Provider for KKP

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

This function reconcile network, subnets, security groups and routers in openstack cluster.
Fixes #8145

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The OpenStack provider is now reconciling user cluster cloud resources on a regular basis.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
