### PR TITLE
fix(metrics-server): correct networkpolicy port for metrics-server

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -53,6 +53,8 @@ const (
 
 	imageName = "metrics-server/metrics-server"
 	imageTag  = "v0.7.0"
+
+	servingPort = 10250
 )
 
 // TLSServingCertSecretReconciler returns a function to manage the TLS serving cert for the metrics server.
@@ -96,7 +98,7 @@ func DeploymentReconciler(imageRewriter registry.ImageRewriter) reconciling.Name
 					Args: []string{
 						"--kubelet-insecure-tls",
 						"--kubelet-use-node-status-port",
-						"--secure-port", "10250",
+						"--secure-port", fmt.Sprintf("%d", servingPort),
 						"--metric-resolution", "15s",
 						"--kubelet-preferred-address-types", "InternalIP,ExternalIP,Hostname",
 						"--v", "1",
@@ -105,7 +107,7 @@ func DeploymentReconciler(imageRewriter registry.ImageRewriter) reconciling.Name
 					},
 					Ports: []corev1.ContainerPort{
 						{
-							ContainerPort: 10250,
+							ContainerPort: servingPort,
 							Name:          "https",
 							Protocol:      corev1.ProtocolTCP,
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
@@ -32,7 +32,7 @@ func NetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		return "metrics-server", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			metricsPort := intstr.FromInt(9153)
-			httpsPort := intstr.FromInt(443)
+			httpsPort := intstr.FromInt(servingPort)
 			protoTcp := corev1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the issue with metrics-server and konnectivity-agent communication. Without that connection lots of interactions are not possible (metrics, deleting namespaces, etc.). This change uses the actual pod port, not the service port. That resolves the issue.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug

Optionally add one or more of the following kinds if applicable:
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix(metrics-server): correct networkpolicy port for metrics-server
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
