### PR TITLE
add new `kubermatic_cluster_owner` metric

### DIFF
--- a/pkg/collectors/clusterbackup.go
+++ b/pkg/collectors/clusterbackup.go
@@ -159,7 +159,7 @@ func (c *clusterBackupCollector) collectDestination(ctx context.Context, ch chan
 	return nil
 }
 
-func (c *clusterBackupCollector) setMetricsForCluster(ch chan<- prometheus.Metric, destination *kubermaticv1.BackupDestination, allObjects []minio.ObjectInfo, destName string, clusterName string) {
+func (c *clusterBackupCollector) setMetricsForCluster(ch chan<- prometheus.Metric, _ *kubermaticv1.BackupDestination, allObjects []minio.ObjectInfo, destName string, clusterName string) {
 	var clusterObjects []minio.ObjectInfo
 	for _, object := range allObjects {
 		if strings.HasPrefix(object.Key, fmt.Sprintf("%s-", clusterName)) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new metric that maps clusters to their owners. To prevent emails leaking into metrics, the emails are resolved to the KKP user, similar to how we do it for projects.

This metric can be useful for the metering component later on, to provide more detailed reports.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add new `kubermatic_cluster_owner` metric on seed clusters, with `cluster_name` and `user` labels.
```

**Documentation**:
```documentation
NONE
```
