### PR TITLE
keep Loki PVCs when STS is deleted

### DIFF
--- a/charts/logging/loki/test/default.yaml.out
+++ b/charts/logging/loki/test/default.yaml.out
@@ -282,10 +282,6 @@ spec:
       partition: 0
   serviceName: loki-headless
   revisionHistoryLimit: 10
-  
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Delete
   selector:
     matchLabels:
       app.kubernetes.io/name: loki
@@ -359,6 +355,16 @@ spec:
             requests:
               cpu: 300m
               memory: 256Mi
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: loki
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: single-binary
+              topologyKey: kubernetes.io/hostname
+        
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/logging/loki/test/values.example.ce.yaml.out
+++ b/charts/logging/loki/test/values.example.ce.yaml.out
@@ -282,10 +282,6 @@ spec:
       partition: 0
   serviceName: loki-headless
   revisionHistoryLimit: 10
-  
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Delete
   selector:
     matchLabels:
       app.kubernetes.io/name: loki
@@ -359,6 +355,16 @@ spec:
             requests:
               cpu: 300m
               memory: 256Mi
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: loki
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: single-binary
+              topologyKey: kubernetes.io/hostname
+        
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/logging/loki/test/values.example.ee.yaml.out
+++ b/charts/logging/loki/test/values.example.ee.yaml.out
@@ -282,10 +282,6 @@ spec:
       partition: 0
   serviceName: loki-headless
   revisionHistoryLimit: 10
-  
-  persistentVolumeClaimRetentionPolicy:
-    whenDeleted: Delete
-    whenScaled: Delete
   selector:
     matchLabels:
       app.kubernetes.io/name: loki
@@ -359,6 +355,16 @@ spec:
             requests:
               cpu: 300m
               memory: 256Mi
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: loki
+                  app.kubernetes.io/instance: release-name
+                  app.kubernetes.io/component: single-binary
+              topologyKey: kubernetes.io/hostname
+        
       volumes:
         - name: tmp
           emptyDir: {}

--- a/charts/logging/loki/values.yaml
+++ b/charts/logging/loki/values.yaml
@@ -90,6 +90,7 @@ loki:
       enabled: true
       size: 15Gi
       storageClass: kubermatic-fast
+      enableStatefulSetAutoDeletePVC: false
 
     resources:
       limits:
@@ -105,20 +106,6 @@ loki:
       prometheus.io/scrape: "true"
       prometheus.io/port: "3100"
       cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
-
-    affinity: {}
-    # podAntiAffinity:
-    #   requiredDuringSchedulingIgnoredDuringExecution:
-    #   - labelSelector:
-    #       matchExpressions:
-    #       - key: app
-    #         operator: In
-    #         values:
-    #         - loki
-    #     topologyKey: "kubernetes.io/hostname"
-
-    nodeSelector: {}
-    tolerations: []
 
   gateway:
     enabled: false


### PR DESCRIPTION
**What this PR does / why we need it**:
The default configuration of Loki will set the `Delete` policy for https://kube-api.ninja/apidocs/1.29/#statefulsetpersistentvolumeclaimretentionpolicy-v1-apps. While it should be okay to say that the PVC is deleted when the STS is scaled to 0 replicas, deleting all PVCs when the STS is deleted is another story. What if we require again to delete the STS in the future, for upgrades? The `persistentVolumeClaimRetentionPolicy` is not immutable, so we could at least document that without changing it, data might get lost.

Not really sure which one is best, but this one seems the safest approach.

I also re-enabled the affinity. It's defaulted to

```yaml
  affinity: |
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        - labelSelector:
            matchLabels:
              {{- include "loki.singleBinarySelectorLabels" . | nindent 10 }}
          topologyKey: kubernetes.io/hostname
```

and should work just fine on KKP seed clusters. We default to a single Loki node, so the affinity should never block us from installing the chart. And requiring admins to either have multiple nodes or explicitly ignore the recommended affinity, is IMHO fine.

**What type of PR is this?**

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
https://github.com/kubermatic/docs/pull/1665
```
