### PR TITLE
chore: improve exclusion check in CNI immutable values validation

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -326,14 +326,21 @@ func GetAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 func ValidateValuesUpdate(newValues, oldValues map[string]any, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	// Validate immutability of specific top-level value subtrees, managed solely by KKP
+	exclusions := []exclusion{
+		{
+			fullPath:  "cni.chainingMode",
+			pathParts: strings.Split("cni.chainingMode", "."),
+		},
+		{
+			fullPath:  "ipam.operator.clusterPoolIPv4PodCIDR",
+			pathParts: strings.Split("ipam.operator.clusterPoolIPv4PodCIDR", "."),
+		},
+	}
 	allErrs = append(allErrs, validateImmutableValues(newValues, oldValues, fieldPath, []string{
 		"cni",
 		"ipam",
 		"ipv6",
-	}, []string{
-		"cni.chainingMode",
-		"ipam.operator.clusterPoolIPv4PodCIDR",
-	})...)
+	}, exclusions)...)
 
 	// Validate that mandatory top-level values are present
 	allErrs = append(allErrs, validateMandatoryValues(newValues, fieldPath, []string{
@@ -361,22 +368,27 @@ func ValidateValuesUpdate(newValues, oldValues map[string]any, fieldPath *field.
 	}
 	allErrs = append(allErrs, validateImmutableValues(newOperator, oldOperator, operPath, []string{
 		"securityContext",
-	}, []string{})...)
+	}, []exclusion{})...)
 
 	return allErrs
 }
 
-func validateImmutableValues(newValues, oldValues map[string]any, fieldPath *field.Path, immutableValues []string, excludedKeys []string) field.ErrorList {
+type exclusion struct {
+	fullPath  string
+	pathParts []string
+}
+
+func validateImmutableValues(newValues, oldValues map[string]any, fieldPath *field.Path, immutableValues []string, exclusions []exclusion) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allowedValues := map[string]bool{}
 
 	for _, v := range immutableValues {
-		for _, exclusion := range excludedKeys {
-			if strings.HasPrefix(exclusion, v) {
-				if excludedKeyExists(newValues, strings.Split(exclusion, ".")...) {
+		for _, exclusion := range exclusions {
+			if strings.HasPrefix(exclusion.fullPath, v) {
+				if excludedKeyExists(newValues, exclusion.pathParts...) {
 					allowedValues[v] = true
 				}
-				if excludedKeyExists(oldValues, strings.Split(exclusion, ".")...) {
+				if excludedKeyExists(oldValues, exclusion.pathParts...) {
 					allowedValues[v] = true
 				}
 			}

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -329,11 +329,11 @@ func ValidateValuesUpdate(newValues, oldValues map[string]any, fieldPath *field.
 	exclusions := []exclusion{
 		{
 			fullPath:  "cni.chainingMode",
-			pathParts: strings.Split("cni.chainingMode", "."),
+			pathParts: []string{"cni", "chainingMode"},
 		},
 		{
 			fullPath:  "ipam.operator.clusterPoolIPv4PodCIDR",
-			pathParts: strings.Split("ipam.operator.clusterPoolIPv4PodCIDR", "."),
+			pathParts: []string{"ipam", "operator", "clusterPoolIPv4PodCIDR"},
 		},
 	}
 	allErrs = append(allErrs, validateImmutableValues(newValues, oldValues, fieldPath, []string{

--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -221,7 +222,7 @@ func TestValidateImmutableValues(t *testing.T) {
 		name            string
 		want            field.ErrorList
 		immutableValues []string
-		acceptedFields  []string
+		acceptedFields  []exclusion
 		fieldPath       *field.Path
 		oldValues       map[string]any
 		newValues       map[string]any
@@ -229,7 +230,7 @@ func TestValidateImmutableValues(t *testing.T) {
 		{
 			name:            "equal spec",
 			immutableValues: []string{"values"},
-			acceptedFields:  []string{},
+			acceptedFields:  []exclusion{},
 			want:            field.ErrorList{},
 			fieldPath:       field.NewPath("spec"),
 			oldValues:       oldValues,
@@ -238,7 +239,7 @@ func TestValidateImmutableValues(t *testing.T) {
 		{
 			name:            "equal values",
 			immutableValues: []string{"cni", "ipam", "ipv6"},
-			acceptedFields:  []string{},
+			acceptedFields:  []exclusion{},
 			want:            field.ErrorList{},
 			fieldPath:       field.NewPath("spec").Child("values"),
 			oldValues:       oldValues,
@@ -247,7 +248,7 @@ func TestValidateImmutableValues(t *testing.T) {
 		{
 			name:            "ipam modified",
 			immutableValues: []string{"cni", "ipam", "ipv6"},
-			acceptedFields:  []string{},
+			acceptedFields:  []exclusion{},
 			want:            field.ErrorList{field.Invalid(field.NewPath("spec").Child("values").Child("ipam"), alteredValues["ipam"], "value is immutable")},
 			fieldPath:       field.NewPath("spec").Child("values"),
 			oldValues:       oldValues,
@@ -256,7 +257,7 @@ func TestValidateImmutableValues(t *testing.T) {
 		{
 			name:            "ipam modified, but the clusterPoolIPv4PodCIDRList is accepted",
 			immutableValues: []string{"cni", "ipam", "ipv6"},
-			acceptedFields:  []string{"ipam.operator.clusterPoolIPv4PodCIDRList"},
+			acceptedFields:  []exclusion{{fullPath: "ipam.operator.clusterPoolIPv4PodCIDRList", pathParts: strings.Split("ipam.operator.clusterPoolIPv4PodCIDRList", ".")}},
 			want:            field.ErrorList{},
 			fieldPath:       field.NewPath("spec").Child("values"),
 			oldValues:       oldValues,


### PR DESCRIPTION
**What this PR does / why we need it**:
Slight improvement to not call strings.Split every time. See also: [comment](https://github.com/kubermatic/kubermatic/pull/12830/files#r1389056565)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
