### PR TITLE
Fixed typo error in the 2.25 changelog

### DIFF
--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -27,7 +27,7 @@ Before upgrading, make sure to read the [general upgrade guidelines](https://doc
     - `velero.restic.deploy` with `velero.deployNodeAgent`
     - `velero.restic.resources` with `velero.nodeAgent.resources`
     - `velero.restic.nodeSelector` with `velero.nodeAgent.nodeSelector`
-    - `velero.restic.affinity` with `velero.restic.affinity`
+    - `velero.restic.affinity` with `velero.nodeAgent.affinity`
     - `velero.restic.tolerations` with `velero.nodeAgent.tolerations`
 - **ACTION REQUIRED:** [User MLA] If you had copied `values.yaml` of loki-distributed chart to further customize it, then please cleanup your copy of `values.yaml` for user-mla to retain your customization only ([#12967](https://github.com/kubermatic/kubermatic/pull/12967))
 - **ACTION REQUIRED:** [User MLA] Cortex chart upgraded to resolve issues for cortex-compactor and improve stability of user-cluster MLA feature. Few actions are required to be taken to use new upgraded charts ([#12935](https://github.com/kubermatic/kubermatic/pull/12935)):


### PR DESCRIPTION
**What this PR does / why we need it**:
To fix the typo error in the 2.25 Changelog for velero release notes.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
