### PR TITLE
apply OCI labels to all container images we build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,23 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
-LABEL maintainer="support@kubermatic.com"
+FROM docker.io/alpine:3.19
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 ENV KUBERMATIC_CHARTS_DIRECTORY=/opt/charts/
 
 # To support a wider range of Kubernetes userclusters, we ship multiple
 # kubectl binaries and deduce which one to use based on the version skew
 # policy.
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.29.1/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.29
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.27.10/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.27
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.29.3/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.29
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.27.12/bin/linux/amd64/kubectl /usr/local/bin/kubectl-1.27
 
 RUN wget -O- https://get.helm.sh/helm-v3.13.3-linux-amd64.tar.gz | tar xzOf - linux-amd64/helm > /usr/local/bin/helm
 
 # We need the ca-certs so the KKP API can verify the certificates of the OIDC server (usually Dex)
 RUN chmod +x /usr/local/bin/kubectl-* /usr/local/bin/helm && apk add ca-certificates
 
-# Do not needless copy all binaries into the image.
+# Do not needless copy all files from _build/ into the image.
 COPY ./_build/kubermatic-operator \
      ./_build/kubermatic-installer \
      ./_build/kubermatic-webhook \

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ docker-build: build
 ifndef DOCKER_BIN
 	$(error "Docker not available in your environment, please install it and retry.")
 endif
-	$(DOCKER_BIN) build $(DOCKER_BUILD_FLAG) .
+	$(DOCKER_BIN) build $(DOCKER_BUILD_FLAG) --label "org.opencontainers.image.version=$(KUBERMATICDOCKERTAG)" .
 
 .PHONY: docker-push
 docker-push:

--- a/addons/Dockerfile
+++ b/addons/Dockerfile
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
-LABEL maintainer="support@kubermatic.com"
+FROM docker.io/alpine:3.19
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/addons/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 ADD ./ /addons/

--- a/cmd/conformance-tester/Dockerfile
+++ b/cmd/conformance-tester/Dockerfile
@@ -12,16 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.18
-LABEL maintainer="support@kubermatic.com"
-ENV KUBECTL_VERSION=v1.27.6
+FROM docker.io/alpine:3.19
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/conformance-tester/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
+
+ENV KUBECTL_VERSION=v1.28.8
 
 RUN apk add --no-cache -U bash ca-certificates curl jq
 
-RUN curl -Lo /usr/bin/kubectl \
-    https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
+RUN curl -Lo /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl && \
     chmod +x /usr/bin/kubectl && \
-    kubectl version --short --client
+    kubectl version --client
 
 COPY ./_build/conformance-tester /usr/local/bin/conformance-tester
+
 WORKDIR /conformance-tester
+USER nobody
+ENTRYPOINT [ "conformance-tester" ]

--- a/cmd/conformance-tester/Makefile
+++ b/cmd/conformance-tester/Makefile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CGO_ENABLED=0
+
 DOCKER_REPO ?= "quay.io/kubermatic"
-GOOS ?= $(shell go env GOOS)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/conformance-tester .
+	go build -v -o ./_build/conformance-tester .
 
 .PHONY: docker
 docker: build
-	docker build -t $(DOCKER_REPO)/conformance-tests:$(TAG) .
+	docker build --tag $(DOCKER_REPO)/conformance-tests:$(TAG) --label "org.opencontainers.image.version=$(TAG)" .

--- a/cmd/etcd-launcher/Dockerfile
+++ b/cmd/etcd-launcher/Dockerfile
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 FROM busybox:1.32.1
-LABEL maintainer="support@kubermatic.com"
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/etcd-launcher/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 COPY ./_build/etcd-launcher /
+
+ENTRYPOINT [ "/etcd-launcher" ]

--- a/cmd/etcd-launcher/Makefile
+++ b/cmd/etcd-launcher/Makefile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CGO_ENABLED=0
+
 DOCKER_REPO ?= "quay.io/kubermatic"
-GOOS ?= $(shell go env GOOS)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/etcd-launcher .
+	go build -v -o ./_build/etcd-launcher .
 
 .PHONY: docker
 docker: build
-	docker build -t $(DOCKER_REPO)/etcd-launcher:$(TAG) .
+	docker build --tag $(DOCKER_REPO)/etcd-launcher:$(TAG) --label "org.opencontainers.image.version=$(TAG)" .

--- a/cmd/kubeletdnat-controller/Dockerfile
+++ b/cmd/kubeletdnat-controller/Dockerfile
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
-LABEL maintainer="support@kubermatic.com"
+FROM docker.io/alpine:3.19
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/kubeletdnat-controller/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 RUN apk add -u --no-cache iptables
 COPY ./_build/kubeletdnat-controller /usr/local/bin/kubeletdnat-controller
+
+ENTRYPOINT [ "kubeletdnat-controller" ]

--- a/cmd/kubeletdnat-controller/Dockerfile.multiarch
+++ b/cmd/kubeletdnat-controller/Dockerfile.multiarch
@@ -28,11 +28,13 @@ WORKDIR /go/src/k8c.io/kubermatic
 COPY . .
 RUN make -C ./cmd/kubeletdnat-controller build
 
-FROM docker.io/alpine:3.18
-LABEL maintainer="support@kubermatic.com"
+FROM docker.io/alpine:3.19
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/kubeletdnat-controller/Dockerfile.multiarch"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 RUN apk add -u --no-cache iptables
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/kubeletdnat-controller/_build/kubeletdnat-controller /usr/local/bin/kubeletdnat-controller
 
-ENTRYPOINT ["/usr/local/bin/kubeletdnat-controller"]
+ENTRYPOINT [ "kubeletdnat-controller" ]

--- a/cmd/kubeletdnat-controller/Makefile
+++ b/cmd/kubeletdnat-controller/Makefile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CGO_ENABLED=0
+
 DOCKER_REPO ?= "quay.io/kubermatic"
-GOOS ?= $(shell go env GOOS)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/kubeletdnat-controller .
+	go build -v -o ./_build/kubeletdnat-controller .
 
 .PHONY: docker
 docker: build
-	docker build -t $(DOCKER_REPO)/kubeletdnat-controller:$(TAG) .
+	docker build --tag $(DOCKER_REPO)/kubeletdnat-controller:$(TAG) --label "org.opencontainers.image.version=$(TAG)" .

--- a/cmd/network-interface-manager/Dockerfile
+++ b/cmd/network-interface-manager/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM gcr.io/distroless/static-debian12
-LABEL maintainer="support@kubermatic.com"
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/network-interface-manager/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 COPY ./_build/network-interface-manager /usr/local/bin/
 

--- a/cmd/network-interface-manager/Dockerfile.multiarch
+++ b/cmd/network-interface-manager/Dockerfile.multiarch
@@ -29,7 +29,9 @@ COPY . .
 RUN make -C ./cmd/network-interface-manager build
 
 FROM gcr.io/distroless/static-debian12
-LABEL maintainer="support@kubermatic.com"
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/network-interface-manager/Dockerfile.multiarch"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/network-interface-manager/_build/network-interface-manager /usr/local/bin/network-interface-manager
 

--- a/cmd/network-interface-manager/Makefile
+++ b/cmd/network-interface-manager/Makefile
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CGO_ENABLED=0
+
 DOCKER_REPO ?= "quay.io/kubermatic"
-GOOS ?= $(shell go env GOOS)
 
 .PHONY: build
 build:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -v -o ./_build/network-interface-manager .
+	go build -v -o ./_build/network-interface-manager .
 
 .PHONY: docker
 docker: build
-	docker build -t $(DOCKER_REPO)/network-interface-manager:$(TAG) .
+	docker build --tag $(DOCKER_REPO)/network-interface-manager:$(TAG) --label "org.opencontainers.image.version=$(TAG)" .
 
 .PHONY: clean
 clean:

--- a/cmd/nodeport-proxy/Dockerfile
+++ b/cmd/nodeport-proxy/Dockerfile
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/alpine:3.18
-LABEL maintainer="support@kubermatic.com"
+FROM docker.io/alpine:3.19
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/nodeport-proxy/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 ADD ./_build/lb-updater /
 ADD ./_build/envoy-manager /

--- a/cmd/nodeport-proxy/Makefile
+++ b/cmd/nodeport-proxy/Makefile
@@ -12,16 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+export CGO_ENABLED=0
+
 DOCKER_REPO ?= "quay.io/kubermatic"
-GOOS ?= $(shell go env GOOS)
 
 .PHONY: lb-updater
 lb-updater:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/lb-updater -v k8c.io/kubermatic/v2/cmd/nodeport-proxy/lb-updater
+	go build -o ./_build/lb-updater -v k8c.io/kubermatic/v2/cmd/nodeport-proxy/lb-updater
 
 .PHONY: envoy-manager
 envoy-manager:
-	GOOS=$(GOOS) CGO_ENABLED=0 go build -o ./_build/envoy-manager -v k8c.io/kubermatic/v2/cmd/nodeport-proxy/envoy-manager
+	go build -o ./_build/envoy-manager -v k8c.io/kubermatic/v2/cmd/nodeport-proxy/envoy-manager
 
 .PHONY: build
 build: envoy-manager lb-updater
@@ -32,7 +33,8 @@ clean:
 
 .PHONY: docker
 docker: build
-	docker build -t $(DOCKER_REPO)/nodeport-proxy:$(TAG) .
+	docker build --tag $(DOCKER_REPO)/nodeport-proxy:$(TAG) --label "org.opencontainers.image.version=$(TAG)" .
 
+.PHONY: test
 test:
 	go test ./...

--- a/cmd/user-ssh-keys-agent/Dockerfile
+++ b/cmd/user-ssh-keys-agent/Dockerfile
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 FROM gcr.io/distroless/static-debian12
-LABEL maintainer="support@kubermatic.com"
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/user-ssh-keys-agent/Dockerfile"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 COPY ./_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 

--- a/cmd/user-ssh-keys-agent/Dockerfile.multiarch
+++ b/cmd/user-ssh-keys-agent/Dockerfile.multiarch
@@ -29,7 +29,9 @@ COPY . .
 RUN make -C ./cmd/user-ssh-keys-agent build
 
 FROM gcr.io/distroless/static-debian12
-LABEL maintainer="support@kubermatic.com"
+LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/cmd/user-ssh-keys-agent/Dockerfile.multiarch"
+LABEL org.opencontainers.image.vendor="Kubermatic"
+LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 COPY --from=builder /go/src/k8c.io/kubermatic/cmd/user-ssh-keys-agent/_build/user-ssh-keys-agent /usr/local/bin/user-ssh-keys-agent
 ENTRYPOINT ["/usr/local/bin/user-ssh-keys-agent"]

--- a/cmd/user-ssh-keys-agent/Makefile
+++ b/cmd/user-ssh-keys-agent/Makefile
@@ -25,4 +25,4 @@ build:
 
 .PHONY: docker
 docker: build
-	docker build -t $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) .
+	docker build --tag $(DOCKER_REPO)/user-ssh-keys-agent:$(TAG) --label "org.opencontainers.image.version=$(TAG)" .

--- a/hack/release-images.sh
+++ b/hack/release-images.sh
@@ -59,11 +59,12 @@ fi
 
 # build Docker images
 PRIMARY_TAG="${1}"
+VERSION_LABEL="org.opencontainers.image.version=${KUBERMATICDOCKERTAG:-$PRIMARY_TAG}"
 make docker-build TAGS="$PRIMARY_TAG"
 make -C cmd/nodeport-proxy docker TAG="$PRIMARY_TAG"
-docker build -t "$DOCKER_REPO/addons:$PRIMARY_TAG" addons
-docker build -t "$DOCKER_REPO/etcd-launcher:$PRIMARY_TAG" -f cmd/etcd-launcher/Dockerfile .
-docker build -t "$DOCKER_REPO/conformance-tests:$PRIMARY_TAG" -f cmd/conformance-tester/Dockerfile .
+docker build --label "$VERSION_LABEL" -t "$DOCKER_REPO/addons:$PRIMARY_TAG" addons
+docker build --label "$VERSION_LABEL" -t "$DOCKER_REPO/etcd-launcher:$PRIMARY_TAG" -f cmd/etcd-launcher/Dockerfile .
+docker build --label "$VERSION_LABEL" -t "$DOCKER_REPO/conformance-tests:$PRIMARY_TAG" -f cmd/conformance-tester/Dockerfile .
 
 # switch to a multi platform-enabled builder
 docker buildx create --use
@@ -79,12 +80,13 @@ buildx_build() {
     # --push would support building multiple archs at the same time.
     docker buildx build \
       --load \
-      --platform="linux/$arch" \
-      --build-arg="GOPROXY=${GOPROXY:-}" \
+      --platform "linux/$arch" \
+      --build-arg "GOPROXY=${GOPROXY:-}" \
       --build-arg "KUBERMATIC_EDITION=$KUBERMATIC_EDITION" \
       --provenance false \
       --file "$file" \
       --tag "$repository:$tag-$arch" \
+      --label "$VERSION_LABEL" \
       $context
   done
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This applies the common OCI labels to all our container images. I especially like the source link :-)

I also bumped our images to Alpine 3.19 in the process.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Improve labels on KKP container images.
- Update container images to Alpine 3.19.
```

**Documentation**:
```documentation
NONE
```
