### PR TITLE
put metering- prefix in front of cronjob names

### DIFF
--- a/codegen/example-yaml/main.go
+++ b/codegen/example-yaml/main.go
@@ -239,7 +239,7 @@ func createExampleSeed(config *kubermaticv1.KubermaticConfiguration) *kubermatic
 			Metering: &kubermaticv1.MeteringConfiguration{
 				Enabled:          false,
 				StorageClassName: "kubermatic-fast",
-				ReportConfigurations: map[string]*kubermaticv1.MeteringReportConfiguration{
+				ReportConfigurations: map[string]kubermaticv1.MeteringReportConfiguration{
 					"weekly": {
 						Schedule: "0 1 * * 6",
 						Interval: 7,

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -929,7 +929,7 @@ type MeteringConfiguration struct {
 	// +kubebuilder:default:={weekly: {schedule: "0 1 * * 6", interval: 7}}
 
 	// ReportConfigurations is a map of report configuration definitions.
-	ReportConfigurations map[string]*MeteringReportConfiguration `json:"reports,omitempty"`
+	ReportConfigurations map[string]MeteringReportConfiguration `json:"reports,omitempty"`
 }
 
 type MeteringReportConfiguration struct {

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -4894,18 +4894,9 @@ func (in *MeteringConfiguration) DeepCopyInto(out *MeteringConfiguration) {
 	*out = *in
 	if in.ReportConfigurations != nil {
 		in, out := &in.ReportConfigurations, &out.ReportConfigurations
-		*out = make(map[string]*MeteringReportConfiguration, len(*in))
+		*out = make(map[string]MeteringReportConfiguration, len(*in))
 		for key, val := range *in {
-			var outVal *MeteringReportConfiguration
-			if val == nil {
-				(*out)[key] = nil
-			} else {
-				inVal := (*in)[key]
-				in, out := &inVal, &outVal
-				*out = new(MeteringReportConfiguration)
-				(*in).DeepCopyInto(*out)
-			}
-			(*out)[key] = outVal
+			(*out)[key] = *val.DeepCopy()
 		}
 	}
 }

--- a/pkg/controller/operator/seed/reconciler_test.go
+++ b/pkg/controller/operator/seed/reconciler_test.go
@@ -125,7 +125,7 @@ func getSeeds(now metav1.Time) map[string]*kubermaticv1.Seed {
 					Enabled:          true,
 					StorageSize:      "10Gi",
 					StorageClassName: "test",
-					ReportConfigurations: map[string]*kubermaticv1.MeteringReportConfiguration{
+					ReportConfigurations: map[string]kubermaticv1.MeteringReportConfiguration{
 						"weekly-test": {
 							Schedule: "0 1 * * 6",
 							Interval: 7,

--- a/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ce.go
@@ -35,6 +35,6 @@ func ReconcileMeteringResources(_ context.Context, _ ctrlruntimeclient.Client, _
 }
 
 // CronJobReconciler returns the func to create/update the metering report cronjob. Available only for ee.
-func CronJobReconciler(_ string, _ *kubermaticv1.MeteringReportConfiguration, _ string, _ registry.ImageRewriter, _ *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
+func CronJobReconciler(_ string, _ kubermaticv1.MeteringReportConfiguration, _ string, _ registry.ImageRewriter, _ *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
 	return nil
 }

--- a/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
+++ b/pkg/controller/operator/seed/resources/metering/wrappers_ee.go
@@ -36,6 +36,6 @@ func ReconcileMeteringResources(ctx context.Context, client ctrlruntimeclient.Cl
 }
 
 // CronJobReconciler returns the func to create/update the metering report cronjob. Available only for ee.
-func CronJobReconciler(rn string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, r registry.ImageRewriter, seed *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
+func CronJobReconciler(rn string, mrc kubermaticv1.MeteringReportConfiguration, caBundleName string, r registry.ImageRewriter, seed *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
 	return metering.CronJobReconciler(rn, mrc, caBundleName, r, seed)
 }

--- a/pkg/ee/metering/cronjob.go
+++ b/pkg/ee/metering/cronjob.go
@@ -39,10 +39,14 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+func cronJobName(reportName string) string {
+	return "metering-" + reportName
+}
+
 // CronJobReconciler returns the func to create/update the metering report cronjob.
-func CronJobReconciler(reportName string, mrc *kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.ImageRewriter, seed *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
+func CronJobReconciler(reportName string, mrc kubermaticv1.MeteringReportConfiguration, caBundleName string, getRegistry registry.ImageRewriter, seed *kubermaticv1.Seed) reconciling.NamedCronJobReconcilerFactory {
 	return func() (string, reconciling.CronJobReconciler) {
-		return reportName, func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
+		return cronJobName(reportName), func(job *batchv1.CronJob) (*batchv1.CronJob, error) {
 			var args []string
 			args = append(args, fmt.Sprintf("--ca-bundle=%s", "/opt/ca-bundle/ca-bundle.pem"))
 			args = append(args, fmt.Sprintf("--prometheus-api=http://%s.%s.svc", prometheus.Name, seed.Namespace))

--- a/pkg/install/images/images.go
+++ b/pkg/install/images/images.go
@@ -430,7 +430,7 @@ func getImagesFromReconcilers(log logrus.FieldLogger, templateData *resources.Te
 	}
 
 	cronjobReconcilers := kubernetescontroller.GetCronJobReconcilers(templateData)
-	if mcjr := metering.CronJobReconciler("reportName", &kubermaticv1.MeteringReportConfiguration{}, "caBundleName", templateData.RewriteImage, seed); mcjr != nil {
+	if mcjr := metering.CronJobReconciler("reportName", kubermaticv1.MeteringReportConfiguration{}, "caBundleName", templateData.RewriteImage, seed); mcjr != nil {
 		cronjobReconcilers = append(cronjobReconcilers, mcjr)
 	}
 

--- a/pkg/webhook/seed/validation_test.go
+++ b/pkg/webhook/seed/validation_test.go
@@ -450,7 +450,7 @@ func TestValidate(t *testing.T) {
 				},
 				Spec: kubermaticv1.SeedSpec{
 					Metering: &kubermaticv1.MeteringConfiguration{
-						ReportConfigurations: map[string]*kubermaticv1.MeteringReportConfiguration{
+						ReportConfigurations: map[string]kubermaticv1.MeteringReportConfiguration{
 							"daily": {
 								Schedule: "*/invalid * * * *",
 							},


### PR DESCRIPTION
**What this PR does / why we need it**:
This prevents naming conflicts by putting a `metering-` prefix in front of CronJob names. When using the internal Minio, it's likely that report names will be short like "daily", and having a CronJob named "daily" is weird.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Metering CronJobs now use a `metering-` prefix; older jobs are automatically removed.
```

**Documentation**:
```documentation
NONE
```
