### PR TITLE
[release/v2.24] Updated Go version to 1.21.11

### DIFF
--- a/.codespell.exclude
+++ b/.codespell.exclude
@@ -4,3 +4,7 @@ keypair
 shouldnot
 uptodate
 nd
+NotIn
+groupin
+showIn
+Bein

--- a/.prow/ccm-migrations.yaml
+++ b/.prow/ccm-migrations.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -70,7 +70,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/dualstack.yaml
+++ b/.prow/dualstack.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -66,7 +66,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -104,7 +104,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -140,7 +140,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -212,7 +212,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -248,7 +248,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -284,7 +284,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -320,7 +320,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -356,7 +356,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -392,7 +392,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -428,7 +428,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -464,7 +464,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -502,7 +502,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -540,7 +540,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -578,7 +578,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:
@@ -616,7 +616,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-dualstack-e2e-test.sh"
           env:

--- a/.prow/features.yaml
+++ b/.prow/features.yaml
@@ -28,7 +28,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-mla-e2e-tests.sh"
           env:
@@ -62,7 +62,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-konnectivity-e2e-test.sh"
           env:
@@ -96,7 +96,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-cilium-e2e-test.sh"
           env:
@@ -130,7 +130,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-etcd-launcher-tests.sh"
           env:
@@ -163,7 +163,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - ./hack/run-nodeport-proxy-e2e-test-in-kind.sh
           securityContext:
@@ -190,7 +190,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-opa-e2e-tests.sh"
           env:
@@ -223,7 +223,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - ./hack/run-expose-strategy-e2e-test-in-kind.sh
           env:
@@ -253,7 +253,7 @@ presubmits:
       preset-e2e-ssh: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-ipam-e2e-tests.sh"
           env:
@@ -289,7 +289,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-anexia.yaml
+++ b/.prow/provider-anexia.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-aws.yaml
+++ b/.prow/provider-aws.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: "ce"
@@ -116,7 +116,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -158,7 +158,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-azure.yaml
+++ b/.prow/provider-azure.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-digitalocean.yaml
+++ b/.prow/provider-digitalocean.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-gcp.yaml
+++ b/.prow/provider-gcp.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -69,7 +69,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/run-offline-test.sh"
           # docker-in-docker needs privileged mode

--- a/.prow/provider-hetzner.yaml
+++ b/.prow/provider-hetzner.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-kubevirt.yaml
+++ b/.prow/provider-kubevirt.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -72,7 +72,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-nutanix.yaml
+++ b/.prow/provider-nutanix.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-openstack.yaml
+++ b/.prow/provider-openstack.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -76,7 +76,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-packet.yaml
+++ b/.prow/provider-packet.yaml
@@ -29,7 +29,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vmware-cloud-director.yaml
+++ b/.prow/provider-vmware-cloud-director.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/provider-vsphere.yaml
+++ b/.prow/provider-vsphere.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -74,7 +74,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -120,7 +120,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -167,7 +167,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee

--- a/.prow/tests.yaml
+++ b/.prow/tests.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-15
           command:
             - make
           args:
@@ -71,7 +71,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-15
           command:
             - ./hack/ci/verify.sh
           resources:
@@ -90,7 +90,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-15
           command:
             - make
             - lint
@@ -131,7 +131,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-15
           command:
             - ./hack/ci/test-github-release.sh
           resources:
@@ -151,7 +151,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - "./hack/ci/test-helm-charts.sh"
           env:
@@ -176,7 +176,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           env:
             - name: KUBERMATIC_EDITION
               value: ee
@@ -203,7 +203,7 @@ presubmits:
       preset-docker-mirror: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-13
+        - image: quay.io/kubermatic/build:go-1.21-node-18-kind-0.20-15
           command:
             - ./hack/ci/trivy-scan.sh
           env:

--- a/addons/canal/canal_v3.23.yaml
+++ b/addons/canal/canal_v3.23.yaml
@@ -355,7 +355,7 @@ spec:
               numAllowedLocalASNumbers:
                 description: Maximum number of local AS numbers that are allowed in
                   the AS path for received routes. This removes BGP loop prevention
-                  and should only be used if absolutely necesssary.
+                  and should only be used if absolutely necessary.
                 format: int32
                 type: integer
               password:

--- a/addons/canal/canal_v3.24.yaml
+++ b/addons/canal/canal_v3.24.yaml
@@ -382,7 +382,7 @@ spec:
               numAllowedLocalASNumbers:
                 description: Maximum number of local AS numbers that are allowed in
                   the AS path for received routes. This removes BGP loop prevention
-                  and should only be used if absolutely necesssary.
+                  and should only be used if absolutely necessary.
                 format: int32
                 type: integer
               password:

--- a/addons/canal/canal_v3.25.yaml
+++ b/addons/canal/canal_v3.25.yaml
@@ -387,7 +387,7 @@ spec:
               numAllowedLocalASNumbers:
                 description: Maximum number of local AS numbers that are allowed in
                   the AS path for received routes. This removes BGP loop prevention
-                  and should only be used if absolutely necesssary.
+                  and should only be used if absolutely necessary.
                 format: int32
                 type: integer
               password:

--- a/addons/canal/canal_v3.26.yaml
+++ b/addons/canal/canal_v3.26.yaml
@@ -523,7 +523,7 @@ spec:
               numAllowedLocalASNumbers:
                 description: Maximum number of local AS numbers that are allowed in
                   the AS path for received routes. This removes BGP loop prevention
-                  and should only be used if absolutely necesssary.
+                  and should only be used if absolutely necessary.
                 format: int32
                 type: integer
               password:

--- a/addons/canal/canal_v3.27.yaml
+++ b/addons/canal/canal_v3.27.yaml
@@ -344,7 +344,7 @@ spec:
               numAllowedLocalASNumbers:
                 description: Maximum number of local AS numbers that are allowed in
                   the AS path for received routes. This removes BGP loop prevention
-                  and should only be used if absolutely necesssary.
+                  and should only be used if absolutely necessary.
                 format: int32
                 type: integer
               password:

--- a/docs/changelogs/CHANGELOG-2.19.md
+++ b/docs/changelogs/CHANGELOG-2.19.md
@@ -496,4 +496,4 @@ The automatic update rules can, if needed, be overwritten using the `spec.versio
 
 ### Known issues
 - CNI: service LoadBalancer not working on Azure RHEL ([8768](https://github.com/kubermatic/kubermatic/issues/8768))
-- Incompatibilty between Kubevirt csi driver and Kubevirt ccm (namespace)([8772](https://github.com/kubermatic/kubermatic/issues/8772))
+- Incompatibility between Kubevirt csi driver and Kubevirt ccm (namespace)([8772](https://github.com/kubermatic/kubermatic/issues/8772))

--- a/docs/proposals/introduce-apps.md
+++ b/docs/proposals/introduce-apps.md
@@ -212,7 +212,7 @@ The functionality of the `ApplicationInstallationController` depends on the sele
   - url → url of the helm repository (HTTP and OCI registry are supported)
   - chartName → name of the helm chart
   - chartVersion → version of the helm chart
-  - crendentials →authentication to the helm registry (user-pw and registryConfigFile are supported)
+  - credentials →authentication to the helm registry (user-pw and registryConfigFile are supported)
 
 **Methods**
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-13 containerize ./hack/update-codegen.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-15 containerize ./hack/update-codegen.sh
 
 sed="sed"
 [ "$(command -v gsed)" ] && sed="gsed"

--- a/hack/verify-licenses.sh
+++ b/hack/verify-licenses.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-13 containerize ./hack/verify-licenses.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-15 containerize ./hack/verify-licenses.sh
 
 go mod vendor
 

--- a/hack/verify-spelling.sh
+++ b/hack/verify-spelling.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 cd $(dirname $0)/..
 source hack/lib.sh
 
-CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-13 containerize ./hack/verify-spelling.sh
+CONTAINERIZE_IMAGE=quay.io/kubermatic/build:go-1.21-node-18-15 containerize ./hack/verify-spelling.sh
 
 echodate "Running codespell..."
 

--- a/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
+++ b/pkg/controller/nodeport-proxy/envoymanager/controller_test.go
@@ -632,7 +632,7 @@ func TestExposeAnnotationPredicate(t *testing.T) {
 			name: "Should be rejected when annotation value is wrong",
 			obj: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{nodeportproxy.DefaultExposeAnnotationKey: "tru"},
+					Annotations: map[string]string{nodeportproxy.DefaultExposeAnnotationKey: "false"},
 				},
 			},
 			expectAccept: false,


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to update Go version to 1.21.11.
Related to https://github.com/kubermatic/infra/pull/2707

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Update Go version to 1.21.11
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
