### PR TITLE
Fix missing image rewrites

### DIFF
--- a/cmd/master-controller-manager/controllers.go
+++ b/cmd/master-controller-manager/controllers.go
@@ -122,7 +122,7 @@ func createAllControllers(ctrlCtx *controllerContext) error {
 	if err := externalcluster.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
 		return fmt.Errorf("failed to create external cluster controller: %w", err)
 	}
-	if err := kubeone.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log); err != nil {
+	if err := kubeone.Add(ctrlCtx.ctx, ctrlCtx.mgr, ctrlCtx.log, ctrlCtx.overwriteRegistry); err != nil {
 		return fmt.Errorf("failed to create kubeone controller: %w", err)
 	}
 	if err := kcstatuscontroller.Add(ctrlCtx.ctx, ctrlCtx.mgr, 1, ctrlCtx.log, ctrlCtx.namespace, ctrlCtx.versions); err != nil {

--- a/cmd/master-controller-manager/main.go
+++ b/cmd/master-controller-manager/main.go
@@ -81,6 +81,7 @@ type controllerContext struct {
 	labelSelectorFunc       func(*metav1.ListOptions)
 	namespace               string
 	versions                kubermatic.Versions
+	overwriteRegistry       string
 
 	configGetter provider.KubermaticConfigurationGetter
 }
@@ -101,6 +102,7 @@ func main() {
 	flag.StringVar(&runOpts.namespace, "namespace", "kubermatic", "The namespace kubermatic runs in, uses to determine where to look for datacenter custom resources.")
 	flag.BoolVar(&runOpts.enableLeaderElection, "enable-leader-election", true, "Enable leader election for controller manager. "+
 		"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&ctrlCtx.overwriteRegistry, "overwrite-registry", "", "registry to use for all images")
 	flag.StringVar(&runOpts.leaderElectionNamespace, "leader-election-namespace", "", "Leader election namespace. In-cluster discovery will be attempted in such case.")
 	flag.Var(&runOpts.featureGates, "feature-gates", "A set of key=value pairs that describe feature gates for various features.")
 	flag.StringVar(&runOpts.configFile, "kubermatic-configuration-file", "", "(for development only) path to a KubermaticConfiguration YAML file")

--- a/cmd/seed-controller-manager/wrappers_ee.go
+++ b/cmd/seed-controller-manager/wrappers_ee.go
@@ -55,7 +55,7 @@ func setupControllers(ctrlCtx *controllerContext) error {
 		return fmt.Errorf("failed to create KubeLB controller: %w", err)
 	}
 
-	if err := clusterbackup.Add(ctrlCtx.mgr, ctrlCtx.runOptions.workerCount, ctrlCtx.runOptions.workerName, ctrlCtx.clientProvider, ctrlCtx.seedGetter, ctrlCtx.log, ctrlCtx.versions); err != nil {
+	if err := clusterbackup.Add(ctrlCtx.mgr, ctrlCtx.runOptions.workerCount, ctrlCtx.runOptions.workerName, ctrlCtx.clientProvider, ctrlCtx.seedGetter, ctrlCtx.log, ctrlCtx.versions, ctrlCtx.runOptions.overwriteRegistry); err != nil {
 		return fmt.Errorf("failed to create Cluster-Backup controller: %w", err)
 	}
 	if err := storagelocation.Add(ctrlCtx.mgr, ctrlCtx.runOptions.workerCount, ctrlCtx.log); err != nil {

--- a/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
+++ b/pkg/controller/operator/master/resources/kubermatic/master-controller-manager.go
@@ -64,6 +64,7 @@ func MasterControllerManagerDeploymentReconciler(cfg *kubermaticv1.KubermaticCon
 				fmt.Sprintf("-namespace=%s", cfg.Namespace),
 				fmt.Sprintf("-pprof-listen-address=%s", *cfg.Spec.MasterController.PProfEndpoint),
 				fmt.Sprintf("-feature-gates=%s", common.StringifyFeatureGates(cfg)),
+				fmt.Sprintf("-overwrite-registry=%s", cfg.Spec.UserCluster.OverwriteRegistry),
 			}
 
 			if cfg.Spec.MasterController.DebugLog {

--- a/pkg/install/images/wrappers_ee.go
+++ b/pkg/install/images/wrappers_ee.go
@@ -31,7 +31,7 @@ import (
 func getAdditionalImagesFromReconcilers(templateData *resources.TemplateData) (images []string, err error) {
 	deploymentReconcilers := []reconciling.NamedDeploymentReconcilerFactory{
 		kubelb.DeploymentReconciler(templateData),
-		velero.DeploymentReconciler(),
+		velero.DeploymentReconciler(templateData),
 	}
 
 	for _, createFunc := range deploymentReconcilers {
@@ -43,7 +43,7 @@ func getAdditionalImagesFromReconcilers(templateData *resources.TemplateData) (i
 		images = append(images, getImagesFromPodSpec(deployment.Spec.Template.Spec)...)
 	}
 
-	_, creator := velero.DaemonSetReconciler()()
+	_, creator := velero.DaemonSetReconciler(templateData)()
 	daemonset, err := creator(&appsv1.DaemonSet{})
 	if err != nil {
 		return nil, err

--- a/pkg/resources/csi/kubevirt/deployment.go
+++ b/pkg/resources/csi/kubevirt/deployment.go
@@ -21,6 +21,7 @@ import (
 
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -102,7 +103,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-driver",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/kubermatic/kubevirt-csi-driver:" + csiVersion,
+					Image:           registry.Must(data.RewriteImage("quay.io/kubermatic/kubevirt-csi-driver:" + csiVersion)),
 					Args: []string{
 						"--endpoint=$(CSI_ENDPOINT)",
 						fmt.Sprintf("--infra-cluster-namespace=%s", data.Cluster().Status.NamespaceName),
@@ -180,7 +181,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-provisioner",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/openshift/origin-csi-external-provisioner:4.13.0",
+					Image:           registry.Must(data.RewriteImage("quay.io/openshift/origin-csi-external-provisioner:4.13.0")),
 					Args: []string{
 						"--csi-address=$(ADDRESS)",
 						"--default-fstype=ext4",
@@ -213,7 +214,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-attacher",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/openshift/origin-csi-external-attacher:4.13.0",
+					Image:           registry.Must(data.RewriteImage("quay.io/openshift/origin-csi-external-attacher:4.13.0")),
 					Args: []string{
 						"--csi-address=$(ADDRESS)",
 						"--kubeconfig=/var/run/secrets/tenantcluster/kubeconfig",
@@ -245,7 +246,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 				{
 					Name:            "csi-liveness-probe",
 					ImagePullPolicy: corev1.PullAlways,
-					Image:           "quay.io/openshift/origin-csi-livenessprobe:4.13.0",
+					Image:           registry.Must(data.RewriteImage("quay.io/openshift/origin-csi-livenessprobe:4.13.0")),
 					Args: []string{
 						"--csi-address=/csi/csi.sock",
 						"--probe-timeout=3s",


### PR DESCRIPTION
**What this PR does / why we need it**:
We forgot to apply the registry overwrite mechanism to

* the Jobs we create to maintain a KubeOne external cluster and
* the code that handles the Velero-based cluster backups and
* the kubevirt CSI deployments

This PR rectifies that oversight.

**Which issue(s) this PR fixes**:
Fixes #13420

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix missing registry overwrites for cluster-backup (Velero) images, kubevirt CSI images and KubeOne jobs
```

**Documentation**:
```documentation
NONE
```
