### PR TITLE
Fix configured envoy image not being used

### DIFF
--- a/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources_integration_test.go
@@ -247,6 +247,13 @@ func TestEnsureResourcesAreDeployedIdempotency(t *testing.T) {
 					Datacenters: map[string]kubermaticv1.Datacenter{
 						testCluster.Spec.Cloud.DatacenterName: {},
 					},
+					NodeportProxy: kubermaticv1.NodeportProxyConfig{
+						Envoy: kubermaticv1.NodePortProxyComponentEnvoy{
+							NodeportProxyComponent: kubermaticv1.NodeportProxyComponent{
+								DockerRepository: defaulting.DefaultEnvoyDockerRepository,
+							},
+						},
+					},
 				},
 			}, nil
 		},

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -154,6 +154,7 @@ type nodePortProxyData interface {
 	RewriteImage(string) (string, error)
 	NodePortProxyTag() string
 	Cluster() *kubermaticv1.Cluster
+	Seed() *kubermaticv1.Seed
 	SupportsFailureDomainZoneAntiAffinity() bool
 }
 
@@ -237,6 +238,8 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 				},
 			}
 
+			seed := data.Seed()
+
 			d.Spec.Template.Spec.Containers = []corev1.Container{{
 				Name:  "envoy-manager",
 				Image: registry.Must(data.RewriteImage(fmt.Sprintf("%s/%s:%s", resources.RegistryQuay, imageName, data.NodePortProxyTag()))),
@@ -263,7 +266,7 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 				},
 			}, {
 				Name:  resources.NodePortProxyEnvoyContainerName,
-				Image: registry.Must(data.RewriteImage(fmt.Sprintf("envoyproxy/envoy-distroless:%s", versions.Envoy))),
+				Image: registry.Must(data.RewriteImage(fmt.Sprintf("%s:%s", seed.Spec.NodeportProxy.Envoy.DockerRepository, versions.Envoy))),
 				Command: []string{
 					"/usr/local/bin/envoy",
 					"-c",

--- a/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-aws-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.28.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-aws-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-aws-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.29.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-aws-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-aws-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-azure-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.28.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-azure-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-azure-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.29.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-azure-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-azure-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-bringyourown-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-bringyourown-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-digitalocean-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-digitalocean-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-edge-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-edge-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-edge-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-edge-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-gcp-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.27.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-gcp-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-gcp-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.28.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-gcp-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-gcp-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.29.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-gcp-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-gcp-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-openstack-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.28.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-openstack-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-openstack-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.29.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-openstack-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-openstack-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vcd-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vcd-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vcd-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vcd-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.27.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.28.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/configmap-vsphere-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/configmap-vsphere-1.29.0-prometheus.yaml
@@ -7,7 +7,7 @@ data:
       scrape_interval: 30s
       external_labels:
         cluster: "de-test-01"
-        seed_cluster: "testdc"
+        seed_cluster: "test-seed"
 
     rule_files:
     - "/etc/prometheus/config/rules*.yaml"

--- a/pkg/resources/test/fixtures/service-azure-1.27.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.27.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.28.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.28.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.29.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.29.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-azure-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-azure-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-bringyourown-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-bringyourown-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-bringyourown-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-bringyourown-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.27.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.27.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.28.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.28.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.29.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.29.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-digitalocean-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-digitalocean-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-edge-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-edge-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-edge-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-edge-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-edge-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-edge-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-gcp-1.27.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.27.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-gcp-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-gcp-1.28.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.28.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-gcp-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-gcp-1.29.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.29.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-gcp-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-gcp-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.27.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.27.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.28.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.28.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.29.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.29.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-openstack-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-openstack-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vcd-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vcd-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vcd-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vcd-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vcd-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vcd-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.27.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.27.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.27.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.27.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.28.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.28.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.28.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.28.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.29.0-front-loadbalancer-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.29.0-front-loadbalancer-externalCloudProvider.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01

--- a/pkg/resources/test/fixtures/service-vsphere-1.29.0-front-loadbalancer.yaml
+++ b/pkg/resources/test/fixtures/service-vsphere-1.29.0-front-loadbalancer.yaml
@@ -1,6 +1,9 @@
 # This file has been generated, DO NOT EDIT.
 
 metadata:
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-connection-idle-timeout: "3600"
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
   creationTimestamp: null
   name: front-loadbalancer
   namespace: cluster-de-test-01


### PR DESCRIPTION
**What this PR does / why we need it**:
I _think_ we should use the same image for the main Envoy (deployed by the KKP Operator) and the usercluster Envoys (deployed by the seed-ctrl-mgr), but I'm not sure?

This PR then cleans up the test fixture generation a bit, hence the noice. Without defaulting the Seed, the generated Deployment would be invalid and cause a panic.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix Envoy image configured for nodeport proxy not being used for the seed's Envoy deployment.
```

**Documentation**:
```documentation
NONE
```
