### PR TITLE
Add `AddonReconciledSuccessfully` condition / phase to addons

### DIFF
--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -36,6 +36,7 @@ const (
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:JSONPath=".status.phase",name="Phase",type="string"
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 
 // Addon specifies a cluster addon. Addons can be installed into user clusters
@@ -94,8 +95,23 @@ type AddonList struct {
 	Items []Addon `json:"items"`
 }
 
+// +kubebuilder:validation:Enum=New;Healthy;Unhealthy
+type AddonPhase string
+
+// These are the valid phases of a project.
+const (
+	AddonNew       AddonPhase = "New"
+	AddonHealthy   AddonPhase = "Healthy"
+	AddonUnhealthy AddonPhase = "Unhealthy"
+)
+
 // AddonStatus contains information about the reconciliation status.
 type AddonStatus struct {
+	// Phase is a description of the current addon status, summarizing the various conditions.
+	// This field is for informational purpose only and no logic should be tied to the phase.
+	// +kubebuilder:default=New
+	Phase AddonPhase `json:"phase,omitempty"`
+
 	Conditions map[AddonConditionType]AddonCondition `json:"conditions,omitempty"`
 }
 

--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -29,7 +29,8 @@ const (
 	// AddonKindName represents "Kind" defined in Kubernetes.
 	AddonKindName = "Addon"
 
-	AddonResourcesCreated AddonConditionType = "AddonResourcesCreatedSuccessfully"
+	AddonResourcesCreated       AddonConditionType = "AddonResourcesCreatedSuccessfully"
+	AddonReconciledSuccessfully AddonConditionType = "AddonReconciledSuccessfully"
 )
 
 // +kubebuilder:object:generate=true
@@ -98,7 +99,7 @@ type AddonStatus struct {
 	Conditions map[AddonConditionType]AddonCondition `json:"conditions,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=AddonResourcesCreatedSuccessfully
+// +kubebuilder:validation:Enum=AddonResourcesCreatedSuccessfully;AddonReconciledSuccessfully
 
 type AddonConditionType string
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -151,6 +151,16 @@ spec:
                       - status
                     type: object
                   type: object
+                phase:
+                  default: New
+                  description: |-
+                    Phase is a description of the current addon status, summarizing the various conditions.
+                    This field is for informational purpose only and no logic should be tied to the phase.
+                  enum:
+                    - New
+                    - Healthy
+                    - Unhealthy
+                  type: string
               type: object
           type: object
       served: true

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -16,6 +16,9 @@ spec:
   scope: Namespaced
   versions:
     - additionalPrinterColumns:
+        - jsonPath: .status.phase
+          name: Phase
+          type: string
         - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR primarily adds a new condition, `AddonReconciledSuccessfully`, to _Addons_. There is already a `AddonResourcesCreatedSuccessfully` condition, but it's set only once. Especially after KKP upgrades, its value diminishes strongly.

The new condition simply tells us if the last reconciliation of the addon was successful. Nice and easy.

This new condition is then used for 2 things:

- The conformance-tester will now wait for all addons to be reconciled successfully, both in regular tests as well as in upgrade tests.
- The condition is used to calculate a phase, similar to clusters. New addons that were never reconciled once are `New`, once they are reconciled at least once they are either `Healthy` or `Unhealthy`. This new phase is then added to the kubectl columns, so a `k get addons -A` will instantly show you the health of all addons on the seed.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* Add new `AddonReconciledSuccessfully` condition to Addon resources.
* Add `Phase` (New/Healthy/Unhealthy) to Addon resources (for informational purpose only, integrations should rely on the individual condition statusses).
```

**Documentation**:
```documentation
NONE
```
