### PR TITLE
Add signout_url_redirect for external OIDC provider

### DIFF
--- a/charts/monitoring/grafana/config/grafana.ini
+++ b/charts/monitoring/grafana/config/grafana.ini
@@ -4,6 +4,7 @@ admin_user = {{ .Values.grafana.user | quote }}
 
 [auth]
 disable_login_form = {{ .Values.grafana.provisioning.configuration.disable_login_form }}
+signout_redirect_url = {{ .Values.grafana.provisioning.configuration.signout_redirect_url }}
 
 [auth.basic]
 enabled = false

--- a/charts/monitoring/grafana/config/grafana.ini
+++ b/charts/monitoring/grafana/config/grafana.ini
@@ -4,7 +4,9 @@ admin_user = {{ .Values.grafana.user | quote }}
 
 [auth]
 disable_login_form = {{ .Values.grafana.provisioning.configuration.disable_login_form }}
+{{ if .Values.grafana.provisioning.configuration.signout_redirect_url }}
 signout_redirect_url = {{ .Values.grafana.provisioning.configuration.signout_redirect_url }}
+{{- end }}
 
 [auth.basic]
 enabled = false

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -117,7 +117,7 @@ grafana:
       disable_login_form: true
 
       # Change this to the URL that will be used to redirect the user
-      # to after signing out from Grafana whne using external OIDC.
+      # to after signing out from Grafana when using external OIDC.
       signout_redirect_url: ""
 
       # Set this to true to allow Viewers to

--- a/charts/monitoring/grafana/values.yaml
+++ b/charts/monitoring/grafana/values.yaml
@@ -116,6 +116,10 @@ grafana:
       # credentials defined above.
       disable_login_form: true
 
+      # Change this to the URL that will be used to redirect the user
+      # to after signing out from Grafana whne using external OIDC.
+      signout_redirect_url: ""
+
       # Set this to true to allow Viewers to
       # edit existing dashboards and explore datasources.
       # Viewers will still not be able to save these changes back


### PR DESCRIPTION
**What this PR does / why we need it**:
If an external OIDC provider is used it would be great to be able to signout and also to end the session in the provider itself.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind feature

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
monitoring: introduce `signout_redirect_url` field to configure the URL to redirect the user to after signing out from Grafana
```

**Documentation**:
link for documentation: [URL redirect after signing out](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/#url-redirect-after-signing-out)

<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/#url-redirect-after-signing-out
```
