### PR TITLE
update oauth2-proxy to 7.6.0

### DIFF
--- a/charts/iap/Chart.yaml
+++ b/charts/iap/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: iap
 version: 9.9.9-dev
-appVersion: v7.4.0
+appVersion: v7.6.0
 description: A Helm chart to install OAuth2-Proxy as an identity-aware proxy.
 keywords:
   - kubermatic

--- a/charts/iap/templates/deployments.yaml
+++ b/charts/iap/templates/deployments.yaml
@@ -86,6 +86,17 @@ spec:
         - name: ca
           mountPath: /etc/ssl/certs
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: config
         configMap:
@@ -101,10 +112,6 @@ spec:
           - key: {{ $.Values.iap.customProviderCA.secretKey }}
             path: {{ $.Values.iap.customProviderCA.secretKey }}
       {{- end }}
-      securityContext:
-        fsGroup: 65534
-        runAsNonRoot: true
-        runAsUser: 65534
       nodeSelector:
 {{ toYaml $.Values.iap.nodeSelector | indent 8 }}
       affinity:

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -80,7 +80,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -123,6 +123,17 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: config
         configMap:
@@ -130,10 +141,6 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      securityContext:
-        fsGroup: 65534
-        runAsNonRoot: true
-        runAsUser: 65534
       nodeSelector:
         {}
       affinity:

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -137,7 +137,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -180,6 +180,17 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: config
         configMap:
@@ -187,10 +198,6 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      securityContext:
-        fsGroup: 65534
-        runAsNonRoot: true
-        runAsUser: 65534
       nodeSelector:
         {}
       affinity:
@@ -231,7 +238,7 @@ spec:
     spec:
       containers:
       - name: oauth2-proxy
-        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
+        image: "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
         imagePullPolicy: IfNotPresent
         args:
         - --provider=oidc
@@ -274,6 +281,17 @@ spec:
         volumeMounts:
         - name: config
           mountPath: /config
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 2000
+          runAsGroup: 2000
+          seccompProfile:
+            type: RuntimeDefault
       volumes:
       - name: config
         configMap:
@@ -281,10 +299,6 @@ spec:
           items:
           - key: config.yaml
             path: config.yaml
-      securityContext:
-        fsGroup: 65534
-        runAsNonRoot: true
-        runAsUser: 65534
       nodeSelector:
         {}
       affinity:

--- a/charts/iap/values.yaml
+++ b/charts/iap/values.yaml
@@ -15,7 +15,7 @@
 iap:
   image:
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: v7.4.0
+    tag: v7.6.0
     pullPolicy: IfNotPresent
 
   # list of image pull secret references, e.g.


### PR DESCRIPTION
**What this PR does / why we need it**:
There were some important CVE fixes and we should have updated this much sooner already.

I updated the container's security context to match the upstream chart ( https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/values.yaml#L241 ).

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
BREAKING CHANGE: Update oauth2-proxy to 7.6.0; this release introduces a change to how auth routes are evaluated using the flags skip-auth-route/skip-auth-regex. The new behaviour uses the regex you specify to evaluate the full path including query parameters. For more details please read the detailed description in https://github.com/oauth2-proxy/oauth2-proxy/issues/2271
```

**Documentation**:
```documentation
NONE
```
