### PR TITLE
Fix additional print columns for cluster templates

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -47,7 +47,8 @@ const (
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:object:generate=true
 // +kubebuilder:object:root=true
-// +kubebuilder:printcolumn:JSONPath=".spec.humanReadableName",name="HumanReadableName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".metadata.labels.name",name="DisplayName",type="string"
+// +kubebuilder:printcolumn:JSONPath=".metadata.labels.scope",name="Scope",type="string"
 // +kubebuilder:printcolumn:JSONPath=".spec.version",name="Version",type="string"
 // +kubebuilder:printcolumn:JSONPath=".metadata.creationTimestamp",name="Age",type="date"
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -16,8 +16,11 @@ spec:
   scope: Cluster
   versions:
     - additionalPrinterColumns:
-        - jsonPath: .spec.humanReadableName
-          name: HumanReadableName
+        - jsonPath: .metadata.labels.name
+          name: DisplayName
+          type: string
+        - jsonPath: .metadata.labels.scope
+          name: Scope
           type: string
         - jsonPath: .spec.version
           name: Version


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, we are using `spec.humanReadableName` to print the display name or human-readable name for the cluster template which is misleading and wrong. This would be the display name for the "cluster" and not the "cluster template" as the display name of cluster template is stored in `labels.Name` instead.

How it looks like after the changes:
<img width="508" alt="Screenshot 2024-06-04 at 19 35 40" src="https://github.com/kubermatic/kubermatic/assets/18264334/ceb6b622-0b57-4337-b04b-63ed5109c2a3">


**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `displayName` and `scope` columns for printing the cluster templates; `kubectl get clustertemplates` will now show the actual display name and scope for the cluster templates.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```

/cc @xrstf