### PR TITLE
[release/v2.24] bump OSM to 1.4.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -81,7 +81,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.12.2
 	k8c.io/kubeone v1.7.0
-	k8c.io/operating-system-manager v1.4.1
+	k8c.io/operating-system-manager v1.4.2
 	k8c.io/reconciler v0.4.0
 	k8s.io/api v0.28.2
 	k8s.io/apiextensions-apiserver v0.28.2

--- a/go.sum
+++ b/go.sum
@@ -1880,8 +1880,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8c.io/kubeone v1.7.0 h1:HDUHcGZWw8v2cN1KWmeUfXVquppqlQLmDgMZdWfg1hA=
 k8c.io/kubeone v1.7.0/go.mod h1:v/rybawEit3+HXPOtHyFyww0laqGzcxL0EJmdiJqQNo=
-k8c.io/operating-system-manager v1.4.1 h1:hUL6YA1h2i0IpiobohsQuIbsz7vDRNsKGEZuO/loPpo=
-k8c.io/operating-system-manager v1.4.1/go.mod h1:4buJRqOn406AYiQ7FGs4tXaySgb6Ro6Hffp6gu6FHY8=
+k8c.io/operating-system-manager v1.4.2 h1:VWbwLvULU6njCNoS/DKaGUbbcJTmnmXYWcYbNe6ka8E=
+k8c.io/operating-system-manager v1.4.2/go.mod h1:4buJRqOn406AYiQ7FGs4tXaySgb6Ro6Hffp6gu6FHY8=
 k8c.io/reconciler v0.4.0 h1:movw1R8Q0/JC8S+d6eq9si5PvLFbX3A0x8yaDlxuFn4=
 k8c.io/reconciler v0.4.0/go.mod h1:oQ9wCN6WyARwRn/8QWTSs3HlQg+7GxWjg45MISLsdD0=
 k8s.io/api v0.28.2 h1:9mpl5mOb6vXZvqbQmankOfPIGiudghwCoLl1EYfUZbw=

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -57,7 +57,7 @@ var (
 )
 
 const (
-	Tag = "v1.4.1"
+	Tag = "v1.4.2"
 )
 
 type operatingSystemManagerData interface {

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.26.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.26.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -61,7 +61,7 @@ spec:
             secretKeyRef:
               key: subscriptionID
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.26.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.26.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system","-external-cloud-provider"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.26.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -46,7 +46,7 @@ spec:
             secretKeyRef:
               key: serviceAccount
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.26.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -82,7 +82,7 @@ spec:
               key: applicationCredentialSecret
               name: cloud-credentials
               optional: true
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.26.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -40,7 +40,7 @@ spec:
         - '{"command":"/usr/local/bin/osm-controller","args":["-kubeconfig","/etc/kubernetes/kubeconfig/kubeconfig","-cluster-dns","169.254.20.10","-health-probe-address","0.0.0.0:8085","-metrics-address","0.0.0.0:8080","-namespace","kube-system"]}'
         command:
         - /http-prober-bin/http-prober
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.26.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: KUBECONFIG
           value: /etc/kubernetes/worker-kubeconfig/kubeconfig
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 8
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -53,7 +53,7 @@ spec:
             secretKeyRef:
               key: password
               name: cloud-credentials
-        image: quay.io/kubermatic/operating-system-manager:v1.4.1
+        image: quay.io/kubermatic/operating-system-manager:v1.4.2
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
This gives us kubermatic/operating-system-manager#381.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* Update operating-system-manager to v1.4.2.
* [ACTION REQUIRED] The latest Ubuntu 22.04 images ship with cloud-init 24.x package. This package has breaking changes and thus rendered our OSPs as incompatible. It's recommended to refresh your machines with latest provided OSPs to ensure that a system-wide package update, that updates cloud-init to 24.x, doesn't break the machines.
```

**Documentation**:
```documentation
NONE
```
