### PR TITLE
fix cluster-autoscaler addon

### DIFF
--- a/addons/Makefile
+++ b/addons/Makefile
@@ -74,13 +74,11 @@ cluster-autoscaler:
 	mkdir -p cluster-autoscaler
 	cat cluster-autoscaler/_header.txt > $(OUTPUT_FILE)
 	helm --namespace kube-system template cluster-autoscaler autoscaler/cluster-autoscaler \
-	  --version 9.34.1 \
+	  --version 9.36.0 \
 	  --set 'cloudProvider=clusterapi' \
-	  --set 'autoDiscovery.clusterName=\{{ "{{ .Cluster.Name }}" }}' \
+	  --set 'autoDiscovery.labels[0].namespace=kube-system' \
 	  --set 'extraEnv.CAPI_GROUP=cluster.k8s.io' \
 	  --set 'securityContext.seccompProfile.type=RuntimeDefault' \
-	  --set 'tolerations[0].effect=NoSchedule' \
-	  --set 'tolerations[0].key=node-role.kubernetes.io/master' \
 	  >> $(OUTPUT_FILE)
 	cat cluster-autoscaler/_footer.txt >> $(OUTPUT_FILE)
 	./templatify-images.sh $(OUTPUT_FILE)

--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -70,8 +70,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
   namespace: kube-system
 spec:
@@ -90,8 +90,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
   namespace: kube-system
 automountServiceAccountToken: true
@@ -104,8 +104,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
 rules:
   - apiGroups:
@@ -270,8 +270,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -290,8 +290,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
   namespace: kube-system
 rules:
@@ -320,8 +320,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
   namespace: kube-system
 roleRef:
@@ -341,8 +341,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
   namespace: kube-system
 spec:
@@ -366,8 +366,8 @@ metadata:
     app.kubernetes.io/instance: "cluster-autoscaler"
     app.kubernetes.io/name: "clusterapi-cluster-autoscaler"
     app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/version: "1.28.2"
-    helm.sh/chart: "cluster-autoscaler-9.34.1"
+    app.kubernetes.io/version: "1.29.0"
+    helm.sh/chart: "cluster-autoscaler-9.36.0"
   name: cluster-autoscaler-clusterapi-cluster-autoscaler
   namespace: kube-system
 spec:
@@ -393,7 +393,7 @@ spec:
             - ./cluster-autoscaler
             - --cloud-provider=clusterapi
             - --namespace=kube-system
-            - --node-group-auto-discovery=clusterapi:clusterName={{ .Cluster.Name }}
+            - --node-group-auto-discovery=clusterapi:namespace=kube-system
             - --logtostderr=true
             - --stderrthreshold=info
             - --v=4
@@ -418,8 +418,7 @@ spec:
             {}
       serviceAccountName: cluster-autoscaler-clusterapi-cluster-autoscaler
       tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
+        []
       securityContext:
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
**What this PR does / why we need it**:
After updating the autoscaler on one of our dev systems, I noticed that the cluster-name based grouping didn't work. And from my quick testing, creating an AWS cluster on dev and installing the autoscaler addon will not work. So I adjusted the config to match what we use in our other system, which @xmudrii recommended to me. Downside is that it will only work for MDs in the kube-system namespace.

I also removed the master toleration. There are no master nodes in a KKP usercluster.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
cluster-autoscaler addon now works based on the namespace instead of cluster names; all MachineDeployments in the `kube-system` namespace are scaled.
```

**Documentation**:
```documentation
NONE
```
