### PR TITLE
[release/v2.24] Add k8s 1.28.x to cluster-autoscaler addon manifests

### DIFF
--- a/addons/cluster-autoscaler/cluster-autoscaler.yaml
+++ b/addons/cluster-autoscaler/cluster-autoscaler.yaml
@@ -25,8 +25,8 @@
 {{ if eq .Cluster.MajorMinorVersion "1.27" }}
 {{ $version = "v1.27.3" }}
 {{ end }}
-{{ if eq .Cluster.MajorMinorVersion "1.27" }}
-{{ $version = "v1.27.3"}}
+{{ if eq .Cluster.MajorMinorVersion "1.28" }}
+{{ $version = "v1.28.2" }}
 {{ end }}
 
 {{ if not (eq $version "UNSUPPORTED") }}


### PR DESCRIPTION
**What this PR does / why we need it**:
We are unable to install cluster-autoscaler addon on k8s 1.28.x clusters on KKP 2.24.x
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug
/kind regression

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add kubernetes 1.28.x support for cluster-autoscaler addon.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
