### PR TITLE
Prevent accidental object deletions

### DIFF
--- a/cmd/kubermatic-webhook/main.go
+++ b/cmd/kubermatic-webhook/main.go
@@ -44,6 +44,7 @@ import (
 	ipampoolvalidation "k8c.io/kubermatic/v2/pkg/webhook/ipampool/validation"
 	kubermaticconfigurationvalidation "k8c.io/kubermatic/v2/pkg/webhook/kubermaticconfiguration/validation"
 	mlaadminsettingmutation "k8c.io/kubermatic/v2/pkg/webhook/mlaadminsetting/mutation"
+	policieswebhook "k8c.io/kubermatic/v2/pkg/webhook/policies"
 	resourcequotavalidation "k8c.io/kubermatic/v2/pkg/webhook/resourcequota/validation"
 	seedwebhook "k8c.io/kubermatic/v2/pkg/webhook/seed"
 	uservalidation "k8c.io/kubermatic/v2/pkg/webhook/user/validation"
@@ -237,6 +238,11 @@ func main() {
 	if err := builder.WebhookManagedBy(mgr).For(&kubermaticv1.GroupProjectBinding{}).WithValidator(groupProjectBindingValidator).Complete(); err != nil {
 		log.Fatalw("Failed to setup GroupProjectBinding validation webhook", zap.Error(err))
 	}
+
+	// /////////////////////////////////////////
+	// setup policies webhook
+
+	policieswebhook.NewAdmissionHandler(log, mgr.GetScheme()).SetupWebhookWithManager(mgr)
 
 	// /////////////////////////////////////////
 	// Here we go!

--- a/pkg/controller/operator/common/resources.go
+++ b/pkg/controller/operator/common/resources.go
@@ -77,6 +77,9 @@ const (
 	// GroupProjectBindingAdmissionWebhookName is the name of the validating webhook for GroupProjectBindings.
 	GroupProjectBindingAdmissionWebhookName = "kubermatic-groupprojectbindings"
 
+	// PoliciesAdmissionWebhookName is the name of the validating webhook that implements deletion policies.
+	PoliciesAdmissionWebhookName = "kubermatic-policies"
+
 	// we use a shared certificate/CA for all webhooks, because multiple webhooks
 	// run in the same controller manager so it's much easier if they all use the
 	// same certs.

--- a/pkg/controller/operator/master/reconciler.go
+++ b/pkg/controller/operator/master/reconciler.go
@@ -434,6 +434,7 @@ func (r *Reconciler) reconcileValidatingWebhooks(ctx context.Context, config *ku
 		common.ApplicationDefinitionValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		kubermatic.ResourceQuotaValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
 		kubermatic.GroupProjectBindingValidatingWebhookConfigurationReconciler(ctx, config, r.Client),
+		common.PoliciesWebhookConfigurationReconciler(ctx, config, r.Client),
 	}
 
 	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, reconcilers, "", r.Client); err != nil {

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -689,6 +689,7 @@ func (r *Reconciler) reconcileAdmissionWebhooks(ctx context.Context, cfg *kuberm
 		kubermaticseed.ClusterValidatingWebhookConfigurationReconciler(ctx, cfg, client),
 		common.ApplicationDefinitionValidatingWebhookConfigurationReconciler(ctx, cfg, client),
 		kubermaticseed.IPAMPoolValidatingWebhookConfigurationReconciler(ctx, cfg, client),
+		common.PoliciesWebhookConfigurationReconciler(ctx, cfg, client),
 	}
 
 	if err := reconciling.ReconcileValidatingWebhookConfigurations(ctx, validatingWebhookReconcilers, "", client); err != nil {

--- a/pkg/controller/operator/seed/reconciler.go
+++ b/pkg/controller/operator/seed/reconciler.go
@@ -205,36 +205,31 @@ func (r *Reconciler) cleanupDeletedSeed(ctx context.Context, cfg *kubermaticv1.K
 		return fmt.Errorf("failed to clean up ClusterRole: %w", err)
 	}
 
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.SeedAdmissionWebhookName(cfg)); err != nil {
-		return fmt.Errorf("failed to clean up Seed ValidatingWebhookConfiguration: %w", err)
+	names := []string{
+		common.SeedAdmissionWebhookName(cfg),
+		common.KubermaticConfigurationAdmissionWebhookName(cfg),
+		common.ApplicationDefinitionAdmissionWebhookName,
+		common.PoliciesAdmissionWebhookName,
+		kubermaticseed.ClusterAdmissionWebhookName,
+		kubermaticseed.IPAMPoolAdmissionWebhookName,
 	}
 
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.KubermaticConfigurationAdmissionWebhookName(cfg)); err != nil {
-		return fmt.Errorf("failed to clean up KubermaticConfiguration ValidatingWebhookConfiguration: %w", err)
+	for _, name := range names {
+		if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, name); err != nil {
+			return fmt.Errorf("failed to clean up %s ValidatingWebhookConfiguration: %w", name, err)
+		}
 	}
 
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, common.ApplicationDefinitionAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up ApplicationDefinition ValidatingWebhookConfiguration: %w", err)
+	names = []string{
+		kubermaticseed.ClusterAdmissionWebhookName,
+		kubermaticseed.AddonAdmissionWebhookName,
+		kubermaticseed.MLAAdminSettingAdmissionWebhookName,
 	}
 
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.ClusterAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up Cluster ValidatingWebhookConfiguration: %w", err)
-	}
-
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.MutatingWebhookConfiguration{}, kubermaticseed.ClusterAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up Cluster MutatingWebhookConfiguration: %w", err)
-	}
-
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.MutatingWebhookConfiguration{}, kubermaticseed.AddonAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up Cluster MutatingWebhookConfiguration: %w", err)
-	}
-
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.MutatingWebhookConfiguration{}, kubermaticseed.MLAAdminSettingAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up Cluster MutatingWebhookConfiguration: %w", err)
-	}
-
-	if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.ValidatingWebhookConfiguration{}, kubermaticseed.IPAMPoolAdmissionWebhookName); err != nil {
-		return fmt.Errorf("failed to clean up IPAMPool ValidatingWebhookConfiguration: %w", err)
+	for _, name := range names {
+		if err := common.CleanupClusterResource(ctx, client, &admissionregistrationv1.MutatingWebhookConfiguration{}, name); err != nil {
+			return fmt.Errorf("failed to clean up %s MutatingWebhookConfiguration: %w", name, err)
+		}
 	}
 
 	// On shared master+seed clusters, the kubermatic-webhook currently has the -seed-name

--- a/pkg/webhook/policies/admission.go
+++ b/pkg/webhook/policies/admission.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policies
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"go.uber.org/zap"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrlruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	// PreventDeletionAnnotation is an annotation that will block any attempts to delete the object
+	// that has it. The value does not matter.
+	PreventDeletionAnnotation = "policy.k8c.io/prevent-deletion"
+)
+
+// AdmissionHandler for validating ApplicationDefinition CRD.
+type AdmissionHandler struct {
+	log     *zap.SugaredLogger
+	decoder *admission.Decoder
+}
+
+// NewAdmissionHandler returns a new validation AdmissionHandler.
+func NewAdmissionHandler(log *zap.SugaredLogger, scheme *runtime.Scheme) *AdmissionHandler {
+	return &AdmissionHandler{
+		log:     log,
+		decoder: admission.NewDecoder(scheme),
+	}
+}
+
+func (h *AdmissionHandler) SetupWebhookWithManager(mgr ctrlruntime.Manager) {
+	mgr.GetWebhookServer().Register("/validate-policies", &webhook.Admission{Handler: h})
+}
+
+func (h *AdmissionHandler) Handle(ctx context.Context, req webhook.AdmissionRequest) webhook.AdmissionResponse {
+	allErrs := field.ErrorList{}
+	obj := &unstructured.Unstructured{}
+
+	switch req.Operation {
+	case admissionv1.Delete:
+		if err := h.decoder.DecodeRaw(req.OldObject, obj); err != nil {
+			return webhook.Errored(http.StatusBadRequest, err)
+		}
+
+		if _, exists := obj.GetAnnotations()[PreventDeletionAnnotation]; exists {
+			allErrs = append(allErrs, field.Forbidden(nil, "object is annotated to prevent deletions"))
+		}
+
+	default:
+		return webhook.Errored(http.StatusBadRequest, fmt.Errorf("%s not supported", req.Operation))
+	}
+
+	if len(allErrs) > 0 {
+		return webhook.Denied(fmt.Sprintf("request %s denied: %v", req.UID, allErrs))
+	}
+
+	return webhook.Allowed(fmt.Sprintf("request %s allowed", req.UID))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a PR to get the discussion going regarding protecting admins from themselves. It's a nice dream to tell everyone "just use RBAC, do not walk around with cluster-admin permissions!", but TBH, I do not even follow this advice and I would guess that many, many other ops people do the same. With a little bit of effort on our side, we could make it much safer to administer a cluster.

There are of course existing policy tools out there, like Kyverno, but @embik suggested adding a super simple policy ourselves instead of relying on admins installing policy tools into their clusters.

This PR therefore adds a super extreme simple webhook that is meant to be extended, hence the somewhat generic "policy webhook" name. The only policy implemented right now is `policy.k8c.io/prevent-deletion`: if a KKP object has this annotation set, the webhook will reject every DELETE request, regardless of RBAC.

More thought would need to be spent if we want to open this functionality up to the users. Currently KKP users cannot set annotations on clusters and allowing them to do so would probably be quite dangerous. Note just this annotation, but also fiddling with the initial MD annotation or similar important things. For the UI it might make more sense to have a dedicated "UI-only deletion prevention" controlled by a label, which would prevent a user from misclicking, but still allow controllers to delete resources when they see fit.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
KKP resources in the `kubermatic.k8c.io` API Group can be annotated with `policy.k8c.io/prevent-deletion` to make the kubermatic-webhook reject any delete attempt (even by cluster-admins). This is meant as a last resort mechanism to prevent accidental deletions by admins during maintenance on a KKP system.
```

**Documentation**:
```documentation
NONE
```
