### PR TITLE
Update MLA Envoy to 1.29.2, improve alertmanager-proxy Helm Chart

### DIFF
--- a/charts/mla/alertmanager-proxy/Chart.yaml
+++ b/charts/mla/alertmanager-proxy/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: alertmanager-proxy
 version: v9.9.9-dev
-appVersion: 0.3.2
+appVersion: 0.3.3
 description: A Helm chart to install KKP MLA Alertmanager Proxy.
 keywords:
   - kubermatic

--- a/charts/mla/alertmanager-proxy/Chart.yaml
+++ b/charts/mla/alertmanager-proxy/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: alertmanager-proxy
 version: v9.9.9-dev
-appVersion: 0.3.1
+appVersion: 0.3.2
 description: A Helm chart to install KKP MLA Alertmanager Proxy.
 keywords:
   - kubermatic

--- a/charts/mla/alertmanager-proxy/templates/authzserver-deployment.yaml
+++ b/charts/mla/alertmanager-proxy/templates/authzserver-deployment.yaml
@@ -37,13 +37,24 @@ spec:
       imagePullSecrets: {{- toYaml .Values.alertmanagerProxy.authz.imagePullSecrets | nindent 8 }}
       {{- end }}
       serviceAccountName: alertmanager-authz-server
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: authz-server
           image: '{{ .Values.alertmanagerProxy.authz.image.repository }}:{{ .Values.alertmanagerProxy.authz.image.tag }}'
-          ports:
-            - containerPort: 50051
           args:
-            - -log-debug=true
+            - -address={{ .Values.alertmanagerProxy.authz.listenAddress.host }}:{{ .Values.alertmanagerProxy.authz.listenAddress.port }}
+            - -log-debug={{ .Values.alertmanagerProxy.authz.logging.debug }}
+            - -log-format={{ .Values.alertmanagerProxy.authz.logging.format }}
+          ports:
+            - containerPort: {{ .Values.alertmanagerProxy.authz.listenAddress.port }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
 {{ toYaml .Values.alertmanagerProxy.authz.resources | indent 12 }}
       nodeSelector:

--- a/charts/mla/alertmanager-proxy/templates/authzserver-deployment.yaml
+++ b/charts/mla/alertmanager-proxy/templates/authzserver-deployment.yaml
@@ -45,7 +45,7 @@ spec:
         - name: authz-server
           image: '{{ .Values.alertmanagerProxy.authz.image.repository }}:{{ .Values.alertmanagerProxy.authz.image.tag }}'
           args:
-            - -address={{ .Values.alertmanagerProxy.authz.listenAddress.host }}:{{ .Values.alertmanagerProxy.authz.listenAddress.port }}
+            - "-address={{ .Values.alertmanagerProxy.authz.listenAddress.host }}:{{ .Values.alertmanagerProxy.authz.listenAddress.port }}"
             - -log-debug={{ .Values.alertmanagerProxy.authz.logging.debug }}
             - -log-format={{ .Values.alertmanagerProxy.authz.logging.format }}
           ports:

--- a/charts/mla/alertmanager-proxy/templates/authzserver-service.yaml
+++ b/charts/mla/alertmanager-proxy/templates/authzserver-service.yaml
@@ -22,8 +22,8 @@ spec:
   type: ClusterIP
   ports:
     - name: http
-      port: 50051
-      targetPort: 50051
+      port: {{ .Values.alertmanagerProxy.authz.listenAddress.port }}
+      targetPort: {{ .Values.alertmanagerProxy.authz.listenAddress.port }}
       protocol: TCP
   selector:
     app.kubernetes.io/name: alertmanager-authz-server

--- a/charts/mla/alertmanager-proxy/templates/proxy-configmap.yaml
+++ b/charts/mla/alertmanager-proxy/templates/proxy-configmap.yaml
@@ -19,17 +19,27 @@ metadata:
 data:
   envoy.yaml: |
     admin:
-      access_log_path: /tmp/admin_access.log
       address:
         socket_address:
           protocol: TCP
           address: 127.0.0.1
           port_value: 9901
-      
+
+    # not yet a stable API, but would solve:
+    #    > There is no configured limit to the number of allowed active downstream connections.
+    #    > Configure a limit in `envoy.resource_monitors.downstream_connections` resource monitor.
+    #
+    # overload_manager:
+    #   resource_monitors:
+    #   - name: "envoy.resource_monitors.global_downstream_max_connections"
+    #     typed_config:
+    #       "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+    #       max_active_downstream_connections: 100
+
     static_resources:
       listeners:
 
-      ### authorization and path rewiting proxy ###
+      ### authorization and path rewriting proxy ###
       - name: listener_http
         address:
           socket_address:
@@ -39,7 +49,7 @@ data:
         filter_chains:
         - filters:
           - name: envoy.filters.network.http_connection_manager
-            typed_config:  
+            typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               stat_prefix: ingress_http
               access_log:
@@ -53,7 +63,7 @@ data:
                 - name: local_service
                   domains: ["*"]
                   # Added this to allow per-route filter disabling for healthcheck endpoint
-                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/ext_authz_filter#per-route-configuration
+                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.29.2/configuration/http/http_filters/ext_authz_filter#per-route-configuration
                   typed_per_filter_config:
                     envoy.filters.http.ext_authz:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
@@ -62,10 +72,9 @@ data:
                           virtual_host: local_service
                   routes:
                   # Added healthcheck route with Authz filter disabled.
-                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/ext_authz_filter#per-route-configuration
+                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.29.2/configuration/http/http_filters/ext_authz_filter#per-route-configuration
                   - match:
                       safe_regex:
-                        google_re2: {}
                         regex: '/ready$'
                     route:
                       cluster: service_backend
@@ -76,24 +85,20 @@ data:
                   # redirect if the path contains only cluster ID without slash (append slash at the end)
                   - match:
                       safe_regex:
-                        google_re2: {}
                         regex: '^/([[:alnum:]]+)$'
                     redirect:
                       regex_rewrite:
                         pattern:
-                          google_re2: {}
                           regex: '^/([[:alnum:]]+)$'
                         substitution: '/\1/'
 
                   # strip tenant ID from the path
                   - match:
                       safe_regex:
-                        google_re2: {}
                         regex: '^/(.+?)/(.*)'
                     route:
                       regex_rewrite:
                         pattern:
-                          google_re2: {}
                           regex: '^/(.+?)/(.*)'
                         substitution: '/api/prom/alertmanager/\2'
                       cluster: service_backend
@@ -110,6 +115,8 @@ data:
                   status_on_error:
                     code: ServiceUnavailable
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
       ### limited access to envoy stats and health ###
       - name: service_stats
@@ -140,6 +147,8 @@ data:
                       cluster: service_stats
               http_filters:
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
       clusters:
       - name: service_backend
@@ -160,7 +169,11 @@ data:
       - name: ext-authz
         type: STRICT_DNS
         connect_timeout: 2s
-        http2_protocol_options: {}
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options: {}
         load_assignment:
           cluster_name: ext-authz
           endpoints:
@@ -169,7 +182,7 @@ data:
                     address:
                       socket_address:
                         address: alertmanager-authz-server
-                        port_value: 50051
+                        port_value: {{ .Values.alertmanagerProxy.authz.listenAddress.port }}
 
       - name: service_stats
         connect_timeout: 0.1s

--- a/charts/mla/alertmanager-proxy/templates/proxy-deployment.yaml
+++ b/charts/mla/alertmanager-proxy/templates/proxy-deployment.yaml
@@ -34,6 +34,7 @@ spec:
         prometheus.io/metrics_path: /stats/prometheus
         prometheus.io/port: "9902"
         prometheus.io/scrape: "true"
+        checksum/envoy-config: {{ include (print $.Template.BasePath "/proxy-configmap.yaml") $ | sha256sum }}
       labels:
         app.kubernetes.io/name: alertmanager-proxy
     spec:
@@ -43,6 +44,11 @@ spec:
       containers:
         - name: envoy
           image: '{{ .Values.alertmanagerProxy.proxy.image.repository }}:{{ .Values.alertmanagerProxy.proxy.image.tag }}'
+          args:
+            - --config-path
+            - /etc/envoy/envoy.yaml
+            - --log-level
+            - {{ .Values.alertmanagerProxy.proxy.logLevel }}
           ports:
             - containerPort: 8080
               name: proxy

--- a/charts/mla/alertmanager-proxy/test/default.yaml.out
+++ b/charts/mla/alertmanager-proxy/test/default.yaml.out
@@ -385,7 +385,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: authz-server
-          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.3.2'
+          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.3.3'
           args:
             - "-address=0.0.0.0:50051"
             - -log-debug=true

--- a/charts/mla/alertmanager-proxy/test/default.yaml.out
+++ b/charts/mla/alertmanager-proxy/test/default.yaml.out
@@ -41,17 +41,27 @@ metadata:
 data:
   envoy.yaml: |
     admin:
-      access_log_path: /tmp/admin_access.log
       address:
         socket_address:
           protocol: TCP
           address: 127.0.0.1
           port_value: 9901
-      
+
+    # not yet a stable API, but would solve:
+    #    > There is no configured limit to the number of allowed active downstream connections.
+    #    > Configure a limit in `envoy.resource_monitors.downstream_connections` resource monitor.
+    #
+    # overload_manager:
+    #   resource_monitors:
+    #   - name: "envoy.resource_monitors.global_downstream_max_connections"
+    #     typed_config:
+    #       "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+    #       max_active_downstream_connections: 100
+
     static_resources:
       listeners:
 
-      ### authorization and path rewiting proxy ###
+      ### authorization and path rewriting proxy ###
       - name: listener_http
         address:
           socket_address:
@@ -61,7 +71,7 @@ data:
         filter_chains:
         - filters:
           - name: envoy.filters.network.http_connection_manager
-            typed_config:  
+            typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
               stat_prefix: ingress_http
               access_log:
@@ -75,7 +85,7 @@ data:
                 - name: local_service
                   domains: ["*"]
                   # Added this to allow per-route filter disabling for healthcheck endpoint
-                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/ext_authz_filter#per-route-configuration
+                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.29.2/configuration/http/http_filters/ext_authz_filter#per-route-configuration
                   typed_per_filter_config:
                     envoy.filters.http.ext_authz:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
@@ -84,10 +94,9 @@ data:
                           virtual_host: local_service
                   routes:
                   # Added healthcheck route with Authz filter disabled.
-                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.18.4/configuration/http/http_filters/ext_authz_filter#per-route-configuration
+                  # Ref: https://www.envoyproxy.io/docs/envoy/v1.29.2/configuration/http/http_filters/ext_authz_filter#per-route-configuration
                   - match:
                       safe_regex:
-                        google_re2: {}
                         regex: '/ready$'
                     route:
                       cluster: service_backend
@@ -98,24 +107,20 @@ data:
                   # redirect if the path contains only cluster ID without slash (append slash at the end)
                   - match:
                       safe_regex:
-                        google_re2: {}
                         regex: '^/([[:alnum:]]+)$'
                     redirect:
                       regex_rewrite:
                         pattern:
-                          google_re2: {}
                           regex: '^/([[:alnum:]]+)$'
                         substitution: '/\1/'
 
                   # strip tenant ID from the path
                   - match:
                       safe_regex:
-                        google_re2: {}
                         regex: '^/(.+?)/(.*)'
                     route:
                       regex_rewrite:
                         pattern:
-                          google_re2: {}
                           regex: '^/(.+?)/(.*)'
                         substitution: '/api/prom/alertmanager/\2'
                       cluster: service_backend
@@ -132,6 +137,8 @@ data:
                   status_on_error:
                     code: ServiceUnavailable
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
       ### limited access to envoy stats and health ###
       - name: service_stats
@@ -162,6 +169,8 @@ data:
                       cluster: service_stats
               http_filters:
               - name: envoy.filters.http.router
+                typed_config:
+                  "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
       clusters:
       - name: service_backend
@@ -182,7 +191,11 @@ data:
       - name: ext-authz
         type: STRICT_DNS
         connect_timeout: 2s
-        http2_protocol_options: {}
+        typed_extension_protocol_options:
+          envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+            "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+            explicit_http_config:
+              http2_protocol_options: {}
         load_assignment:
           cluster_name: ext-authz
           endpoints:
@@ -366,13 +379,24 @@ spec:
         app.kubernetes.io/name: alertmanager-authz-server
     spec:
       serviceAccountName: alertmanager-authz-server
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: authz-server
-          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.3.1'
+          image: 'quay.io/kubermatic/alertmanager-authorization-server:0.3.2'
+          args:
+            - "-address=0.0.0.0:50051"
+            - -log-debug=true
+            - -log-format=json
           ports:
             - containerPort: 50051
-          args:
-            - -log-debug=true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           resources:
             limits:
               cpu: 200m
@@ -431,12 +455,18 @@ spec:
         prometheus.io/metrics_path: /stats/prometheus
         prometheus.io/port: "9902"
         prometheus.io/scrape: "true"
+        checksum/envoy-config: 3c0a21b9487766c1666b8cdcf94149009069426e596eb0bafc707d865c3949cb
       labels:
         app.kubernetes.io/name: alertmanager-proxy
     spec:
       containers:
         - name: envoy
-          image: 'docker.io/envoyproxy/envoy:v1.18.3'
+          image: 'docker.io/envoyproxy/envoy:v1.29.2'
+          args:
+            - --config-path
+            - /etc/envoy/envoy.yaml
+            - --log-level
+            - info
           ports:
             - containerPort: 8080
               name: proxy

--- a/charts/mla/alertmanager-proxy/values.yaml
+++ b/charts/mla/alertmanager-proxy/values.yaml
@@ -18,11 +18,12 @@ alertmanagerProxy:
     backendPort: 8080
     image:
       repository: "docker.io/envoyproxy/envoy"
-      tag: "v1.18.3"
+      tag: "v1.29.2"
     # list of image pull secret references, e.g.
     # imagePullSecrets:
     #   - name: docker-io-pull-secret
     imagePullSecrets: []
+    logLevel: info
     replicas: 1
     resources:
       requests:
@@ -46,7 +47,7 @@ alertmanagerProxy:
   authz:
     image:
       repository: "quay.io/kubermatic/alertmanager-authorization-server"
-      tag: "0.3.1"
+      tag: "0.3.2"
     # list of image pull secret references, e.g.
     # imagePullSecrets:
     #   - name: quay-io-pull-secret
@@ -59,6 +60,12 @@ alertmanagerProxy:
       limits:
         cpu: 200m
         memory: 64Mi
+    logging:
+      debug: true
+      format: json # json or console
+    listenAddress:
+      host: 0.0.0.0
+      port: 50051
     nodeSelector: {}
     affinity:
       podAntiAffinity:

--- a/charts/mla/alertmanager-proxy/values.yaml
+++ b/charts/mla/alertmanager-proxy/values.yaml
@@ -47,7 +47,7 @@ alertmanagerProxy:
   authz:
     image:
       repository: "quay.io/kubermatic/alertmanager-authorization-server"
-      tag: "0.3.2"
+      tag: "0.3.3"
     # list of image pull secret references, e.g.
     # imagePullSecrets:
     #   - name: quay-io-pull-secret


### PR DESCRIPTION
**What this PR does / why we need it**:
This builds upon #13221, but mainly makes a _major_ version bump for Envoy, from 1.18 to 1.29. I tested the config changes on dev and besides one warning that I could not get rid of (see the comment in the envoy ConfigMap), it seems to work fine and allowed me to access the Alertmanager on dev.

**What type of PR is this?**
/kind cleanup
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Update Alertmanager Authorization Envoy to v1.29.2
- Improve alertmanager-proxy Helm Chart: do not require root permissions, drop capabilities and make logging/ports configurable
```

**Documentation**:
```documentation
NONE
```
