### PR TITLE
Update usercluster kube-state-metrics to 2.12.0

### DIFF
--- a/charts/cert-manager/test/test-certmanager.sh
+++ b/charts/cert-manager/test/test-certmanager.sh
@@ -35,8 +35,8 @@ helm upgrade \
 
 if ! which cmctl; then
   echodate "Downloading cmctl..."
-  OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sLo cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/latest/download/cmctl-$OS-$ARCH.tar.gz
-  tar xzf cmctl.tar.gz
+  OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sLo cmctl "https://github.com/cert-manager/cmctl/releases/download/v2.0.0/cmctl_${OS}_${ARCH}"
+  chmod +x cmctl
 
   function cmctl_cleanup {
     echodate "Cleaning up..."

--- a/charts/monitoring/kube-state-metrics/templates/cluster-role-binding.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/cluster-role-binding.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: '{{ .Values.kubeStateMetrics.image.tag }}'
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/charts/monitoring/kube-state-metrics/templates/cluster-role.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/cluster-role.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: '{{ .Values.kubeStateMetrics.image.tag }}'
   name: kube-state-metrics
 rules:
 - apiGroups:

--- a/charts/monitoring/kube-state-metrics/templates/crs-configmap.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/crs-configmap.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: '{{ .Values.kubeStateMetrics.image.tag }}'
 data:
   config.yaml: |
     {{- toYaml .Values.kubeStateMetrics.customResourceState.config | nindent 4 }}

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -27,12 +27,13 @@ spec:
         app: kube-state-metrics
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: '{{ .Values.kubeStateMetrics.image.tag }}'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8080'
         kubermatic.io/chart: kube-state-metrics
         fluentbit.io/parser: glog
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     spec:
       serviceAccountName: kube-state-metrics
       automountServiceAccountToken: true
@@ -53,6 +54,8 @@ spec:
         - name: customresourcestate-config
           mountPath: /etc/customresourcestate
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
         {{- end }}
         ports:
         - containerPort: 8080
@@ -62,7 +65,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 8081
+            port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
         livenessProbe:
@@ -78,6 +81,10 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         resources:
 {{ toYaml .Values.kubeStateMetrics.resources | indent 10 }}
 
@@ -112,8 +119,10 @@ spec:
           periodSeconds: 10
         resources:
 {{ toYaml .Values.kubeStateMetrics.resizer.resources | indent 10 }}
-{{- if .Values.kubeStateMetrics.customResourceState.enabled }}
       volumes:
+        - name: tmp
+          emptyDir: {}
+{{- if .Values.kubeStateMetrics.customResourceState.enabled }}
         - name: customresourcestate-config
           configMap:
             name: kube-state-metrics-customresourcestate-config

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -43,11 +43,8 @@ spec:
       containers:
       - name: kube-state-metrics
         image: '{{ .Values.kubeStateMetrics.image.repository }}:{{ .Values.kubeStateMetrics.image.tag }}'
-        # Ref: https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/#what-is-new-in-v2-0
-        # Issue and solutions: https://github.com/kubernetes/kube-state-metrics/issues/1501#issuecomment-863020915
-        # and https://github.com/kubernetes/kube-state-metrics/issues/1489#issuecomment-851970288
         args:
-        - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
+        - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance],persistentvolumeclaims=[excluded-from-alerts]
         {{- if .Values.kubeStateMetrics.customResourceState.enabled }}
         - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
         volumeMounts:

--- a/charts/monitoring/kube-state-metrics/templates/deployment.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/deployment.yaml
@@ -47,12 +47,14 @@ spec:
         - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance],persistentvolumeclaims=[excluded-from-alerts]
         {{- if .Values.kubeStateMetrics.customResourceState.enabled }}
         - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
+        {{- end }}
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+        {{- if .Values.kubeStateMetrics.customResourceState.enabled }}
         - name: customresourcestate-config
           mountPath: /etc/customresourcestate
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
         {{- end }}
         ports:
         - containerPort: 8080

--- a/charts/monitoring/kube-state-metrics/templates/service-account.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/service-account.yaml
@@ -13,11 +13,11 @@
 # limitations under the License.
 
 apiVersion: v1
-automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: '{{ .Values.kubeStateMetrics.image.tag }}'
   name: kube-state-metrics
+automountServiceAccountToken: false

--- a/charts/monitoring/kube-state-metrics/templates/service.yaml
+++ b/charts/monitoring/kube-state-metrics/templates/service.yaml
@@ -18,7 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: '{{ .Values.kubeStateMetrics.image.tag }}'
   name: kube-state-metrics
 spec:
   clusterIP: None

--- a/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
+++ b/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
@@ -417,11 +417,11 @@ spec:
         - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance],persistentvolumeclaims=[excluded-from-alerts]
         - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
         volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         - name: customresourcestate-config
           mountPath: /etc/customresourcestate
           readOnly: true
-        - name: tmp
-          mountPath: /tmp
         ports:
         - containerPort: 8080
           name: http-metrics

--- a/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
+++ b/charts/monitoring/kube-state-metrics/test/values.custom-resource-state.yaml.out
@@ -27,14 +27,14 @@ spec:
 # limitations under the License.
 
 apiVersion: v1
-automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: 'v2.12.0'
   name: kube-state-metrics
+automountServiceAccountToken: false
 ---
 # Source: kube-state-metrics/templates/crs-configmap.yaml
 # Copyright 2020 The Kubermatic Kubernetes Platform contributors.
@@ -57,7 +57,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: 'v2.12.0'
 data:
   config.yaml: |
     spec:
@@ -111,7 +111,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: 'v2.12.0'
   name: kube-state-metrics
 rules:
 - apiGroups:
@@ -267,7 +267,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: 'v2.12.0'
   name: kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -356,7 +356,7 @@ metadata:
   labels:
     app.kubernetes.io/component: exporter
     app.kubernetes.io/name: kube-state-metrics
-    app.kubernetes.io/version: 2.8.2
+    app.kubernetes.io/version: 'v2.12.0'
   name: kube-state-metrics
 spec:
   clusterIP: None
@@ -400,28 +400,28 @@ spec:
         app: kube-state-metrics
         app.kubernetes.io/component: exporter
         app.kubernetes.io/name: kube-state-metrics
-        app.kubernetes.io/version: 2.8.2
+        app.kubernetes.io/version: 'v2.12.0'
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '8080'
         kubermatic.io/chart: kube-state-metrics
         fluentbit.io/parser: glog
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: tmp
     spec:
       serviceAccountName: kube-state-metrics
       automountServiceAccountToken: true
       containers:
       - name: kube-state-metrics
         image: 'registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0'
-        # Ref: https://kubernetes.io/blog/2021/04/13/kube-state-metrics-v-2-0/#what-is-new-in-v2-0
-        # Issue and solutions: https://github.com/kubernetes/kube-state-metrics/issues/1501#issuecomment-863020915
-        # and https://github.com/kubernetes/kube-state-metrics/issues/1489#issuecomment-851970288
         args:
-        - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance]
+        - --metric-labels-allowlist=pods=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance,component,part-of,app,unit],deployments=[app.kubernetes.io/name,app.kubernetes.io/component,app.kubernetes.io/instance],persistentvolumeclaims=[excluded-from-alerts]
         - --custom-resource-state-config-file=/etc/customresourcestate/config.yaml
         volumeMounts:
         - name: customresourcestate-config
           mountPath: /etc/customresourcestate
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
         ports:
         - containerPort: 8080
           name: http-metrics
@@ -430,7 +430,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /
-            port: 8081
+            port: 8080
           initialDelaySeconds: 5
           timeoutSeconds: 5
         livenessProbe:
@@ -446,6 +446,10 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsUser: 65534
+          runAsGroup: 65534
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           limits:
             cpu: 2
@@ -491,6 +495,8 @@ spec:
             cpu: 50m
             memory: 32Mi
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: customresourcestate-config
           configMap:
             name: kube-state-metrics-customresourcestate-config

--- a/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/general-kube-kubelet.yaml
@@ -40,7 +40,7 @@ groups:
           and
           kubelet_volume_stats_used_bytes{job="kubelet"} > 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1m
@@ -61,7 +61,7 @@ groups:
           and
           kubelet_volume_stats_used_bytes{job="kubelet"} > 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1m
@@ -82,7 +82,7 @@ groups:
           and
           kubelet_volume_stats_inodes_used{job="kubelet"} > 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1m
@@ -105,7 +105,7 @@ groups:
           and
           predict_linear(kubelet_volume_stats_inodes_free{job="kubelet"}[6h], 4 * 24 * 3600) < 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1h

--- a/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
+++ b/charts/monitoring/prometheus/rules/src/general/kube-kubelet.yaml
@@ -39,7 +39,7 @@ groups:
           and
           kubelet_volume_stats_used_bytes{job="kubelet"} > 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1m
@@ -60,7 +60,7 @@ groups:
           and
           kubelet_volume_stats_used_bytes{job="kubelet"} > 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1m
@@ -81,7 +81,7 @@ groups:
           and
           kubelet_volume_stats_inodes_used{job="kubelet"} > 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1m
@@ -104,7 +104,7 @@ groups:
           and
           predict_linear(kubelet_volume_stats_inodes_free{job="kubelet"}[6h], 4 * 24 * 3600) < 0
           unless on(namespace, persistentvolumeclaim)
-          kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+          kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
           unless on(namespace, persistentvolumeclaim)
           kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
         for: 1h

--- a/charts/monitoring/prometheus/test/default.yaml.out
+++ b/charts/monitoring/prometheus/test/default.yaml.out
@@ -400,7 +400,7 @@ data:
               and
               kubelet_volume_stats_used_bytes{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -421,7 +421,7 @@ data:
               and
               kubelet_volume_stats_used_bytes{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -442,7 +442,7 @@ data:
               and
               kubelet_volume_stats_inodes_used{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -465,7 +465,7 @@ data:
               and
               predict_linear(kubelet_volume_stats_inodes_free{job="kubelet"}[6h], 4 * 24 * 3600) < 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1h

--- a/charts/monitoring/prometheus/test/values.example.ce.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ce.yaml.out
@@ -400,7 +400,7 @@ data:
               and
               kubelet_volume_stats_used_bytes{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -421,7 +421,7 @@ data:
               and
               kubelet_volume_stats_used_bytes{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -442,7 +442,7 @@ data:
               and
               kubelet_volume_stats_inodes_used{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -465,7 +465,7 @@ data:
               and
               predict_linear(kubelet_volume_stats_inodes_free{job="kubelet"}[6h], 4 * 24 * 3600) < 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1h

--- a/charts/monitoring/prometheus/test/values.example.ee.yaml.out
+++ b/charts/monitoring/prometheus/test/values.example.ee.yaml.out
@@ -400,7 +400,7 @@ data:
               and
               kubelet_volume_stats_used_bytes{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -421,7 +421,7 @@ data:
               and
               kubelet_volume_stats_used_bytes{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -442,7 +442,7 @@ data:
               and
               kubelet_volume_stats_inodes_used{job="kubelet"} > 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1m
@@ -465,7 +465,7 @@ data:
               and
               predict_linear(kubelet_volume_stats_inodes_free{job="kubelet"}[6h], 4 * 24 * 3600) < 0
               unless on(namespace, persistentvolumeclaim)
-              kube_persistentvolumeclaim_access_mode{ access_mode="ReadOnlyMany"} == 1
+              kube_persistentvolumeclaim_access_mode{access_mode="ReadOnlyMany"} == 1
               unless on(namespace, persistentvolumeclaim)
               kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"} == 1
             for: 1h

--- a/cmd/conformance-tester/pkg/tests/metrics.go
+++ b/cmd/conformance-tester/pkg/tests/metrics.go
@@ -28,7 +28,6 @@ import (
 	ctypes "k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/types"
 	"k8c.io/kubermatic/v2/cmd/conformance-tester/pkg/util"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
-	"k8c.io/kubermatic/v2/pkg/semver"
 	"k8c.io/kubermatic/v2/pkg/util/wait"
 
 	corev1 "k8s.io/api/core/v1"
@@ -90,22 +89,23 @@ func TestUserClusterMetrics(ctx context.Context, log *zap.SugaredLogger, opts *c
 	}
 
 	expected := sets.New(
+		// etcd
 		"etcd_disk_backend_defrag_duration_seconds_sum",
-		"kube_daemonset_labels",
+		// kube-state-metrics
+		"kube_configmap_info",
+		// user cluster kubelets
 		"kubelet_runtime_operations_duration_seconds_count",
+		// machine-controller
 		"machine_controller_machines_total",
+		// kube controller-manager
 		"replicaset_controller_sorting_deletion_age_ratio_bucket",
+		// kube apiserver
 		"apiserver_request_total",
-		"workqueue_retries_total",
+		// kube scheduler
+		"scheduler_schedule_attempts_total",
+		// cadvisor
 		"machine_cpu_cores",
 	)
-
-	if cluster.Spec.Version.LessThan(semver.NewSemverOrDie("v1.23.0")) {
-		expected.Insert("scheduler_e2e_scheduling_duration_seconds_count")
-	} else {
-		// this metric is only available in 1.23 and replaces scheduler_e2e_scheduling_duration_seconds_counts
-		expected.Insert("scheduler_scheduling_attempt_duration_seconds_count")
-	}
 
 	fetched := sets.New(data.Data...)
 	missing := expected.Difference(fetched)

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics.yaml
@@ -15,7 +15,7 @@ spec:
   template:
     metadata:
       annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:
@@ -38,7 +38,16 @@ spec:
         - '{"command":"/kube-state-metrics","args":["--kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","--port","8080","--telemetry-port","8081"]}'
         command:
         - /http-prober-bin/http-prober
-        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.8.2
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.12.0
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 15
         name: kube-state-metrics
         ports:
         - containerPort: 8080
@@ -50,7 +59,7 @@ spec:
         readinessProbe:
           failureThreshold: 3
           httpGet:
-            path: /healthz
+            path: /
             port: 8080
             scheme: HTTP
           periodSeconds: 10
@@ -58,15 +67,28 @@ spec:
           timeoutSeconds: 15
         resources:
           limits:
-            cpu: 100m
+            cpu: 150m
             memory: 1Gi
           requests:
-            cpu: 10m
-            memory: 12Mi
+            cpu: 50m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 65534
+          runAsNonRoot: true
+          runAsUser: 65534
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         - mountPath: /etc/kubernetes/kubeconfig
           name: kube-state-metrics-kubeconfig
           readOnly: true
+        - mountPath: /tmp
+          name: tmp
         - mountPath: /http-prober-bin
           name: http-prober-bin
       imagePullSecrets:
@@ -82,10 +104,14 @@ spec:
         volumeMounts:
         - mountPath: /http-prober-bin
           name: http-prober-bin
+      securityContext:
+        fsGroup: 65534
       volumes:
       - name: kube-state-metrics-kubeconfig
         secret:
           secretName: kube-state-metrics-kubeconfig
+      - emptyDir: {}
+        name: tmp
       - emptyDir: {}
         name: http-prober-bin
 status: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This aligns the KSM version for userclusters with the version we have for the seed. I also added more security context options and raised the resources a bit, in line with a random upstream chart: https://artifacthub.io/packages/helm/bitnami/kube-state-metrics

Since KSM 2.10+ disables the `_labels` metrics by default, I checked where we need those and if we can leave them disabled. It turns out we need the `_labels` metrics in 4 different spots:

* for the `KubePersistentVolumeFillingUp` alerts in the Seed MLA; these rules rely on `kube_persistentvolumeclaim_labels{label_excluded_from_alerts="true"}` to be provided by the seed-KSM (i.e. the one from our Helm chart). Interestingly, our Seed-KSM is not configured to provide this label, so this PR also fixes that slight oversight.
* Some recording rules require `sum(kube_pod_labels{job="kube-state-metrics"}) by (namespace, pod, label_app)`. That is fine, `app` is already an enabled Pod label.
* The recording rule for `:ready_kube_controller_managers:sum` relies on `(sum by (pod) (kube_pod_labels{label_component="kube-controller-manager"}))` -- also fine.
* Likewise, `:ready_kube_schedulers:sum` does the same.

So besides the missing PVC labels, we gucci. None of the labels are federated out of a usercluster Prometheus into the seed Prometheus.

Since we do not enable `_labels` metrics anymore, I adjusted the conformance-tester to instead check for another KSM-provided metric.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update usercluster kube-state-metrics to 2.12.0
```

**Documentation**:
```documentation
NONE
```
