### PR TITLE
[release/v2.23] Don't propagate cloud-config secret to user cluster

### DIFF
--- a/addons/csi/azure-disk/csi-azuredisk-controller.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-controller.yaml
@@ -18,7 +18,7 @@
 # - image source includes registry templating
 # - removal of tolerations
 # - set spec.replicas=1 since leader elections are configured
-# - mount cloud-config instead of using host path
+# - mount cloud-config-csi instead of using host path
 # - add a securityContext
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
@@ -202,6 +202,6 @@ spec:
           emptyDir: {}
         - name: cloud-config
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
 {{ end }}
 {{ end }}

--- a/addons/csi/azure-disk/csi-azuredisk-node.yaml
+++ b/addons/csi/azure-disk/csi-azuredisk-node.yaml
@@ -17,7 +17,7 @@
 # Changes:
 # - image source includes registry templating
 # - removal of scheduling hints
-# - mount cloud-config instead of using host path
+# - mount cloud-config-csi instead of using host path
 # - add seccomp profile
 
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
@@ -182,7 +182,7 @@ spec:
             type: Directory
           name: sys-class
         - secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
           name: cloud-config
 ---
 {{ end }}

--- a/addons/csi/azure-file/csi-azurefile-controller.yaml
+++ b/addons/csi/azure-file/csi-azurefile-controller.yaml
@@ -195,6 +195,6 @@ spec:
           emptyDir: {}
         - name: cloud-config
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
 {{ end }}
 {{ end }}

--- a/addons/csi/azure-file/csi-azurefile-node.yaml
+++ b/addons/csi/azure-file/csi-azurefile-node.yaml
@@ -17,7 +17,7 @@
 # Changes:
 # - image source includes registry templating
 # - removal of scheduling hints
-# - mount cloud-config instead of using host path
+# - mount cloud-config-csi instead of using host path
 # - add seccomp profile
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 {{ if eq .Cluster.CloudProviderName "azure" }}
@@ -166,7 +166,7 @@ spec:
             type: Directory
           name: device-dir
         - secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
           name: cloud-config
 {{ end }}
 {{ end }}

--- a/addons/csi/openstack/controllerplugin.yaml
+++ b/addons/csi/openstack/controllerplugin.yaml
@@ -171,7 +171,7 @@ spec:
           emptyDir:
         - name: cloud-config
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
         - name: ca-bundle
           configMap:
             name: ca-bundle

--- a/addons/csi/openstack/nodeplugin.yaml
+++ b/addons/csi/openstack/nodeplugin.yaml
@@ -157,7 +157,7 @@ spec:
             type: Directory
         - name: secret-cinderplugin
           secret:
-            secretName: cloud-config
+            secretName: cloud-config-csi
         - name: ca-bundle
           configMap:
             name: ca-bundle

--- a/pkg/controller/seed-controller-manager/kubernetes/resources.go
+++ b/pkg/controller/seed-controller-manager/kubernetes/resources.go
@@ -429,7 +429,7 @@ func (r *Reconciler) GetSecretReconcilers(ctx context.Context, data *resources.T
 	namespace := data.Cluster().Status.NamespaceName
 
 	creators := []reconciling.NamedSecretReconcilerFactory{
-		cloudconfig.SecretReconciler(data),
+		cloudconfig.SecretReconciler(data, resources.CloudConfigSecretName),
 		certificates.RootCAReconciler(data),
 		certificates.FrontProxyCAReconciler(),
 		resources.ImagePullSecretReconciler(r.dockerPullConfigJSON),

--- a/pkg/resources/cloudconfig/secret.go
+++ b/pkg/resources/cloudconfig/secret.go
@@ -44,9 +44,9 @@ type creatorData interface {
 }
 
 // SecretReconciler returns a function to create the Secret containing the cloud-config.
-func SecretReconciler(data creatorData) reconciling.NamedSecretReconcilerFactory {
+func SecretReconciler(data creatorData, name string) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
-		return resources.CloudConfigSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
+		return name, func(cm *corev1.Secret) (*corev1.Secret, error) {
 			if cm.Data == nil {
 				cm.Data = map[string][]byte{}
 			}


### PR DESCRIPTION
This is an manual cherry-pick of https://github.com/kubermatic/kubermatic/pull/13366

Since KKP 2.23 doesn't support disabling CSI drivers, this backport has been altered and removed the logics around it.

/assign ahmedwaleedmalik

```release-note
Fixes a bug where unrequired  `cloud-config` secret was being propagated to the user clusters
```

/kind bug