### PR TITLE
Add gzip support for etcd snapshots

### DIFF
--- a/cmd/etcd-launcher/cmd_snapshot.go
+++ b/cmd/etcd-launcher/cmd_snapshot.go
@@ -17,10 +17,16 @@ limitations under the License.
 package main
 
 import (
+	"compress/gzip"
+	"context"
 	"fmt"
+	"io"
+	"os"
+	"slices"
 	"strings"
 
 	"github.com/spf13/cobra"
+	client "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/etcdutl/v3/snapshot"
 	"go.uber.org/zap"
 
@@ -30,8 +36,11 @@ import (
 type snapshotOptions struct {
 	options
 
-	file string
+	file        string
+	compression string
 }
+
+var validCompressions = []string{"gzip"}
 
 func SnapshotCommand(log *zap.SugaredLogger) *cobra.Command {
 	opt := snapshotOptions{}
@@ -43,6 +52,10 @@ func SnapshotCommand(log *zap.SugaredLogger) *cobra.Command {
 		SilenceUsage: true,
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			opts.CopyInto(&opt.options)
+
+			if opt.compression != "" && !slices.Contains(validCompressions, opt.compression) {
+				return fmt.Errorf("invalid --compression algorithm, must be one of %v", validCompressions)
+			}
 
 			return nil
 		},
@@ -57,6 +70,7 @@ func SnapshotCommand(log *zap.SugaredLogger) *cobra.Command {
 		return err
 	})
 
+	cmd.PersistentFlags().StringVar(&opt.compression, "compress", "", fmt.Sprintf("compression to use (one of: %v)", validCompressions))
 	cmd.PersistentFlags().StringVar(&opt.file, "file", "/backup/snapshot.db", "file to save database snapshot to")
 
 	return cmd
@@ -94,28 +108,77 @@ func SnapshotFunc(log *zap.SugaredLogger, opt *snapshotOptions) cobraFuncE {
 		// or autoscaling-caused rescheduling event is happening). So we loop
 		// over all endpoints and try to take a snapshot.
 		for _, config := range configs {
+			clog := log.With("endpoints", strings.Join(config.Endpoints, ","))
+
 			if len(config.Endpoints) != 1 {
-				log.Warnw("unexpected number of endpoints, skipping this configuration", "endpoints", strings.Join(config.Endpoints, ","))
+				clog.Warn("unexpected number of endpoints, skipping this configuration")
 				continue
 			}
 
-			snapv3 := snapshot.NewV3(log.Desugar())
-			err := snapv3.Save(ctx, config, opt.file)
+			err := createSnapshot(ctx, clog, config, opt)
 
 			// if the snapshot was successful, we have what we want and do not
 			// need to loop over the remaining endpoints. We can exit the program
 			// successfully then.
 			if err == nil {
-				log.Infow("saved snapshot from endpoint", "endpoint", strings.Join(config.Endpoints, ","), "file", opt.file)
+				clog.Infow("saved snapshot from endpoint", "file", opt.file)
 				return nil
 			}
 
 			// log an error if we were not able to take a snapshot, before the loop
 			// moves on to the next one.
-			log.Errorw("failed to save snapshot from endpoint, trying next endpoint", "endpoint", strings.Join(config.Endpoints, ","), zap.Error(err))
+			clog.Errorw("failed to save snapshot from endpoint, trying next endpoint", zap.Error(err))
 		}
 
 		// we failed to take any snapshot, so we need to exit the program with an error.
 		return fmt.Errorf("exhausted all endpoints, no snapshot was successful")
 	})
+}
+
+func createSnapshot(ctx context.Context, log *zap.SugaredLogger, etcdConfig client.Config, opt *snapshotOptions) error {
+	snapv3 := snapshot.NewV3(log.Desugar())
+
+	if opt.compression == "" {
+		return snapv3.Save(ctx, etcdConfig, opt.file)
+	}
+
+	tmpFile := opt.file + ".tmp"
+	defer os.Remove(tmpFile)
+
+	err := snapv3.Save(ctx, etcdConfig, tmpFile)
+	if err != nil {
+		return err
+	}
+
+	compressedFile, err := os.Create(opt.file)
+	if err != nil {
+		return err
+	}
+	defer compressedFile.Close()
+
+	rawFile, err := os.Open(tmpFile)
+	if err != nil {
+		return err
+	}
+	defer rawFile.Close()
+
+	var compressor io.WriteCloser
+
+	switch opt.compression {
+	case "gzip":
+		compressor, err = gzip.NewWriterLevel(compressedFile, gzip.BestCompression)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown compression algorithm %q", opt.compression)
+	}
+
+	defer compressor.Close()
+
+	if _, err = io.Copy(compressor, rawFile); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/etcd-launcher/pkg/etcd/snapshot.go
+++ b/cmd/etcd-launcher/pkg/etcd/snapshot.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2023 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package etcd
+
+import (
+	"compress/gzip"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	client "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/etcdutl/v3/snapshot"
+	"go.uber.org/zap"
+)
+
+type SnapshotOptions struct {
+	File        string
+	Compression string
+}
+
+var ValidCompressions = []string{"gzip"}
+
+func CreateSnapshot(ctx context.Context, log *zap.SugaredLogger, etcdConfig client.Config, opt *SnapshotOptions) error {
+	snapv3 := snapshot.NewV3(log.Desugar())
+
+	if opt.Compression == "" {
+		return snapv3.Save(ctx, etcdConfig, opt.File)
+	}
+
+	tmpFile := opt.File + ".tmp"
+	defer os.Remove(tmpFile)
+
+	err := snapv3.Save(ctx, etcdConfig, tmpFile)
+	if err != nil {
+		return err
+	}
+
+	compressedFile, err := os.Create(opt.File)
+	if err != nil {
+		return err
+	}
+	defer compressedFile.Close()
+
+	rawFile, err := os.Open(tmpFile)
+	if err != nil {
+		return err
+	}
+	defer rawFile.Close()
+
+	var compressor io.WriteCloser
+
+	switch opt.Compression {
+	case "gzip":
+		compressor, err = gzip.NewWriterLevel(compressedFile, gzip.BestCompression)
+		if err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unknown compression algorithm %q", opt.Compression)
+	}
+
+	defer compressor.Close()
+
+	if _, err = io.Copy(compressor, rawFile); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func DecompressSnapshot(filename string) (string, error) {
+	ext := filepath.Ext(filename)
+
+	switch ext {
+	case ".db":
+		return filename, nil
+
+	case ".gz", ".gzip":
+		rawFilename := strings.TrimSuffix(filename, ext)
+
+		rawFile, err := os.Create(rawFilename)
+		if err != nil {
+			return "", err
+		}
+		defer rawFile.Close()
+
+		compressedFile, err := os.Open(filename)
+		if err != nil {
+			return "", err
+		}
+		defer compressedFile.Close()
+
+		var decompressor io.ReadCloser
+
+		switch ext {
+		case ".gz", ".gzip":
+			decompressor, err = gzip.NewReader(compressedFile)
+			if err != nil {
+				return "", err
+			}
+		default:
+			panic("Inner switch statement is out-of-sync with outer switch statement.")
+		}
+
+		defer decompressor.Close()
+
+		if _, err = io.Copy(rawFile, decompressor); err != nil {
+			return "", err
+		}
+
+		return rawFilename, nil
+
+	default:
+		return "", fmt.Errorf("unsupported backup file extension %q", ext)
+	}
+}

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -222,7 +222,7 @@ spec:
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \
           --host-bucket='%(bucket).'$ENDPOINT \
-          put /backup/snapshot.db s3://$BUCKET_NAME/$CLUSTER-$BACKUP_TO_CREATE
+          put /backup/snapshot.db.gz s3://$BUCKET_NAME/$CLUSTER-$BACKUP_TO_CREATE
       volumeMounts:
       - name: etcd-backup
         mountPath: /backup

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -222,7 +222,7 @@ spec:
           --secret_key=$SECRET_ACCESS_KEY \
           --host=$ENDPOINT \
           --host-bucket='%(bucket).'$ENDPOINT \
-          put /backup/snapshot.db s3://$BUCKET_NAME/$CLUSTER-$BACKUP_TO_CREATE
+          put /backup/snapshot.db.gz s3://$BUCKET_NAME/$CLUSTER-$BACKUP_TO_CREATE
       volumeMounts:
       - name: etcd-backup
         mountPath: /backup

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller.go
@@ -381,7 +381,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		backupConfig.Status.CurrentBackups = []kubermaticv1.BackupStatus{{}}
 		backupToSchedule = &backupConfig.Status.CurrentBackups[0]
 		backupToSchedule.ScheduledTime = metav1.NewTime(r.clock.Now())
-		backupToSchedule.BackupName = fmt.Sprintf("%s.db", backupConfig.Name)
+		backupToSchedule.BackupName = fmt.Sprintf("%s.db.gz", backupConfig.Name)
 		requeueAfter = 0
 	} else {
 		// compute the pending (i.e. latest past) and the next (i.e. earliest future) backup time,
@@ -414,7 +414,7 @@ func (r *Reconciler) ensurePendingBackupIsScheduled(ctx context.Context, backupC
 		backupConfig.Status.CurrentBackups = append(backupConfig.Status.CurrentBackups, kubermaticv1.BackupStatus{})
 		backupToSchedule = &backupConfig.Status.CurrentBackups[len(backupConfig.Status.CurrentBackups)-1]
 		backupToSchedule.ScheduledTime = metav1.NewTime(pendingBackupTime)
-		backupToSchedule.BackupName = fmt.Sprintf("%s-%s.db", backupConfig.Name, backupToSchedule.ScheduledTime.UTC().Format("2006-01-02t15-04-05"))
+		backupToSchedule.BackupName = fmt.Sprintf("%s-%s.db.gz", backupConfig.Name, backupToSchedule.ScheduledTime.UTC().Format("2006-01-02t15-04-05"))
 		requeueAfter = nextBackupTime.Sub(now)
 	}
 

--- a/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
+++ b/pkg/controller/seed-controller-manager/etcdbackup/etcd_backup_controller_test.go
@@ -221,7 +221,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(10, 0).UTC()),
-					BackupName:    "testbackup.db",
+					BackupName:    "testbackup.db.gz",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -328,7 +328,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 				},
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(1200, 0).UTC()),
-					BackupName:    "testbackup-1970-01-01t00-20-00.db",
+					BackupName:    "testbackup-1970-01-01t00-20-00.db.gz",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -347,7 +347,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(3600*24*15, 0).UTC()),
-					BackupName:    "testbackup-1970-01-16t00-00-00.db",
+					BackupName:    "testbackup-1970-01-16t00-00-00.db.gz",
 					JobName:       "testcluster-backup-testbackup-create-xxxx",
 					DeleteJobName: "testcluster-backup-testbackup-delete-xxxx",
 				},
@@ -366,7 +366,7 @@ func TestEnsurePendingBackupIsScheduled(t *testing.T) {
 			expectedBackups: []kubermaticv1.BackupStatus{
 				{
 					ScheduledTime: metav1.NewTime(time.Unix(10, 0).UTC()),
-					BackupName:    "long-backup-config-name-abcdefghijk.db",
+					BackupName:    "long-backup-config-name-abcdefghijk.db.gz",
 					JobName:       "testcluster-backup-long-backup-config-name-abcdefghijk-creaxxxx",
 					DeleteJobName: "testcluster-backup-long-backup-config-name-abcdefghijk-delexxxx",
 				},

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -748,7 +748,7 @@ command:
     --secret_key=$SECRET_ACCESS_KEY \
     --host=$ENDPOINT \
     --host-bucket='%(bucket).'$ENDPOINT \
-    put /backup/snapshot.db s3://$BUCKET_NAME/$CLUSTER-$BACKUP_TO_CREATE
+    put /backup/snapshot.db.gz s3://$BUCKET_NAME/$CLUSTER-$BACKUP_TO_CREATE
 volumeMounts:
 - name: etcd-backup
   mountPath: /backup

--- a/pkg/resources/etcd/backup/jobs.go
+++ b/pkg/resources/etcd/backup/jobs.go
@@ -196,7 +196,8 @@ func snapshotCommand(cluster *kubermaticv1.Cluster) []string {
 		"--etcd-client-cert-file=/etc/etcd/pki/client/backup-etcd-client.crt",
 		"--etcd-client-key-file=/etc/etcd/pki/client/backup-etcd-client.key",
 		fmt.Sprintf("--cluster=%s", cluster.Name),
-		"--file=/backup/snapshot.db",
+		"--file=/backup/snapshot.db.gz",
+		"--compress=gzip",
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds basic support for gzipping the etcd snapshot files. For creating those compressed backups, `--compress` has to be set (and is so by KKP), when restoring KKP doesn't care what is configured, but just deduces the compression based on the filename. This is a) because it's simple and b) it would allow admins to retro-actively compress their backups, as long as they also update the status on the EtcdBackupConfig objects.

**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
* etcd snapshots are now gzip-compressed before being uploaded to the backup storage.
* [ACTION REQUIRED] The default backup store container (`spec.seedController.backupStoreContainer` in the `KubermaticConfiguration` needs to upload `/backup/snapshot.db.gz` instead of `/backup/snapshot.db`; if you have customized the store container, please adjust your scripting accordingly. The `BACKUP_TO_CREATE` env variable also now contains the filename with an additional `.gz` ending.
```

**Documentation**:
```documentation
NONE
```
