### PR TITLE
use plain semver versions for Helm charts

### DIFF
--- a/charts/backup/velero/Chart.yaml
+++ b/charts/backup/velero/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: velero
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v1.10.1
 description: A Helm chart for Velero
 keywords:

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: cert-manager
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v1.12.2
 description: A Helm chart for cert-manager
 keywords:

--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: iap
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v7.4.0
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:

--- a/charts/kubermatic-operator/Chart.yaml
+++ b/charts/kubermatic-operator/Chart.yaml
@@ -14,8 +14,8 @@
 
 apiVersion: v1
 name: kubermatic-operator
-version: v9.9.9-dev
-appVersion: v9.9.9-dev
+version: 9.9.9-dev
+appVersion: 9.9.9-dev
 description: Helm chart to install the Kubermatic Operator
 keywords:
   - kubermatic

--- a/charts/logging/loki/Chart.yaml
+++ b/charts/logging/loki/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: loki
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v2.5.0
 description: "Loki: like Prometheus, but for logs."
 keywords:

--- a/charts/logging/promtail/Chart.yaml
+++ b/charts/logging/promtail/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: promtail
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v2.5.0
 description: "Responsible for gathering logs and sending them to Loki"
 keywords:

--- a/charts/minio/Chart.yaml
+++ b/charts/minio/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: minio
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: RELEASE.2023-05-04T21-44-30Z
 description: minio
 keywords:

--- a/charts/mla/alertmanager-proxy/Chart.yaml
+++ b/charts/mla/alertmanager-proxy/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: alertmanager-proxy
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 0.3.3
 description: A Helm chart to install KKP MLA Alertmanager Proxy.
 keywords:

--- a/charts/mla/consul/Chart.yaml
+++ b/charts/mla/consul/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: consul
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 1.14.2
 kubeVersion: ">=1.21.0-0"
 description: Official HashiCorp Consul Chart

--- a/charts/mla/cortex/Chart.yaml
+++ b/charts/mla/cortex/Chart.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 apiVersion: v2
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v1.14.1
 description: 'Horizontally scalable, highly available, multi-tenant, long term Prometheus.'
 home: https://cortexmetrics.io/

--- a/charts/mla/grafana/Chart.yaml
+++ b/charts/mla/grafana/Chart.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 apiVersion: v2
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 10.2.2
 description: The leading tool for querying and visualizing time series and metrics.
 home: https://grafana.net

--- a/charts/mla/loki-distributed/Chart.yaml
+++ b/charts/mla/loki-distributed/Chart.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 apiVersion: v2
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 2.9.2
 description: Helm chart for Grafana Loki in microservices mode
 home: https://grafana.github.io/helm-charts

--- a/charts/mla/minio-lifecycle-mgr/Chart.yaml
+++ b/charts/mla/minio-lifecycle-mgr/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: minio-lifecycle-mgr
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 0.1.0
 description: A Helm chart to install Minio Bucket Lifecycle Manager.
 keywords:

--- a/charts/mla/minio/Chart.yaml
+++ b/charts/mla/minio/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 description: High Performance, Kubernetes Native Object Storage
 name: minio
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: RELEASE.2023-04-28T18-11-17Z
 keywords:
   - storage

--- a/charts/monitoring/alertmanager/Chart.yaml
+++ b/charts/monitoring/alertmanager/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: alertmanager
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v0.25.0
 description: Alertmanager for Kubermatic
 keywords:

--- a/charts/monitoring/blackbox-exporter/Chart.yaml
+++ b/charts/monitoring/blackbox-exporter/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: blackbox-exporter
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v0.23.0
 description: Deploys the Prometheus Blackbox Exporter
 keywords:

--- a/charts/monitoring/grafana/Chart.yaml
+++ b/charts/monitoring/grafana/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: grafana
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 9.5.1
 description: Grafana for Kubermatic
 keywords:

--- a/charts/monitoring/helm-exporter/Chart.yaml
+++ b/charts/monitoring/helm-exporter/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: helm-exporter
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 1.2.5
 description: Exports Helm release information to Prometheus
 keywords:

--- a/charts/monitoring/karma/Chart.yaml
+++ b/charts/monitoring/karma/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: karma
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v0.114
 description: Dashboard for Prometheus Alertmanager
 keywords:

--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: kube-state-metrics
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v2.8.2
 description: Kube-State-Metrics for Kubermatic
 keywords:

--- a/charts/monitoring/node-exporter/Chart.yaml
+++ b/charts/monitoring/node-exporter/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: node-exporter
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v1.5.0
 description: Prometheus Node Exporter for Kubermatic
 keywords:

--- a/charts/monitoring/prometheus/Chart.yaml
+++ b/charts/monitoring/prometheus/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: prometheus
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v2.43.1
 description: Prometheus Monitoring for Kubernetes
 keywords:

--- a/charts/nginx-ingress-controller/Chart.yaml
+++ b/charts/nginx-ingress-controller/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v2
 name: nginx-ingress-controller
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: 1.9.3
 description: nginx-ingress-controller
 keywords:

--- a/charts/oauth/Chart.yaml
+++ b/charts/oauth/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: oauth
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v2.36.0
 description: Dex
 keywords:

--- a/charts/s3-exporter/Chart.yaml
+++ b/charts/s3-exporter/Chart.yaml
@@ -14,7 +14,7 @@
 
 apiVersion: v1
 name: s3-exporter
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v0.7.1
 keywords:
   - kubermatic

--- a/charts/telemetry/Chart.yaml
+++ b/charts/telemetry/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: telemetry
 description: A Helm chart to install Kubermatic telemetry agents
-version: v9.9.9-dev
+version: 9.9.9-dev
 appVersion: v0.5.0
 keywords:
   - telemetry

--- a/hack/ci/deploy.sh
+++ b/hack/ci/deploy.sh
@@ -86,7 +86,7 @@ function deploy {
 # silence complaints by Helm
 chmod 600 "$KUBECONFIG"
 
-set_helm_charts_version "v9.9.9-${GIT_HEAD_HASH}" "${GIT_HEAD_HASH}"
+set_helm_charts_version "9.9.9-${GIT_HEAD_HASH}" "${GIT_HEAD_HASH}"
 copy_crds_to_chart
 set_crds_version_annotation
 

--- a/hack/ci/github-release.sh
+++ b/hack/ci/github-release.sh
@@ -207,11 +207,11 @@ if ! $DRY_RUN; then
   releaseID=$(echo "$releasedata" | jq -r '.id')
 fi
 
-# prepare source for archiving (prepend "v9.9.9" if GIT_TAG is only
+# prepare source for archiving (prepend "9.9.9" if GIT_TAG is only
 # a hash, because Helm requires a semver version)
 CHART_TAG="$GIT_TAG"
 if [[ "$CHART_TAG" != v* ]]; then
-  CHART_TAG="v9.9.9-$CHART_TAG"
+  CHART_TAG="9.9.9-$CHART_TAG"
 fi
 
 set_helm_charts_version "$CHART_TAG" "$GIT_TAG"

--- a/hack/ci/release-images.sh
+++ b/hack/ci/release-images.sh
@@ -98,7 +98,7 @@ if [ -z "${NO_IMAGES:-}" ]; then
 
   # prepare Helm charts, do not use $KUBERMATICDOCKERTAG for the chart version,
   # as it could just be a git hash and we need to ensure a proper semver version
-  set_helm_charts_version "${GIT_HEAD_TAG:-v9.9.9-$GIT_HEAD_HASH}" "$KUBERMATICDOCKERTAG"
+  set_helm_charts_version "${GIT_HEAD_TAG:-9.9.9-$GIT_HEAD_HASH}" "$KUBERMATICDOCKERTAG"
 
   # make sure that the main container image contains ready made CRDs, as the installer
   # will take them from the operator chart and not use the compiled-in versions.

--- a/hack/ci/run-offline-test.sh
+++ b/hack/ci/run-offline-test.sh
@@ -132,7 +132,7 @@ retry 5 buildah login -u "$QUAY_IO_USERNAME" -p "$QUAY_IO_PASSWORD" quay.io
 echodate "Building and pushing Docker images"
 
 # prepare Helm charts
-set_helm_charts_version "v9.9.9-${GIT_HEAD_HASH}"
+set_helm_charts_version "9.9.9-${GIT_HEAD_HASH}"
 
 retry 5 ./../release-images.sh ${GIT_HEAD_HASH} $(git tag -l --points-at HEAD)
 echodate "Successfully finished building and pushing quay images"

--- a/hack/lib.sh
+++ b/hack/lib.sh
@@ -435,7 +435,11 @@ set_helm_charts_version() {
   local version="$1"
   local dockerTag="${2:-$version}"
 
-  echodate "Setting Helm chart version to $version..."
+  # trim leading v; Helm allows "v1.2.3" as chart versions, but some other tools
+  # consuming charts are more strict and require pure, prefixless semvers.
+  local semver="${version#v}"
+
+  echodate "Setting Helm chart version to $semver..."
 
   while IFS= read -r -d '' chartFile; do
     chart="$(basename $(dirname "$chartFile"))"
@@ -443,7 +447,7 @@ set_helm_charts_version() {
       continue
     fi
 
-    yq --inplace ".version = \"$version\"" "$chartFile"
+    yq --inplace ".version = \"$semver\"" "$chartFile"
     if [ "$chart" = "kubermatic-operator" ]; then
       yq --inplace ".appVersion = \"$version\"" "$chartFile"
       yq --inplace ".kubermaticOperator.image.tag = \"$dockerTag\"" "$(dirname "$chartFile")/values.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:
The Semver2 docs state clearly:

> No, “v1.2.3” is not a semantic version. However, prefixing a semantic version with a “v” is a common way (in English) to indicate it is a version number. Abbreviating “version” as “v” is often seen with version control. Example: `git tag v1.2.3 -m "Release version 1.2.3"`, in which case “v1.2.3” is a tag name and the semantic version is “1.2.3”.

( https://semver.org/spec/v2.0.0.html#is-v123-a-semantic-version )

Helm itself is chill and humane, but other tools are not so relaxed:

* https://github.com/envoyproxy/gateway/issues/2940
* https://github.com/fluxcd/helm-controller/issues/670
* https://github.com/fluxcd/flux2/issues/3766

For these reasons this PR switches our Helm Chart versions to be "pure" (my word) semvers. Everything else (especially Git Tags and container tags) stays the same.

**What type of PR is this?**
/kind bug
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
All Helm charts now use a plain semver (without leading "v") as their `version`, allowing for easier integration with Flux and other tools that do not allow leading "v" (like Helm does). Git tags and container image tags are not affected by this change.
```

**Documentation**:
```documentation
NONE
```
