### PR TITLE
Update kube-state-metrics to v2.12

### DIFF
--- a/charts/monitoring/kube-state-metrics/Chart.yaml
+++ b/charts/monitoring/kube-state-metrics/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v1
 name: kube-state-metrics
 version: 9.9.9-dev
-appVersion: v2.8.2
+appVersion: v2.12.0
 description: Kube-State-Metrics for Kubermatic
 keywords:
   - kubermatic

--- a/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
+++ b/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
@@ -411,7 +411,7 @@ spec:
       automountServiceAccountToken: true
       containers:
       - name: kube-state-metrics
-        image: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2'
+        image: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0'
         # Ref: https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/#what-is-new-in-v2-0
         # Issue and solutions: https://github.com/kubernetes/kube-state-metrics/issues/1501#issuecomment-863020915
         # and https://github.com/kubernetes/kube-state-metrics/issues/1489#issuecomment-851970288

--- a/charts/monitoring/kube-state-metrics/values.yaml
+++ b/charts/monitoring/kube-state-metrics/values.yaml
@@ -15,7 +15,7 @@
 kubeStateMetrics:
   image:
     repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-    tag: v2.8.2
+    tag: v2.12.0
   # list of image pull secret references, e.g.
   # imagePullSecrets:
   #   - name: registry-k8s-io-pull-secret
@@ -42,7 +42,7 @@ kubeStateMetrics:
     enabled: false
     # Add ClusterRole permissions to list/watch the customResources defined in the config to rbac.extraRules
     config: {}
-  
+
   resizer:
     image:
       repository: registry.k8s.io/autoscaling/addon-resizer


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will mostly likely cause some follow ups, as we see how any changed metrics might affect our Grafana dashboards.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update kube-state-metrics to v2.12.
```

**Documentation**:
```documentation
NONE
```
