### PR TITLE
[release/v2.23] Improve helm repository prefix handling for system applications

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -506,7 +506,7 @@ spec:
       # The Secret must exist in the namespace where KKP is installed (default is "kubermatic").
       # The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to "helm".
       helmRegistryConfigFile: null
-      # HelmRepository specifies OCI repository containing Helm charts of system Applications.
+      # HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
       helmRepository: quay.io/kubermatic/helm-charts
   # Versions configures the available and default Kubernetes versions and updates.
   versions:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -506,7 +506,7 @@ spec:
       # The Secret must exist in the namespace where KKP is installed (default is "kubermatic").
       # The Secret must be annotated with `apps.kubermatic.k8c.io/secret-type:` set to "helm".
       helmRegistryConfigFile: null
-      # HelmRepository specifies OCI repository containing Helm charts of system Applications.
+      # HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
       helmRepository: quay.io/kubermatic/helm-charts
   # Versions configures the available and default Kubernetes versions and updates.
   versions:

--- a/pkg/apis/kubermatic/v1/configuration.go
+++ b/pkg/apis/kubermatic/v1/configuration.go
@@ -313,7 +313,7 @@ type KubermaticAddonsConfiguration struct {
 
 // SystemApplicationsConfiguration contains configuration for system Applications (e.g. CNI).
 type SystemApplicationsConfiguration struct {
-	// HelmRepository specifies OCI repository containing Helm charts of system Applications.
+	// HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
 	HelmRepository string `json:"helmRepository,omitempty"`
 	// HelmRegistryConfigFile optionally holds the ref and key in the secret for the OCI registry credential file.
 	// The value is dockercfg file that follows the same format rules as ~/.docker/config.json

--- a/pkg/cni/cilium/cilium.go
+++ b/pkg/cni/cilium/cilium.go
@@ -34,9 +34,16 @@ import (
 
 const (
 	ciliumHelmChartName = "cilium"
-
 	ciliumImageRegistry = "quay.io/cilium/"
+	ociPrefix           = "oci://"
 )
+
+func toOciUrl(s string) string {
+	if strings.HasPrefix(s, ociPrefix) {
+		return s
+	}
+	return ociPrefix + s
+}
 
 // ApplicationDefinitionReconciler creates Cilium ApplicationDefinition managed by KKP to be used
 // for installing Cilium CNI into KKP usr clusters.
@@ -69,7 +76,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.0",
-								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -82,7 +89,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.3",
-								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -95,7 +102,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.4",
-								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -108,7 +115,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.6",
-								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -121,7 +128,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.7",
-								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},
@@ -134,7 +141,7 @@ func ApplicationDefinitionReconciler(config *kubermaticv1.KubermaticConfiguratio
 							Helm: &appskubermaticv1.HelmSource{
 								ChartName:    ciliumHelmChartName,
 								ChartVersion: "1.13.8",
-								URL:          "oci://" + config.Spec.UserCluster.SystemApplications.HelmRepository,
+								URL:          toOciUrl(config.Spec.UserCluster.SystemApplications.HelmRepository),
 								Credentials:  credentials,
 							},
 						},

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticconfigurations.yaml
@@ -1460,7 +1460,7 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         helmRepository:
-                          description: HelmRepository specifies OCI repository containing Helm charts of system Applications.
+                          description: HelmRepository specifies OCI repository containing Helm charts of system Applications e.g. oci://localhost:5000/myrepo.
                           type: string
                       type: object
                   type: object

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -607,7 +607,7 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 		return configCopy, err
 	}
 
-	if err := defaultDockerRepo(&configCopy.Spec.UserCluster.SystemApplications.HelmRepository, DefaultSystemApplicationsHelmRepository, "userCluster.systemApplications.helmRepository", logger); err != nil {
+	if err := defaultHelmRepo(&configCopy.Spec.UserCluster.SystemApplications.HelmRepository, DefaultSystemApplicationsHelmRepository, "userCluster.systemApplications.helmRepository", logger); err != nil {
 		return configCopy, err
 	}
 
@@ -656,6 +656,15 @@ func DefaultConfiguration(config *kubermaticv1.KubermaticConfiguration, logger *
 	}
 
 	return configCopy, nil
+}
+
+func defaultHelmRepo(repo *string, defaultRepo string, key string, logger *zap.SugaredLogger) error {
+	if *repo != "" && strings.HasPrefix(*repo, "oci://") {
+		normalizedRepo := strings.TrimPrefix(*repo, "oci://")
+		return defaultDockerRepo(&normalizedRepo, defaultRepo, key, logger)
+	}
+
+	return defaultDockerRepo(repo, defaultRepo, key, logger)
 }
 
 func defaultDockerRepo(repo *string, defaultRepo string, key string, logger *zap.SugaredLogger) error {


### PR DESCRIPTION
This is a **manual** cherry-pick of https://github.com/kubermatic/kubermatic/pull/13336

/assign ahmedwaleedmalik

```release-note
Improve helm repository prefix handling for system applications; only prepend `oci://` prefix if it doesn't already exist in the specified URL
```

/kind bug