### PR TITLE
Addon upgrade integration tests

### DIFF
--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -255,7 +255,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+        - image: quay.io/kubermatic/integration-tests:k8s-1.29.1-rev0
           command:
             - "./hack/ci/run-addons-integration-test.sh"
           resources:

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -245,3 +245,23 @@ presubmits:
             limits:
               memory: 4Gi
               cpu: 2
+
+  - name: pre-kubermatic-test-addon-upgrades
+    decorate: true
+    always_run: false
+    run_if_changed: "(addons/|pkg/test/addon|pkg/addon|pkg/controller/seed-controller-manager/addon.*)"
+    clone_uri: "ssh://git@github.com/kubermatic/kubermatic.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.22-node-20-kind-0.22-3
+          command:
+            - "./hack/ci/run-addons-integration-test.sh"
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 2
+            limits:
+              memory: 4Gi
+              cpu: 2

--- a/hack/ci/run-addons-integration-test.sh
+++ b/hack/ci/run-addons-integration-test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+cd $(dirname $0)/../..
+source hack/lib.sh
+
+# thank you https://stackoverflow.com/a/64390598
+function change_minor() {
+  local delimiter=.
+  local array=($(echo "$1" | tr $delimiter '\n'))
+  array[1]=$((array[1]+$2))
+  echo $(local IFS=$delimiter ; echo "${array[*]}")
+}
+
+# determine current and previous versions/branches
+CURRENT_BRANCH="${PULL_BASE_REF:-main}"
+CURRENT_RELEASE=
+PREVIOUS_BRANCH=
+PREVIOUS_RELEASE=
+
+if [[ "$CURRENT_BRANCH" == "main" ]]; then
+  # find the most recent release branch and return its version, like "v2.25"
+  PREVIOUS_RELEASE="$(git branch --list 'release/v*' --format '%(refname:lstrip=3)' | sort -rV | head -n1)"
+  CURRENT_RELEASE="$(change_minor "$PREVIOUS_RELEASE" 1)"
+elif [[ "$CURRENT_BRANCH" =~ ^release/v ]]; then
+  CURRENT_RELEASE="$(basename "$CURRENT_BRANCH")"
+  PREVIOUS_RELEASE="$(change_minor "$CURRENT_RELEASE" -1)"
+else
+  echodate "Error: PULL_BASE_REF ($PULL_BASE_REF) does not point to main or a release branch."
+  exit 1
+fi
+
+PREVIOUS_BRANCH="release/$PREVIOUS_RELEASE"
+
+echodate "Current KKP release : $CURRENT_RELEASE ($CURRENT_BRANCH)"
+echodate "Previous KKP release: $PREVIOUS_RELEASE ($PREVIOUS_BRANCH)"
+
+TEST_NAME="Pre-warm Go build cache"
+echodate "Attempting to pre-warm Go build cache"
+
+beforeGocache=$(nowms)
+make download-gocache
+pushElapsed gocache_download_duration_milliseconds $beforeGocache
+
+# restore addons at the previous release state
+currentAddons="$(mktemp -d)"
+cp -ar addons/* "$currentAddons"
+
+previousAddons="$(mktemp -d)"
+git checkout "$PREVIOUS_BRANCH" -- addons/
+cp -ar addons/* "$previousAddons"
+
+# check if addons are compatible
+echodate "Testing addon upgrade compatibility…"
+
+go_test addon_integration -timeout 30m -tags addon_integration -v ./pkg/test/addon \
+  -previous "$previousAddons" \
+  -current "$currentAddons"
+
+echodate "Tests completed successfully!"

--- a/hack/ci/run-addons-integration-test.sh
+++ b/hack/ci/run-addons-integration-test.sh
@@ -23,8 +23,11 @@ source hack/lib.sh
 function change_minor() {
   local delimiter=.
   local array=($(echo "$1" | tr $delimiter '\n'))
-  array[1]=$((array[1]+$2))
-  echo $(local IFS=$delimiter ; echo "${array[*]}")
+  array[1]=$((array[1] + $2))
+  echo $(
+    local IFS=$delimiter
+    echo "${array[*]}"
+  )
 }
 
 # determine current and previous versions/branches

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -38,6 +38,7 @@ boilerplate \
   -exclude pkg/crd/k8s.io \
   -exclude pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/static \
   -exclude pkg/provider/cloud/eks/authenticator \
+  -exclude pkg/test/addon/data \
   -exclude .github
 
 echodate "Checking Kubermatic EE licenses..."

--- a/pkg/test/addon/data/cluster-aws.yaml
+++ b/pkg/test/addon/data/cluster-aws.yaml
@@ -1,0 +1,189 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    kubermatic.io/aws-region: eu-west-1
+  creationTimestamp: "2023-05-22T10:06:59Z"
+  finalizers:
+  - kubermatic.k8c.io/cleanup-aws
+  - kubermatic.k8c.io/cleanup-backups
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/delete-nodes
+  generation: 11
+  labels:
+    project-id: l8zvpg6dph
+  name: avznsmznpt
+  resourceVersion: "669050555"
+  uid: 228f9bf9-3203-4b1e-b485-eed3598e0462
+spec:
+  auditLogging: {}
+  cloud:
+    aws:
+      credentialsReference:
+        name: credential-aws-avznsmznpt
+        namespace: kubermatic
+      instanceProfileName: kubernetes-avznsmznpt
+      nodePortsAllowedIPRanges:
+        cidrBlocks:
+        - 0.0.0.0/0
+      roleARN: kubernetes-avznsmznpt-control-plane
+      routeTableID: rtb-0fa00466c420a3a96
+      securityGroupID: sg-025fc15d1095ecbc4
+      vpcID: vpc-05b5e4db034fe2fa0
+    dc: aws-eu-west-1a-mirror
+    providerName: aws
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ipvs
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+  cniPlugin:
+    type: canal
+    version: v3.25
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: false
+  exposeStrategy: NodePort
+  features:
+    apiserverNetworkPolicy: true
+    ccmClusterName: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubernetesDashboard: {}
+  mla: {}
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.27.6
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-avznsmznpt.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 32479
+    url: https://yadda.yadda.yadda:32479
+  conditions:
+    AddonControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:05Z"
+      lastTransitionTime: "2024-03-21T19:19:03Z"
+      status: "True"
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:02Z"
+      lastTransitionTime: "2024-03-21T19:18:50Z"
+      status: "True"
+    BackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:51:58Z"
+      status: "True"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:51:58Z"
+      lastTransitionTime: "2023-10-02T20:13:10Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:22Z"
+      lastTransitionTime: "2024-02-08T16:19:40Z"
+      status: "True"
+    ClusterInitialized:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:16Z"
+      message: Cluster has been initialized successfully
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:16Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:02Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.22.2
+      lastHeartbeatTime: "2023-05-22T10:06:59Z"
+      status: "True"
+    MonitoringControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:04Z"
+      lastTransitionTime: "2024-02-08T16:19:39Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-04-04T20:19:43Z"
+      lastTransitionTime: "2024-04-04T20:19:43Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:04Z"
+      lastTransitionTime: "2023-11-27T21:39:09Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:06Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusUp
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusUp
+    etcd: HealthStatusUp
+    konnectivity: HealthStatusUp
+    machineController: HealthStatusUp
+    operatingSystemManager: HealthStatusUp
+    scheduler: HealthStatusUp
+    userClusterControllerManager: HealthStatusUp
+  lastProviderReconciliation: "2024-04-08T14:28:41Z"
+  namespaceName: cluster-avznsmznpt
+  phase: Running
+  resourceUsage:
+    cpu: "12"
+    memory: 48G
+    storage: 400G
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.27.6
+    controlPlane: 1.27.6
+    controllerManager: 1.27.6
+    oldestNodeVersion: 1.27.6
+    scheduler: 1.27.6

--- a/pkg/test/addon/data/cluster-azure.yaml
+++ b/pkg/test/addon/data/cluster-azure.yaml
@@ -1,0 +1,179 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  creationTimestamp: "2024-04-08T17:02:08Z"
+  finalizers:
+  - kubermatic.k8c.io/cleanup-azure-availability-set
+  - kubermatic.k8c.io/cleanup-azure-resource-group
+  - kubermatic.k8c.io/cleanup-azure-route-table
+  - kubermatic.k8c.io/cleanup-azure-security-group
+  - kubermatic.k8c.io/cleanup-azure-subnet
+  - kubermatic.k8c.io/cleanup-azure-vnet
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/delete-nodes
+  generation: 9
+  labels:
+    project-id: b92gxwjjgc
+  name: bxtnbqjk8j
+  resourceVersion: "372216410"
+  uid: 02c6f17e-4c9f-4b81-8df2-a139760f0f1c
+spec:
+  auditLogging: {}
+  cloud:
+    azure:
+      assignAvailabilitySet: true
+      availabilitySet: kubernetes-bxtnbqjk8j
+      credentialsReference:
+        name: credential-azure-bxtnbqjk8j
+        namespace: kubermatic
+      loadBalancerSKU: standard
+      nodePortsAllowedIPRanges:
+        cidrBlocks: []
+      resourceGroup: kubernetes-bxtnbqjk8j
+      routeTable: kubernetes-bxtnbqjk8j
+      securityGroup: kubernetes-bxtnbqjk8j
+      subnet: kubernetes-bxtnbqjk8j
+      vnet: kubernetes-bxtnbqjk8j
+      vnetResourceGroup: ""
+    dc: azure-westeurope
+    providerName: azure
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ebpf
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+    tunnelingAgentIP: 100.64.30.10
+  cniPlugin:
+    type: cilium
+    version: 1.14.3
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: Tunneling
+  features:
+    apiserverNetworkPolicy: true
+    ccmClusterName: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: false
+  kubernetesDashboard: {}
+  mla: {}
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.28.7
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-bxtnbqjk8j.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 6443
+    url: https://yadda.yadda.yadda:6443
+  conditions:
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:42Z"
+      lastTransitionTime: "2024-04-08T17:02:42Z"
+      status: "True"
+    CNIControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:08Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:27Z"
+      lastTransitionTime: "2024-04-08T17:02:27Z"
+      status: "True"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:41Z"
+      lastTransitionTime: "2024-04-08T17:02:41Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:24Z"
+      lastTransitionTime: "2024-04-08T17:02:24Z"
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:09Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:09Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:09Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:09Z"
+      message: Some control plane components did not finish updating
+      reason: ClusterUpdateSuccessful
+      status: "False"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:08Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T17:02:28Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusProvisioning
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusProvisioning
+    etcd: HealthStatusProvisioning
+    konnectivity: HealthStatusUp
+    machineController: HealthStatusProvisioning
+    operatingSystemManager: HealthStatusProvisioning
+    scheduler: HealthStatusProvisioning
+    userClusterControllerManager: HealthStatusProvisioning
+  lastProviderReconciliation: "2024-04-08T17:02:27Z"
+  namespaceName: cluster-bxtnbqjk8j
+  phase: Creating
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.28.7
+    controlPlane: 1.28.7
+    controllerManager: 1.28.7
+    scheduler: 1.28.7

--- a/pkg/test/addon/data/cluster-digitalocean.yaml
+++ b/pkg/test/addon/data/cluster-digitalocean.yaml
@@ -1,0 +1,184 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    kubermatic.io/initial-cni-values-request: ""
+  creationTimestamp: "2024-04-08T21:29:41Z"
+  finalizers:
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/delete-nodes
+  generation: 3
+  labels:
+    project-id: b92gxwjjgc
+  name: i44l9s7vrm
+  resourceVersion: "372348939"
+  uid: 119363e4-1132-45e7-8b87-f6811ba96a49
+spec:
+  auditLogging: {}
+  cloud:
+    dc: do-fra1
+    digitalocean:
+      credentialsReference:
+        name: credential-digitalocean-i44l9s7vrm
+        namespace: kubermatic
+    providerName: digitalocean
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ipvs
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+    tunnelingAgentIP: 100.64.30.10
+  cniPlugin:
+    type: canal
+    version: v3.26
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: Tunneling
+  features:
+    apiserverNetworkPolicy: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: false
+  kubernetesDashboard: {}
+  mla: {}
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.28.7
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-i44l9s7vrm.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 6443
+    url: https://yadda.yadda.yadda:6443
+  conditions:
+    AddonControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:31:01Z"
+      lastTransitionTime: "2024-04-08T21:31:01Z"
+      status: "True"
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:30:21Z"
+      lastTransitionTime: "2024-04-08T21:30:21Z"
+      status: "True"
+    CSIAddonInUse:
+      kubermaticVersion: ea50f1ae5a39272476d98a054e83208c2191be0d
+      lastHeartbeatTime: "2024-04-08T21:30:50Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:29:42Z"
+      status: "True"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:30:20Z"
+      lastTransitionTime: "2024-04-08T21:30:20Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:29:56Z"
+      status: "True"
+    ClusterInitialized:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:30:47Z"
+      message: Cluster has been initialized successfully
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:30:22Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:29:44Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:29:44Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:29:42Z"
+      status: "True"
+    MonitoringControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:30:34Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:30:44Z"
+      lastTransitionTime: "2024-04-08T21:30:44Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:29:42Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0-38-gea50f1ae5
+      lastHeartbeatTime: "2024-04-08T21:29:56Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusUp
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusUp
+    etcd: HealthStatusUp
+    konnectivity: HealthStatusUp
+    machineController: HealthStatusUp
+    operatingSystemManager: HealthStatusUp
+    scheduler: HealthStatusUp
+    userClusterControllerManager: HealthStatusUp
+  namespaceName: cluster-i44l9s7vrm
+  phase: Running
+  resourceUsage:
+    cpu: "2"
+    memory: 2048M
+    storage: 60G
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.28.7
+    controlPlane: 1.28.7
+    controllerManager: 1.28.7
+    scheduler: 1.28.7

--- a/pkg/test/addon/data/cluster-gcp.yaml
+++ b/pkg/test/addon/data/cluster-gcp.yaml
@@ -1,0 +1,201 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  creationTimestamp: "2024-04-05T12:23:15Z"
+  finalizers:
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-gcp-firewall-icmp
+  - kubermatic.k8c.io/cleanup-gcp-firewall-nodeport
+  - kubermatic.k8c.io/cleanup-gcp-firewall-self
+  - kubermatic.k8c.io/cleanup-gcp-routes
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/delete-nodes
+  generation: 5
+  labels:
+    is-credential-preset: "true"
+    project-id: l9xc9ncnwz
+  name: tcqm6m2jsw
+  resourceVersion: "436540953"
+  uid: ef0ce36b-3cba-43cf-8e01-9e649d55900a
+spec:
+  auditLogging: {}
+  cloud:
+    dc: gcp-westeurope
+    gcp:
+      credentialsReference:
+        name: credential-gcp-tcqm6m2jsw
+        namespace: kubermatic
+      network: global/networks/default
+      nodePortsAllowedIPRanges:
+        cidrBlocks: []
+      subnetwork: ""
+    providerName: gcp
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ebpf
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+    tunnelingAgentIP: 100.64.30.10
+  cniPlugin:
+    type: cilium
+    version: 1.14.3
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: Tunneling
+  features:
+    apiserverNetworkPolicy: true
+    ccmClusterName: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: false
+  kubernetesDashboard:
+    enabled: true
+  mla: {}
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.29.2
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-tcqm6m2jsw.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 6443
+    url: https://yadda.yadda.yadda:6443
+  conditions:
+    AddonControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:25:20Z"
+      status: "True"
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T13:13:20Z"
+      lastTransitionTime: "2024-04-08T13:13:20Z"
+      status: "True"
+    CNIControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:23:15Z"
+      status: "False"
+    CSIAddonInUse:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T17:03:54Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:23:27Z"
+      lastTransitionTime: "2024-04-05T12:23:27Z"
+      status: "True"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:24:07Z"
+      lastTransitionTime: "2024-04-05T12:24:07Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:23:34Z"
+      status: "True"
+    ClusterInitialized:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:26:46Z"
+      message: Cluster has been initialized successfully
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:24:15Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:23:19Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:23:23Z"
+      lastTransitionTime: "2024-04-05T12:23:23Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:23:15Z"
+      status: "True"
+    MonitoringControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:24:24Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T16:24:04Z"
+      lastTransitionTime: "2024-04-08T16:24:04Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T12:23:15Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T13:04:48Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusUp
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusUp
+    etcd: HealthStatusUp
+    konnectivity: HealthStatusUp
+    kubernetesDashboard: HealthStatusUp
+    machineController: HealthStatusUp
+    operatingSystemManager: HealthStatusUp
+    scheduler: HealthStatusUp
+    userClusterControllerManager: HealthStatusUp
+  lastProviderReconciliation: "2024-04-08T13:04:48Z"
+  namespaceName: cluster-tcqm6m2jsw
+  phase: Running
+  resourceUsage:
+    cpu: "6"
+    memory: 12288M
+    storage: 75G
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.29.2
+    controlPlane: 1.29.2
+    controllerManager: 1.29.2
+    oldestNodeVersion: 1.29.2
+    scheduler: 1.29.2

--- a/pkg/test/addon/data/cluster-hetzner.yaml
+++ b/pkg/test/addon/data/cluster-hetzner.yaml
@@ -1,0 +1,197 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    kubermatic.k8c.io/migrated-hetzner-csi-addon: v2.25.0
+  creationTimestamp: "2024-04-05T13:05:50Z"
+  finalizers:
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubelb-ccm
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/delete-nodes
+  generation: 5
+  labels:
+    is-credential-preset: "true"
+    project-id: l9xc9ncnwz
+  name: dxdrgjffxh
+  resourceVersion: "436538763"
+  uid: ed30a00e-9029-40b7-94a7-46cce0a0d6fe
+spec:
+  auditLogging: {}
+  cloud:
+    dc: hetzner-fsn1
+    hetzner:
+      credentialsReference:
+        name: credential-hetzner-dxdrgjffxh
+        namespace: kubermatic
+    providerName: hetzner
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: iptables
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+    tunnelingAgentIP: 100.64.30.10
+  cniPlugin:
+    type: cilium
+    version: 1.14.3
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: Tunneling
+  features:
+    apiserverNetworkPolicy: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: true
+  kubernetesDashboard: {}
+  mla: {}
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.28.7
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-dxdrgjffxh.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 6443
+    url: https://yadda.yadda.yadda:6443
+  conditions:
+    AddonControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-07T16:54:27Z"
+      lastTransitionTime: "2024-04-07T16:54:27Z"
+      status: "True"
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T16:01:48Z"
+      lastTransitionTime: "2024-04-08T16:01:48Z"
+      status: "True"
+    CNIControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:05:51Z"
+      status: "False"
+    CSIAddonInUse:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T16:59:16Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:05:52Z"
+      status: "True"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:07:06Z"
+      lastTransitionTime: "2024-04-05T13:07:06Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-07T13:17:27Z"
+      lastTransitionTime: "2024-04-07T13:17:27Z"
+      status: "True"
+    ClusterInitialized:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:07:45Z"
+      message: Cluster has been initialized successfully
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:07:06Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:05:55Z"
+      status: "True"
+    KubeLBControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T15:43:24Z"
+      lastTransitionTime: "2024-04-08T15:43:24Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:05:57Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:07:24Z"
+      lastTransitionTime: "2024-04-05T13:07:24Z"
+      status: "True"
+    MonitoringControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:07:23Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T16:03:09Z"
+      lastTransitionTime: "2024-04-08T16:03:09Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T13:05:51Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-07T17:27:24Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusUp
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusUp
+    etcd: HealthStatusUp
+    konnectivity: HealthStatusUp
+    kubelb: HealthStatusUp
+    kubernetesDashboard: HealthStatusUp
+    machineController: HealthStatusUp
+    operatingSystemManager: HealthStatusUp
+    scheduler: HealthStatusUp
+    userClusterControllerManager: HealthStatusUp
+  namespaceName: cluster-dxdrgjffxh
+  phase: Running
+  resourceUsage:
+    cpu: "0"
+    memory: "0"
+    storage: "0"
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.28.7
+    controlPlane: 1.28.7
+    controllerManager: 1.28.7
+    scheduler: 1.28.7

--- a/pkg/test/addon/data/cluster-kubevirt.yaml
+++ b/pkg/test/addon/data/cluster-kubevirt.yaml
@@ -1,0 +1,203 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  creationTimestamp: "2024-04-09T10:54:25Z"
+  finalizers:
+  - kubermatic.k8c.io/alertmanager
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-kubevirt-namespace
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/delete-nodes
+  - kubermatic.k8c.io/mla
+  generation: 3
+  labels:
+    project-id: b92gxwjjgc
+  name: q9zvvdffm5
+  resourceVersion: "372744773"
+  uid: c558fdaf-5ae1-46b8-8214-b7a96c315d60
+spec:
+  auditLogging: {}
+  cloud:
+    dc: kv-hamburg
+    kubevirt:
+      credentialsReference:
+        name: credential-kubevirt-q9zvvdffm5
+        namespace: kubermatic
+      storageClasses:
+      - isDefaultClass: true
+        name: px-csi-db
+    providerName: kubevirt
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.26.0.0/16
+    proxyMode: ebpf
+    services:
+      cidrBlocks:
+      - 10.241.0.0/20
+    tunnelingAgentIP: 100.64.30.10
+  cniPlugin:
+    type: cilium
+    version: 1.14.3
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: Tunneling
+  features:
+    apiserverNetworkPolicy: true
+    ccmClusterName: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: false
+  kubernetesDashboard:
+    enabled: true
+  mla:
+    monitoringEnabled: true
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.28.7
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-q9zvvdffm5.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 6443
+    url: https://yadda.yadda.yadda:6443
+  conditions:
+    AddonControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:12Z"
+      lastTransitionTime: "2024-04-09T10:55:12Z"
+      status: "True"
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:08Z"
+      lastTransitionTime: "2024-04-09T10:55:08Z"
+      status: "True"
+    CNIControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:25Z"
+      status: "False"
+    CSIAddonInUse:
+      kubermaticVersion: 4a0ef6fa2f4706caf3aec9d18b95918e5b813993
+      lastHeartbeatTime: "2024-04-09T10:55:37Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:32Z"
+      lastTransitionTime: "2024-04-09T10:54:32Z"
+      status: "True"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:07Z"
+      lastTransitionTime: "2024-04-09T10:55:07Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:43Z"
+      status: "True"
+    ClusterInitialized:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:30Z"
+      message: Cluster has been initialized successfully
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:11Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:27Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:33Z"
+      lastTransitionTime: "2024-04-09T10:54:33Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:25Z"
+      lastTransitionTime: "2024-04-09T10:55:25Z"
+      status: "True"
+    MonitoringControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:21Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:29Z"
+      lastTransitionTime: "2024-04-09T10:55:29Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:26Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:44Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    alertmanagerConfig: HealthStatusUp
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusUp
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusUp
+    etcd: HealthStatusUp
+    konnectivity: HealthStatusUp
+    kubernetesDashboard: HealthStatusUp
+    machineController: HealthStatusUp
+    mlaGateway: HealthStatusUp
+    monitoring: HealthStatusDown
+    operatingSystemManager: HealthStatusUp
+    scheduler: HealthStatusUp
+    userClusterControllerManager: HealthStatusUp
+  lastProviderReconciliation: "2024-04-09T10:55:37Z"
+  namespaceName: cluster-q9zvvdffm5
+  phase: Running
+  resourceUsage:
+    cpu: "2"
+    memory: 8Gi
+    storage: 10G
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.28.7
+    controlPlane: 1.28.7
+    controllerManager: 1.28.7
+    scheduler: 1.28.7

--- a/pkg/test/addon/data/cluster-nutanix.yaml
+++ b/pkg/test/addon/data/cluster-nutanix.yaml
@@ -1,0 +1,180 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  creationTimestamp: "2023-05-22T10:06:59Z"
+  finalizers:
+  - kubermatic.k8c.io/cleanup-backups
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/delete-nodes
+  generation: 11
+  labels:
+    project-id: l8zvpg6dph
+  name: h23g23jhh
+  resourceVersion: "669050555"
+  uid: 228f9bf9-3203-4b1e-b485-eed3598e0462
+spec:
+  auditLogging: {}
+  cloud:
+    nutanix:
+      credentialsReference:
+        name: credential-nutanix-h23g23jhh
+        namespace: kubermatic
+      clusterName: dev
+      projectName: my-project
+    dc: nutanix-eu
+    providerName: nutanix
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ipvs
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+  cniPlugin:
+    type: canal
+    version: v3.25
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: false
+  exposeStrategy: NodePort
+  features:
+    apiserverNetworkPolicy: true
+    ccmClusterName: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubernetesDashboard: {}
+  mla: {}
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.27.6
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-h23g23jhh.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 32479
+    url: https://yadda.yadda.yadda:32479
+  conditions:
+    AddonControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:05Z"
+      lastTransitionTime: "2024-03-21T19:19:03Z"
+      status: "True"
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:02Z"
+      lastTransitionTime: "2024-03-21T19:18:50Z"
+      status: "True"
+    BackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:51:58Z"
+      status: "True"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:51:58Z"
+      lastTransitionTime: "2023-10-02T20:13:10Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:22Z"
+      lastTransitionTime: "2024-02-08T16:19:40Z"
+      status: "True"
+    ClusterInitialized:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:16Z"
+      message: Cluster has been initialized successfully
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:16Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:02Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.22.2
+      lastHeartbeatTime: "2023-05-22T10:06:59Z"
+      status: "True"
+    MonitoringControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:04Z"
+      lastTransitionTime: "2024-02-08T16:19:39Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-04-04T20:19:43Z"
+      lastTransitionTime: "2024-04-04T20:19:43Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:04Z"
+      lastTransitionTime: "2023-11-27T21:39:09Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.23.12
+      lastHeartbeatTime: "2024-03-25T12:52:06Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusUp
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusUp
+    etcd: HealthStatusUp
+    konnectivity: HealthStatusUp
+    machineController: HealthStatusUp
+    operatingSystemManager: HealthStatusUp
+    scheduler: HealthStatusUp
+    userClusterControllerManager: HealthStatusUp
+  lastProviderReconciliation: "2024-04-08T14:28:41Z"
+  namespaceName: cluster-h23g23jhh
+  phase: Running
+  resourceUsage:
+    cpu: "12"
+    memory: 48G
+    storage: 400G
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.27.6
+    controlPlane: 1.27.6
+    controllerManager: 1.27.6
+    oldestNodeVersion: 1.27.6
+    scheduler: 1.27.6

--- a/pkg/test/addon/data/cluster-openstack.yaml
+++ b/pkg/test/addon/data/cluster-openstack.yaml
@@ -1,0 +1,177 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  creationTimestamp: "2024-04-09T10:54:52Z"
+  finalizers:
+  - kubermatic.k8c.io/alertmanager
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-openstack-network-v2
+  - kubermatic.k8c.io/cleanup-openstack-security-group
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/mla
+  generation: 5
+  labels:
+    project-id: b92gxwjjgc
+  name: amjvnwj5wr
+  resourceVersion: "372744741"
+  uid: 0590a5c5-804a-4cf3-a8b9-a63d80023af7
+spec:
+  auditLogging: {}
+  cloud:
+    dc: my-openstack-dc
+    openstack:
+      credentialsReference:
+        name: credential-openstack-amjvnwj5wr
+        namespace: kubermatic
+      floatingIPPool: ext-net
+      network: kubernetes-amjvnwj5wr
+      nodePortsAllowedIPRanges:
+        cidrBlocks: []
+      routerID: ""
+      securityGroups: kubernetes-amjvnwj5wr
+      subnetID: ""
+    providerName: openstack
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ebpf
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+    tunnelingAgentIP: 100.64.30.10
+  cniPlugin:
+    type: cilium
+    version: 1.14.3
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: Tunneling
+  features:
+    apiserverNetworkPolicy: true
+    ccmClusterName: true
+    etcdLauncher: true
+    externalCloudProvider: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: false
+  kubernetesDashboard:
+    enabled: true
+  mla:
+    monitoringEnabled: true
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.28.7
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-amjvnwj5wr.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 6443
+    url: https://yadda.yadda.yadda:6443
+  conditions:
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:53Z"
+      status: "False"
+    CNIControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:53Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:55Z"
+      status: "False"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:53Z"
+      status: "False"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:10Z"
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:34Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:53Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:55Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:53Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:55:34Z"
+      lastTransitionTime: "2024-04-09T10:55:34Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:53Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:54:53Z"
+      message: Update in progress, control plane is not yet healthy.
+      reason: Progressing
+      status: "True"
+  extendedHealth:
+    alertmanagerConfig: HealthStatusUp
+    apiserver: HealthStatusProvisioning
+    applicationController: HealthStatusProvisioning
+    controller: HealthStatusProvisioning
+    etcd: HealthStatusUp
+    konnectivity: HealthStatusProvisioning
+    kubernetesDashboard: HealthStatusProvisioning
+    machineController: HealthStatusProvisioning
+    mlaGateway: HealthStatusUp
+    operatingSystemManager: HealthStatusProvisioning
+    scheduler: HealthStatusProvisioning
+    userClusterControllerManager: HealthStatusProvisioning
+  namespaceName: cluster-amjvnwj5wr
+  phase: Creating
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.28.7
+    controlPlane: 1.28.7
+    controllerManager: 1.28.7
+    scheduler: 1.28.7

--- a/pkg/test/addon/data/cluster-vmwareclouddirector.yaml
+++ b/pkg/test/addon/data/cluster-vmwareclouddirector.yaml
@@ -1,0 +1,169 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  creationTimestamp: "2024-04-09T10:56:42Z"
+  finalizers:
+  - kubermatic.k8c.io/alertmanager
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/cleanup-vmware-cloud-director-vapp
+  - kubermatic.k8c.io/mla
+  generation: 4
+  labels:
+    project-id: b92gxwjjgc
+  name: sfjpjlfdvx
+  resourceVersion: "372746175"
+  uid: 24cd214c-a0b0-4df5-b0bc-adb98923ae5c
+spec:
+  auditLogging: {}
+  cloud:
+    dc: vmware-cloud-director-ger
+    providerName: vmwareclouddirector
+    vmwareclouddirector:
+      credentialsReference:
+        name: credential-vmware-cloud-director-sfjpjlfdvx
+        namespace: kubermatic
+      csi:
+        filesystem: ext4
+        storageProfile: Intermediate
+      ovdcNetwork: machine-controller-e2e
+      vapp: kubernetes-sfjpjlfdvx
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ebpf
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+    tunnelingAgentIP: 100.64.30.10
+  cniPlugin:
+    type: cilium
+    version: 1.14.3
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: Tunneling
+  features:
+    apiserverNetworkPolicy: true
+    etcdLauncher: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: false
+  kubernetesDashboard:
+    enabled: true
+  mla:
+    monitoringEnabled: true
+  oidc: {}
+  opaIntegration:
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.28.7
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-sfjpjlfdvx.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 6443
+    url: https://yadda.yadda.yadda:6443
+  conditions:
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:43Z"
+      status: "False"
+    CNIControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:43Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:53Z"
+      status: "True"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:45Z"
+      status: "False"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:59Z"
+      lastTransitionTime: "2024-04-09T10:56:59Z"
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:45Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:46Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:43Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:45Z"
+      message: Some control plane components did not finish updating
+      reason: ClusterUpdateSuccessful
+      status: "False"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:56:43Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0-41-g4a0ef6fa2
+      lastHeartbeatTime: "2024-04-09T10:57:00Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    alertmanagerConfig: HealthStatusUp
+    apiserver: HealthStatusProvisioning
+    applicationController: HealthStatusProvisioning
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusProvisioning
+    etcd: HealthStatusProvisioning
+    konnectivity: HealthStatusProvisioning
+    kubernetesDashboard: HealthStatusUp
+    machineController: HealthStatusProvisioning
+    mlaGateway: HealthStatusDown
+    operatingSystemManager: HealthStatusProvisioning
+    scheduler: HealthStatusProvisioning
+    userClusterControllerManager: HealthStatusProvisioning
+  lastProviderReconciliation: "2024-04-09T10:56:52Z"
+  namespaceName: cluster-sfjpjlfdvx
+  phase: Creating
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.28.7
+    controlPlane: 1.28.7
+    controllerManager: 1.28.7
+    scheduler: 1.28.7

--- a/pkg/test/addon/data/cluster-vsphere.yaml
+++ b/pkg/test/addon/data/cluster-vsphere.yaml
@@ -1,0 +1,216 @@
+apiVersion: kubermatic.k8c.io/v1
+kind: Cluster
+metadata:
+  annotations:
+    kubermatic.k8c.io/migrated-vsphere-csi-addon: v2.25.0
+  creationTimestamp: "2024-02-15T10:24:28Z"
+  finalizers:
+  - kubermatic.k8c.io/alertmanager
+  - kubermatic.k8c.io/cleanup-credentials-secrets
+  - kubermatic.k8c.io/cleanup-etcdbackupconfigs
+  - kubermatic.k8c.io/cleanup-kubermatic-constraints
+  - kubermatic.k8c.io/cleanup-namespace
+  - kubermatic.k8c.io/cleanup-usersshkeys-cluster-ids
+  - kubermatic.k8c.io/cleanup-vsphere-folder
+  - kubermatic.k8c.io/delete-nodes
+  - kubermatic.k8c.io/mla
+  generation: 5
+  labels:
+    is-credential-preset: "true"
+    project-id: rzrtln2fs7
+    template-instance-id: rzrtln2fs7-sig-vsphere-mla-6xbwszj5bp
+  name: efm8xdc57n
+  resourceVersion: "436539200"
+  uid: 0d836110-1a12-4c4f-baa4-7ee33c896155
+spec:
+  auditLogging: {}
+  cloud:
+    dc: vsphere
+    providerName: vsphere
+    vsphere:
+      credentialsReference:
+        name: credential-vsphere-efm8xdc57n
+        namespace: kubermatic
+      datastore: vsan
+      folder: /path/to/efm8xdc57n
+      infraManagementUser: {}
+      password: ""
+      storagePolicy: ""
+      username: ""
+      vmNetName: /path/to/network/Default Network
+  clusterNetwork:
+    dnsDomain: cluster.local
+    ipFamily: IPv4
+    ipvs:
+      strictArp: true
+    konnectivityEnabled: true
+    nodeCidrMaskSizeIPv4: 24
+    nodeLocalDNSCacheEnabled: true
+    pods:
+      cidrBlocks:
+      - 172.25.0.0/16
+    proxyMode: ebpf
+    services:
+      cidrBlocks:
+      - 10.240.16.0/20
+  cniPlugin:
+    type: cilium
+    version: 1.14.3
+  componentsOverride:
+    apiserver:
+      nodePortRange: 30000-32767
+      replicas: 2
+    controllerManager:
+      leaderElection: {}
+      replicas: 1
+    etcd:
+      clusterSize: 3
+      diskSize: 5Gi
+    konnectivityProxy: {}
+    nodePortProxyEnvoy:
+      resources: {}
+    prometheus: {}
+    scheduler:
+      leaderElection: {}
+      replicas: 1
+  containerRuntime: containerd
+  enableOperatingSystemManager: true
+  enableUserSSHKeyAgent: true
+  exposeStrategy: NodePort
+  features:
+    apiserverNetworkPolicy: true
+    etcdLauncher: true
+    externalCloudProvider: true
+    vsphereCSIClusterID: true
+  humanReadableName: test cluster
+  kubelb:
+    enabled: false
+  kubernetesDashboard:
+    enabled: true
+  mla:
+    loggingEnabled: true
+    monitoringEnabled: true
+  oidc: {}
+  opaIntegration:
+    enabled: true
+    webhookTimeoutSeconds: 10
+  pause: false
+  version: 1.27.10
+status:
+  address:
+    adminToken: xxxxxx.xxxxxxxxxxxxxxxx
+    externalName: yadda.yadda.yadda
+    internalURL: apiserver-external.cluster-efm8xdc57n.svc.cluster.local.
+    ip: 1.2.3.4
+    port: 31480
+    url: https://yadda.yadda.yadda:31480
+  conditions:
+    AddonControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-05T16:53:34Z"
+      lastTransitionTime: "2024-04-05T16:53:34Z"
+      status: "True"
+    AddonInstallerControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T16:01:53Z"
+      lastTransitionTime: "2024-04-08T16:01:53Z"
+      status: "True"
+    CNIControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:53Z"
+      status: "False"
+    CSIAddonInUse:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T17:00:12Z"
+      status: "False"
+    CloudControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:49Z"
+      lastTransitionTime: "2024-02-15T10:24:38Z"
+      status: "True"
+    ClusterBackupControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:47Z"
+      status: "True"
+    ClusterControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-25T08:33:40Z"
+      lastTransitionTime: "2024-03-25T08:33:40Z"
+      status: "True"
+    ClusterInitialized:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:51Z"
+      message: Cluster has been initialized successfully
+      status: "True"
+    EtcdClusterInitialized:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:51Z"
+      message: Etcd Cluster has been initialized successfully
+      status: "True"
+    IPAMControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:53Z"
+      status: "True"
+    MLAControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:51Z"
+      lastTransitionTime: "2024-02-15T10:24:35Z"
+      status: "True"
+    MachineDeploymentReconciledSuccessfully:
+      kubermaticVersion: v2.24.2
+      lastHeartbeatTime: "2024-02-15T10:25:34Z"
+      lastTransitionTime: "2024-02-15T10:25:34Z"
+      status: "True"
+    MonitoringControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:50Z"
+      status: "True"
+    SeedResourcesUpToDate:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-04-08T16:03:16Z"
+      lastTransitionTime: "2024-04-08T16:03:16Z"
+      message: All control plane components are up to date
+      reason: ClusterUpdateSuccessful
+      status: "True"
+    UpdateControllerReconciledSuccessfully:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-15T13:44:47Z"
+      status: "True"
+    UpdateProgress:
+      kubermaticVersion: v2.25.0
+      lastHeartbeatTime: "2024-03-17T18:24:21Z"
+      message: No update in progress, cluster has reached its desired version.
+      reason: UpToDate
+      status: "True"
+  extendedHealth:
+    alertmanagerConfig: HealthStatusUp
+    apiserver: HealthStatusUp
+    applicationController: HealthStatusUp
+    cloudProviderInfrastructure: HealthStatusUp
+    controller: HealthStatusUp
+    etcd: HealthStatusUp
+    gatekeeperAudit: HealthStatusUp
+    gatekeeperController: HealthStatusUp
+    konnectivity: HealthStatusUp
+    kubernetesDashboard: HealthStatusUp
+    logging: HealthStatusUp
+    machineController: HealthStatusUp
+    mlaGateway: HealthStatusUp
+    monitoring: HealthStatusUp
+    operatingSystemManager: HealthStatusUp
+    scheduler: HealthStatusUp
+    userClusterControllerManager: HealthStatusUp
+  lastProviderReconciliation: "2024-04-08T12:01:06Z"
+  namespaceName: cluster-efm8xdc57n
+  phase: Running
+  resourceUsage:
+    cpu: "8"
+    memory: 16384M
+    storage: 20G
+  userEmail: user@example.com
+  versions:
+    apiserver: 1.27.10
+    controlPlane: 1.27.10
+    controllerManager: 1.27.10
+    oldestNodeVersion: 1.27.10
+    scheduler: 1.27.10

--- a/pkg/test/addon/matrix.go
+++ b/pkg/test/addon/matrix.go
@@ -34,8 +34,7 @@ var (
 		kubermaticv1.VMwareCloudDirectorCloudProvider,
 	}
 
-	// anyProvider is used when we want to test against, but do not care against
-	// which provider
+	// anyProvider is used when we want to test against, but do not care against which provider.
 	anyProvider = []kubermaticv1.ProviderType{kubermaticv1.AWSCloudProvider}
 
 	AddonProviderMatrix = map[string][]kubermaticv1.ProviderType{

--- a/pkg/test/addon/matrix.go
+++ b/pkg/test/addon/matrix.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+)
+
+var (
+	csiProviders = []kubermaticv1.ProviderType{
+		kubermaticv1.AWSCloudProvider,
+		kubermaticv1.AzureCloudProvider,
+		kubermaticv1.DigitaloceanCloudProvider,
+		kubermaticv1.GCPCloudProvider,
+		kubermaticv1.HetznerCloudProvider,
+		kubermaticv1.KubevirtCloudProvider,
+		kubermaticv1.NutanixCloudProvider,
+		kubermaticv1.OpenstackCloudProvider,
+		kubermaticv1.VSphereCloudProvider,
+		kubermaticv1.VMwareCloudDirectorCloudProvider,
+	}
+
+	// anyProvider is used when we want to test against, but do not care against
+	// which provider
+	anyProvider = []kubermaticv1.ProviderType{kubermaticv1.AWSCloudProvider}
+
+	AddonProviderMatrix = map[string][]kubermaticv1.ProviderType{
+		"aws-node-termination-handler": {kubermaticv1.AWSCloudProvider},
+		"azure-cloud-node-manager":     {kubermaticv1.AzureCloudProvider},
+		"canal":                        anyProvider,
+		"cilium":                       anyProvider,
+		"cluster-autoscaler":           anyProvider,
+		"csi":                          csiProviders,
+		"default-storage-class":        csiProviders,
+		"hubble":                       anyProvider,
+		"kube-proxy":                   anyProvider,
+		"kube-state-metrics":           anyProvider,
+		"kubeadm-configmap":            anyProvider,
+		"kubelet-configmap":            anyProvider,
+		"metallb":                      anyProvider,
+		"multus":                       anyProvider,
+		"node-exporter":                anyProvider,
+		"openvpn":                      anyProvider,
+		"pod-security-policy":          anyProvider,
+		"rbac":                         anyProvider,
+	}
+
+	// Some addons rely on the manifests provided by another addon. This map
+	// contains these dependencies and is evaluated recursively. Addons not listed
+	// here have no dependencies.
+	RequiredAddons = map[string][]string{
+		// default-storage-class relies on the CSI addon installing the snapshot CRDs
+		"default-storage-class": {"csi"},
+	}
+)

--- a/pkg/test/addon/setup_test.go
+++ b/pkg/test/addon/setup_test.go
@@ -1,4 +1,4 @@
-//-- go:build addonupgrade
+//go:build addon_integration
 
 /*
 Copyright 2024 The Kubermatic Kubernetes Platform contributors.

--- a/pkg/test/addon/setup_test.go
+++ b/pkg/test/addon/setup_test.go
@@ -1,0 +1,98 @@
+//-- go:build addonupgrade
+
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"context"
+	"testing"
+
+	"k8c.io/kubermatic/v2/pkg/addon"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func installAddon(t *testing.T, client ctrlruntimeclient.Client, provider kubermaticv1.ProviderType, addonName string, allAddons map[string]*addon.Addon) *kubermaticv1.Cluster {
+	for _, required := range RequiredAddons[addonName] {
+		t.Logf("Installing required %s addon…", required)
+		installAddon(t, client, provider, required, allAddons)
+	}
+
+	cluster := loadCluster(t, provider)
+	setupClusterForAddon(t, cluster, addonName)
+
+	data := getTemplateData(t, cluster)
+
+	addonObj := allAddons[addonName]
+	if addonObj == nil {
+		t.Fatalf("No such addon: %s", addonName)
+	}
+
+	manifests, err := allAddons[addonName].Render("", data)
+	if err != nil {
+		t.Fatalf("Failed to render addon %s: %v", addonName, err)
+	}
+
+	setupEnvForAddon(t, client, provider, addonName, allAddons)
+	applyManifests(t, client, manifests)
+
+	return cluster
+}
+
+func setupEnvForAddon(t *testing.T, client ctrlruntimeclient.Client, provider kubermaticv1.ProviderType, addonName string, allAddons map[string]*addon.Addon) {
+	// NOP
+}
+
+func setupClusterForAddon(t *testing.T, cluster *kubermaticv1.Cluster, addonName string) {
+	// NOP
+}
+
+// setupEnvForUpgrade simulates the migration steps the KKP installer or addon controller
+// might perform between KKP releases. Re-implementing those steps in a cheap way here is
+// easier than turning this test case into a full-blown e2e test.
+func setupEnvForUpgrade(t *testing.T, client ctrlruntimeclient.Client, provider kubermaticv1.ProviderType, cluster *kubermaticv1.Cluster, addonName string) {
+	ctx := context.Background()
+
+	for _, required := range RequiredAddons[addonName] {
+		setupEnvForUpgrade(t, client, provider, cluster, required)
+	}
+
+	// failed to update object: CSIDriver.storage.k8s.io "csi.vsphere.vmware.com" is invalid: spec.podInfoOnMount: Invalid value: false: field is immutable
+	// https://github.com/kubermatic/kubermatic/pull/12936
+	if addonName == "csi" && provider == kubermaticv1.VSphereCloudProvider {
+		driver := &storagev1.CSIDriver{}
+		driver.Name = "csi.vsphere.vmware.com"
+		if err := client.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
+			t.Fatalf("Failed to delete VSphere CSI Driver: %v", err)
+		}
+	}
+
+	// ClusterRoleBinding for Azure's CSI was changed.
+	// https://github.com/kubermatic/kubermatic/pull/13250
+	if addonName == "csi" && provider == kubermaticv1.AzureCloudProvider {
+		driver := &rbacv1.ClusterRoleBinding{}
+		driver.Name = "csi-azuredisk-node-secret-binding"
+		if err := client.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
+			t.Fatalf("Failed to delete Azure CSI ClusterRoleBinding: %v", err)
+		}
+	}
+}

--- a/pkg/test/addon/setup_test.go
+++ b/pkg/test/addon/setup_test.go
@@ -89,9 +89,9 @@ func setupEnvForUpgrade(t *testing.T, client ctrlruntimeclient.Client, provider 
 	// ClusterRoleBinding for Azure's CSI was changed.
 	// https://github.com/kubermatic/kubermatic/pull/13250
 	if addonName == "csi" && provider == kubermaticv1.AzureCloudProvider {
-		driver := &rbacv1.ClusterRoleBinding{}
-		driver.Name = "csi-azuredisk-node-secret-binding"
-		if err := client.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
+		crb := &rbacv1.ClusterRoleBinding{}
+		crb.Name = "csi-azuredisk-node-secret-binding"
+		if err := client.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
 			t.Fatalf("Failed to delete Azure CSI ClusterRoleBinding: %v", err)
 		}
 	}

--- a/pkg/test/addon/upgrade_test.go
+++ b/pkg/test/addon/upgrade_test.go
@@ -1,4 +1,4 @@
-//-- go:build addonupgrade
+//go:build addon_integration
 
 /*
 Copyright 2024 The Kubermatic Kubernetes Platform contributors.

--- a/pkg/test/addon/upgrade_test.go
+++ b/pkg/test/addon/upgrade_test.go
@@ -1,0 +1,317 @@
+//-- go:build addonupgrade
+
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package addon
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+
+	"k8c.io/kubermatic/v2/pkg/addon"
+	addonutils "k8c.io/kubermatic/v2/pkg/addon"
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/defaulting"
+	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/util/wait"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/rest"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	currentAddonsPath  string
+	previousAddonsPath string
+)
+
+func init() {
+	flag.StringVar(&currentAddonsPath, "current", "../../../addons", "path to all addons for the current KKP version")
+	flag.StringVar(&previousAddonsPath, "previous", "", "path to all addons for the current KKP version")
+
+	ctrlruntimelog.SetLogger(zapr.NewLogger(zap.NewNop()))
+}
+
+func TestAddonsCanBeUpgraded(t *testing.T) {
+	currentAddons, err := addonutils.LoadAddonsFromDirectory(currentAddonsPath)
+	if err != nil {
+		t.Fatalf("Failed to load current addons from %s: %v", currentAddonsPath, err)
+	}
+
+	if previousAddonsPath == "" {
+		testAddonsCanBeApplied(t, currentAddons)
+	} else {
+		previousAddons, err := addonutils.LoadAddonsFromDirectory(previousAddonsPath)
+		if err != nil {
+			t.Fatalf("Failed to load previous addons from %s: %v", previousAddonsPath, err)
+		}
+
+		testAddonsCanBeUpgraded(t, previousAddons, currentAddons)
+	}
+}
+
+func testAddonsCanBeApplied(t *testing.T, addons map[string]*addon.Addon) {
+	for _, addonName := range sets.List(sets.KeySet(addons)) {
+		providersToTest, exists := AddonProviderMatrix[addonName]
+		if !exists {
+			t.Fatalf("No providers configured for addon %s, please update pkg/test/addon/matrix.go.", addonName)
+		}
+
+		for _, provider := range providersToTest {
+			t.Run(fmt.Sprintf("%s@%s", addonName, provider), func(t *testing.T) {
+				testAddonCanBeApplied(t, addonName, provider, addons)
+			})
+		}
+	}
+}
+
+func testAddonCanBeApplied(t *testing.T, addonName string, provider kubermaticv1.ProviderType, allAddons map[string]*addon.Addon) {
+	t.Parallel()
+	_, client := createTestEnv(t)
+	installAddon(t, client, provider, addonName, allAddons)
+}
+
+func testAddonsCanBeUpgraded(t *testing.T, previousAddons, currentAddons map[string]*addon.Addon) {
+	previousAddonNames := sets.KeySet(previousAddons)
+
+	for _, addonName := range sets.List(previousAddonNames) {
+		providersToTest, exists := AddonProviderMatrix[addonName]
+		if !exists {
+			t.Fatalf("No providers configured for addon %s, please update pkg/test/addon/matrix.go.", addonName)
+		}
+
+		for _, provider := range providersToTest {
+			t.Run(fmt.Sprintf("%s@%s", addonName, provider), func(t *testing.T) {
+				testAddonCanBeUpgraded(t, addonName, provider, previousAddons, currentAddons)
+			})
+		}
+	}
+
+	// for all newly added addons, still test if they apply
+	newAddonNames := sets.KeySet(currentAddons).Difference(previousAddonNames)
+
+	for _, addonName := range sets.List(newAddonNames) {
+		providersToTest, exists := AddonProviderMatrix[addonName]
+		if !exists {
+			t.Fatalf("No providers configured for addon %s, please update pkg/test/addon/matrix.go.", addonName)
+		}
+
+		for _, provider := range providersToTest {
+			t.Run(fmt.Sprintf("%s@%s", addonName, provider), func(t *testing.T) {
+				testAddonCanBeApplied(t, addonName, provider, currentAddons)
+			})
+		}
+	}
+}
+
+func testAddonCanBeUpgraded(t *testing.T, addonName string, provider kubermaticv1.ProviderType, previousAddons, currentAddons map[string]*addon.Addon) {
+	t.Parallel()
+
+	_, client := createTestEnv(t)
+
+	t.Log("Applying previous manifests…")
+	cluster := installAddon(t, client, provider, addonName, previousAddons)
+
+	if _, ok := currentAddons[addonName]; ok {
+		t.Log("Applying current manifests…")
+		setupEnvForUpgrade(t, client, provider, cluster, addonName)
+		installAddon(t, client, provider, addonName, currentAddons)
+	} else {
+		t.Log("Addon was deleted, no upgrade possible.")
+	}
+}
+
+func applyManifests(t *testing.T, client ctrlruntimeclient.Client, manifests []runtime.RawExtension) {
+	success := true
+	for _, manifest := range manifests {
+		if err := applyManifest(t, client, manifest); err != nil {
+			t.Errorf("Failed to apply: %v", err)
+			success = false
+		}
+	}
+
+	if !success {
+		t.FailNow()
+	}
+}
+
+func applyManifest(t *testing.T, client ctrlruntimeclient.Client, manifest runtime.RawExtension) error {
+	kubeObj := &unstructured.Unstructured{}
+	if _, _, err := unstructured.UnstructuredJSONScheme.Decode(manifest.Raw, nil, kubeObj); err != nil {
+		return fmt.Errorf("invalid object in rendered YAML: %w", err)
+	}
+
+	ctx := context.Background()
+
+	existing := kubeObj.DeepCopy()
+	if err := client.Get(ctx, ctrlruntimeclient.ObjectKeyFromObject(existing), existing); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to get %s %s: %w", kubeObj.GetKind(), kubeObj.GetName(), err)
+		}
+
+		// t.Logf("Creating %s %s…", kubeObj.GetKind(), kubeObj.GetName())
+		if err := client.Create(ctx, kubeObj); err != nil {
+			return fmt.Errorf("failed to create object: %w", err)
+		}
+
+		if kubeObj.GetKind() == "CustomResourceDefinition" {
+			waitForEstablishedCRD(t, client, kubeObj.GetName())
+		}
+	} else {
+		kubeObj.SetResourceVersion(existing.GetResourceVersion())
+
+		// t.Logf("Updating %s %s…", kubeObj.GetKind(), kubeObj.GetName())
+		if err := client.Update(ctx, kubeObj); err != nil {
+			return fmt.Errorf("failed to update object: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func waitForEstablishedCRD(t *testing.T, client ctrlruntimeclient.Client, crdName string) {
+	key := types.NamespacedName{Name: crdName}
+
+	err := wait.Poll(context.Background(), 100*time.Millisecond, 5*time.Second, func(ctx context.Context) (transient error, terminal error) {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := client.Get(ctx, key, crd); err != nil {
+			return err, nil
+		}
+
+		for _, cond := range crd.Status.Conditions {
+			if cond.Type == apiextensionsv1.Established {
+				if cond.Status == apiextensionsv1.ConditionTrue {
+					return nil, nil
+				}
+
+				return fmt.Errorf("%s condition is %s", apiextensionsv1.Established, cond.Status), nil
+			}
+		}
+
+		return fmt.Errorf("CRD has no %s condition", apiextensionsv1.Established), nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to wait for CRD: %v", err)
+	}
+}
+
+func createTestEnv(t *testing.T) (*rest.Config, ctrlruntimeclient.Client) {
+	testEnv := &envtest.Environment{}
+
+	// disable webhooks; it's impossible for the target services to ever become ready
+	apiserver := testEnv.ControlPlane.GetAPIServer()
+	args := apiserver.Configure()
+	args.Append("disable-admission-plugins", "ValidatingAdmissionWebhook", "MutatingAdmissionWebhook")
+
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("Failed to start envTest: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := testEnv.Stop(); err != nil {
+			t.Fatalf("Failed to stop envTest: %v", err)
+		}
+	})
+
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to setup scheme: %v", err)
+	}
+	if err := rbacv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to setup scheme: %v", err)
+	}
+	if err := storagev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("Failed to setup scheme: %v", err)
+	}
+
+	client, err := ctrlruntimeclient.New(cfg, ctrlruntimeclient.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create kube client: %v", err)
+	}
+
+	return cfg, client
+}
+
+func getTemplateData(t *testing.T, cluster *kubermaticv1.Cluster) *addonutils.TemplateData {
+	data, err := addonutils.NewTemplateData(
+		cluster,
+		resources.Credentials{},
+		"<kubeconfig>",
+		"1.2.3.4", // DNS cluster IP
+		"5.6.7.8", // DNS resolver IP
+		nil,       // IPAM allocations
+		nil,       // extra vars
+	)
+	if err != nil {
+		t.Fatalf("Failed to create template data: %v", err)
+	}
+
+	return data
+}
+
+func loadCluster(t *testing.T, provider kubermaticv1.ProviderType) *kubermaticv1.Cluster {
+	clusterFile := fmt.Sprintf("data/cluster-%s.yaml", provider)
+
+	content, err := os.ReadFile(clusterFile)
+	if err != nil {
+		t.Fatalf("Failed to read cluster file: %v", err)
+	}
+
+	raw := &unstructured.Unstructured{}
+	if err := yaml.NewYAMLOrJSONDecoder(bytes.NewReader(content), 1024).Decode(raw); err != nil {
+		t.Fatalf("Failed to decode: %v", err)
+	}
+
+	cluster := &kubermaticv1.Cluster{}
+	if err = yaml.UnmarshalStrict(content, cluster); err != nil {
+		t.Fatalf("File is not a valid Cluster: %v", err)
+	}
+
+	// always auto-assume the current stable Kubernetes version, nobody will want
+	// to keep bumping those YAML files...
+	defaultVersion := *defaulting.DefaultKubernetesVersioning.Default
+
+	cluster.Spec.Version = defaultVersion
+	cluster.Status.Versions = kubermaticv1.ClusterVersionsStatus{
+		ControlPlane:      defaultVersion,
+		Apiserver:         defaultVersion,
+		ControllerManager: defaultVersion,
+		Scheduler:         defaultVersion,
+	}
+
+	return cluster
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a new integration test to verify addon upgrades. It has happened quite a few times that we update addons and since the e2e tests only install the latest versions, we notice upgrade issues too late.

I provoked one example failure in https://public-prow.loodse.com/view/gs/prow-dev-public-data/pr-logs/pull/kubermatic_kubermatic/13256/pre-kubermatic-test-addon-upgrades/1777736396186849280

Full e2e tests (setup KKP, create usercluster, install addon, upgrade KKP, wait for addons to be reconciled again) would be very expensive and slow, so these new tests are just integration tests running against an envtest. So the tests will not catch serious issues (like broken image references), but those are usually caught by the e2e tests themselves already.

Since the new tests are not full e2e tests, I did not re-use the migration logic from the addon controller for some of our addons. Running the controller would be annoyingly complex and re-implementing the migration step is often trivial (there is no need to take older KKP release and annotation handling into account, for example). Plus since the tests will scream at you, there is little chance of the migration steps to be outdated.

The new tests live in `pkg/test/addon` and can be run in 2 modes:

* with no further flags (besides the `addon_integration` Go tag), this will simply test if all addons in `addons/` can be successfully applied.
* with `-previous`, the tests will for every combination of addon/provider setup an envtest, install the previous addon and then the new one.

Since addons create different manifests based on the cluster/cloud provider, there is a configuration matrix that defines which providers to use for which addon. I added example cluster YAML files for every relevant provider.

The version detection in the shell script is based on branches because the release branch is the last thing we do when actually creating a new release. if going by tags, we'd need to filter out pre-releases.

**What type of PR is this?**
/kind regression

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Compatibility of addons is now automatically tested against previous KKP releases to prevent addons failing to change immutable fields.
```

**Documentation**:
```documentation
NONE
```
