### PR TITLE
Improve helm repository prefix handling for system applications

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -452,7 +452,7 @@ spec:
       # The Secret must exist in the namespace where KKP is installed (default is "kubermatic").
       # The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to "helm".
       helmRegistryConfigFile: null
-      # HelmRepository specifies OCI repository containing Helm charts of system Applications.
+      # HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
       helmRepository: quay.io/kubermatic/helm-charts
   # Versions configures the available and default Kubernetes versions and updates.
   versions:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -452,7 +452,7 @@ spec:
       # The Secret must exist in the namespace where KKP is installed (default is "kubermatic").
       # The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to "helm".
       helmRegistryConfigFile: null
-      # HelmRepository specifies OCI repository containing Helm charts of system Applications.
+      # HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
       helmRepository: quay.io/kubermatic/helm-charts
   # Versions configures the available and default Kubernetes versions and updates.
   versions:

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -324,7 +324,7 @@ type KubermaticAddonsConfiguration struct {
 
 // SystemApplicationsConfiguration contains configuration for system Applications (e.g. CNI).
 type SystemApplicationsConfiguration struct {
-	// HelmRepository specifies OCI repository containing Helm charts of system Applications.
+	// HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
 	HelmRepository string `json:"helmRepository,omitempty"`
 	// HelmRegistryConfigFile optionally holds the ref and key in the secret for the OCI registry credential file.
 	// The value is dockercfg file that follows the same format rules as ~/.docker/config.json

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -35,12 +35,15 @@ import (
 
 const (
 	ciliumHelmChartName = "cilium"
-
 	ciliumImageRegistry = "quay.io/cilium/"
+	ociPrefix           = "oci://"
 )
 
 func toOciUrl(s string) string {
-	return "oci://" + s
+	if strings.HasPrefix(s, ociPrefix) {
+		return s
+	}
+	return ociPrefix + s
 }
 
 // ApplicationDefinitionReconciler creates Cilium ApplicationDefinition managed by KKP to be used

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -2316,7 +2316,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         helmRepository:
-                          description: HelmRepository specifies OCI repository containing Helm charts of system Applications.
+                          description: HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
                           type: string
                       type: object
                   type: object

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -556,7 +556,7 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 		return configCopy, err
 	}
 
-	if err := defaultDockerRepo(&configCopy.Spec.UserCluster.SystemApplications.HelmRepository, DefaultSystemApplicationsHelmRepository, "userCluster.systemApplications.helmRepository", logger); err != nil {
+	if err := defaultHelmRepo(&configCopy.Spec.UserCluster.SystemApplications.HelmRepository, DefaultSystemApplicationsHelmRepository, "userCluster.systemApplications.helmRepository", logger); err != nil {
 		return configCopy, err
 	}
 
@@ -605,6 +605,15 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 	}
 
 	return configCopy, nil
+}
+
+func defaultHelmRepo(repo *string, defaultRepo string, key string, logger *zap.SugaredLogger) error {
+	if *repo != "" && strings.HasPrefix(*repo, "oci://") {
+		normalizedRepo := strings.TrimPrefix(*repo, "oci://")
+		return defaultDockerRepo(&normalizedRepo, defaultRepo, key, logger)
+	}
+
+	return defaultDockerRepo(repo, defaultRepo, key, logger)
 }
 
 func defaultDockerRepo(repo *string, defaultRepo string, key string, logger *zap.SugaredLogger) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
I'm labeling this as a bug since the way `systemApplications.helmRepository` is treated in the code-behind, prepending `oci://` without checking the provided value is wrong. Since in apps we always expect an absolute URL with the protocol, see https://github.com/kubermatic/kubermatic/blob/release/v2.25/pkg/apis/apps.kubermatic/v1/application_definition.go#L54-L57 as an example.

The current behavior adds unpredictableness to the process and if we specify a URL with protocol, we end up with errors like:

```
"failed to apply default values: invalid docker repository 'oci://registry.ixcloud.ch/kubermatic-helm-charts' configured for userCluster.systemApplications.helmRepository: invalid reference format"
``` 

Which doesn't make a lot of sense. I have also added an example in the documentation for the field to at least give end users a point of reference of how the value looks like.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:
An alternative to this is to just document an example like https://github.com/kubermatic/kubermatic/pull/13336/files#diff-40a7434d85c7c187ef87f7374ca2c5668950cd3d27b521c2e07e2a6500e49fe9R455 without `oci://` prefix and just leave it up to the users to "read the docs".

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improve helm repository prefix handling for system applications; only prepend `oci://` prefix if it doesn't already exist in the specified URL
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/assign @karol