### PR TITLE
Add ManagedByLabel to user ClusterBackup resources

### DIFF
--- a/pkg/ee/cluster-backup/controller.go
+++ b/pkg/ee/cluster-backup/controller.go
@@ -31,6 +31,7 @@ import (
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"go.uber.org/zap"
 
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticv1helper "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1/helper"
 	clusterclient "k8c.io/kubermatic/v2/pkg/cluster/client"
@@ -62,7 +63,7 @@ import (
 )
 
 const (
-	ControllerName = "cluster-backup-controller"
+	ControllerName = resources.ClusterBakcupControllerName
 )
 
 // UserClusterClientProvider provides functionality to get a user cluster client.
@@ -323,6 +324,7 @@ func (r *reconciler) undeployClusterBackupUserClusterCRDs(ctx context.Context, u
 		LabelSelector: labels.SelectorFromSet(
 			map[string]string{
 				"component": "velero",
+				appskubermaticv1.ApplicationManagedByLabel: resources.ClusterBakcupControllerName,
 			}),
 	}
 	if err := userClusterClient.List(ctx, crdList, listOpts); err != nil {

--- a/pkg/ee/cluster-backup/controller.go
+++ b/pkg/ee/cluster-backup/controller.go
@@ -63,7 +63,10 @@ import (
 )
 
 const (
-	ControllerName = resources.ClusterBakcupControllerName
+	ControllerName = resources.ClusterBackupControllerName
+
+	clusterBackupComponentLabelKey   = "component"
+	clusterBackupComponentLabelValue = "velero"
 )
 
 // UserClusterClientProvider provides functionality to get a user cluster client.
@@ -308,12 +311,26 @@ func (r *reconciler) undeployClusterBackupUserClusterResources(ctx context.Conte
 	}
 
 	for _, resource := range userClusterResources {
+		if err := doSafeDelete(ctx, userClusterClient, resource); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func doSafeDelete(ctx context.Context, client ctrlruntimeclient.Client, resource ctrlruntimeclient.Object) error {
+	if err := client.Get(ctx, types.NamespacedName{Name: resource.GetName(), Namespace: resource.GetNamespace()}, resource); err != nil {
+		if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to list cluster backup user-cluster resources: %w", err)
+	}
+	if isManagedBackupResource(resource) {
 		// skip err if resource doesn't exist or if the API for it doesn't exist
-		if err := userClusterClient.Delete(ctx, resource); err != nil && !(apierrors.IsNotFound(err) || meta.IsNoMatchError(err)) {
+		if err := client.Delete(ctx, resource); err != nil && !(apierrors.IsNotFound(err) || meta.IsNoMatchError(err)) {
 			return fmt.Errorf("failed to delete cluster backup user-cluster resource: %w", err)
 		}
 	}
-
 	return nil
 }
 
@@ -323,8 +340,8 @@ func (r *reconciler) undeployClusterBackupUserClusterCRDs(ctx context.Context, u
 	listOpts := &ctrlruntimeclient.ListOptions{
 		LabelSelector: labels.SelectorFromSet(
 			map[string]string{
-				"component": "velero",
-				appskubermaticv1.ApplicationManagedByLabel: resources.ClusterBakcupControllerName,
+				clusterBackupComponentLabelKey:             clusterBackupComponentLabelValue,
+				appskubermaticv1.ApplicationManagedByLabel: resources.ClusterBackupControllerName,
 			}),
 	}
 	if err := userClusterClient.List(ctx, crdList, listOpts); err != nil {
@@ -340,4 +357,9 @@ func (r *reconciler) undeployClusterBackupUserClusterCRDs(ctx context.Context, u
 
 func inSameProject(cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBackupStorageLocation) bool {
 	return cluster.Labels[kubermaticv1.ProjectIDLabelKey] == cbsl.Labels[kubermaticv1.ProjectIDLabelKey]
+}
+
+func isManagedBackupResource(resource ctrlruntimeclient.Object) bool {
+	labels := resource.GetLabels()
+	return labels[appskubermaticv1.ApplicationManagedByLabel] == resources.ClusterBackupControllerName
 }

--- a/pkg/ee/cluster-backup/resources/user-cluster/cluster_backup.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/cluster_backup.go
@@ -66,6 +66,7 @@ func NamespaceReconciler() reconciling.NamedNamespaceReconcilerFactory {
 				"pod-security.kubernetes.io/warn":            "privileged",
 				"pod-security.kubernetes.io/warn-version":    "latest",
 			}
+			ns.Labels = resources.ApplyManagedByLabelWithName(ns.Labels, resources.ClusterBackupControllerName)
 			return ns, nil
 		}
 	}
@@ -75,7 +76,7 @@ func NamespaceReconciler() reconciling.NamedNamespaceReconcilerFactory {
 func ServiceAccountReconciler() reconciling.NamedServiceAccountReconcilerFactory {
 	return func() (string, reconciling.ServiceAccountReconciler) {
 		return resources.ClusterBackupServiceAccountName, func(sa *corev1.ServiceAccount) (*corev1.ServiceAccount, error) {
-			sa.Labels = resources.ApplyManagedByLabelWithName(map[string]string{}, resources.ClusterBakcupControllerName)
+			sa.Labels = resources.ApplyManagedByLabelWithName(map[string]string{}, resources.ClusterBackupControllerName)
 			return sa, nil
 		}
 	}
@@ -87,7 +88,7 @@ func ClusterRoleBindingReconciler() reconciling.NamedClusterRoleBindingReconcile
 		return ClusterRoleBindingName, func(crb *rbacv1.ClusterRoleBinding) (*rbacv1.ClusterRoleBinding, error) {
 			crb.Labels = resources.ApplyManagedByLabelWithName(
 				resources.BaseAppLabels(clusterBackupAppName, nil),
-				resources.ClusterBakcupControllerName,
+				resources.ClusterBackupControllerName,
 			)
 
 			crb.RoleRef = rbacv1.RoleRef{
@@ -118,7 +119,7 @@ func BSLReconciler(ctx context.Context, cluster *kubermaticv1.Cluster, cbsl *kub
 			}
 			bsl.Labels = resources.ApplyManagedByLabelWithName(
 				resources.BaseAppLabels(clusterBackupAppName, nil),
-				resources.ClusterBakcupControllerName,
+				resources.ClusterBackupControllerName,
 			)
 			bsl.Spec = *cbsl.Spec.DeepCopy()
 			// we set this bsl as default and remove the secret reference to make it use the default velero secret.

--- a/pkg/ee/cluster-backup/resources/user-cluster/crds.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/crds.go
@@ -80,7 +80,7 @@ func loadCRD(filename string) (*apiextensionsv1.CustomResourceDefinition, error)
 func CRDReconciler(crd apiextensionsv1.CustomResourceDefinition) reconciling.NamedCustomResourceDefinitionReconcilerFactory {
 	return func() (string, reconciling.CustomResourceDefinitionReconciler) {
 		return crd.Name, func(target *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			target.Labels = resources.ApplyManagedByLabelWithName(crd.Labels, resources.ClusterBakcupControllerName)
+			target.Labels = resources.ApplyManagedByLabelWithName(crd.Labels, resources.ClusterBackupControllerName)
 			target.Annotations = crd.Annotations
 			target.Spec = crd.Spec
 

--- a/pkg/ee/cluster-backup/resources/user-cluster/crds.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/crds.go
@@ -28,6 +28,7 @@ import (
 	"embed"
 	"fmt"
 
+	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -79,7 +80,7 @@ func loadCRD(filename string) (*apiextensionsv1.CustomResourceDefinition, error)
 func CRDReconciler(crd apiextensionsv1.CustomResourceDefinition) reconciling.NamedCustomResourceDefinitionReconcilerFactory {
 	return func() (string, reconciling.CustomResourceDefinitionReconciler) {
 		return crd.Name, func(target *apiextensionsv1.CustomResourceDefinition) (*apiextensionsv1.CustomResourceDefinition, error) {
-			target.Labels = crd.Labels
+			target.Labels = resources.ApplyManagedByLabelWithName(crd.Labels, resources.ClusterBakcupControllerName)
 			target.Annotations = crd.Annotations
 			target.Spec = crd.Spec
 

--- a/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
@@ -46,10 +46,9 @@ func DeploymentReconciler() reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return DeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			baseLabels := resources.BaseAppLabels(DeploymentName, nil)
-			kubernetes.EnsureLabels(
-				dep,
-				resources.ApplyManagedByLabelWithName(baseLabels, resources.ClusterBakcupControllerName),
-			)
+			kubernetes.EnsureLabels(dep, baseLabels)
+
+			dep.Labels = resources.ApplyManagedByLabelWithName(dep.Labels, resources.ClusterBackupControllerName)
 
 			dep.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: baseLabels,

--- a/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
@@ -46,7 +46,10 @@ func DeploymentReconciler() reconciling.NamedDeploymentReconcilerFactory {
 	return func() (string, reconciling.DeploymentReconciler) {
 		return DeploymentName, func(dep *appsv1.Deployment) (*appsv1.Deployment, error) {
 			baseLabels := resources.BaseAppLabels(DeploymentName, nil)
-			kubernetes.EnsureLabels(dep, baseLabels)
+			kubernetes.EnsureLabels(
+				dep,
+				resources.ApplyManagedByLabelWithName(baseLabels, resources.ClusterBakcupControllerName),
+			)
 
 			dep.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: baseLabels,
@@ -154,7 +157,6 @@ func getVolumes() []corev1.Volume {
 				},
 			},
 		},
-
 		{
 			Name:         "plugins",
 			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},

--- a/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
@@ -72,7 +72,7 @@ func DaemonSetReconciler() reconciling.NamedDaemonSetReconcilerFactory {
 			baseLabels := resources.BaseAppLabels(DaemonSetName, map[string]string{"component": "velero"})
 			kubernetes.EnsureLabels(
 				ds,
-				resources.ApplyManagedByLabelWithName(baseLabels, resources.ClusterBakcupControllerName),
+				resources.ApplyManagedByLabelWithName(baseLabels, resources.ClusterBackupControllerName),
 			)
 
 			podLabels := resources.BaseAppLabels(DaemonSetName, veleroAdditionalLabels)

--- a/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/node_agent.go
@@ -69,7 +69,11 @@ var (
 func DaemonSetReconciler() reconciling.NamedDaemonSetReconcilerFactory {
 	return func() (string, reconciling.DaemonSetReconciler) {
 		return DaemonSetName, func(ds *appsv1.DaemonSet) (*appsv1.DaemonSet, error) {
-			ds.Labels = resources.BaseAppLabels(DaemonSetName, map[string]string{"component": "velero"})
+			baseLabels := resources.BaseAppLabels(DaemonSetName, map[string]string{"component": "velero"})
+			kubernetes.EnsureLabels(
+				ds,
+				resources.ApplyManagedByLabelWithName(baseLabels, resources.ClusterBakcupControllerName),
+			)
 
 			podLabels := resources.BaseAppLabels(DaemonSetName, veleroAdditionalLabels)
 			ds.Spec.Selector = &metav1.LabelSelector{

--- a/pkg/ee/cluster-backup/resources/user-cluster/secret.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/secret.go
@@ -44,7 +44,7 @@ import (
 func SecretReconciler(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBackupStorageLocation) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
 		return CloudCredentialsSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
-			cm.Labels = resources.ApplyManagedByLabelWithName(cm.Labels, resources.ClusterBakcupControllerName)
+			cm.Labels = resources.ApplyManagedByLabelWithName(cm.Labels, resources.ClusterBackupControllerName)
 			refName := cbsl.Spec.Credential.Name
 			refNamespace := resources.KubermaticNamespace
 

--- a/pkg/ee/cluster-backup/resources/user-cluster/secret.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/secret.go
@@ -44,6 +44,7 @@ import (
 func SecretReconciler(ctx context.Context, client ctrlruntimeclient.Client, cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBackupStorageLocation) reconciling.NamedSecretReconcilerFactory {
 	return func() (string, reconciling.SecretReconciler) {
 		return CloudCredentialsSecretName, func(cm *corev1.Secret) (*corev1.Secret, error) {
+			cm.Labels = resources.ApplyManagedByLabelWithName(cm.Labels, resources.ClusterBakcupControllerName)
 			refName := cbsl.Spec.Credential.Name
 			refNamespace := resources.KubermaticNamespace
 

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -1072,7 +1072,7 @@ const (
 	ClusterBackupUsername             = "velero"
 	ClusterBackupServiceAccountName   = "velero"
 	ClusterBackupNamespaceName        = "velero"
-	ClusterBakcupControllerName       = "cluster-backup-controller"
+	ClusterBackupControllerName       = "cluster-backup-controller"
 )
 
 var DefaultApplicationCacheSize = resource.MustParse("300Mi")

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minio/minio-go/v7"
 	"go.uber.org/zap"
 
+	appskubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/apps.kubermatic/v1"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
@@ -1071,6 +1072,7 @@ const (
 	ClusterBackupUsername             = "velero"
 	ClusterBackupServiceAccountName   = "velero"
 	ClusterBackupNamespaceName        = "velero"
+	ClusterBakcupControllerName       = "cluster-backup-controller"
 )
 
 var DefaultApplicationCacheSize = resource.MustParse("300Mi")
@@ -1255,6 +1257,16 @@ func AppClusterLabels(appName, clusterName string, additionalLabels map[string]s
 	podLabels["cluster"] = clusterName
 
 	return podLabels
+}
+
+// ApplyManagedByLabelWithName Adds the `app.kubernetes.io/managed-by=operatorName` label to a set of labels.
+func ApplyManagedByLabelWithName(labels map[string]string, operatorName string) map[string]string {
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[appskubermaticv1.ApplicationManagedByLabel] = operatorName
+
+	return labels
 }
 
 // CertWillExpireSoon returns if the certificate will expire in the next 30 days.


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes a bug where Velero CRDs are removed from user clusters if it's deployed externally and Cluster Backup is disabled.
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #13393

**What type of PR is this?**
<!--
Add one of the following kinds:

/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes #13393 where externally deployed Velero CRDs are removed automatically from user user cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
