### PR TITLE
Render Helm manifests to map instead of a string

### DIFF
--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -309,7 +309,7 @@ func (h HelmClient) shouldUpgrade(chartLoc string, currentRelease *release.Relea
 		!equality.Semantic.DeepEqual(currentManifests, newManifests), nil
 }
 
-func (h HelmClient) renderManifests(chart *chart.Chart, values chartutil.Values) (string, error) {
+func (h HelmClient) renderManifests(chart *chart.Chart, values chartutil.Values) (map[string]string, error) {
 	options := chartutil.ReleaseOptions{
 		Name:      chart.Name(),
 		Namespace: h.targetNamespace,
@@ -319,26 +319,21 @@ func (h HelmClient) renderManifests(chart *chart.Chart, values chartutil.Values)
 
 	valuesToRender, err := chartutil.ToRenderValues(chart, values, options, nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	restConfig, err := h.restClientGetter.ToRESTConfig()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	engine := engine.New(restConfig)
 	manifests, err := engine.Render(chart, valuesToRender)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	var allManifests strings.Builder
-	for _, manifest := range manifests {
-		allManifests.WriteString(manifest)
-	}
-
-	return allManifests.String(), nil
+	return manifests, nil
 }
 
 // Install the chart located at chartLoc into targetNamespace. If the chart was already installed, an error is returned.

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -326,7 +326,6 @@ func (h HelmClient) renderManifests(chart *chart.Chart, values chartutil.Values)
 	if err != nil {
 		return nil, err
 	}
-
 	engine := engine.New(restConfig)
 	manifests, err := engine.Render(chart, valuesToRender)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Unordered strings have been triggering unnecessary Helm upgrades. We don't need to template manifests as a string the way Helm does at this moment.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12095

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
