### PR TITLE
Fix null pointer exception while listing storage classes

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -914,10 +914,8 @@ func (r *Reconciler) checkCSIAddonInUse(ctx context.Context, log *zap.SugaredLog
 	}
 
 	// Get CSI drivers created by the csi addon
-	if err := userClusterClient.List(ctx, csiDriverList, csiDriverListOption); apierrors.IsNotFound(err) {
-		return corev1.ConditionUnknown, ""
-	} else if err != nil {
-		return corev1.ConditionUnknown, fmt.Sprintf("failed to list csi drivers with %v label : %v", csiAddonStorageClassLabel, err)
+	if err := userClusterClient.List(ctx, csiDriverList, csiDriverListOption); err != nil {
+		return corev1.ConditionUnknown, fmt.Sprintf("failed to list csi drivers with %v label: %v", csiAddonStorageClassLabel, err)
 	}
 	// map to hold csi drivers to storage classes list
 	csiToSC := make(map[string][]string)
@@ -930,12 +928,12 @@ func (r *Reconciler) checkCSIAddonInUse(ctx context.Context, log *zap.SugaredLog
 		// get all the storage classes that are using the csi driver created by csi addon as provisioner
 		storageCLassList, err := r.storageClassesForProvisioner(ctx, cluster, csiDriverList.Items[i].Name)
 		if err != nil {
-			return corev1.ConditionUnknown, fmt.Sprintf("failed to get the list of storage classes using %v provisioner : %v", csiDriverList.Items[i].Name, err)
+			return corev1.ConditionUnknown, fmt.Sprintf("failed to get the list of storage classes using %v provisioner: %v", csiDriverList.Items[i].Name, err)
 		}
 		for j := 0; j < len(storageCLassList); j++ {
 			pvcList, err := r.pvcsForStorageClass(ctx, cluster, storageCLassList[j])
 			if err != nil {
-				return corev1.ConditionUnknown, fmt.Sprintf("failed to get the list of PVCs referring the %v storage class : %v", storageCLassList[j], err)
+				return corev1.ConditionUnknown, fmt.Sprintf("failed to get the list of PVCs referring the %v storage class: %v", storageCLassList[j], err)
 			}
 			if len(pvcList) > 0 {
 				csiToSC[csiDriverList.Items[i].Name] = append(csiToSC[csiDriverList.Items[i].Name], storageCLassList[j])
@@ -969,10 +967,8 @@ func (r *Reconciler) storageClassesForProvisioner(ctx context.Context, cluster *
 		return storageCLassesForProvisioner, fmt.Errorf("failed to get client for usercluster: %w", err)
 	}
 	storageCLassList := &storagev1.StorageClassList{}
-	if err := cl.List(ctx, storageCLassList); apierrors.IsNotFound(err) {
-		return storageCLassesForProvisioner, nil
-	} else if err != nil {
-		return storageCLassesForProvisioner, fmt.Errorf("failed to get storage classes using provisioner %v : %w", provisionerName, err)
+	if err := cl.List(ctx, storageCLassList); err != nil {
+		return storageCLassesForProvisioner, fmt.Errorf("failed to get storage classes using provisioner %v: %w", provisionerName, err)
 	}
 	for i := 0; i < len(storageCLassList.Items); i++ {
 		if storageCLassList.Items[i].Provisioner == provisionerName {
@@ -989,14 +985,13 @@ func (r *Reconciler) pvcsForStorageClass(ctx context.Context, cluster *kubermati
 		return pvcsForStorageClass, fmt.Errorf("failed to get client for usercluster: %w", err)
 	}
 	pvcList := &corev1.PersistentVolumeClaimList{}
-	if err := cl.List(ctx, pvcList); apierrors.IsNotFound(err) {
-		return pvcsForStorageClass, nil
-	} else if err != nil {
-		return pvcsForStorageClass, fmt.Errorf("failed to get the list of PVCs referring the %v storage class : %w", storageClassName, err)
+	if err := cl.List(ctx, pvcList); err != nil {
+		return pvcsForStorageClass, fmt.Errorf("failed to get the list of PVCs referring the %v storage class: %w", storageClassName, err)
 	}
-	for i := 0; i < len(pvcList.Items); i++ {
-		if *pvcList.Items[i].Spec.StorageClassName == storageClassName {
-			pvcsForStorageClass = append(pvcsForStorageClass, pvcList.Items[i].Name)
+
+	for _, item := range pvcList.Items {
+		if item.Spec.StorageClassName != nil && *item.Spec.StorageClassName == storageClassName {
+			pvcsForStorageClass = append(pvcsForStorageClass, item.Name)
 		}
 	}
 	return pvcsForStorageClass, nil
@@ -1009,9 +1004,7 @@ func (r *Reconciler) pvsForProvisioner(ctx context.Context, cluster *kubermaticv
 		return pvsForProvisioner, fmt.Errorf("failed to get client for usercluster: %w", err)
 	}
 	pvList := &corev1.PersistentVolumeList{}
-	if err := cl.List(ctx, pvList); apierrors.IsNotFound(err) {
-		return pvsForProvisioner, nil
-	} else if err != nil {
+	if err := cl.List(ctx, pvList); err != nil {
 		return pvsForProvisioner, fmt.Errorf("failed to get the list of PVs having %v as provisioner : %w", provisionerName, err)
 	}
 	for i := 0; i < len(pvList.Items); i++ {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a nil pointer dereference/exception.

```go
I0502 13:38:49.412623       1 reflector.go:351] Caches populated for *v1.Node from k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229
I0502 13:38:50.794488       1 reflector.go:351] Caches populated for *v1.EndpointSlice from k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229
I0502 13:38:51.793732       1 reflector.go:351] Caches populated for *v1.Pod from k8s.io/client-go@v0.29.1/tools/cache/reflector.go:229
{"level":"info","time":"2024-05-02T13:39:11.296Z","caller":"runtime/panic.go:770","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"kkp-addon-controller","object":{"name":"csi","namespace":"cluster-hwlf8cnwfn"},"namespace":"cluster-hwlf8cnwfn","name":"csi","reconcileID":"fb530971-59f7-4b3d-9482-1b312c497151"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x1c1f7cf]

goroutine 624 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
        sigs.k8s.io/controller-runtime@v0.17.1/pkg/internal/controller/controller.go:116 +0x1e5
panic({0x4527660?, 0x7e47850?})
        runtime/panic.go:770 +0x132
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).pvcsForStorageClass(0xc003f979b0?, {0x569d4f8, 0xc00607f5f0}, 0x3?, {0xc0094cd610, 0xa})
        k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:942 +0x22f
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).checkCSIAddonInUse(0xc0001ec540, {0x569d4f8, 0xc00607f5f0}, 0x0?, 0xc0075a3808)
        k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:880 +0xb0c
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).csiAddonInUseStatus(0xc0001ec540, {0x569d4f8, 0xc00607f5f0}, 0xc006896cd8?, 0xc0075a3808)
        k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:835 +0x45
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).ensureIsInstalled(0xc0001ec540, {0x569d4f8, 0xc00607f5f0}, 0xc000a0bd58, 0xc0075a8380, 0xc0075a3808)
        k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:714 +0xcd3
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).reconcile(0xc0001ec540, {0x569d4f8, 0xc00607f5f0}, 0xc000a0bd58, 0xc0075a8380, 0xc0075a3808)
        k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:335 +0x545
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).Reconcile.func1()
        k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:263 +0x2b
k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper.ClusterReconcileWrapper({0x569d4f8, 0xc00607f5f0}, {0x56bc2c0, 0xc0009b2870}, {0x7ffc21e47f22, 0x0}, 0xc0075a3808, {{0x5646d70, 0x7}, {0x5646d78, ...}, ...}, ...)
        k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper/helper.go:86 +0xd6
k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon.(*Reconciler).Reconcile(0xc0001ec540, {0x569d4f8, 0xc00607f5f0}, {{{0xc001602bd0, 0x12}, {0xc0014fb216, 0x3}}})
        k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/addon_controller.go:255 +0x5b2
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x56a4ae8?, {0x569d4f8?, 0xc00607f5f0?}, {{{0xc001602bd0?, 0xb?}, {0xc0014fb216?, 0x0?}}})
        sigs.k8s.io/controller-runtime@v0.17.1/pkg/internal/controller/controller.go:119 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000f3a820, {0x569d530, 0xc000f52be0}, {0x4892880, 0xc004667140})
        sigs.k8s.io/controller-runtime@v0.17.1/pkg/internal/controller/controller.go:316 +0x3bc
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000f3a820, {0x569d530, 0xc000f52be0})
        sigs.k8s.io/controller-runtime@v0.17.1/pkg/internal/controller/controller.go:266 +0x1be
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
        sigs.k8s.io/controller-runtime@v0.17.1/pkg/internal/controller/controller.go:227 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 286
        sigs.k8s.io/controller-runtime@v0.17.1/pkg/internal/controller/controller.go:223 +0x50c
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix null pointer exception that occurred while our controllers checked whether the CSI addon is in use or not
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
