### PR TITLE
Fix duplicate imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -60,6 +60,7 @@ linters:
     - nosprintfhostport
     - predeclared
     - promlinter
+    - revive
     - staticcheck
     - tenv
     - unconvert
@@ -89,6 +90,12 @@ issues:
   - singleCaseSwitch # in most cases this is the beginning of a lookup table and should be kept an obvious table
 
 linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant
+      - name: duplicated-imports
+        severity: warning
+
   depguard:
     rules:
       main:

--- a/cmd/http-prober/main.go
+++ b/cmd/http-prober/main.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -214,7 +213,7 @@ func crdCheckerFromFlag(flag string, cfg *rest.Config) (func() error, error) {
 	return nil, fmt.Errorf("comma-separating the flag value did not yield exactly two or four results, but %d", len(splitVal))
 }
 
-func staticCrdChecker(group, version, resource, namespace string, cfg *restclient.Config) func() error {
+func staticCrdChecker(group, version, resource, namespace string, cfg *rest.Config) func() error {
 	return func() error {
 		client, err := dynamic.NewForConfig(cfg)
 		if err != nil {
@@ -237,7 +236,7 @@ func staticCrdChecker(group, version, resource, namespace string, cfg *restclien
 	}
 }
 
-func dynamicCrdChecker(kind, apiVersion string, cfg *restclient.Config) func() error {
+func dynamicCrdChecker(kind, apiVersion string, cfg *rest.Config) func() error {
 	list := &unstructured.UnstructuredList{}
 	list.SetKind(kind)
 	list.SetAPIVersion(apiVersion)

--- a/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/usersshkey-synchronizer/controller.go
@@ -26,7 +26,6 @@ import (
 	controllerutil "k8c.io/kubermatic/v2/pkg/controller/util"
 	predicateutil "k8c.io/kubermatic/v2/pkg/controller/util/predicate"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
-	kuberneteshelper "k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/util/workerlabel"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -61,7 +60,7 @@ type Reconciler struct {
 	masterClient ctrlruntimeclient.Client
 	log          *zap.SugaredLogger
 	workerName   string
-	seedClients  kuberneteshelper.SeedClientMap
+	seedClients  kubernetes.SeedClientMap
 }
 
 func Add(
@@ -80,7 +79,7 @@ func Add(
 		log:          log.Named(ControllerName),
 		workerName:   workerName,
 		masterClient: mgr.GetClient(),
-		seedClients:  kuberneteshelper.SeedClientMap{},
+		seedClients:  kubernetes.SeedClientMap{},
 	}
 
 	bldr := builder.ControllerManagedBy(mgr).
@@ -213,7 +212,7 @@ func buildUserSSHKeysForCluster(clusterName string, keys *kubermaticv1.UserSSHKe
 }
 
 // enqueueAllClusters enqueues all clusters.
-func enqueueAllClusters(clients kuberneteshelper.SeedClientMap, workerSelector labels.Selector) handler.EventHandler {
+func enqueueAllClusters(clients kubernetes.SeedClientMap, workerSelector labels.Selector) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, a ctrlruntimeclient.Object) []reconcile.Request {
 		var requests []reconcile.Request
 

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/gatekeeper/crds.go
@@ -18,7 +18,6 @@ package gatekeeper
 
 import (
 	"embed"
-	_ "embed"
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/resources/reconciling"

--- a/pkg/install/images/addons.go
+++ b/pkg/install/images/addons.go
@@ -22,7 +22,6 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8c.io/kubermatic/v2/pkg/addon"
-	addonutil "k8c.io/kubermatic/v2/pkg/addon"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/resources"
 
@@ -38,7 +37,7 @@ var (
 func getImagesFromAddons(log logrus.FieldLogger, addons map[string]*addon.Addon, cluster *kubermaticv1.Cluster) ([]string, error) {
 	credentials := resources.Credentials{}
 
-	addonData, err := addonutil.NewTemplateData(cluster, credentials, "", "", "", nil, nil)
+	addonData, err := addon.NewTemplateData(cluster, credentials, "", "", "", nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create addon template data: %w", err)
 	}
@@ -55,7 +54,7 @@ func getImagesFromAddons(log logrus.FieldLogger, addons map[string]*addon.Addon,
 	return images, nil
 }
 
-func getImagesFromAddon(log logrus.FieldLogger, addonObj *addon.Addon, decoder runtime.Decoder, data *addonutil.TemplateData) ([]string, error) {
+func getImagesFromAddon(log logrus.FieldLogger, addonObj *addon.Addon, decoder runtime.Decoder, data *addon.TemplateData) ([]string, error) {
 	log.Debug("Processing addon…")
 
 	manifests, err := addonObj.Render("", data)

--- a/pkg/test/e2e/expose-strategy/tunneling_test.go
+++ b/pkg/test/e2e/expose-strategy/tunneling_test.go
@@ -28,7 +28,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/jig"
 	"k8c.io/kubermatic/v2/pkg/test/e2e/utils"
-	e2eutils "k8c.io/kubermatic/v2/pkg/test/e2e/utils"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
 
 	"k8s.io/utils/ptr"
@@ -57,7 +56,7 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 		t.Fatalf("Failed to get credentials: %v", err)
 	}
 
-	seedClient, seedConfig, err := e2eutils.GetClients()
+	seedClient, seedConfig, err := utils.GetClients()
 	if err != nil {
 		t.Fatalf("failed to get client for seed cluster: %v", err)
 	}
@@ -92,7 +91,7 @@ func TestExposeKubernetesApiserver(t *testing.T) {
 		t.Fatalf("Failed to deploy agent: %v", err)
 	}
 
-	client := &clientJig{e2eutils.TestPodConfig{
+	client := &clientJig{utils.TestPodConfig{
 		Log:           logger,
 		Namespace:     cluster.Status.NamespaceName,
 		Client:        seedClient,


### PR DESCRIPTION
**What this PR does / why we need it**:
This enables a new sublinter in revive to prevent duplicate Go import statements with different aliases.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
