### PR TITLE
Update container image tags for KKP-owned images

### DIFF
--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -44,7 +44,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/integration-tests:8-4
+        - image: quay.io/kubermatic/integration-tests:k8s-1.29.1-rev0
           command:
             - make
             - test-integration

--- a/charts/minio/test/enable-ingress.yaml.out
+++ b/charts/minio/test/enable-ingress.yaml.out
@@ -185,7 +185,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.4.0'
+        image: 'quay.io/kubermatic/util:2.5.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/image-pull-secret.yaml.out
+++ b/charts/minio/test/image-pull-secret.yaml.out
@@ -187,7 +187,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.4.0'
+        image: 'quay.io/kubermatic/util:2.5.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ce.yaml.out
+++ b/charts/minio/test/values.example.ce.yaml.out
@@ -186,7 +186,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.4.0'
+        image: 'quay.io/kubermatic/util:2.5.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/test/values.example.ee.yaml.out
+++ b/charts/minio/test/values.example.ee.yaml.out
@@ -186,7 +186,7 @@ spec:
             cpu: 100m
             memory: 32Mi
       - name: backup
-        image: 'quay.io/kubermatic/util:2.4.0'
+        image: 'quay.io/kubermatic/util:2.5.0'
         args:
         - /bin/sh
         - -c

--- a/charts/minio/values.yaml
+++ b/charts/minio/values.yaml
@@ -80,7 +80,7 @@ minio:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.4.0
+      tag: 2.5.0
 
   # If your cluster does not have a default storage class,
   # you can specify the class to use for Minio. Note that

--- a/charts/mla/alertmanager-proxy/Chart.yaml
+++ b/charts/mla/alertmanager-proxy/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: alertmanager-proxy
 version: v9.9.9-dev
-appVersion: 0.3.0
+appVersion: 0.3.1
 description: A Helm chart to install KKP MLA Alertmanager Proxy.
 keywords:
   - kubermatic

--- a/charts/mla/alertmanager-proxy/test/default.yaml.out
+++ b/charts/mla/alertmanager-proxy/test/default.yaml.out
@@ -368,7 +368,7 @@ spec:
       serviceAccountName: alertmanager-authz-server
       containers:
         - name: authz-server
-          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.3.0'
+          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.3.1'
           ports:
             - containerPort: 50051
           args:

--- a/charts/mla/alertmanager-proxy/values.yaml
+++ b/charts/mla/alertmanager-proxy/values.yaml
@@ -46,7 +46,7 @@ alertmanagerProxy:
   authz:
     image:
       repository: "quay.io/kubermatic/alertmanager-authorization-server"
-      tag: "0.3.0"
+      tag: "0.3.1"
     # list of image pull secret references, e.g.
     # imagePullSecrets:
     #   - name: quay-io-pull-secret

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -28,7 +28,7 @@ grafana:
     tag: 2.5.0
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
-    tag: 1.3.2
+    tag: 1.3.3
 
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -25,7 +25,7 @@ grafana:
     tag: 9.5.1
   utilImage:
     repository: quay.io/kubermatic/util
-    tag: 2.4.0
+    tag: 2.5.0
   pluginImage:
     repository: quay.io/kubermatic/grafana-plugins
     tag: 1.3.2

--- a/charts/monitoring/karma/values.yaml
+++ b/charts/monitoring/karma/values.yaml
@@ -55,7 +55,7 @@ karma:
       pullPolicy: IfNotPresent
     initContainer:
       repository: quay.io/kubermatic/util
-      tag: 2.4.0
+      tag: 2.5.0
       pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -46,7 +46,7 @@ prometheus:
     enabled: true
     image:
       repository: quay.io/kubermatic/util
-      tag: 2.4.0
+      tag: 2.5.0
     timeout: 60m
 
   # Specify additional external labels which will be added to all

--- a/charts/s3-exporter/Chart.yaml
+++ b/charts/s3-exporter/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: s3-exporter
 version: v9.9.9-dev
-appVersion: v0.7
+appVersion: v0.7.1
 keywords:
   - kubermatic
   - prometheus

--- a/charts/s3-exporter/values.yaml
+++ b/charts/s3-exporter/values.yaml
@@ -15,7 +15,7 @@
 s3Exporter:
   image:
     repository: quay.io/kubermatic/s3-exporter
-    tag: v0.7
+    tag: v0.7.1
     # list of image pull secret references, e.g.
   # imagePullSecrets:
   #   - name: quay-io-pull-secret

--- a/hack/ci/testdata/minio_bucket_job.yaml
+++ b/hack/ci/testdata/minio_bucket_job.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: mc
-          image: quay.io/kubermatic/util:2.4.0
+          image: quay.io/kubermatic/util:2.5.0
           args:
             - /bin/sh
             - -c

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -109,7 +109,7 @@ is_containerized() {
 
 containerize() {
   local cmd="$1"
-  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.4.0}"
+  local image="${CONTAINERIZE_IMAGE:-quay.io/kubermatic/util:2.5.0}"
   local gocache="${CONTAINERIZE_GOCACHE:-/tmp/.gocache}"
   local gomodcache="${CONTAINERIZE_GOMODCACHE:-/tmp/.gomodcache}"
   local skip="${NO_CONTAINERIZE:-}"

--- a/pkg/controller/master-controller-manager/seed-proxy/resources.go
+++ b/pkg/controller/master-controller-manager/seed-proxy/resources.go
@@ -250,7 +250,7 @@ func masterDeploymentReconciler(seed *kubermaticv1.Seed, secret *corev1.Secret, 
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "proxy",
-					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kubermatic/util:2.4.0")),
+					Image:   registry.Must(imageRewriter(resources.RegistryQuay + "/kubermatic/util:2.5.0")),
 					Command: []string{"/bin/bash"},
 					Args:    []string{"-c", strings.TrimSpace(proxyScript)},
 					Env: []corev1.EnvVar{

--- a/pkg/resources/apiserver/is-running.go
+++ b/pkg/resources/apiserver/is-running.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	tag                = "v0.5.0"
+	tag                = "v0.5.1"
 	emptyDirVolumeName = "http-prober-bin"
 	initContainerName  = "copy-http-prober"
 )

--- a/pkg/resources/cloudcontroller/gcp.go
+++ b/pkg/resources/cloudcontroller/gcp.go
@@ -195,7 +195,7 @@ func gcpDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDepl
 func getGCPInitContainer(data *resources.TemplateData) corev1.Container {
 	return corev1.Container{
 		Name:    "decode-sa",
-		Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.4.0")),
+		Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.5.0")),
 		Command: []string{"/bin/sh"},
 		Args: []string{
 			"-c",

--- a/pkg/resources/encryption/job.go
+++ b/pkg/resources/encryption/job.go
@@ -75,7 +75,7 @@ func EncryptionJobCreator(data encryptionData, cluster *kubermaticv1.Cluster, se
 					Containers: []corev1.Container{
 						{
 							Name:    "encryption-runner",
-							Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.4.0")),
+							Image:   registry.Must(data.RewriteImage(resources.RegistryQuay + "/kubermatic/util:2.5.0")),
 							Command: []string{"/bin/bash", "-c"},
 							Args: []string{
 								fmt.Sprintf(encryptionJobScript, resourceList),

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -204,7 +204,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
@@ -204,7 +204,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -204,7 +204,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
@@ -204,7 +204,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -204,7 +204,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager.yaml
@@ -204,7 +204,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
@@ -121,7 +121,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -127,7 +127,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -127,7 +127,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -127,7 +127,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -127,7 +127,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -127,7 +127,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
@@ -127,7 +127,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
@@ -117,7 +117,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
@@ -101,7 +101,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
@@ -123,7 +123,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
@@ -118,7 +118,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
@@ -98,7 +98,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
@@ -98,7 +98,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
@@ -107,7 +107,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
@@ -97,7 +97,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
@@ -98,7 +98,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -113,7 +113,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
@@ -98,7 +98,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
@@ -98,7 +98,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
@@ -98,7 +98,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -194,7 +194,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
@@ -194,7 +194,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:
@@ -133,7 +133,7 @@ spec:
         - base64 -d /input/serviceAccount > /scratch/serviceAccount.json
         command:
         - /bin/sh
-        image: quay.io/kubermatic/util:2.4.0
+        image: quay.io/kubermatic/util:2.5.0
         name: decode-sa
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -194,7 +194,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
@@ -194,7 +194,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:
@@ -133,7 +133,7 @@ spec:
         - base64 -d /input/serviceAccount > /scratch/serviceAccount.json
         command:
         - /bin/sh
-        image: quay.io/kubermatic/util:2.4.0
+        image: quay.io/kubermatic/util:2.5.0
         name: decode-sa
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -194,7 +194,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager.yaml
@@ -194,7 +194,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:
@@ -133,7 +133,7 @@ spec:
         - base64 -d /input/serviceAccount > /scratch/serviceAccount.json
         command:
         - /bin/sh
-        image: quay.io/kubermatic/util:2.4.0
+        image: quay.io/kubermatic/util:2.5.0
         name: decode-sa
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
@@ -112,7 +112,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
@@ -102,7 +102,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
@@ -86,7 +86,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
@@ -108,7 +108,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
@@ -103,7 +103,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -138,7 +138,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -148,7 +148,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -148,7 +148,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -138,7 +138,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -144,7 +144,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
@@ -144,7 +144,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -139,7 +139,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
@@ -139,7 +139,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -138,7 +138,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -148,7 +148,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -148,7 +148,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -138,7 +138,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -144,7 +144,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
@@ -144,7 +144,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -139,7 +139,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
@@ -139,7 +139,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -138,7 +138,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -148,7 +148,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
@@ -148,7 +148,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
@@ -138,7 +138,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
@@ -122,7 +122,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -144,7 +144,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
@@ -144,7 +144,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -139,7 +139,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
@@ -139,7 +139,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -135,7 +135,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
@@ -131,7 +131,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
@@ -126,7 +126,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -135,7 +135,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
@@ -131,7 +131,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
@@ -126,7 +126,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-controller-manager.yaml
@@ -188,7 +188,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
@@ -135,7 +135,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
@@ -125,7 +125,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
@@ -80,7 +80,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
@@ -131,7 +131,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
@@ -126,7 +126,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager.yaml
@@ -192,7 +192,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
@@ -76,7 +76,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard.yaml
@@ -78,7 +78,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
@@ -119,7 +119,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
@@ -109,7 +109,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server-externalCloudProvider.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-metrics-server.yaml
@@ -177,7 +177,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
@@ -93,7 +93,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler-externalCloudProvider.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler.yaml
@@ -168,7 +168,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
@@ -115,7 +115,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
@@ -110,7 +110,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -111,7 +111,7 @@ spec:
         - /bin/cp
         - /usr/local/bin/http-prober
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/http-prober:v0.5.0
+        image: quay.io/kubermatic/http-prober:v0.5.1
         name: copy-http-prober
         resources: {}
         volumeMounts:


### PR DESCRIPTION
**What this PR does / why we need it**:
In #13189 we defined new tags for our images, to ensure all of them were built once using CI.

This PR now ensures KKP actually uses these new images.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
