### PR TITLE
do not resync all caches every 2 seconds

### DIFF
--- a/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
+++ b/pkg/controller/shared/seed-controller-lifecycle/seed_controller_lifecycle.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -98,11 +97,9 @@ func Add(
 	// prepare a shared cache across all future master managers; this cache
 	// will be wrapped so that ctrlruntime cannot start and stop it, which
 	// would cause it to close the same channels multiple times and panic
-	resync := 2 * time.Second
 	cache, err := cache.New(mgr.GetConfig(), cache.Options{
-		Scheme:     mgr.GetScheme(),
-		Mapper:     mgr.GetRESTMapper(),
-		SyncPeriod: &resync,
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
So, in #4823 I introduced a shared cache across all seed controllers in the seed-lifecycle-controller-manager. I never wrote down why I chose a 2s resync time, but it worked and it never seemed to cause any issues.

Recently though we realized what a terrible mistake that was, as the KKP master-ctrl-mgr will actually honor this stupid flag and resynced everything every 2 seconds. Meaning all controllers reconciled everything every 2 seconds. This made the master-ctrl-mgr basically burn a CPU core constantly.

This PR removes the custom resync period, as it's documented as

```go
	// SyncPeriod determines the minimum frequency at which watched resources are
	// reconciled. A lower period will correct entropy more quickly, but reduce
	// responsiveness to change if there are many watched resources. Change this
	// value only if you know what you are doing. Defaults to 10 hours if unset.
	// there will a 10 percent jitter between the SyncPeriod of all controllers
	// so that all controllers will not send list requests simultaneously.
```

Merging this has this effect to the controller reconciles:

![2024-03-25 11_30_57-View panel - Controller Manager - Kubermatic - Dashboards - Grafana — Mozilla Fi](https://github.com/kubermatic/kubermatic/assets/127499/5229cf0a-9c5d-4d62-8e30-275cd4b0b907)


**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix high CPU usage in master-controller-manager.
```

**Documentation**:
```documentation
NONE
```
