### PR TITLE
Change Azure load balancer SKU default value to Standard

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster.go
+++ b/pkg/apis/kubermatic/v1/cluster.go
@@ -1075,7 +1075,7 @@ type AzureCloudSpec struct {
 	// at cluster creation and `AssignAvailabilitySet` is set to `true`, a new availability set will be created and this field
 	// will be updated to the generated availability set's name.
 	AvailabilitySet string `json:"availabilitySet"`
-	// LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used.
+	// LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "standard" will be used.
 	LoadBalancerSKU LBSKU `json:"loadBalancerSKU"` //nolint:tagliatelle
 }
 

--- a/pkg/apis/kubermatic/v1/preset.go
+++ b/pkg/apis/kubermatic/v1/preset.go
@@ -188,7 +188,7 @@ type Azure struct {
 	// If set to empty string at cluster creation, a new security group will be created and this field will be updated to
 	// the generated security group's name. If no subnet is defined at cluster creation, this field should be empty as well.
 	SecurityGroup string `json:"securityGroup,omitempty"`
-	// LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used
+	// LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "standard" will be used
 	LoadBalancerSKU LBSKU `json:"loadBalancerSKU"` //nolint:tagliatelle
 }
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clusters.yaml
@@ -513,7 +513,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         loadBalancerSKU:
-                          description: LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used.
+                          description: LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "standard" will be used.
                           enum:
                             - standard
                             - basic

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -504,7 +504,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         loadBalancerSKU:
-                          description: LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used.
+                          description: LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "standard" will be used.
                           enum:
                             - standard
                             - basic

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_presets.yaml
@@ -182,7 +182,7 @@ spec:
                       description: Only enabled presets will be available in the KKP dashboard.
                       type: boolean
                     loadBalancerSKU:
-                      description: LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "basic" will be used
+                      description: LoadBalancerSKU sets the LB type that will be used for the Azure cluster, possible values are "basic" and "standard", if empty, "standard" will be used
                       enum:
                         - standard
                         - basic

--- a/pkg/provider/cloud/azure/provider.go
+++ b/pkg/provider/cloud/azure/provider.go
@@ -292,7 +292,7 @@ func (a *Azure) DefaultCloudSpec(ctx context.Context, clusterSpec *kubermaticv1.
 	}
 
 	if clusterSpec.Cloud.Azure.LoadBalancerSKU == "" {
-		clusterSpec.Cloud.Azure.LoadBalancerSKU = kubermaticv1.AzureBasicLBSKU
+		clusterSpec.Cloud.Azure.LoadBalancerSKU = kubermaticv1.AzureStandardLBSKU
 	}
 
 	if clusterSpec.Cloud.Azure.NodePortsAllowedIPRanges == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Change Azure load balancer SKU default value to Standard. On 30 September 2025, Azure Basic Load Balancer will be retired. You can continue to use your existing Basic Load Balancers until then, but you'll no longer be able to deploy new ones after 31 March 2025.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13069

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Change Azure load balancer SKU default value to Standard 
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
