### PR TITLE
[release/v2.25] Add CSIDrivers for DigitalOcean and Azure File in Kubernetes 1.29

### DIFF
--- a/addons/csi/azure-file/csi-azurefile-driver.yaml
+++ b/addons/csi/azure-file/csi-azurefile-driver.yaml
@@ -32,6 +32,10 @@
 {{ $version = "v1.28.3" }}
 {{ $snapshot = "v6.2.1" }}
 {{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.29" }}
+{{ $version = "v1.29.2" }}
+{{ $snapshot = "v6.2.2" }}
+{{ end }}
 
 ---
 apiVersion: storage.k8s.io/v1

--- a/addons/csi/digitalocean/csi-driver.yaml
+++ b/addons/csi/digitalocean/csi-driver.yaml
@@ -34,6 +34,9 @@
 {{ if eq .Cluster.MajorMinorVersion "1.28" }}
 {{ $version = "v4.7.1" }}
 {{ end }}
+{{ if eq .Cluster.MajorMinorVersion "1.29" }}
+{{ $version = "v4.8.0" }}
+{{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}
 ---


### PR DESCRIPTION
**What this PR does / why we need it**:
I recently noticed that we missed configuring the CSIDrivers for AzureFile and Digitalocean in Kubernetes 1.29. #13314 fixes it for the main branch, but cannot be backported.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add CSIDriver support for DigitalOcean and Azure File in Kubernetes 1.29.
```

**Documentation**:
```documentation
NONE
```
