### PR TITLE
Don't propagate cloud-config secret to user cluster

### DIFF
--- a/addons/csi/azure-disk/csi-azuredisk-controller.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-controller.yaml
@@ -18,7 +18,7 @@
 # - image source includes registry templating
 # - removal of tolerations
 # - set spec.replicas=1 since leader elections are configured
-# - mount cloud-config instead of using host path
+# - mount cloud-config-csi instead of using host path
 # - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
@@ -223,6 +223,6 @@ spec:
           emptyDir: {}
         - name: cloud-config
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
 {{ end }}
 {{ end }}

--- a/addons/csi/azure-disk/csi-azuredisk-node.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-node.yaml
@@ -17,7 +17,7 @@
 # Changes:
 # - image source includes registry templating
 # - removal of scheduling hints
-# - mount cloud-config instead of using host path
+# - mount cloud-config-csi instead of using host path
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
@@ -198,7 +198,7 @@ spec:
             type: Directory
           name: sys-class
         - secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
           name: cloud-config
 ---
 {{ end }}

--- a/addons/csi/azure-file/csi-azurefile-controller.yaml
+++ b/addons/csi/azure-file/csi-azurefile-controller.yaml
@@ -19,7 +19,7 @@
 # - set replicas=1 (pod has a leader election)
 # - removal of tolerations
 # - add security context
-# - mount cloud-config for credentials
+# - mount cloud-config-csi for credentials
 # - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
@@ -218,6 +218,6 @@ spec:
           emptyDir: {}
         - name: cloud-config
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
 {{ end }}
 {{ end }}

--- a/addons/csi/azure-file/csi-azurefile-node.yaml
+++ b/addons/csi/azure-file/csi-azurefile-node.yaml
@@ -17,7 +17,7 @@
 # Changes:
 # - image source includes registry templating
 # - removal of scheduling hints
-# - mount cloud-config instead of using host path
+# - mount cloud-config-csi instead of using host path
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
@@ -183,7 +183,7 @@ spec:
             type: Directory
           name: device-dir
         - secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
           name: cloud-config
 {{ end }}
 {{ end }}

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -20,7 +20,7 @@
 #  - added security context
 #  - make Topology feature gate dynamic
 #  - add KKP CABundle
-#  - load cloud-config
+#  - load cloud-config-csi
 #  - add NetworkPolicy
 #  - add "cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir" annotation to template
 #
@@ -185,7 +185,7 @@ spec:
           emptyDir:
         - name: cloud-config
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
         - name: ca-bundle
           configMap:
             name: ca-bundle

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -159,7 +159,7 @@ spec:
             type: Directory
         - name: secret-cinderplugin
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
         - name: ca-bundle
           configMap:
             name: ca-bundle

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -477,7 +477,7 @@ func (r *Reconciler) GetSecretReconcilers(ctx context.Context, data *resources.T
 	namespace := data.Cluster().Status.NamespaceName
 
 	creators := []reconciling.NamedSecretReconcilerFactory{
-		cloudconfig.SecretReconciler(data),
+		cloudconfig.SecretReconciler(data, resources.CloudConfigSecretName),
 		certificates.RootCAReconciler(data),
 		certificates.FrontProxyCAReconciler(),
 		resources.ImagePullSecretReconciler(r.dockerPullConfigJSON),

--- a/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/deletion.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/cloudcontroller/deletion.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloudcontroller
+
+import (
+	"k8c.io/kubermatic/v2/pkg/resources"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func ResourcesForDeletion(namespace string) []ctrlruntimeclient.Object {
+	return []ctrlruntimeclient.Object{
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resources.CSICloudConfigSecretName,
+				Namespace: namespace,
+			},
+		},
+	}
+}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -276,7 +276,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
-	if !cluster.Spec.DisableCSIDriver {
+	if cluster.Spec.DisableCSIDriver {
 		if err := r.ensureCSIDriverResourcesAreRemoved(ctx); err != nil {
 			return err
 		}

--- a/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/reconciler.go
@@ -83,15 +83,10 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to get userSSHKeys: %w", err)
 	}
-	cloudConfig, err := r.cloudConfig(ctx, resources.CloudConfigSeedSecretName)
-	if err != nil {
-		return fmt.Errorf("failed to get cloudConfig: %w", err)
-	}
 
 	data := reconcileData{
 		caCert:       caCert,
 		userSSHKeys:  userSSHKeys,
-		cloudConfig:  cloudConfig,
 		ccmMigration: r.ccmMigration || r.ccmMigrationCompleted,
 	}
 
@@ -101,8 +96,17 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 	}
 
 	if !cluster.Spec.DisableCSIDriver {
-		if r.cloudProvider == kubermaticv1.VSphereCloudProvider || r.cloudProvider == kubermaticv1.VMwareCloudDirectorCloudProvider || (r.cloudProvider == kubermaticv1.NutanixCloudProvider && r.nutanixCSIEnabled) {
+		if r.cloudProvider == kubermaticv1.VSphereCloudProvider ||
+			r.cloudProvider == kubermaticv1.VMwareCloudDirectorCloudProvider ||
+			(r.cloudProvider == kubermaticv1.NutanixCloudProvider && r.nutanixCSIEnabled) {
 			data.csiCloudConfig, err = r.cloudConfig(ctx, resources.CSICloudConfigSecretName)
+			if err != nil {
+				return fmt.Errorf("failed to get csi config: %w", err)
+			}
+		} else if r.cloudProvider == kubermaticv1.AzureCloudProvider ||
+			r.cloudProvider == kubermaticv1.OpenstackCloudProvider {
+			// Azure and Openstack CSI drivers don't have dedicated CSI cloud config.
+			data.csiCloudConfig, err = r.cloudConfig(ctx, resources.CloudConfigSecretName)
 			if err != nil {
 				return fmt.Errorf("failed to get csi config: %w", err)
 			}
@@ -272,6 +276,12 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		}
 	}
 
+	if !cluster.Spec.DisableCSIDriver {
+		if err := r.ensureCSIDriverResourcesAreRemoved(ctx); err != nil {
+			return err
+		}
+	}
+
 	// This code supports switching between OpenVPN and Konnectivity setup (in both directions).
 	// It can be removed one release after deprecating OpenVPN.
 	if r.isKonnectivityEnabled {
@@ -295,6 +305,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -879,9 +890,7 @@ func (r *reconciler) reconcileConfigMaps(ctx context.Context, data reconcileData
 }
 
 func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) error {
-	creators := []reconciling.NamedSecretReconcilerFactory{
-		cloudcontroller.CloudConfig(data.cloudConfig, resources.CloudConfigSecretName),
-	}
+	creators := []reconciling.NamedSecretReconcilerFactory{}
 	if !r.isKonnectivityEnabled {
 		creators = append(creators, openvpn.ClientCertificate(data.openVPNCACert))
 	} else {
@@ -894,9 +903,12 @@ func (r *reconciler) reconcileSecrets(ctx context.Context, data reconcileData) e
 	}
 
 	if data.csiCloudConfig != nil {
+		if r.cloudProvider == kubermaticv1.AzureCloudProvider || r.cloudProvider == kubermaticv1.OpenstackCloudProvider || r.cloudProvider == kubermaticv1.VSphereCloudProvider {
+			creators = append(creators, cloudcontroller.CloudConfig(data.csiCloudConfig, resources.CSICloudConfigSecretName))
+		}
+
 		if r.cloudProvider == kubermaticv1.VSphereCloudProvider {
-			creators = append(creators, cloudcontroller.CloudConfig(data.csiCloudConfig, resources.CSICloudConfigSecretName),
-				csisnapshotter.TLSServingCertificateReconciler(resources.CSISnapshotValidationWebhookName, data.caCert))
+			creators = append(creators, csisnapshotter.TLSServingCertificateReconciler(resources.CSISnapshotValidationWebhookName, data.caCert))
 			if data.ccmMigration {
 				creators = append(creators, csimigration.TLSServingCertificateReconciler(data.caCert))
 			}
@@ -1158,7 +1170,6 @@ type reconcileData struct {
 	mlaGatewayCACert  *resources.ECDSAKeyPair
 	userSSHKeys       map[string][]byte
 	cloudProviderName string
-	cloudConfig       []byte
 	clusterVersion    semver.Semver
 	// csiCloudConfig is currently used only by vSphere, VMware Cloud Director and Nutanix,
 	// who need it to properly configure the external CSI driver; however this can be nil if the
@@ -1370,6 +1381,16 @@ func (r *reconciler) ensureMLAIsRemoved(ctx context.Context) error {
 		}
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to ensure mla is removed/not present: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *reconciler) ensureCSIDriverResourcesAreRemoved(ctx context.Context) error {
+	for _, resource := range cloudcontroller.ResourcesForDeletion(metav1.NamespaceSystem) {
+		err := r.Client.Delete(ctx, resource)
+		if err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to ensure CSI driver resources are removed/not present: %w", err)
 		}
 	}
 	return nil

--- a/pkg/resources/cloudconfig/secret.go
+++ b/pkg/resources/cloudconfig/secret.go
@@ -44,9 +44,9 @@ type creatorData interface {
 }
 
 // SecretReconciler returns a function to create the Secret containing the cloud-config.
-func SecretReconciler(data creatorData) reconciling.NamedSecretReconcilerFactory {
+func SecretReconciler(data creatorData, name string) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return resources.CloudConfigSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
+		return name, func(cm *corev1.Secret) (*corev1.Secret, error) {
 			if cm.Data == nil {
 				cm.Data = map[string][]byte{}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
The secret `cloud-config` is not required in the user clusters. The only use case for it is the CSI drivers and for that, the `cloud-config-csi` should be used instead of `cloud-config`.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a bug where unrequired  `cloud-config` secret was being propagated to the user clusters
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
