### PR TITLE
fix addon controller reconciling too frequently

### DIFF
--- a/pkg/addon/types.go
+++ b/pkg/addon/types.go
@@ -112,6 +112,13 @@ func NewTemplateData(
 		}
 	}
 
+	var clusterVersion *semverlib.Version
+	if s := cluster.Status.Versions.ControlPlane.Semver(); s != nil {
+		clusterVersion = s
+	} else {
+		clusterVersion = cluster.Spec.Version.Semver()
+	}
+
 	return &TemplateData{
 		DatacenterName: cluster.Spec.Cloud.DatacenterName,
 		Variables:      variables,
@@ -129,8 +136,8 @@ func NewTemplateData(
 			OwnerEmail:        cluster.Status.UserEmail,
 			Address:           cluster.Status.Address,
 			CloudProviderName: providerName,
-			Version:           semverlib.MustParse(cluster.Status.Versions.ControlPlane.String()),
-			MajorMinorVersion: cluster.Status.Versions.ControlPlane.MajorMinor(),
+			Version:           clusterVersion,
+			MajorMinorVersion: fmt.Sprintf("%d.%d", clusterVersion.Major(), clusterVersion.Minor()),
 			Features:          sets.KeySet(cluster.Spec.Features),
 			Network: ClusterNetwork{
 				DNSDomain:            cluster.Spec.ClusterNetwork.DNSDomain,

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"reflect"
 	"strings"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/addon"
 	addonutils "k8c.io/kubermatic/v2/pkg/addon"
+	"k8c.io/kubermatic/v2/pkg/apis/equality"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
@@ -50,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -156,27 +157,57 @@ func Add(
 		return requests
 	})
 
-	// Only react to cluster update events when our condition changed, or when CNI config changed
 	clusterPredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldObj := e.ObjectOld.(*kubermaticv1.Cluster)
 			newObj := e.ObjectNew.(*kubermaticv1.Cluster)
-			oldCondition := oldObj.Status.Conditions[kubermaticv1.ClusterConditionAddonControllerReconcilingSuccess]
-			newCondition := newObj.Status.Conditions[kubermaticv1.ClusterConditionAddonControllerReconcilingSuccess]
-			if !reflect.DeepEqual(oldCondition, newCondition) {
+
+			reconcile, err := shouldReconcileCluster(oldObj, newObj)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("failed to diff clusters: %w", err))
 				return true
 			}
-			if !reflect.DeepEqual(oldObj.Spec.CNIPlugin, newObj.Spec.CNIPlugin) {
-				return true
-			}
-			return false
+
+			return reconcile
 		},
 	}
 	if err := c.Watch(source.Kind(mgr.GetCache(), &kubermaticv1.Cluster{}), enqueueClusterAddons, clusterPredicate); err != nil {
 		return err
 	}
 
-	return c.Watch(source.Kind(mgr.GetCache(), &kubermaticv1.Addon{}), &handler.EnqueueRequestForObject{})
+	return c.Watch(source.Kind(mgr.GetCache(), &kubermaticv1.Addon{}), &handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{})
+}
+
+func shouldReconcileCluster(oldCluster, newCluster *kubermaticv1.Cluster) (bool, error) {
+	// kubeconfig and credentials are external Secrets, so they can have no influence on this
+	// decision and can be left with dummy values; in a more elaborate implementation, the real
+	// kubeconfig/credentials resourceVersions could be remembered also in the AddonStatus, but at
+	// that point we're re-implementing the Applications feature.
+	// If kubeconfig/credentials change, we rely on the auto-resync behaviour of Kubernetes.
+
+	createData := func(cluster *kubermaticv1.Cluster) (*addonutils.TemplateData, error) {
+		return addonutils.NewTemplateData(
+			cluster,
+			resources.Credentials{},
+			"<kubeconfig>",
+			"1.2.3.4", // cluster DNS
+			"5.6.7.8", // DNS resolver
+			nil,
+			nil,
+		)
+	}
+
+	oldData, err := createData(oldCluster)
+	if err != nil {
+		return false, fmt.Errorf("failed to create template data for old cluster: %w", err)
+	}
+
+	newData, err := createData(newCluster)
+	if err != nil {
+		return false, fmt.Errorf("failed to create template data for new cluster: %w", err)
+	}
+
+	return !equality.Semantic.DeepEqual(oldData, newData), nil
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -205,12 +236,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, r.garbageCollectAddon(ctx, log, addon)
 	}
 
+	log = r.log.With("cluster", cluster.Name, "addon", addon.Name)
+
 	if cluster.Status.Versions.ControlPlane == "" {
 		log.Debug("Skipping because the cluster has no version status yet, skipping")
 		return reconcile.Result{}, nil
 	}
 
-	log = r.log.With("cluster", cluster.Name, "addon", addon.Name)
+	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusUp {
+		log.Debug("API server is not running, trying again in 3 seconds")
+		return reconcile.Result{RequeueAfter: 3 * time.Second}, nil
+	}
 
 	// Add a wrapping here so we can emit an event on error
 	result, err := kubermaticv1helper.ClusterReconcileWrapper(
@@ -264,11 +300,6 @@ func (r *Reconciler) garbageCollectAddon(ctx context.Context, log *zap.SugaredLo
 }
 
 func (r *Reconciler) reconcile(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) (*reconcile.Result, error) {
-	if cluster.Status.ExtendedHealth.Apiserver != kubermaticv1.HealthStatusUp {
-		log.Debug("API server is not running, trying again in 3 seconds")
-		return &reconcile.Result{RequeueAfter: 3 * time.Second}, nil
-	}
-
 	reqeueAfter, err := r.ensureRequiredResourceTypesExist(ctx, log, addon, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to check if all required resources exist: %w", err)
@@ -662,6 +693,7 @@ func (r *Reconciler) ensureResourcesCreatedConditionIsSet(ctx context.Context, a
 	}
 
 	oldAddon := addon.DeepCopy()
+
 	setAddonCondition(addon, kubermaticv1.AddonResourcesCreated, corev1.ConditionTrue)
 	return r.Client.Status().Patch(ctx, addon, ctrlruntimeclient.MergeFrom(oldAddon))
 }

--- a/pkg/webhook/addon/mutation/mutation.go
+++ b/pkg/webhook/addon/mutation/mutation.go
@@ -138,7 +138,7 @@ func (h *AdmissionHandler) ensureClusterReference(ctx context.Context, addon *ku
 	addon.Spec.Cluster = corev1.ObjectReference{
 		Name:       cluster.Name,
 		Namespace:  "",
-		UID:        cluster.UID,
+		UID:        "",
 		APIVersion: cluster.APIVersion,
 		Kind:       "Cluster",
 	}

--- a/pkg/webhook/addon/mutation/mutation_test.go
+++ b/pkg/webhook/addon/mutation/mutation_test.go
@@ -63,7 +63,6 @@ func TestHandle(t *testing.T) {
 		APIVersion: cluster.APIVersion,
 		Kind:       cluster.Kind,
 		Name:       cluster.Name,
-		UID:        cluster.UID,
 	}
 
 	tests := []struct {
@@ -98,7 +97,6 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("add", "/spec/cluster/apiVersion", "kubermatic.k8c.io/v1"),
 				jsonpatch.NewOperation("add", "/spec/cluster/kind", "Cluster"),
 				jsonpatch.NewOperation("add", "/spec/cluster/name", "xyz"),
-				jsonpatch.NewOperation("add", "/spec/cluster/uid", "12345"),
 			},
 		},
 		{
@@ -132,7 +130,7 @@ func TestHandle(t *testing.T) {
 				jsonpatch.NewOperation("replace", "/spec/cluster/apiVersion", "kubermatic.k8c.io/v1"),
 				jsonpatch.NewOperation("replace", "/spec/cluster/kind", "Cluster"),
 				jsonpatch.NewOperation("replace", "/spec/cluster/name", "xyz"),
-				jsonpatch.NewOperation("replace", "/spec/cluster/uid", "12345"),
+				jsonpatch.NewOperation("remove", "/spec/cluster/uid", nil),
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
In #4773 we tried to make the addon controller reconcile less frequently. The logic was to only react to Cluster changes if the `AddonControllerReconcilingSuccess` condition changed. The only controller setting this condition is the addon controller itself (looking back at the original PR, I don't really understand it... but I was young and dumber).

However this condition on the _Cluster_ object isn't really saying much. If you have 3 addons, one of them fails, it is basically random which status the `AddonControllerReconcilingSuccess` on the Cluster object will have.

Even worse: Suppose all your addons are happy and healthy. Now you change a field like the Cluster Owner or any other field that is part of the addon TemplateData. Even though you changed the Cluster object, no reconciliation will happen because neither the CNI values nor the condition has changed.

Additionally, _Addon_ objects are reconciled even when their status changes. This isn't much of a problem right now, because there is only 1 Condition and it only gets set exactly once and never heartbeats, but if the status is extended (an I have a branch ready for that :grin: ), then status changes on an addon should also be ignored.

To that effect, this PR adjusts the watches:

* Clusters are reconciled when the TemplateData we derive from them changed. TemplateData is the only thing that could influence how an addon is rendered. Note that external resources, like the kubeconfig, are not taken into account: We'd need to store somehow the revision of each related object, so we can diff those as well (recursively) and at that point we begin to re-implement the Applications feature. So for addons I chose the simple approach of relying on the auto-resync interval of controller-runtime to reconcile _all_ addons after a number of hours, regardless of state.
* Addons are only reconciled if their generation is changed, i.e. not just the status.
* I also noticed some diffs where we removed the UID we set ourselves. In Addons, the cluster ref doesn't care about the UID and it should be left blank. I adjusted the code a bit to ensure we ourselves do not set it, saving one more reconciliation per addon.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Addons reconciliation is triggered more consistently for changes to Cluster objects, reducing the overall number of unnecessary addon reconciliations.
```

**Documentation**:
```documentation
NONE
```
