### PR TITLE
Applications: discover if a release is stuck and rollback if necessary

### DIFF
--- a/pkg/applications/fake/fake_installer.go
+++ b/pkg/applications/fake/fake_installer.go
@@ -59,7 +59,7 @@ func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.Suga
 	return util.NoStatusUpdate, nil
 }
 
-func (a *ApplicationInstallerRecorder) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+func (a *ApplicationInstallerRecorder) IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 	// NOOP
 	return false, nil
 }
@@ -90,7 +90,7 @@ func (a ApplicationInstallerLogger) Delete(ctx context.Context, log *zap.Sugared
 	return util.NoStatusUpdate, nil
 }
 
-func (a ApplicationInstallerLogger) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+func (a ApplicationInstallerLogger) IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 	// NOOP
 	return false, nil
 }
@@ -137,7 +137,7 @@ func (c CustomApplicationInstaller) Delete(ctx context.Context, log *zap.Sugared
 	return util.NoStatusUpdate, nil
 }
 
-func (c CustomApplicationInstaller) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+func (c CustomApplicationInstaller) IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 	// NOOP
 	return false, nil
 }

--- a/pkg/applications/fake/fake_installer.go
+++ b/pkg/applications/fake/fake_installer.go
@@ -59,6 +59,15 @@ func (a *ApplicationInstallerRecorder) Delete(ctx context.Context, log *zap.Suga
 	return util.NoStatusUpdate, nil
 }
 
+func (a *ApplicationInstallerRecorder) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	// NOOP
+	return false, nil
+}
+
+func (a *ApplicationInstallerRecorder) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+	return nil
+}
+
 // ApplicationInstallerLogger is a fake ApplicationInstaller that just logs actions. it's used for the development of the controller.
 type ApplicationInstallerLogger struct {
 }
@@ -79,6 +88,16 @@ func (a ApplicationInstallerLogger) Apply(ctx context.Context, log *zap.SugaredL
 func (a ApplicationInstallerLogger) Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error) {
 	log.Debugf("Uninstall application %s. applicationVersion=%v", applicationInstallation.Name, applicationInstallation.Status.ApplicationVersion)
 	return util.NoStatusUpdate, nil
+}
+
+func (a ApplicationInstallerLogger) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	// NOOP
+	return false, nil
+}
+
+func (a ApplicationInstallerLogger) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+	// NOOP
+	return nil
 }
 
 // CustomApplicationInstaller is an applicationInstaller in which every function can be independently mocked.
@@ -116,4 +135,14 @@ func (c CustomApplicationInstaller) Delete(ctx context.Context, log *zap.Sugared
 		return c.DeleteFunc(ctx, log, seedClient, userClient, applicationInstallation)
 	}
 	return util.NoStatusUpdate, nil
+}
+
+func (c CustomApplicationInstaller) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	// NOOP
+	return false, nil
+}
+
+func (c CustomApplicationInstaller) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+	// NOOP
+	return nil
 }

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -416,6 +416,26 @@ func (h HelmClient) Uninstall(releaseName string) (*release.UninstallReleaseResp
 	return uninstallReleaseResponse, err
 }
 
+// GetMetadata wraps helms GetMetadata command to be used with our ActionConfig
+func (h HelmClient) GetMetadata(releaseName string) (*action.Metadata, error) {
+	client := action.NewGetMetadata(h.actionConfig)
+	res, err := client.Run(releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("Could not retrieve metadata for release %q: %w", releaseName, err)
+	}
+	return res, nil
+}
+
+// Rollback wraps helms Rollback command to be used with our ActionConfig
+func (h HelmClient) Rollback(releaseName string) error {
+	client := action.NewRollback(h.actionConfig)
+	err := client.Run(releaseName)
+	if err != nil {
+		return fmt.Errorf("Could not rollback release %q: %w", releaseName, err)
+	}
+	return nil
+}
+
 // buildDependencies adds missing repositories and then does a Helm dependency build (i.e. download the chart dependencies
 // from repositories into "charts" folder).
 func (h HelmClient) buildDependencies(chartLoc string, auth AuthSettings) (*chart.Chart, error) {

--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -416,7 +416,7 @@ func (h HelmClient) Uninstall(releaseName string) (*release.UninstallReleaseResp
 	return uninstallReleaseResponse, err
 }
 
-// GetMetadata wraps helms GetMetadata command to be used with our ActionConfig
+// GetMetadata wraps helms GetMetadata command to be used with our ActionConfig.
 func (h HelmClient) GetMetadata(releaseName string) (*action.Metadata, error) {
 	client := action.NewGetMetadata(h.actionConfig)
 	res, err := client.Run(releaseName)
@@ -426,7 +426,7 @@ func (h HelmClient) GetMetadata(releaseName string) (*action.Metadata, error) {
 	return res, nil
 }
 
-// Rollback wraps helms Rollback command to be used with our ActionConfig
+// Rollback wraps helms Rollback command to be used with our ActionConfig.
 func (h HelmClient) Rollback(releaseName string) error {
 	client := action.NewRollback(h.actionConfig)
 	err := client.Run(releaseName)

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -45,8 +45,8 @@ type ApplicationInstaller interface {
 	// Delete function uninstalls the application on the user-cluster and returns an error if the uninstallation has failed. StatusUpdater is guaranteed to be non nil. This is idempotent.
 	Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error)
 
-	// IsReleaseStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries
-	IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+	// IsStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries
+	IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
 
 	// Rollback rolls an Application back to the previous release
 	Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
@@ -145,14 +145,14 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 	return nil
 }
 
-// IsReleaseStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries.
-func (a *ApplicationManager) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+// IsStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries.
+func (a *ApplicationManager) IsStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
 		return false, fmt.Errorf("failed to initialize template provider: %w", err)
 	}
 
-	return templateProvider.IsReleaseStuck(applicationInstallation)
+	return templateProvider.IsStuck(applicationInstallation)
 }
 
 // Rollback rolls an Application back to the previous release.

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -44,6 +44,12 @@ type ApplicationInstaller interface {
 
 	// Delete function uninstalls the application on the user-cluster and returns an error if the uninstallation has failed. StatusUpdater is guaranteed to be non nil. This is idempotent.
 	Delete(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error)
+
+	// IsReleaseStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries
+	IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+
+	// Rollback rolls an Application back to the previous release
+	Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }
 
 // ApplicationManager handles the installation / uninstallation of an Application on the user-cluster.
@@ -137,4 +143,24 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 		}
 	}
 	return nil
+}
+
+// IsReleaseStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries
+func (a *ApplicationManager) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	if err != nil {
+		return false, fmt.Errorf("failed to initialize template provider: %w", err)
+	}
+
+	return templateProvider.IsReleaseStuck(applicationInstallation)
+}
+
+// Rollback rolls an Application back to the previous release
+func (a *ApplicationManager) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to initialize template provider: %w", err)
+	}
+
+	return templateProvider.Rollback(applicationInstallation)
 }

--- a/pkg/applications/installer.go
+++ b/pkg/applications/installer.go
@@ -145,7 +145,7 @@ func (a *ApplicationManager) reconcileNamespace(ctx context.Context, log *zap.Su
 	return nil
 }
 
-// IsReleaseStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries
+// IsReleaseStuck determines if a release is stuck. Its main purpose is to detect inconsistent behavior in upstream Application libraries.
 func (a *ApplicationManager) IsReleaseStuck(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {
@@ -155,7 +155,7 @@ func (a *ApplicationManager) IsReleaseStuck(ctx context.Context, log *zap.Sugare
 	return templateProvider.IsReleaseStuck(applicationInstallation)
 }
 
-// Rollback rolls an Application back to the previous release
+// Rollback rolls an Application back to the previous release.
 func (a *ApplicationManager) Rollback(ctx context.Context, log *zap.SugaredLogger, seedClient ctrlruntimeclient.Client, userClient ctrlruntimeclient.Client, applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	templateProvider, err := providers.NewTemplateProvider(ctx, seedClient, a.Kubeconfig, a.ApplicationCache, log, applicationInstallation, a.SecretNamespace)
 	if err != nil {

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -208,3 +208,76 @@ func getDeployOpts(appDefinition *appskubermaticv1.ApplicationDefinition, appIns
 	// Fallback to default options.
 	return helmclient.NewDeployOpts(false, 0, false, false)
 }
+
+// IsReleaseStuck aims to identify if a helm release is stuck. This targets an upstream issue in helm, which has not been resolved. For further details see:
+// - https://github.com/helm/helm/issues/7476
+// - https://github.com/helm/helm/issues/4558
+func (h HelmTemplate) IsReleaseStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+	// if the release was successful, exit early
+	if applicationInstallation.Status.Conditions[appskubermaticv1.Ready].Status == "True" {
+		return false, nil
+	}
+	// currently we observe the stuck error exclusively with this message. If it does not exist, exit early
+	if applicationInstallation.Status.Conditions[appskubermaticv1.Ready].Message != "another operation (install/upgrade/rollback) is in progress" {
+		return false, nil
+	}
+
+	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
+	if err != nil {
+		return false, fmt.Errorf("failed to create helmCacheDir: %w", err)
+	}
+
+	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
+	restClientGetter := &genericclioptions.ConfigFlags{
+		KubeConfig: &h.Kubeconfig,
+		Namespace:  &applicationInstallation.Spec.Namespace.Name,
+	}
+	helmClient, err := helmclient.NewClient(
+		h.Ctx,
+		restClientGetter,
+		helmclient.NewSettings(helmCacheDir),
+		applicationInstallation.Spec.Namespace.Name,
+		h.Log)
+	if err != nil {
+		return false, fmt.Errorf("failed to create helmClient: %w", err)
+	}
+
+	// retrieve metadata of the latest release
+	releaseName := getReleaseName(applicationInstallation)
+	metadata, err := helmClient.GetMetadata(releaseName)
+	if err != nil {
+		return false, fmt.Errorf("failed to retrieve metadata for checking if release %q is stuck: %w", releaseName, err)
+	}
+
+	// if the status of the release is not still pending, exit early
+	if metadata.Status != "pending-upgrade" {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// Rollback rolls an Application back to the previous release
+func (h HelmTemplate) Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
+	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
+	if err != nil {
+		return fmt.Errorf("failed to create helmCacheDir: %w", err)
+	}
+
+	defer util.CleanUpHelmTempDir(helmCacheDir, h.Log)
+	restClientGetter := &genericclioptions.ConfigFlags{
+		KubeConfig: &h.Kubeconfig,
+		Namespace:  &applicationInstallation.Spec.Namespace.Name,
+	}
+	helmClient, err := helmclient.NewClient(
+		h.Ctx,
+		restClientGetter,
+		helmclient.NewSettings(helmCacheDir),
+		applicationInstallation.Spec.Namespace.Name,
+		h.Log)
+	if err != nil {
+		return fmt.Errorf("failed to create helmClient: %w", err)
+	}
+
+	return helmClient.Rollback(getReleaseName(applicationInstallation))
+}

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -257,7 +257,7 @@ func (h HelmTemplate) IsReleaseStuck(applicationInstallation *appskubermaticv1.A
 	return true, nil
 }
 
-// Rollback rolls an Application back to the previous release
+// Rollback rolls an Application back to the previous release.
 func (h HelmTemplate) Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error {
 	helmCacheDir, err := util.CreateHelmTempDir(h.CacheDir)
 	if err != nil {

--- a/pkg/applications/providers/template/helm.go
+++ b/pkg/applications/providers/template/helm.go
@@ -209,10 +209,10 @@ func getDeployOpts(appDefinition *appskubermaticv1.ApplicationDefinition, appIns
 	return helmclient.NewDeployOpts(false, 0, false, false)
 }
 
-// IsReleaseStuck aims to identify if a helm release is stuck. This targets an upstream issue in helm, which has not been resolved. For further details see:
+// IsStuck aims to identify if a helm release is stuck. This targets an upstream issue in helm, which has not been resolved. For further details see:
 // - https://github.com/helm/helm/issues/7476
 // - https://github.com/helm/helm/issues/4558
-func (h HelmTemplate) IsReleaseStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
+func (h HelmTemplate) IsStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error) {
 	// if the release was successful, exit early
 	if applicationInstallation.Status.Conditions[appskubermaticv1.Ready].Status == "True" {
 		return false, nil

--- a/pkg/applications/providers/types.go
+++ b/pkg/applications/providers/types.go
@@ -59,6 +59,12 @@ type TemplateProvider interface {
 
 	// Uninstall the application.
 	Uninstall(applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error)
+
+	// Check if a Release is stuck
+	IsReleaseStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+
+	// Rollback the Application to the previous release
+	Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error
 }
 
 // NewTemplateProvider return the concrete implementation of TemplateProvider according to the templateMethod.

--- a/pkg/applications/providers/types.go
+++ b/pkg/applications/providers/types.go
@@ -60,8 +60,8 @@ type TemplateProvider interface {
 	// Uninstall the application.
 	Uninstall(applicationInstallation *appskubermaticv1.ApplicationInstallation) (util.StatusUpdater, error)
 
-	// Check if a Release is stuck
-	IsReleaseStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
+	// Check if a release is stuck
+	IsStuck(applicationInstallation *appskubermaticv1.ApplicationInstallation) (bool, error)
 
 	// Rollback the Application to the previous release
 	Rollback(applicationInstallation *appskubermaticv1.ApplicationInstallation) error

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -244,7 +244,7 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 
 	// Because some upstream tools are not completely idempotent, we need a check to make sure a release is not stuck.
 	// This should be run before we make any changes to the status field, so we can use it in our analysis
-	stuck, err := r.appInstaller.IsReleaseStuck(ctx, log, r.seedClient, r.userClient, appInstallation)
+	stuck, err := r.appInstaller.IsStuck(ctx, log, r.seedClient, r.userClient, appInstallation)
 	if err != nil {
 		return fmt.Errorf("failed to check if the previous release is stuck: %w", err)
 	}

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -249,9 +249,11 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return fmt.Errorf("failed to check if the previous release is stuck: %w", err)
 	}
 	if stuck {
+		log.Infof("Release %q seems to be stuck in pending even after timeout, attempting rollback now")
 		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
 			return fmt.Errorf("failed to rollback release: %w", err)
 		}
+		log.Infof("Release %q has been rolled back successfully")
 	}
 
 	downloadDest, err := os.MkdirTemp(r.appInstaller.GetAppCache(), appInstallation.Namespace+"-"+appInstallation.Name)

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -249,7 +249,9 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return fmt.Errorf("failed to check if the previous release is stuck: %w", err)
 	}
 	if stuck {
-		r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation)
+		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
+			return fmt.Errorf("failed to rollback release: %w", err)
+		}
 	}
 
 	downloadDest, err := os.MkdirTemp(r.appInstaller.GetAppCache(), appInstallation.Namespace+"-"+appInstallation.Name)

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -249,11 +249,11 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return fmt.Errorf("failed to check if the previous release is stuck: %w", err)
 	}
 	if stuck {
-		log.Infof("Release %q seems to be stuck, attempting rollback now")
+		log.Infof("Release for ApplicationInstallation seems to be stuck, attempting rollback now")
 		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
 			return fmt.Errorf("failed to rollback release: %w", err)
 		}
-		log.Infof("Release %q has been rolled back successfully")
+		log.Infof("Release for ApplicationInstallation has been rolled back successfully")
 	}
 
 	downloadDest, err := os.MkdirTemp(r.appInstaller.GetAppCache(), appInstallation.Namespace+"-"+appInstallation.Name)

--- a/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/application-installation-controller/controller.go
@@ -249,7 +249,7 @@ func (r *reconciler) handleInstallation(ctx context.Context, log *zap.SugaredLog
 		return fmt.Errorf("failed to check if the previous release is stuck: %w", err)
 	}
 	if stuck {
-		log.Infof("Release %q seems to be stuck in pending even after timeout, attempting rollback now")
+		log.Infof("Release %q seems to be stuck, attempting rollback now")
 		if err := r.appInstaller.Rollback(ctx, log, r.seedClient, r.userClient, appInstallation); err != nil {
 			return fmt.Errorf("failed to rollback release: %w", err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes an issue caused by a helm inconsistency (for more details see below) in which a helm release can be stuck in a "pending-install" state  and never be fully rolled out. This has been observed in multiple clusters now, but being an inconsistency, there is no reliable way to reproduce this consistently.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes https://github.com/kubermatic/kubermatic/issues/12846

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

During the research we came to the following conclusion:
This is not directly related to an AppInstallController being destroyed while a helm release is still in progress. In all testing the AppController would delete the "broken" release and re-created it. Instead this seems to be related to a fluke in helm, which many people have encountered (see https://github.com/helm/helm/issues/7476 for more details).

The current approach is to check for a variety of conditions that we have observed at customer clusters and do a `helm rollback` to the previous version if a release appears to be stuck. This comes with the drawback, that after the rollback has been completed we will start a new release with the current version. 
However out of all the following alternatives, I think this is the best option. Alternatives considered were:
* always use the `atomic` flag -> scrapped because then end-users would loose the ability to debug applications where there is a legitimate issue in an helm chart after it has reached the timeout
* delete the complete helm secret, thus forcing a re-rollout of the app -> with this the complete helm history would be lost, so we decided against this option.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Addressing inconsistencies in helm that lead to an Application stuck in "pending-install"
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
