### PR TITLE
Let S3-exporter run as nonroot

### DIFF
--- a/charts/s3-exporter/templates/deployment.yaml
+++ b/charts/s3-exporter/templates/deployment.yaml
@@ -36,28 +36,30 @@ spec:
       {{- if .Values.s3Exporter.imagePullSecrets }}
       imagePullSecrets: {{- toYaml .Values.s3Exporter.imagePullSecrets | nindent 8 }}
       {{- end }}
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: s3-exporter
           image: '{{ .Values.s3Exporter.image.repository }}:{{ .Values.s3Exporter.image.tag }}'
           args:
-          - -endpoint={{ .Values.s3Exporter.endpoint }}
-          - -access-key-id=$(ACCESS_KEY_ID)
-          - -secret-access-key=$(SECRET_ACCESS_KEY)
-          - -bucket={{ .Values.s3Exporter.bucket }}
-{{- if .Values.s3Exporter.caBundleConfigMap }}
-          - -ca-bundle=/etc/cabundle/cabundle.pem
-{{- end }}
+            - -endpoint={{ .Values.s3Exporter.endpoint }}
+            - -bucket={{ .Values.s3Exporter.bucket }}
+            {{- if .Values.s3Exporter.caBundleConfigMap }}
+            - -ca-bundle=/etc/cabundle/cabundle.pem
+            {{- end }}
           env:
-          - name: ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: kubermatic-s3-credentials
-                key: ACCESS_KEY_ID
-          - name: SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: kubermatic-s3-credentials
-                key: SECRET_ACCESS_KEY
+            - name: ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: kubermatic-s3-credentials
+                  key: ACCESS_KEY_ID
+            - name: SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kubermatic-s3-credentials
+                  key: SECRET_ACCESS_KEY
           resources:
 {{ toYaml .Values.s3Exporter.resources | indent 12 }}
 {{- with .Values.s3Exporter.caBundleConfigMap }}
@@ -65,6 +67,11 @@ spec:
             - name: cabundle
               mountPath: /etc/cabundle
               readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
       volumes:
         - name: cabundle
           configMap:

--- a/charts/s3-exporter/values.yaml
+++ b/charts/s3-exporter/values.yaml
@@ -15,7 +15,7 @@
 s3Exporter:
   image:
     repository: quay.io/kubermatic/s3-exporter
-    tag: v0.7.1
+    tag: v0.7.2
     # list of image pull secret references, e.g.
   # imagePullSecrets:
   #   - name: quay-io-pull-secret


### PR DESCRIPTION
**What this PR does / why we need it**:
0.7.2 switched the base image, so now we can make use of it and configure the Deployment to not require root permissions. I also removed the 2 CLI flags, as the exporter will itself look up the env vars, no need for us to leak the credentials via CLI flags.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
S3-Exporter does not run with root permissions and does not leak credentials via CLI flags anymore.
```

**Documentation**:
```documentation
NONE
```
