### PR TITLE
set release tag for minio/mc

### DIFF
--- a/charts/mla/minio-lifecycle-mgr/test/config.yaml.out
+++ b/charts/mla/minio-lifecycle-mgr/test/config.yaml.out
@@ -79,7 +79,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: minio
-              image: 'docker.io/minio/mc:latest'
+              image: 'docker.io/minio/mc:RELEASE.2024-03-13T23-51-57Z'
               imagePullPolicy: 'IfNotPresent'
               command:
                 - /bin/sh

--- a/charts/mla/minio-lifecycle-mgr/test/default.yaml.out
+++ b/charts/mla/minio-lifecycle-mgr/test/default.yaml.out
@@ -79,7 +79,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: minio
-              image: 'docker.io/minio/mc:latest'
+              image: 'docker.io/minio/mc:RELEASE.2024-03-13T23-51-57Z'
               imagePullPolicy: 'IfNotPresent'
               command:
                 - /bin/sh

--- a/charts/mla/minio-lifecycle-mgr/test/image-pull-secret.yaml.out
+++ b/charts/mla/minio-lifecycle-mgr/test/image-pull-secret.yaml.out
@@ -81,7 +81,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: minio
-              image: 'docker.io/minio/mc:latest'
+              image: 'docker.io/minio/mc:RELEASE.2024-03-13T23-51-57Z'
               imagePullPolicy: 'IfNotPresent'
               command:
                 - /bin/sh

--- a/charts/mla/minio-lifecycle-mgr/values.yaml
+++ b/charts/mla/minio-lifecycle-mgr/values.yaml
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 lifecycleMgr:
+  ## Set default imageTag for `minio/mc` to `RELEASE.2024-03-13T23-51-57Z`
+  ## (which at the time corresponded to `latest`)
+  ##
   image:
     repository: docker.io/minio/mc
     tag: RELEASE.2024-03-13T23-51-57Z

--- a/charts/mla/minio-lifecycle-mgr/values.yaml
+++ b/charts/mla/minio-lifecycle-mgr/values.yaml
@@ -14,7 +14,7 @@
 lifecycleMgr:
   image:
     repository: docker.io/minio/mc
-    tag: latest
+    tag: RELEASE.2024-03-13T23-51-57Z
     pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the tag in the mla/minio-lifecycle-mgr helm chart from `latest` to `RELEASE.2024-03-13T23-51-57Z` (which corresponds to latest at the time of this writing).
Using `latest`is problematic, as the underlying image and thus sha256 digest changes constantly and with each new release of minio/mc, not providing a stable and well defined version of the image. The change to a specific release tag will remove this unpredictability.

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
The image tag in the included `mla/minio-lifecycle-mgr` helm chart has been changed from `latest` to `RELEASE.2024-03-13T23-51-57Z`.
```

**Documentation**:
```documentation
NONE
```
