### PR TITLE
update configmap-reloader to 0.12.0

### DIFF
--- a/charts/monitoring/alertmanager/values.yaml
+++ b/charts/monitoring/alertmanager/values.yaml
@@ -18,8 +18,8 @@ alertmanager:
     tag: v0.25.0
     pullPolicy: IfNotPresent
   configReloaderImage:
-    repository: docker.io/jimmidyson/configmap-reload
-    tag: v0.8.0
+    repository: ghcr.io/jimmidyson/configmap-reload
+    tag: v0.12.0
     pullPolicy: IfNotPresent
   # list of image pull secret references, e.g.
   # imagePullSecrets:

--- a/charts/monitoring/prometheus/templates/statefulset.yaml
+++ b/charts/monitoring/prometheus/templates/statefulset.yaml
@@ -126,9 +126,9 @@ spec:
         image: '{{ .Values.prometheus.configReloaderImage.repository }}:{{ .Values.prometheus.configReloaderImage.tag }}'
         imagePullPolicy: {{ .Values.prometheus.configReloaderImage.pullPolicy }}
         args:
-        - --volume-dir=/etc/prometheus/config
-        - --volume-dir=/etc/prometheus/rules
-        - --webhook-url=http://localhost:9090/-/reload
+        - -volume-dir=/etc/prometheus/config
+        - -volume-dir=/etc/prometheus/rules
+        - -webhook-url=http://localhost:9090/-/reload
         resources:
 {{ toYaml .Values.prometheus.containers.reloader.resources | indent 10 }}
         volumeMounts:

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -32,8 +32,8 @@ prometheus:
     compressWAL: true
 
   configReloaderImage:
-    repository: docker.io/jimmidyson/configmap-reload
-    tag: v0.8.0
+    repository: ghcr.io/jimmidyson/configmap-reload
+    tag: v0.12.0
     pullPolicy: IfNotPresent
 
   # If you install Prometheus using a different Helm release name,


### PR DESCRIPTION
**What this PR does / why we need it**:
A very long overdue update. There's no changelog or even GitHub releases, so I presume nothing has changed besides more recent dependencies and Go version.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update configmap-reload to 0.12.0; container image is now pulled from `ghcr.io/jimmidyson/configmap-reload` instead of Docker Hub
```

**Documentation**:
```documentation
NONE
```
