### PR TITLE
Enable local command for Enterprise Edition

### DIFF
--- a/cmd/kubermatic-installer/main_ee.go
+++ b/cmd/kubermatic-installer/main_ee.go
@@ -40,6 +40,7 @@ func addCommands(cmd *cobra.Command, logger *logrus.Logger, versions kubermaticv
 		PrintCommand(),
 		VersionCommand(logger, versions),
 		MirrorImagesCommand(logger, versions),
+		LocalCommand(logger),
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Even though the `local kind` command is there just to test KKP out, I still don't see any reason for omitting it out from the Enterprise Edition.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable local command for Enterprise Edition
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
https://github.com/kubermatic/docs/pull/1671
```
/kind bug
/assign @xrstf 