### PR TITLE
add dynamic base id to envoy agent on user cluster

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/envoy-agent/daemonset.go
@@ -169,7 +169,7 @@ func getContainers(versions kubermatic.Versions, imageRewriter registry.ImageRew
 
 			// This amount of logs will be kept for the Tech Preview of
 			// the new expose strategy
-			Args: []string{"--config-path", "etc/envoy/envoy.yaml"},
+			Args: []string{"--config-path", "etc/envoy/envoy.yaml", "--use-dynamic-base-id"},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "config-volume",


### PR DESCRIPTION
**What this PR does / why we need it**:

If Cilium envoy daemon set is used together with Tunneling, there will be a conflict between this envoy and our envoy agent running on the user cluster, as Cilium by default hardcodes its base_id to 0. 
For running multiple Envoys on the same machine, each running Envoy will need a unique base ID so that the shared memory regions do not conflict.
```bash
[2023-12-14 15:34:09.986][1][debug][init] [external/envoy/source/common/init/watcher_impl.cc:31] init manager Server destroyed
unable to bind domain socket with base_id=0, id=0, errno=98 (see --base-id option)
```

This PR adds a dynamic base id to Envoy instead of hardcoding different base_ids in Cilium and envoy agent.
As we are not using hot restarts, this has no other limitations
https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-use-dynamic-base-id

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12922

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
TBD
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
