### PR TITLE
Add velero and kubeLB images to the list of mirrored images

### DIFF
--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -478,6 +478,13 @@ func getImagesFromReconcilers(log logrus.FieldLogger, templateData *resources.Te
 		images = append(images, getImagesFromPodSpec(daemonset.Spec.Template.Spec)...)
 	}
 
+	// Add images for Enterprise Edition addons/components.
+	additionalImages, err := getAdditionalImagesFromReconcilers(templateData)
+	if err != nil {
+		return nil, err
+	}
+
+	images = append(images, additionalImages...)
 	return images, nil
 }
 
@@ -637,6 +644,8 @@ func getTemplateData(config *kubermaticv1.KubermaticConfiguration, clusterVersio
 		resources.VMwareCloudDirectorCSIKubeconfigSecretName,
 		resources.CSICloudConfigSecretName,
 		resources.VMwareCloudDirectorCSISecretName,
+		resources.KubeLBCCMKubeconfigSecretName,
+		resources.KubeLBManagerKubeconfigSecretName,
 	})
 	datacenter := &kubermaticv1.Datacenter{
 		Spec: kubermaticv1.DatacenterSpec{

--- a/pkg/install/images/wrappers_ce.go
+++ b/pkg/install/images/wrappers_ce.go
@@ -1,0 +1,29 @@
+//go:build !ee
+
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+)
+
+// getAdditionalImagesFromReconcilers returns the images used by the reconcilers for Enterprise Edition addons/components.
+// Since this is the Community Edition, this function is no-op and would always return nil,nil.
+func getAdditionalImagesFromReconcilers(_ *resources.TemplateData) ([]string, error) {
+	return nil, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
We forgot to add KubeLB and Velero images to our mirrored images list.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add images for velero and kubeLB to mirrored images list
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/cc @xrstf 