### PR TITLE
Use ValuesBlock in Cilium

### DIFF
--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -282,10 +282,10 @@ func (ad *ApplicationDefinitionSpec) GetDefaultValues() ([]byte, error) {
 // Will return an error if both fields are set.
 func (ai *ApplicationDefinitionSpec) GetParsedDefaultValues() (map[string]interface{}, error) {
 	values := make(map[string]interface{})
-	if len(ai.DefaultValues.Raw) > 0 && string(ai.DefaultValues.Raw) != "{}" && ai.DefaultValuesBlock != "" {
+	if !isEmptyRawExtension(ai.DefaultValues) && ai.DefaultValuesBlock != "" {
 		return nil, fmt.Errorf("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously. Please delete one of them.")
 	}
-	if len(ai.DefaultValues.Raw) > 0 && string(ai.DefaultValues.Raw) != "{}" {
+	if !isEmptyRawExtension(ai.DefaultValues) {
 		err := json.Unmarshal(ai.DefaultValues.Raw, &values)
 		return values, err
 	}

--- a/pkg/apis/apps.kubermatic/v1/application_definition.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition.go
@@ -17,11 +17,13 @@ limitations under the License.
 package v1
 
 import (
+	"encoding/json"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -274,4 +276,19 @@ func (ad *ApplicationDefinitionSpec) GetDefaultValues() ([]byte, error) {
 		return []byte(ad.DefaultValuesBlock), nil
 	}
 	return nil, nil
+}
+
+// GetParsedDefaultValues parses the values either from the DefaultValues or DefaultValuesBlock field.
+// Will return an error if both fields are set.
+func (ai *ApplicationDefinitionSpec) GetParsedDefaultValues() (map[string]interface{}, error) {
+	values := make(map[string]interface{})
+	if len(ai.DefaultValues.Raw) > 0 && string(ai.DefaultValues.Raw) != "{}" && ai.DefaultValuesBlock != "" {
+		return nil, fmt.Errorf("the fields DefaultValues and DefaultValuesBlock cannot be used simultaneously. Please delete one of them.")
+	}
+	if len(ai.DefaultValues.Raw) > 0 && string(ai.DefaultValues.Raw) != "{}" {
+		err := json.Unmarshal(ai.DefaultValues.Raw, &values)
+		return values, err
+	}
+	err := yaml.Unmarshal([]byte(ai.DefaultValuesBlock), &values)
+	return values, err
 }

--- a/pkg/apis/apps.kubermatic/v1/application_definition_test.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/pkg/apis/apps.kubermatic/v1/application_definition_test.go
+++ b/pkg/apis/apps.kubermatic/v1/application_definition_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGetParsedDefaultValues(t *testing.T) {
+	tt := map[string]struct {
+		appIn       ApplicationDefinitionSpec
+		expResponse map[string]interface{}
+		expError    bool
+	}{
+		"Values set": {
+			appIn: ApplicationDefinitionSpec{
+				DefaultValues: &runtime.RawExtension{Raw: []byte(`{"not-empty":"value"}`)},
+			},
+			expResponse: map[string]interface{}{"not-empty": "value"},
+			expError:    false,
+		},
+		"ValuesBlock set": {
+			appIn: ApplicationDefinitionSpec{
+				DefaultValuesBlock: "not-empty:\n  value",
+			},
+			expResponse: map[string]interface{}{"not-empty": "value"},
+			expError:    false,
+		},
+		"ValuesBlock set and Values Defaulted": {
+			appIn: ApplicationDefinitionSpec{
+				DefaultValues:      &runtime.RawExtension{Raw: []byte("{}")},
+				DefaultValuesBlock: "not-empty:\n  value",
+			},
+			expResponse: map[string]interface{}{"not-empty": "value"},
+			expError:    false,
+		},
+		"Both Values and ValuesBlock set": {
+			appIn: ApplicationDefinitionSpec{
+				DefaultValues:      &runtime.RawExtension{Raw: []byte(`{"not-empty":"value"}`)},
+				DefaultValuesBlock: "not-empty:\n  value",
+			},
+			expResponse: nil,
+			expError:    true,
+		},
+	}
+
+	for name, tc := range tt {
+		t.Run(name, func(t *testing.T) {
+			res, err := tc.appIn.GetParsedDefaultValues()
+			if tc.expError == false && err != nil {
+				t.Errorf("Expected Error to be nil, but got %v", err)
+			}
+			if tc.expError == true && err == nil {
+				t.Errorf("Expected Error to be present, but was nil")
+			}
+			assert.Equal(t, tc.expResponse, res)
+		})
+	}
+}

--- a/pkg/apis/apps.kubermatic/v1/empty.go
+++ b/pkg/apis/apps.kubermatic/v1/empty.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+// isEmptyRawExtension checks if a RawExtension is empty.
+// In the coniiijkkjjjkkhhhtext of Applications, we consider a RawExtension to
+// empty, if it is nil, zero characters, or "{}", which is the
+// default empty value from kube-api.
+func isEmptyRawExtension(re *runtime.RawExtension) bool {
+	if re == nil {
+		return true
+	}
+	if len(re.Raw) == 0 || string(re.Raw) == "{}" {
+		return true
+	}
+	return false
+}

--- a/pkg/apis/apps.kubermatic/v1/empty.go
+++ b/pkg/apis/apps.kubermatic/v1/empty.go
@@ -19,7 +19,7 @@ package v1
 import "k8s.io/apimachinery/pkg/runtime"
 
 // isEmptyRawExtension checks if a RawExtension is empty.
-// In the coniiijkkjjjkkhhhtext of Applications, we consider a RawExtension to
+// In the context of Applications, we consider a RawExtension to be
 // empty, if it is nil, zero characters, or "{}", which is the
 // default empty value from kube-api.
 func isEmptyRawExtension(re *runtime.RawExtension) bool {

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	"golang.org/x/exp/maps"
-	"sigs.k8s.io/yaml"
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -30,6 +29,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/yaml"
 )
 
 const (

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -17,11 +17,11 @@ limitations under the License.
 package cilium
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"golang.org/x/exp/maps"
+	"sigs.k8s.io/yaml"
 
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
@@ -29,7 +29,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -228,8 +227,13 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 				},
 			}
 
+			// to make it compatible with older cilium controller versions, convert any DefaultValues into DefaultValuesBlock
+			if err := convertDefaultValuesToDefaultValuesBlock(app); err != nil {
+				return app, fmt.Errorf("failed to convert DefaultValues into DefaultValuesBlock: %w", err)
+			}
+
 			// we want to allow overriding the default values, so reconcile them only if nil
-			if app.Spec.DefaultValues == nil {
+			if app.Spec.DefaultValuesBlock == "" || app.Spec.DefaultValuesBlock == "{}" {
 				defaultValues := map[string]any{
 					"operator": map[string]any{
 						"replicas": 1,
@@ -249,11 +253,11 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 						},
 					},
 				}
-				rawValues, err := json.Marshal(defaultValues)
+				rawValues, err := yaml.Marshal(defaultValues)
 				if err != nil {
 					return app, fmt.Errorf("failed to marshall default CNI values: %w", err)
 				}
-				app.Spec.DefaultValues = &runtime.RawExtension{Raw: rawValues}
+				app.Spec.DefaultValuesBlock = string(rawValues)
 			}
 			return app, nil
 		}
@@ -471,4 +475,16 @@ func excludedKeyExists(values map[string]any, keys ...string) bool {
 	}
 
 	return false
+}
+
+func convertDefaultValuesToDefaultValuesBlock(app *appskubermaticv1.ApplicationDefinition) error {
+	if app.Spec.DefaultValues != nil {
+		oldDefVals, err := yaml.JSONToYAML(app.Spec.DefaultValues.Raw)
+		if err != nil {
+			return err
+		}
+		app.Spec.DefaultValuesBlock = string(oldDefVals)
+		app.Spec.DefaultValues = nil
+	}
+	return nil
 }

--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/cni"

--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -23,10 +23,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/cni"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 )
@@ -269,6 +272,52 @@ func TestValidateImmutableValues(t *testing.T) {
 			if got := validateImmutableValues(tt.newValues, tt.oldValues, tt.fieldPath, tt.immutableValues, tt.acceptedFields); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("%s: validateImmutableValues() = %v, want %v", tt.name, got, tt.want)
 			}
+		})
+	}
+}
+
+func TestConvertValuesToValuesBlock(t *testing.T) {
+	tests := []struct {
+		name   string
+		appIn  *appskubermaticv1.ApplicationDefinition
+		expApp *appskubermaticv1.ApplicationDefinition
+	}{
+		{
+			name: "already using DefaultValuesBlock, nothing to do",
+			appIn: &appskubermaticv1.ApplicationDefinition{
+				Spec: appskubermaticv1.ApplicationDefinitionSpec{
+					DefaultValuesBlock: "key: value",
+				},
+			},
+			expApp: &appskubermaticv1.ApplicationDefinition{
+				Spec: appskubermaticv1.ApplicationDefinitionSpec{
+					DefaultValuesBlock: "key: value",
+				},
+			},
+		},
+		{
+			name: "using DefaultValues, convert to DefaultValuesBlock",
+			appIn: &appskubermaticv1.ApplicationDefinition{
+				Spec: appskubermaticv1.ApplicationDefinitionSpec{
+					DefaultValues: &runtime.RawExtension{Raw: []byte(`{"key": "value"}`)},
+				},
+			},
+			expApp: &appskubermaticv1.ApplicationDefinition{
+				Spec: appskubermaticv1.ApplicationDefinitionSpec{
+					DefaultValuesBlock: "key: value\n",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := convertDefaultValuesToDefaultValuesBlock(tt.appIn)
+			if err != nil {
+				t.Error(err)
+			}
+
+			assert.Equal(t, tt.appIn, tt.expApp)
 		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses ValuesBlock instead of Values for Cilium. This is needed because otherwise when you change the values in the UI, the API will convert Values to ValuesBlock, but the controller will still try to populate Values, leading to an issue.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes [#6646](https://github.com/kubermatic/dashboard/issues/6646)

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix an issue which prohibited users to specify custom values for Cilium system application
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
