### PR TITLE
Add an option to enable etcd backups in k8c settings

### DIFF
--- a/pkg/apis/kubermatic/v1/settings.go
+++ b/pkg/apis/kubermatic/v1/settings.go
@@ -73,6 +73,9 @@ type SettingSpec struct {
 	// EnableClusterBackup enables the Cluster Backup feature in the dashboard.
 	EnableClusterBackups *bool `json:"enableClusterBackup,omitempty"`
 
+	// EnableEtcdBackup enables the etcd Backup feature in the dashboard.
+	EnableEtcdBackup bool `json:"enableEtcdBackup,omitempty"`
+
 	// DisableAdminKubeconfig disables the admin kubeconfig functionality on the dashboard.
 	DisableAdminKubeconfig bool `json:"disableAdminKubeconfig,omitempty"`
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_kubermaticsettings.yaml
@@ -139,6 +139,9 @@ spec:
                 enableDashboard:
                   description: EnableDashboard enables the link to the Kubernetes dashboard for a user cluster.
                   type: boolean
+                enableEtcdBackup:
+                  description: EnableEtcdBackup enables the etcd Backup feature in the dashboard.
+                  type: boolean
                 enableExternalClusterImport:
                   type: boolean
                 enableOIDCKubeconfig:


### PR DESCRIPTION
**What this PR does / why we need it**:

add new option in admin settings to enable/disable etcd backups.

**Which issue(s) this PR fixes**:

ref [#6677](https://github.com/kubermatic/dashboard/issues/6677)

**What type of PR is this?**
/kind feature

```release-note
Add new admin option to enable/disable etcd Backups
```

```documentation
NONE
```