### PR TITLE
[release/v2.25]Add changelogs for KKP Apr 2024 patch releases

### DIFF
--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -12,6 +12,32 @@
 - [v2.23.9](#v2239)
 - [v2.23.10](#v22310)
 - [v2.23.11](#v22311)
+- [v2.23.12](#v22312)
+- [v2.23.13](#v22313)
+
+## [v2.23.13](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.13)
+
+### API Changes
+
+- Add `spec.componentsOverride.operatingSystemManager` to allow overriding OSM settings and resources ([#13288](https://github.com/kubermatic/kubermatic/pull/13288))
+
+### Bugfixes
+
+- Fix high CPU usage in master-controller-manager ([#13217](https://github.com/kubermatic/kubermatic/pull/13217))
+
+
+## [v2.23.12](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.12)
+
+### Bugfixes
+
+- Exclude `test` folders which contain symlinks that break once the archive is untarred ([#13151](https://github.com/kubermatic/kubermatic/pull/13151))
+- Fix a bug where OSPs were not being listed for VMware Cloud Director ([#6592](https://github.com/kubermatic/dashboard/pull/6592))       
+- Fix invalid project ID in API requests for Nutanix provider ([#6572](https://github.com/kubermatic/dashboard/pull/6572))
+- Fix a bug where dedicated credentials were incorrectly being required as mandatory input when editing vSphere provider settings for a cluster ([#6567](https://github.com/kubermatic/dashboard/pull/6567))
+
+
+### Chore
+- Update to Go 1.20.13 ([#13165](https://github.com/kubermatic/kubermatic/pull/13165)) and ([#6594](https://github.com/kubermatic/dashboard/pull/6594))
 
 ## [v2.23.11](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.11)
 

--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -25,6 +25,11 @@
 
 - Fix high CPU usage in master-controller-manager ([#13217](https://github.com/kubermatic/kubermatic/pull/13217))
 
+### Updates
+
+- Add Canal CNI version v3.27.3 ([#13308](https://github.com/kubermatic/kubermatic/pull/13308))
+- Add support for Kubernetes 1.27.13 (fixes CVE-2024-3177) ([#13300](https://github.com/kubermatic/kubermatic/pull/13300))
+
 
 ## [v2.23.12](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.12)
 

--- a/docs/changelogs/CHANGELOG-2.24.md
+++ b/docs/changelogs/CHANGELOG-2.24.md
@@ -21,6 +21,7 @@
 ### Updates
 
 - Add Canal CNI version v3.27.3, having a fix to the ipset incompatibility bug ([#13246](https://github.com/kubermatic/kubermatic/pull/13246))
+- Add support for Kubernetes 1.27.13 and 1.28.9 (fixes CVE-2024-3177) ([#13299](https://github.com/kubermatic/kubermatic/pull/13299))     
 - Update to Go 1.21.9 ([#13247](https://github.com/kubermatic/kubermatic/pull/13247))
 
 ### Cleanup

--- a/docs/changelogs/CHANGELOG-2.24.md
+++ b/docs/changelogs/CHANGELOG-2.24.md
@@ -5,6 +5,49 @@
 - [v2.24.2](#v2242)
 - [v2.24.3](#v2243)
 - [v2.24.4](#v2244)
+- [v2.24.5](#v2245)
+- [v2.24.6](#v2246)
+
+## [v2.24.6](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.6)
+
+### API Changes
+
+- Add `spec.componentsOverride.operatingSystemManager` to allow overriding OSM settings and resources ([#13287](https://github.com/kubermatic/kubermatic/pull/13287))
+
+### Bugfixes
+
+- Fix high CPU usage in master-controller-manager ([#13209](https://github.com/kubermatic/kubermatic/pull/13209))
+
+### Updates
+
+- Add Canal CNI version v3.27.3, having a fix to the ipset incompatibility bug ([#13246](https://github.com/kubermatic/kubermatic/pull/13246))
+- Update to Go 1.21.9 ([#13247](https://github.com/kubermatic/kubermatic/pull/13247))
+
+### Cleanup
+
+- Addons reconciliation is triggered more consistently for changes to Cluster objects, reducing the overall number of unnecessary addon reconciliations ([#13252](https://github.com/kubermatic/kubermatic/pull/13252))
+
+## [v2.24.5](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.5)
+
+### Bugfixes
+
+- Add images for Velero and KubeLB to mirrored images list ([#13198](https://github.com/kubermatic/kubermatic/pull/13198))
+- Exclude `test` folders which contain symlinks that break once the archive is untarred ([#13151](https://github.com/kubermatic/kubermatic/pull/13151))
+- Fix missing image registry override for hubble-ui components if Cilium is deployed as System Application ([#13139](https://github.com/kubermatic/kubermatic/pull/13139))
+- Fix: usercluster-controller-manager failed to reconcile cluster with disable CSI drivers ([#13183](https://github.com/kubermatic/kubermatic/pull/13183))
+- Fix Azure loadbalancer-related issues by updating Azure CCM from v1.28.0 to v1.28.5 for the user clusters created with Kubernetes v1.28 ([#13173](https://github.com/kubermatic/kubermatic/pull/13173))
+- Fix a bug where OSPs were not being listed for VMware Cloud Director ([#6592](https://github.com/kubermatic/dashboard/pull/6592))       
+- Fix invalid project ID in API requests for Nutanix provider ([#6572](https://github.com/kubermatic/dashboard/pull/6572))
+- Fix a bug where dedicated credentials were incorrectly being required as mandatory input when editing vSphere provider settings for a cluster ([#6567](https://github.com/kubermatic/dashboard/pull/6567))
+
+
+### Chore
+
+- Update to Go 1.21.8 ([#13164](https://github.com/kubermatic/kubermatic/pull/13164)) and ([#6593](https://github.com/kubermatic/dashboard/pull/6593))
+
+### Design
+
+- Improve compatibility with cluster-autoscaler 1.27.1+: Pods using temporary volumes are now marked as evictable ([#13197](https://github.com/kubermatic/kubermatic/pull/13197))
 
 ## [v2.24.4](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.4)
 

--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -17,27 +17,25 @@
 - Fix high CPU usage in master-controller-manager ([#13209](https://github.com/kubermatic/kubermatic/pull/13209))
 - Fix increased reconcile rate for ClusterBackupStorageLocation objects on seed clusters ([#13218](https://github.com/kubermatic/kubermatic/pull/13218))
 
+### New Features
+
+- Add new `kubermatic_cluster_owner` metric on seed clusters, with `cluster_name` and `user` labels ([#13194](https://github.com/kubermatic/kubermatic/pull/13194))
+
 ### Updates
-
-- Add Canal CNI version v3.27.3, having a fix to the ipset incompatibility bug ([#13245](https://github.com/kubermatic/kubermatic/pull/13245))
-- Update Cilium to 1.14.9 and 1.13.14, mitigating CVE-2024-28860 and CVE-2024-28248 ([#13242](https://github.com/kubermatic/kubermatic/pull/13242))
-
-### Cleanup
-
-- Addons reconciliation is triggered more consistently for changes to Cluster objects, reducing the overall number of unnecessary addon reconciliations ([#13252](https://github.com/kubermatic/kubermatic/pull/13252))
-
-### Design
-
-- Improve compatibility with cluster-autoscaler 1.27.1+: Pods using temporary volumes are now marked as evictable ([#13180](https://github.com/kubermatic/kubermatic/pull/13180))
-
-### New Feature
 
 - KKP(EE): Bump to Metering 1.2.1 ([#13185](https://github.com/kubermatic/kubermatic/pull/13185))
     - Update Metering to v1.2.1.
     - Add `format` to metering report configuration, allowing to generate JSON files instead of CSV.
     - Add `cloud-provider`, `datacenter` and `cluster-owner` columns to the generated metering reports
-- Add new `kubermatic_cluster_owner` metric on seed clusters, with `cluster_name` and `user` labels ([#13194](https://github.com/kubermatic/kubermatic/pull/13194))
+- Add Canal CNI version v3.27.3, having a fix to the ipset incompatibility bug ([#13245](https://github.com/kubermatic/kubermatic/pull/13245))
+- Update Cilium to 1.14.9 and 1.13.14, mitigating CVE-2024-28860 and CVE-2024-28248 ([#13242](https://github.com/kubermatic/kubermatic/pull/13242))
+- Improve compatibility with cluster-autoscaler 1.27.1+: Pods using temporary volumes are now marked as evictable ([#13180](https://github.com/kubermatic/kubermatic/pull/13180))
 - The image tag in the included `mla/minio-lifecycle-mgr` helm chart has been changed from `latest` to `RELEASE.2024-03-13T23-51-57Z` ([#13199](https://github.com/kubermatic/kubermatic/pull/13199))
+
+### Cleanup
+
+- Addons reconciliation is triggered more consistently for changes to Cluster objects, reducing the overall number of unnecessary addon reconciliations ([#13252](https://github.com/kubermatic/kubermatic/pull/13252))
+
 
 ## [v2.25.0](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.0)
 

--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -1,6 +1,43 @@
 # Kubermatic 2.25
 
 - [v2.25.0](#v2250)
+- [v2.25.1](#v2251)
+
+## [v2.25.1](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.1)
+
+### API Changes
+
+- Add `spec.componentsOverride.operatingSystemManager` to allow overriding OSM settings and resources ([#13285](https://github.com/kubermatic/kubermatic/pull/13285))
+
+### Bugfixes
+
+- Add images for Velero and KubeLB to mirrored images list ([#13192](https://github.com/kubermatic/kubermatic/pull/13192))
+- Cluster-autoscaler addon now works based on the namespace instead of cluster names; all MachineDeployments in the `kube-system` namespace are scaled ([#13202](https://github.com/kubermatic/kubermatic/pull/13202))
+- Fix `csi` Addon not applying cleanly on Azure user clusters that were created with KKP <= 2.24 ([#13250](https://github.com/kubermatic/kubermatic/pull/13250))
+- Fix high CPU usage in master-controller-manager ([#13209](https://github.com/kubermatic/kubermatic/pull/13209))
+- Fix increased reconcile rate for ClusterBackupStorageLocation objects on seed clusters ([#13218](https://github.com/kubermatic/kubermatic/pull/13218))
+
+### Updates
+
+- Add Canal CNI version v3.27.3, having a fix to the ipset incompatibility bug ([#13245](https://github.com/kubermatic/kubermatic/pull/13245))
+- Update Cilium to 1.14.9 and 1.13.14, mitigating CVE-2024-28860 and CVE-2024-28248 ([#13242](https://github.com/kubermatic/kubermatic/pull/13242))
+
+### Cleanup
+
+- Addons reconciliation is triggered more consistently for changes to Cluster objects, reducing the overall number of unnecessary addon reconciliations ([#13252](https://github.com/kubermatic/kubermatic/pull/13252))
+
+### Design
+
+- Improve compatibility with cluster-autoscaler 1.27.1+: Pods using temporary volumes are now marked as evictable ([#13180](https://github.com/kubermatic/kubermatic/pull/13180))
+
+### New Feature
+
+- KKP(EE): Bump to Metering 1.2.1 ([#13185](https://github.com/kubermatic/kubermatic/pull/13185))
+    - Update Metering to v1.2.1.
+    - Add `format` to metering report configuration, allowing to generate JSON files instead of CSV.
+    - Add `cloud-provider`, `datacenter` and `cluster-owner` columns to the generated metering reports
+- Add new `kubermatic_cluster_owner` metric on seed clusters, with `cluster_name` and `user` labels ([#13194](https://github.com/kubermatic/kubermatic/pull/13194))
+- The image tag in the included `mla/minio-lifecycle-mgr` helm chart has been changed from `latest` to `RELEASE.2024-03-13T23-51-57Z` ([#13199](https://github.com/kubermatic/kubermatic/pull/13199))
 
 ## [v2.25.0](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.0)
 

--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -16,6 +16,8 @@
 - Fix `csi` Addon not applying cleanly on Azure user clusters that were created with KKP <= 2.24 ([#13250](https://github.com/kubermatic/kubermatic/pull/13250))
 - Fix high CPU usage in master-controller-manager ([#13209](https://github.com/kubermatic/kubermatic/pull/13209))
 - Fix increased reconcile rate for ClusterBackupStorageLocation objects on seed clusters ([#13218](https://github.com/kubermatic/kubermatic/pull/13218))
+- Fix telemetry agent container images not starting up ([#13309](https://github.com/kubermatic/kubermatic/pull/13309))
+- Resolve conflict in determining available Kubernetes versions where upgrades where possible in `Cluster` object but not via the Dashboard ([#6651](https://github.com/kubermatic/dashboard/pull/6651))
 
 ### New Features
 
@@ -28,9 +30,11 @@
     - Add `format` to metering report configuration, allowing to generate JSON files instead of CSV.
     - Add `cloud-provider`, `datacenter` and `cluster-owner` columns to the generated metering reports
 - Add Canal CNI version v3.27.3, having a fix to the ipset incompatibility bug ([#13245](https://github.com/kubermatic/kubermatic/pull/13245))
+- Add support for Kubernetes 1.27.13, 1.28.9 and 1.29.4 (fixes CVE-2024-3177) ([#13298](https://github.com/kubermatic/kubermatic/pull/13298))
 - Update Cilium to 1.14.9 and 1.13.14, mitigating CVE-2024-28860 and CVE-2024-28248 ([#13242](https://github.com/kubermatic/kubermatic/pull/13242))
 - Improve compatibility with cluster-autoscaler 1.27.1+: Pods using temporary volumes are now marked as evictable ([#13180](https://github.com/kubermatic/kubermatic/pull/13180))
 - The image tag in the included `mla/minio-lifecycle-mgr` helm chart has been changed from `latest` to `RELEASE.2024-03-13T23-51-57Z` ([#13199](https://github.com/kubermatic/kubermatic/pull/13199))
+- Update to Go 1.22.2 ([#6650](https://github.com/kubermatic/dashboard/pull/6650))
 
 ### Cleanup
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds changelogs for KKP Apr 2024 patch releases (2.25.1, 2.24.6 and 2.23.13). 
Also sync the last KKP patch releases (2.24.5 and 2.23.12) changelogs. 

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
