### PR TITLE
fix the creation of network more than one time

### DIFF
--- a/pkg/provider/cloud/openstack/network.go
+++ b/pkg/provider/cloud/openstack/network.go
@@ -84,10 +84,10 @@ func getDefaultExternalNetwork(netClient *gophercloud.ServiceClient) (*NetworkWi
 	return nil, errors.New("no external network found")
 }
 
-func createUserClusterNetwork(netClient *gophercloud.ServiceClient, clusterName string) (*osnetworks.Network, error) {
+func createUserClusterNetwork(netClient *gophercloud.ServiceClient, networkName string) (*osnetworks.Network, error) {
 	iTrue := true
 	res := osnetworks.Create(netClient, osnetworks.CreateOpts{
-		Name:         resourceNamePrefix + clusterName,
+		Name:         networkName,
 		AdminStateUp: &iTrue,
 	})
 	if res.Err != nil {

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -287,10 +287,9 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 		if existingNetwork != nil {
 			return cluster, nil
 		}
-	}
+	} else {
 
-	// If NetworkName not specified, Create network with name kubernetes-clusterid.
-	if networkName == "" {
+		// If NetworkName not specified, Create network with name kubernetes-clusterid.
 		networkName = resourceNamePrefix + cluster.Name
 	}
 

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -289,18 +289,14 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 		}
 	}
 
-	// This variable will be used to update the cluster object.
-	network := networkName
-
 	// If NetworkName not specified, Create network with name kubernetes-clusterid.
 	if networkName == "" {
-		network = resourceNamePrefix + cluster.Name
-		networkName = cluster.Name
+		networkName = resourceNamePrefix + cluster.Name
 	}
 
 	cluster, err := update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kubernetes.AddFinalizer(cluster, NetworkCleanupFinalizer)
-		cluster.Spec.Cloud.Openstack.Network = network
+		cluster.Spec.Cloud.Openstack.Network = networkName
 	})
 
 	if err != nil {

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -296,7 +296,7 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 
 	cluster, err := update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kubernetes.AddFinalizer(cluster, NetworkCleanupFinalizer)
-		cluster.Spec.Cloud.Openstack.Network = networkName
+		cluster.Spec.Cloud.Openstack.Network = resourceNamePrefix + networkName
 	})
 
 	if err != nil {

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -288,7 +288,6 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 			return cluster, nil
 		}
 	} else {
-
 		// If NetworkName not specified, Create network with name kubernetes-clusterid.
 		networkName = resourceNamePrefix + cluster.Name
 	}

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -294,17 +294,21 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 		networkName = cluster.Name
 	}
 
-	newNetwork, err := createUserClusterNetwork(netClient, networkName)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the kubermatic network: %w", err)
-	}
-	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	cluster, err := update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kubernetes.AddFinalizer(cluster, NetworkCleanupFinalizer)
-		cluster.Spec.Cloud.Openstack.Network = newNetwork.Name
+		cluster.Spec.Cloud.Openstack.Network = networkName
 	})
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to update network cluster: %w", err)
 	}
+
+	_, err = createUserClusterNetwork(netClient, networkName)
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the kubermatic network: %w", err)
+	}
+
 	return cluster, nil
 }
 
@@ -385,16 +389,16 @@ func reconcileSecurityGroup(ctx context.Context, netClient *gophercloud.ServiceC
 
 	req.nodePortsCIDRs = resources.GetNodePortsAllowedIPRanges(cluster, cluster.Spec.Cloud.Openstack.NodePortsAllowedIPRanges, cluster.Spec.Cloud.Openstack.NodePortsAllowedIPRange)
 
-	secGroupName, err := createSecurityGroup(netClient, req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create the user cluster security group: %w", err)
-	}
-	cluster, err = update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
+	cluster, err := update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kubernetes.AddFinalizer(cluster, SecurityGroupCleanupFinalizer)
-		cluster.Spec.Cloud.Openstack.SecurityGroups = secGroupName
+		cluster.Spec.Cloud.Openstack.SecurityGroups = securityGroup
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to add security group name to cluster: %w", err)
+	}
+	_, err = createSecurityGroup(netClient, req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create the user cluster security group: %w", err)
 	}
 	return cluster, nil
 }

--- a/pkg/provider/cloud/openstack/provider.go
+++ b/pkg/provider/cloud/openstack/provider.go
@@ -289,14 +289,18 @@ func reconcileNetwork(ctx context.Context, netClient *gophercloud.ServiceClient,
 		}
 	}
 
-	// If NetworkName not specified, Create network with name kubernetes-clusterid
+	// This variable will be used to update the cluster object.
+	network := networkName
+
+	// If NetworkName not specified, Create network with name kubernetes-clusterid.
 	if networkName == "" {
+		network = resourceNamePrefix + cluster.Name
 		networkName = cluster.Name
 	}
 
 	cluster, err := update(ctx, cluster.Name, func(cluster *kubermaticv1.Cluster) {
 		kubernetes.AddFinalizer(cluster, NetworkCleanupFinalizer)
-		cluster.Spec.Cloud.Openstack.Network = resourceNamePrefix + networkName
+		cluster.Spec.Cloud.Openstack.Network = network
 	})
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
make the reconciler update the cluster object before create cloud resource (network and security groups) to avoid issues with currency since the cluster object is reconciled by other controllers! 
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes the issue of creating the network more than one time by updating the cluster object before create the cloud resource! So if the update process fails, we will not need to create the resource

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
