### PR TITLE
bump usercluster/metering Prometheus to 2.51.1

### DIFF
--- a/pkg/ee/metering/prometheus/sts.go
+++ b/pkg/ee/metering/prometheus/sts.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	version = "v2.45.0"
+	version = "v2.51.1"
 )
 
 func getPrometheusImage(overwriter registry.ImageRewriter) string {

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -33,7 +33,7 @@ import (
 
 const (
 	name = "prometheus"
-	tag  = "v2.43.1"
+	tag  = "v2.51.1"
 
 	volumeConfigName = "config"
 	volumeDataName   = "data"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-edge-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-edge-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-edge-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus.yaml
@@ -36,7 +36,7 @@ spec:
         - --web.enable-lifecycle
         - --storage.tsdb.no-lockfile
         - --web.route-prefix=/
-        image: quay.io/prometheus/prometheus:v2.43.1
+        image: quay.io/prometheus/prometheus:v2.51.1
         livenessProbe:
           failureThreshold: 10
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings the Prometheus instances we deploy from within KKP up to the latest/same version as our Helm chart.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* Update usercluster Prometheus to 2.51.1
* Update metering Prometheus to 2.51.1
```

**Documentation**:
```documentation
NONE
```
