### PR TITLE
Allow custom tag & tag-suffix for kubermatic API image

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -17,6 +17,10 @@ spec:
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
     dockerRepository: quay.io/kubermatic/dashboard
+    # DockerTagSuffix is appended to the KKP version used for referring to the custom Kubermatic API image.
+    # If left empty, either the `DockerTag` if specified or the original Kubermatic API Docker image tag will be used.
+    # With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
+    dockerTagSuffix: ""
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -264,7 +268,7 @@ spec:
     dockerRepository: quay.io/kubermatic/dashboard
     # DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
     # If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
-    # With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+    # With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
     dockerTagSuffix: ""
     # ExtraVolumeMounts allows to mount additional volumes into the UI container.
     extraVolumeMounts: null

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -17,6 +17,10 @@ spec:
     debugLog: false
     # DockerRepository is the repository containing the Kubermatic REST API image.
     dockerRepository: quay.io/kubermatic/dashboard-ee
+    # DockerTagSuffix is appended to the KKP version used for referring to the custom Kubermatic API image.
+    # If left empty, either the `DockerTag` if specified or the original Kubermatic API Docker image tag will be used.
+    # With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
+    dockerTagSuffix: ""
     # PProfEndpoint controls the port the API should listen on to provide pprof
     # data. This port is never exposed from the container and only available via port-forwardings.
     pprofEndpoint: :6600
@@ -264,7 +268,7 @@ spec:
     dockerRepository: quay.io/kubermatic/dashboard-ee
     # DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
     # If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
-    # With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+    # With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
     dockerTagSuffix: ""
     # ExtraVolumeMounts allows to mount additional volumes into the UI container.
     extraVolumeMounts: null

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -130,6 +130,17 @@ type KubermaticAuthConfiguration struct {
 type KubermaticAPIConfiguration struct {
 	// DockerRepository is the repository containing the Kubermatic REST API image.
 	DockerRepository string `json:"dockerRepository,omitempty"`
+	// DockerTag is used to overwrite the Kubermatic API Docker image tag and is only for development
+	// purposes. This field must not be set in production environments. If DockerTag is specified then
+	// DockerTagSuffix will be ignored.
+	// ---
+	//nolint:staticcheck
+	//lint:ignore SA5008 omitgenyaml is used by the example-yaml-generator
+	DockerTag string `json:"dockerTag,omitempty,omitgenyaml"`
+	// DockerTagSuffix is appended to the KKP version used for referring to the custom Kubermatic API image.
+	// If left empty, either the `DockerTag` if specified or the original Kubermatic API Docker image tag will be used.
+	// With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
+	DockerTagSuffix string `json:"dockerTagSuffix,omitempty"`
 	// AccessibleAddons is a list of addons that should be enabled in the API.
 	AccessibleAddons []string `json:"accessibleAddons,omitempty"`
 	// PProfEndpoint controls the port the API should listen on to provide pprof
@@ -156,7 +167,7 @@ type KubermaticUIConfiguration struct {
 	DockerTag string `json:"dockerTag,omitempty,omitgenyaml"`
 	// DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
 	// If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
-	// With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+	// With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
 	DockerTagSuffix string `json:"dockerTagSuffix,omitempty"`
 	// Config sets flags for various dashboard features.
 	Config string `json:"config,omitempty"`

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -242,11 +242,11 @@ func APIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerNa
 				args = append(args, fmt.Sprintf("-worker-name=%s", workerName))
 			}
 
-			tag := versions.UI
-			if cfg.Spec.UI.DockerTag != "" {
-				tag = cfg.Spec.UI.DockerTag
-			} else if cfg.Spec.UI.DockerTagSuffix != "" {
-				tag = fmt.Sprintf("%s-%s", versions.Kubermatic, cfg.Spec.UI.DockerTagSuffix)
+			tag := versions.Kubermatic
+			if cfg.Spec.API.DockerTag != "" {
+				tag = cfg.Spec.API.DockerTag
+			} else if cfg.Spec.API.DockerTagSuffix != "" {
+				tag = fmt.Sprintf("%s-%s", versions.Kubermatic, cfg.Spec.API.DockerTagSuffix)
 			}
 
 			d.Spec.Template.Spec.Volumes = volumes

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -58,6 +58,19 @@ spec:
                     dockerRepository:
                       description: DockerRepository is the repository containing the Kubermatic REST API image.
                       type: string
+                    dockerTag:
+                      description: |-
+                        DockerTag is used to overwrite the Kubermatic API Docker image tag and is only for development
+                        purposes. This field must not be set in production environments. If DockerTag is specified then
+                        DockerTagSuffix will be ignored.
+                        ---
+                      type: string
+                    dockerTagSuffix:
+                      description: |-
+                        DockerTagSuffix is appended to the KKP version used for referring to the custom Kubermatic API image.
+                        If left empty, either the `DockerTag` if specified or the original Kubermatic API Docker image tag will be used.
+                        With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
+                      type: string
                     pprofEndpoint:
                       description: |-
                         PProfEndpoint controls the port the API should listen on to provide pprof
@@ -456,7 +469,7 @@ spec:
                       description: |-
                         DockerTagSuffix is appended to the KKP version used for referring to the custom dashboard image.
                         If left empty, either the `DockerTag` if specified or the original dashboard Docker image tag will be used.
-                        With DockerTagSuffix the tag becomes <KKP_VERSION:SUFFIX> i.e. "v2.15.0-SUFFIX".
+                        With DockerTagSuffix the tag becomes <KKP_VERSION-SUFFIX> i.e. "v2.15.0-SUFFIX".
                       type: string
                     extraVolumeMounts:
                       description: ExtraVolumeMounts allows to mount additional volumes into the UI container.


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently when we specify a image tag/tag-suffix for dashboard in the KKP configuration, the same is used for KKP API as well, this PR enables admins to set different tag/tag-suffix for KKP UI & KKP API.

**Which issue(s) this PR fixes**:
Fixes #12464

**What type of PR is this?**

/kind feature
/kind api-change

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Separate container image tag/tag-suffix can be set for KKP UI & KKP API.
**ACTION REQUIRED**: If custom image tag/tag-suffix is being used for KKP UI & the admin desires to use the same (or different) custom tag/tag-suffix for the Kubermatic API image as well, then it needs to be explicitly set in the `KubermaticConfiguration.spec.api.dockerTag/dockerTagSuffix` otherwise the default tag for the KKP version will be used.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
