### PR TITLE
Update deprecated kubeProxyReplacement setting in Cilium

### DIFF
--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -291,7 +291,7 @@ func GetAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 	valuesBackend := map[string]any{}
 
 	if cluster.Spec.ClusterNetwork.ProxyMode == resources.EBPFProxyMode {
-		values["kubeProxyReplacement"] = "strict"
+		values["kubeProxyReplacement"] = "true"
 		values["k8sServiceHost"] = cluster.Status.Address.ExternalName
 		values["k8sServicePort"] = cluster.Status.Address.Port
 
@@ -302,7 +302,7 @@ func GetAppInstallOverrideValues(cluster *kubermaticv1.Cluster, overwriteRegistr
 			}
 		}
 	} else {
-		values["kubeProxyReplacement"] = "disabled"
+		values["kubeProxyReplacement"] = "false"
 		values["sessionAffinity"] = true
 		valuesCni["chainingMode"] = "portmap"
 	}

--- a/pkg/cni/cilium/cilium_test.go
+++ b/pkg/cni/cilium/cilium_test.go
@@ -69,13 +69,13 @@ func TestGetCiliumAppInstallOverrideValues(t *testing.T) {
 			name:              "default values",
 			cluster:           testCluster,
 			overwriteRegistry: "",
-			expectedValues:    `{"certgen":{"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"cni":{"exclusive":false},"hubble":{"relay":{"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"ui":{"backend":{},"frontend":{},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDRList":["192.168.0.0/24","192.168.178.0/24"]}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","nodePort":{"range":"30000,31777"},"operator":{"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}`,
+			expectedValues:    `{"certgen":{"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"cni":{"exclusive":false},"hubble":{"relay":{"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"ui":{"backend":{},"frontend":{},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDRList":["192.168.0.0/24","192.168.178.0/24"]}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"true","nodePort":{"range":"30000,31777"},"operator":{"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}`,
 		},
 		{
 			name:              "default values with overwrite registry",
 			cluster:           testCluster,
 			overwriteRegistry: "myregistry.io",
-			expectedValues:    `{"certgen":{"image":{"repository":"myregistry.io/cilium/certgen","useDigest":false},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"cni":{"exclusive":false},"hubble":{"relay":{"image":{"repository":"myregistry.io/cilium/hubble-relay","useDigest":false},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"ui":{"backend":{"image":{"repository":"myregistry.io/cilium/hubble-ui-backend","useDigest":false}},"frontend":{"image":{"repository":"myregistry.io/cilium/hubble-ui","useDigest":false}},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}},"image":{"repository":"myregistry.io/cilium/cilium","useDigest":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDRList":["192.168.0.0/24","192.168.178.0/24"]}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"strict","nodePort":{"range":"30000,31777"},"operator":{"image":{"repository":"myregistry.io/cilium/operator","useDigest":false},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}`,
+			expectedValues:    `{"certgen":{"image":{"repository":"myregistry.io/cilium/certgen","useDigest":false},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"cni":{"exclusive":false},"hubble":{"relay":{"image":{"repository":"myregistry.io/cilium/hubble-relay","useDigest":false},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"ui":{"backend":{"image":{"repository":"myregistry.io/cilium/hubble-ui-backend","useDigest":false}},"frontend":{"image":{"repository":"myregistry.io/cilium/hubble-ui","useDigest":false}},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}},"image":{"repository":"myregistry.io/cilium/cilium","useDigest":false},"ipam":{"operator":{"clusterPoolIPv4MaskSize":"16","clusterPoolIPv4PodCIDRList":["192.168.0.0/24","192.168.178.0/24"]}},"k8sServiceHost":"cluster.kubermatic.test","k8sServicePort":6443,"kubeProxyReplacement":"true","nodePort":{"range":"30000,31777"},"operator":{"image":{"repository":"myregistry.io/cilium/operator","useDigest":false},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}},"securityContext":{"seccompProfile":{"type":"RuntimeDefault"}}},"podSecurityContext":{"seccompProfile":{"type":"RuntimeDefault"}}}`,
 		},
 	}
 	for _, testCase := range testCases {
@@ -126,7 +126,7 @@ func TestValidateCiliumValuesUpdate(t *testing.T) {
 		{
 			name: "Change mandatory value",
 			testValuesModifier: func(values map[string]any) {
-				values["kubeProxyReplacement"] = "disabled"
+				values["kubeProxyReplacement"] = "false"
 			},
 			expectedError: "[]",
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Cilium kubeProxyReplacement values strict, partial, probe, and disabled have been deprecated, migrating to either true or false is required.
  
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->


**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind chore
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cilium kubeProxyReplacement values strict, partial, probe, and disabled have been deprecated, please use true or false instead.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
