### PR TITLE
Set SecurityContext on KKP/OSM/MC containers

### DIFF
--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -73,3 +73,12 @@ spec:
           protocol: TCP
         resources:
 {{ .Values.kubermaticOperator.resources | toYaml | indent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop:
+            - ALL
+          seccompProfile:
+            type: RuntimeDefault

--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          runAsUser: 65534
+          runAsGroup: 65534
           capabilities:
             drop:
             - ALL

--- a/charts/kubermatic-operator/templates/deployment.yaml
+++ b/charts/kubermatic-operator/templates/deployment.yaml
@@ -76,11 +76,13 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-          runAsNonRoot: true
-          runAsUser: 65534
-          runAsGroup: 65534
           capabilities:
             drop:
             - ALL
-          seccompProfile:
-            type: RuntimeDefault
+      securityContext:
+        fsGroup: 65534
+        runAsUser: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -104,6 +104,8 @@ var (
 		AllowPrivilegeEscalation: resources.Bool(false),
 		ReadOnlyRootFilesystem:   resources.Bool(true),
 		RunAsNonRoot:             resources.Bool(true),
+		RunAsUser:                resources.Int64(65534),
+		RunAsGroup:               resources.Int64(65534),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				corev1.Capability("ALL"),

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -97,6 +97,24 @@ const (
 	SkipReconcilingAnnotation = "kubermatic.k8c.io/skip-reconciling"
 )
 
+var (
+	// ContainerSecurityContext is a default common security context for containers
+	// in the kubermatic/kubermatic container image.
+	ContainerSecurityContext = corev1.SecurityContext{
+		AllowPrivilegeEscalation: resources.Bool(false),
+		ReadOnlyRootFilesystem:   resources.Bool(true),
+		RunAsNonRoot:             resources.Bool(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{
+				corev1.Capability("ALL"),
+			},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+)
+
 func DockercfgSecretReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
 		return DockercfgSecretName, func(s *corev1.Secret) (*corev1.Secret, error) {

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -103,14 +103,20 @@ var (
 	ContainerSecurityContext = corev1.SecurityContext{
 		AllowPrivilegeEscalation: resources.Bool(false),
 		ReadOnlyRootFilesystem:   resources.Bool(true),
-		RunAsNonRoot:             resources.Bool(true),
-		RunAsUser:                resources.Int64(65534),
-		RunAsGroup:               resources.Int64(65534),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{
 				corev1.Capability("ALL"),
 			},
 		},
+	}
+
+	// PodSecurityContext is a default common security context for Pods
+	// using the kubermatic/kubermatic image.
+	PodSecurityContext = corev1.PodSecurityContext{
+		RunAsNonRoot: resources.Bool(true),
+		RunAsUser:    resources.Int64(65534),
+		RunAsGroup:   resources.Int64(65534),
+		FSGroup:      resources.Int64(65534),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},

--- a/pkg/controller/operator/common/webhook.go
+++ b/pkg/controller/operator/common/webhook.go
@@ -288,6 +288,7 @@ func WebhookDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, vers
 			}
 
 			d.Spec.Template.Spec.Volumes = volumes
+			d.Spec.Template.Spec.SecurityContext = &PodSecurityContext
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "webhook",

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -253,6 +253,7 @@ func APIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerNa
 			}
 
 			d.Spec.Template.Spec.Volumes = volumes
+			d.Spec.Template.Spec.SecurityContext = &common.PodSecurityContext
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "api",

--- a/pkg/controller/operator/master/resources/kubermatic/api.go
+++ b/pkg/controller/operator/master/resources/kubermatic/api.go
@@ -22,6 +22,7 @@ import (
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
 	"k8c.io/kubermatic/v2/pkg/features"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -170,17 +171,19 @@ func APIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerNa
 				},
 			}
 
+			labels := apiPodLabels()
+
 			d.Spec.Replicas = cfg.Spec.API.Replicas
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: apiPodLabels(),
+				MatchLabels: labels,
 			}
 
-			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
-			d.Spec.Template.Annotations = map[string]string{
+			kubernetes.EnsureLabels(&d.Spec.Template, labels)
+			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/port":   "8085",
 				"fluentbit.io/parser":  "json_iso",
-			}
+			})
 
 			d.Spec.Template.Spec.ServiceAccountName = apiServiceAccountName
 
@@ -269,9 +272,10 @@ func APIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerNa
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					VolumeMounts:   volumeMounts,
-					Resources:      cfg.Spec.API.Resources,
-					ReadinessProbe: &probe,
+					VolumeMounts:    volumeMounts,
+					Resources:       cfg.Spec.API.Resources,
+					ReadinessProbe:  &probe,
+					SecurityContext: &common.ContainerSecurityContext,
 				},
 			}
 

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -21,6 +21,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -40,17 +41,19 @@ func masterControllerManagerPodLabels() map[string]string {
 func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, workerName string, versions kubermatic.Versions) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return common.MasterControllerManagerDeploymentName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+			labels := masterControllerManagerPodLabels()
+
 			d.Spec.Replicas = cfg.Spec.MasterController.Replicas
 			d.Spec.Selector = &metav1.LabelSelector{
-				MatchLabels: masterControllerManagerPodLabels(),
+				MatchLabels: labels,
 			}
 
-			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
-			d.Spec.Template.Annotations = map[string]string{
+			kubernetes.EnsureLabels(&d.Spec.Template, labels)
+			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
 				"prometheus.io/scrape": "true",
 				"prometheus.io/port":   "8085",
 				"fluentbit.io/parser":  "json_iso",
-			}
+			})
 
 			d.Spec.Template.Spec.ServiceAccountName = serviceAccountName
 
@@ -87,7 +90,8 @@ func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticCon
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					Resources: cfg.Spec.MasterController.Resources,
+					Resources:       cfg.Spec.MasterController.Resources,
+					SecurityContext: &common.ContainerSecurityContext,
 				},
 			}
 

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -76,6 +76,7 @@ func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticCon
 				args = append(args, fmt.Sprintf("-worker-name=%s", workerName))
 			}
 
+			d.Spec.Template.Spec.SecurityContext = &common.PodSecurityContext
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "controller-manager",

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -21,6 +21,7 @@ import (
 
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/controller/operator/common"
+	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -46,7 +47,7 @@ func UIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, versions 
 				MatchLabels: uiPodLabels(),
 			}
 
-			d.Spec.Template.Labels = d.Spec.Selector.MatchLabels
+			kubernetes.EnsureLabels(&d.Spec.Template, d.Spec.Selector.MatchLabels)
 
 			d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 				RunAsNonRoot: ptr.To(true),
@@ -85,8 +86,9 @@ func UIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, versions 
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					VolumeMounts: volumeMounts,
-					Resources:    cfg.Spec.UI.Resources,
+					VolumeMounts:    volumeMounts,
+					Resources:       cfg.Spec.UI.Resources,
+					SecurityContext: &common.ContainerSecurityContext,
 				},
 			}
 

--- a/pkg/controller/operator/master/resources/kubermatic/ui.go
+++ b/pkg/controller/operator/master/resources/kubermatic/ui.go
@@ -73,6 +73,8 @@ func UIDeploymentReconciler(cfg *kubermaticv1.KubermaticConfiguration, versions 
 				volumeMounts = append(volumeMounts, cfg.Spec.UI.ExtraVolumeMounts...)
 			}
 
+			d.Spec.Template.Spec.SecurityContext = &common.PodSecurityContext
+
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    "webserver",

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -180,6 +180,7 @@ func SeedControllerManagerDeploymentReconciler(workerName string, versions kuber
 				)
 			}
 
+			d.Spec.Template.Spec.SecurityContext = &common.PodSecurityContext
 			d.Spec.Template.Spec.Volumes = volumes
 			d.Spec.Template.Spec.InitContainers = []corev1.Container{
 				createAddonsInitContainer(cfg.Spec.UserCluster.Addons, sharedAddonVolume, versions.Kubermatic),

--- a/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
+++ b/pkg/controller/operator/seed/resources/kubermatic/seed-controller-manager.go
@@ -186,8 +186,9 @@ func SeedControllerManagerDeploymentReconciler(workerName string, versions kuber
 							Protocol:      corev1.ProtocolTCP,
 						},
 					},
-					VolumeMounts: volumeMounts,
-					Resources:    cfg.Spec.SeedController.Resources,
+					VolumeMounts:    volumeMounts,
+					Resources:       cfg.Spec.SeedController.Resources,
+					SecurityContext: &common.ContainerSecurityContext,
 				},
 			}
 

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -155,6 +155,17 @@ func DeploymentReconcilerWithoutInitWrapper(data machinecontrollerData) reconcil
 			if t := data.MachineControllerImageTag(); t != "" {
 				tag = t
 			}
+
+			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: resources.Bool(true),
+				RunAsUser:    resources.Int64(65534),
+				RunAsGroup:   resources.Int64(65534),
+				FSGroup:      resources.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    Name,
@@ -198,16 +209,10 @@ func DeploymentReconcilerWithoutInitWrapper(data machinecontrollerData) reconcil
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: resources.Bool(false),
 						ReadOnlyRootFilesystem:   resources.Bool(true),
-						RunAsNonRoot:             resources.Bool(true),
-						RunAsUser:                resources.Int64(65534),
-						RunAsGroup:               resources.Int64(65534),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								corev1.Capability("ALL"),
 							},
-						},
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -115,6 +115,16 @@ func WebhookDeploymentReconciler(data machinecontrollerData) reconciling.NamedDe
 				tag = t
 			}
 
+			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: resources.Bool(true),
+				RunAsUser:    resources.Int64(65534),
+				RunAsGroup:   resources.Int64(65534),
+				FSGroup:      resources.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    Name,
@@ -172,16 +182,10 @@ func WebhookDeploymentReconciler(data machinecontrollerData) reconciling.NamedDe
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: resources.Bool(false),
 						ReadOnlyRootFilesystem:   resources.Bool(true),
-						RunAsNonRoot:             resources.Bool(true),
-						RunAsUser:                resources.Int64(65534),
-						RunAsGroup:               resources.Int64(65534),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								corev1.Capability("ALL"),
 							},
-						},
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -167,6 +167,16 @@ func DeploymentReconcilerWithoutInitWrapper(data operatingSystemManagerData) rec
 				tag = t
 			}
 
+			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: resources.Bool(true),
+				RunAsUser:    resources.Int64(65534),
+				RunAsGroup:   resources.Int64(65534),
+				FSGroup:      resources.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.OperatingSystemManagerContainerName,
@@ -212,16 +222,10 @@ func DeploymentReconcilerWithoutInitWrapper(data operatingSystemManagerData) rec
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: resources.Bool(false),
 						ReadOnlyRootFilesystem:   resources.Bool(true),
-						RunAsNonRoot:             resources.Bool(true),
-						RunAsUser:                resources.Int64(65534),
-						RunAsGroup:               resources.Int64(65534),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								corev1.Capability("ALL"),
 							},
-						},
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -209,6 +209,21 @@ func DeploymentReconcilerWithoutInitWrapper(data operatingSystemManagerData) rec
 							ReadOnly:  true,
 						},
 					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: resources.Bool(false),
+						ReadOnlyRootFilesystem:   resources.Bool(true),
+						RunAsNonRoot:             resources.Bool(true),
+						RunAsUser:                resources.Int64(65534),
+						RunAsGroup:               resources.Int64(65534),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								corev1.Capability("ALL"),
+							},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			}
 

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -156,6 +156,21 @@ func WebhookDeploymentReconciler(data operatingSystemManagerData) reconciling.Na
 							ReadOnly:  true,
 						},
 					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: resources.Bool(false),
+						ReadOnlyRootFilesystem:   resources.Bool(true),
+						RunAsNonRoot:             resources.Bool(true),
+						RunAsUser:                resources.Int64(65534),
+						RunAsGroup:               resources.Int64(65534),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								corev1.Capability("ALL"),
+							},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			}
 			err = resources.SetResourceRequirements(dep.Spec.Template.Spec.Containers, webhookResourceRequirements, nil, dep.Annotations)

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -93,6 +93,16 @@ func WebhookDeploymentReconciler(data operatingSystemManagerData) reconciling.Na
 				tag = t
 			}
 
+			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: resources.Bool(true),
+				RunAsUser:    resources.Int64(65534),
+				RunAsGroup:   resources.Int64(65534),
+				FSGroup:      resources.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
+
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
 					Name:    resources.OperatingSystemManagerContainerName,
@@ -159,16 +169,10 @@ func WebhookDeploymentReconciler(data operatingSystemManagerData) reconciling.Na
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: resources.Bool(false),
 						ReadOnlyRootFilesystem:   resources.Bool(true),
-						RunAsNonRoot:             resources.Bool(true),
-						RunAsUser:                resources.Int64(65534),
-						RunAsGroup:               resources.Int64(65534),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								corev1.Capability("ALL"),
 							},
-						},
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -101,11 +101,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -130,6 +125,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -95,6 +95,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -102,6 +113,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -125,6 +138,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -108,11 +108,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -138,6 +133,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -102,11 +102,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -108,11 +108,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -138,6 +133,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -102,11 +102,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -101,11 +101,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -130,6 +125,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -95,6 +95,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -102,6 +113,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -125,6 +138,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -106,6 +117,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -106,6 +117,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -101,11 +101,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -130,6 +125,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -95,6 +95,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -102,6 +113,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -125,6 +138,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -108,11 +108,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -138,6 +133,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -102,11 +102,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -108,11 +108,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -138,6 +133,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -102,11 +102,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -101,11 +101,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -130,6 +125,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -95,6 +95,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -102,6 +113,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -125,6 +138,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -106,6 +117,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -106,6 +117,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -101,11 +101,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -130,6 +125,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -95,6 +95,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -102,6 +113,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -125,6 +138,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -108,11 +108,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -138,6 +133,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -102,11 +102,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
@@ -108,11 +108,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -138,6 +133,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -102,11 +102,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
@@ -101,11 +101,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -130,6 +125,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -95,6 +95,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -102,6 +113,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -125,6 +138,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -106,6 +117,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -106,6 +117,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -101,6 +101,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -108,6 +119,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -107,11 +107,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -108,11 +108,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -114,11 +114,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -114,11 +114,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -108,11 +108,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -101,6 +101,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -108,6 +119,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -107,11 +107,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -118,6 +113,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -118,6 +113,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -105,6 +105,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -112,6 +123,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -137,6 +150,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -111,11 +111,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -142,6 +137,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -105,6 +105,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -112,6 +123,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -137,6 +150,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
@@ -111,11 +111,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -142,6 +137,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -135,6 +130,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -135,6 +130,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -101,6 +101,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -108,6 +119,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -107,11 +107,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -108,11 +108,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -114,11 +114,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -114,11 +114,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -108,11 +108,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -101,6 +101,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -108,6 +119,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -107,11 +107,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -118,6 +113,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -118,6 +113,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -105,6 +105,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -112,6 +123,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -137,6 +150,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -111,11 +111,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -142,6 +137,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -105,6 +105,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -112,6 +123,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -137,6 +150,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
@@ -111,11 +111,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -142,6 +137,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -135,6 +130,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -135,6 +130,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -101,6 +101,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -108,6 +119,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -107,11 +107,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -108,11 +108,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -114,11 +114,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
@@ -114,11 +114,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -108,11 +108,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -101,6 +101,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -108,6 +119,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -131,6 +144,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
@@ -107,11 +107,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -118,6 +113,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -118,6 +113,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -105,6 +105,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -112,6 +123,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -137,6 +150,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -111,11 +111,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -142,6 +137,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -105,6 +105,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -112,6 +123,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -137,6 +150,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
@@ -111,11 +111,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -142,6 +137,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -135,6 +130,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
@@ -99,6 +99,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
@@ -105,11 +105,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -135,6 +130,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -88,11 +88,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -94,11 +94,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -124,6 +119,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -81,6 +81,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -88,6 +99,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -111,6 +124,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -87,11 +87,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -116,6 +111,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
@@ -91,11 +91,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -122,6 +117,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -85,6 +85,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -92,6 +103,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -117,6 +130,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
@@ -85,11 +85,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -115,6 +110,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
@@ -79,6 +79,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -88,11 +88,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -94,11 +94,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -124,6 +119,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -81,6 +81,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -88,6 +99,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -111,6 +124,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -87,11 +87,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -116,6 +111,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
@@ -91,11 +91,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -122,6 +117,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -85,6 +85,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -92,6 +103,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -117,6 +130,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
@@ -85,11 +85,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -115,6 +110,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
@@ -79,6 +79,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -88,11 +88,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
@@ -94,11 +94,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -124,6 +119,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -81,6 +81,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -88,6 +99,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -111,6 +124,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
@@ -87,11 +87,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -116,6 +111,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
@@ -91,11 +91,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -122,6 +117,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -85,6 +85,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -92,6 +103,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -117,6 +130,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
@@ -85,11 +85,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -115,6 +110,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
@@ -79,6 +79,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
@@ -91,11 +91,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -122,6 +117,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -85,6 +85,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -92,6 +103,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -117,6 +130,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
@@ -85,11 +85,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -115,6 +110,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
@@ -79,6 +79,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
@@ -91,11 +91,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -122,6 +117,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -85,6 +85,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -92,6 +103,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -117,6 +130,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
@@ -85,11 +85,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -115,6 +110,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
@@ -79,6 +79,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
@@ -91,11 +91,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -122,6 +117,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -85,6 +85,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -92,6 +103,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -117,6 +130,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
@@ -85,11 +85,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -115,6 +110,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
@@ -79,6 +79,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,6 +75,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,11 +81,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -103,6 +98,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -75,6 +75,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -81,11 +81,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -103,6 +98,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,6 +75,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,11 +81,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -103,6 +98,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -75,6 +75,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -81,11 +81,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -103,6 +98,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +124,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -93,11 +93,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
@@ -92,11 +92,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -121,6 +116,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -86,6 +86,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -93,6 +104,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -116,6 +129,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -75,6 +75,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -81,11 +81,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -103,6 +98,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
@@ -75,6 +75,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
@@ -81,11 +81,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -103,6 +98,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
@@ -96,11 +96,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -90,6 +90,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -97,6 +108,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -122,6 +135,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
@@ -90,11 +90,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -120,6 +115,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
@@ -84,6 +84,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -128,11 +128,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -157,6 +152,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -122,6 +122,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +140,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -152,6 +165,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -135,11 +135,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -165,6 +160,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -129,11 +129,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -129,11 +129,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -135,11 +135,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -165,6 +160,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -128,11 +128,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -157,6 +152,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -122,6 +122,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +140,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -152,6 +165,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -117,11 +117,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -139,6 +134,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -111,6 +111,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -117,11 +117,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -139,6 +134,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -111,6 +111,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -126,6 +126,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -133,6 +144,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -158,6 +171,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -132,11 +132,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -163,6 +158,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -126,6 +126,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -133,6 +144,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -158,6 +171,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
@@ -132,11 +132,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -163,6 +158,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -120,6 +120,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -126,11 +126,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -156,6 +151,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
@@ -120,6 +120,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
@@ -126,11 +126,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -156,6 +151,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -128,11 +128,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -157,6 +152,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -122,6 +122,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +140,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -152,6 +165,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -135,11 +135,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -165,6 +160,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -129,11 +129,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -129,11 +129,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -135,11 +135,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -165,6 +160,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -128,11 +128,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -157,6 +152,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -122,6 +122,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +140,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -152,6 +165,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -117,11 +117,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -139,6 +134,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -111,6 +111,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -117,11 +117,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -139,6 +134,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -111,6 +111,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -126,6 +126,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -133,6 +144,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -158,6 +171,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -132,11 +132,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -163,6 +158,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -126,6 +126,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -133,6 +144,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -158,6 +171,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
@@ -132,11 +132,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -163,6 +158,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -120,6 +120,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -126,11 +126,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -156,6 +151,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
@@ -120,6 +120,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
@@ -126,11 +126,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -156,6 +151,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -128,11 +128,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -157,6 +152,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -122,6 +122,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +140,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -152,6 +165,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -135,11 +135,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -165,6 +160,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -129,11 +129,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -129,11 +129,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
@@ -135,11 +135,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -165,6 +160,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
@@ -128,11 +128,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -157,6 +152,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -122,6 +122,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -129,6 +140,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -152,6 +165,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -117,11 +117,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -139,6 +134,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -111,6 +111,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
@@ -117,11 +117,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -139,6 +134,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
@@ -111,6 +111,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -126,6 +126,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -133,6 +144,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -158,6 +171,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -132,11 +132,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -163,6 +158,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -126,6 +126,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -133,6 +144,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -158,6 +171,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
@@ -132,11 +132,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -163,6 +158,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -120,6 +120,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -126,11 +126,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -156,6 +151,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
@@ -120,6 +120,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
@@ -126,11 +126,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -156,6 +151,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -122,11 +122,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -152,6 +147,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -116,11 +116,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -115,11 +115,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -109,6 +109,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -116,6 +127,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -139,6 +152,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
@@ -119,11 +119,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -150,6 +145,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -113,6 +113,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -120,6 +131,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -145,6 +158,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
@@ -107,6 +107,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
@@ -113,11 +113,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -143,6 +138,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -122,11 +122,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -152,6 +147,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -116,11 +116,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -115,11 +115,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -109,6 +109,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -116,6 +127,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -139,6 +152,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
@@ -119,11 +119,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -150,6 +145,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -113,6 +113,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -120,6 +131,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -145,6 +158,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
@@ -107,6 +107,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
@@ -113,11 +113,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -143,6 +138,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
@@ -122,11 +122,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -152,6 +147,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -116,11 +116,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
@@ -115,11 +115,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -144,6 +139,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -109,6 +109,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -116,6 +127,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -139,6 +152,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
@@ -75,11 +75,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -97,6 +92,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
@@ -69,6 +69,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
@@ -119,11 +119,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -150,6 +145,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -113,6 +113,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -120,6 +131,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -145,6 +158,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
@@ -107,6 +107,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
@@ -113,11 +113,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -143,6 +138,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -100,6 +111,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -123,6 +136,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -128,6 +123,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -106,11 +106,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -100,11 +100,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -100,11 +100,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -106,11 +106,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -100,6 +111,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -123,6 +136,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -128,6 +123,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -88,11 +88,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,6 +82,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -88,11 +88,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -82,6 +82,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -97,6 +97,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -104,6 +115,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -129,6 +142,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -103,11 +103,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -134,6 +129,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -97,6 +97,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -104,6 +115,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -129,6 +142,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
@@ -103,11 +103,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -134,6 +129,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -97,11 +97,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -91,6 +91,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
@@ -97,11 +97,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
@@ -91,6 +91,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -100,6 +111,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -123,6 +136,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -128,6 +123,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -106,11 +106,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -100,11 +100,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -100,11 +100,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -106,11 +106,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -100,6 +111,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -123,6 +136,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -128,6 +123,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -88,11 +88,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,6 +82,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -88,11 +88,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -82,6 +82,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -97,6 +97,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -104,6 +115,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -129,6 +142,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -103,11 +103,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -134,6 +129,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -97,6 +97,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -104,6 +115,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -129,6 +142,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
@@ -103,11 +103,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -134,6 +129,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -97,11 +97,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -91,6 +91,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
@@ -97,11 +97,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
@@ -91,6 +91,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -100,6 +111,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -123,6 +136,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -128,6 +123,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -106,11 +106,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm","-node-external-cloud-provider"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -100,11 +100,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
@@ -36,7 +36,7 @@ spec:
         - -timeout
         - "1"
         - -command
-        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-namespace","cluster-de-test-01","-tls-cert-path=/tmp/cert/cert.pem","-tls-key-path=/tmp/cert/key.pem","-use-osm"]}'
+        - '{"command":"/usr/local/bin/webhook","args":["-worker-cluster-kubeconfig","/etc/kubernetes/worker-kubeconfig/kubeconfig","-listen-address","0.0.0.0:9876","-namespace","cluster-de-test-01","-ca-bundle","/etc/kubernetes/pki/ca-bundle/ca-bundle.pem","-tls-cert-path","/etc/kubernetes/pki/serving-cert/cert.pem","-tls-key-path","/etc/kubernetes/pki/serving-cert/key.pem","-use-osm"]}'
         - --crd-to-wait-for
         - Machine,cluster.k8s.io/v1alpha1
         command:
@@ -100,11 +100,22 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
           readOnly: true
-        - mountPath: /tmp/cert
+        - mountPath: /etc/kubernetes/pki/serving-cert
           name: machinecontroller-webhook-serving-cert
           readOnly: true
         - mountPath: /etc/kubernetes/pki/ca-bundle

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
@@ -106,11 +106,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: machinecontroller-kubeconfig
@@ -136,6 +131,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller-webhook
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
@@ -93,6 +93,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -100,6 +111,8 @@ spec:
         - mountPath: /etc/kubernetes/pki/ca-bundle
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp
+          name: temp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -123,6 +136,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
@@ -99,11 +99,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: machinecontroller-kubeconfig
@@ -128,6 +123,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-machine-controller
       volumes:
       - name: machinecontroller-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -88,11 +88,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,6 +82,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
@@ -80,11 +80,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       volumes:
       - name: operatingsystemmanager-webhook-kubeconfig
         secret:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
@@ -74,6 +74,17 @@ spec:
           requests:
             cpu: 10m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/worker-kubeconfig
           name: operatingsystemmanager-webhook-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
@@ -88,11 +88,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig
@@ -110,6 +105,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-operating-system-manager
       volumes:
       - name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
@@ -82,6 +82,17 @@ spec:
           requests:
             cpu: 50m
             memory: 128Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: operatingsystemmanager-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -97,6 +97,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -104,6 +115,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -129,6 +142,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -103,11 +103,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -134,6 +129,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"
@@ -97,6 +97,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -104,6 +115,8 @@ spec:
         - mountPath: /opt/ca-bundle/
           name: ca-bundle
           readOnly: true
+        - mountPath: /tmp/
+          name: temp
         - mountPath: /applications-cache
           name: applications-cache
         - mountPath: /http-prober-bin
@@ -129,6 +142,8 @@ spec:
       - configMap:
           name: ca-bundle
         name: ca-bundle
+      - emptyDir: {}
+        name: temp
       - emptyDir:
           sizeLimit: 300Mi
         name: applications-cache

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
@@ -103,11 +103,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: internal-admin-kubeconfig
@@ -134,6 +129,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: kubermatic-usercluster-controller-manager
       volumes:
       - name: internal-admin-kubeconfig

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -97,11 +97,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -91,6 +91,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
@@ -97,11 +97,6 @@ spec:
             drop:
             - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 65534
-          runAsNonRoot: true
-          runAsUser: 65534
-          seccompProfile:
-            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert
@@ -127,6 +122,13 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: usercluster-webhook
       volumes:
       - name: webhook-serving-cert

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
@@ -91,6 +91,17 @@ spec:
           requests:
             cpu: 25m
             memory: 32Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /opt/webhook-serving-cert/
           name: webhook-serving-cert

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -195,6 +195,21 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 							},
 						},
 					},
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: resources.Bool(false),
+						ReadOnlyRootFilesystem:   resources.Bool(true),
+						RunAsNonRoot:             resources.Bool(true),
+						RunAsUser:                resources.Int64(65534),
+						RunAsGroup:               resources.Int64(65534),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								corev1.Capability("ALL"),
+							},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			}
 

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -161,6 +161,16 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 				},
 			}
 
+			d.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: resources.Bool(true),
+				RunAsUser:    resources.Int64(65534),
+				RunAsGroup:   resources.Int64(65534),
+				FSGroup:      resources.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
+
 			d.Spec.Template.Spec.Volumes = volumes
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
@@ -198,16 +208,10 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: resources.Bool(false),
 						ReadOnlyRootFilesystem:   resources.Bool(true),
-						RunAsNonRoot:             resources.Bool(true),
-						RunAsUser:                resources.Int64(65534),
-						RunAsGroup:               resources.Int64(65534),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								corev1.Capability("ALL"),
 							},
-						},
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -124,7 +124,7 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 				"prometheus.io/path":   "/metrics",
 				"prometheus.io/port":   "8085",
 				// these volumes should not block the autoscaler from evicting the pod
-				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: resources.ApplicationCacheVolumeName,
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: strings.Join([]string{resources.ApplicationCacheVolumeName, "temp"}, ","),
 			})
 
 			dep.Spec.Template.Spec.Volumes = volumes
@@ -296,6 +296,21 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 						TimeoutSeconds:   15,
 					},
 					VolumeMounts: getVolumeMounts(data),
+					SecurityContext: &corev1.SecurityContext{
+						AllowPrivilegeEscalation: resources.Bool(false),
+						ReadOnlyRootFilesystem:   resources.Bool(true),
+						RunAsNonRoot:             resources.Bool(true),
+						RunAsUser:                resources.Int64(65534),
+						RunAsGroup:               resources.Int64(65534),
+						Capabilities: &corev1.Capabilities{
+							Drop: []corev1.Capability{
+								corev1.Capability("ALL"),
+							},
+						},
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: corev1.SeccompProfileTypeRuntimeDefault,
+						},
+					},
 				},
 			}
 
@@ -336,6 +351,12 @@ func getVolumes(data userclusterControllerData) []corev1.Volume {
 			},
 		},
 		{
+			Name: "temp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
 			Name: resources.ApplicationCacheVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{
@@ -370,6 +391,10 @@ func getVolumeMounts(data userclusterControllerData) []corev1.VolumeMount {
 			Name:      "ca-bundle",
 			MountPath: "/opt/ca-bundle/",
 			ReadOnly:  true,
+		},
+		{
+			Name:      "temp",
+			MountPath: "/tmp/",
 		},
 		{
 			Name:      resources.ApplicationCacheVolumeName,

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -266,6 +266,16 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 				return nil, err
 			}
 
+			dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+				RunAsNonRoot: resources.Bool(true),
+				RunAsUser:    resources.Int64(65534),
+				RunAsGroup:   resources.Int64(65534),
+				FSGroup:      resources.Int64(65534),
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: corev1.SeccompProfileTypeRuntimeDefault,
+				},
+			}
+
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 			dep.Spec.Template.Spec.Containers = []corev1.Container{
 				{
@@ -299,16 +309,10 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 					SecurityContext: &corev1.SecurityContext{
 						AllowPrivilegeEscalation: resources.Bool(false),
 						ReadOnlyRootFilesystem:   resources.Bool(true),
-						RunAsNonRoot:             resources.Bool(true),
-						RunAsUser:                resources.Int64(65534),
-						RunAsGroup:               resources.Int64(65534),
 						Capabilities: &corev1.Capabilities{
 							Drop: []corev1.Capability{
 								corev1.Capability("ALL"),
 							},
-						},
-						SeccompProfile: &corev1.SeccompProfile{
-							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
It's high time we set proper security contexts on our own software. So I set them on all KKP-owned containers (KKP, MC, OSM). Some containers use temp files (seed-ctrl-mgr for addons/apps, usercluster-ctrl-mgr for something, OSM for vsphere iso generation), so those now get a dedicated tempdir volume for `/tmp`.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add SecurityContext to KKP operator/controller-manager containers, including OSM and machine-controller.
```

**Documentation**:
```documentation
NONE
```
