### PR TITLE
fix usercluster-ctrl-mgr spamming oldest node version in its logs

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
+++ b/pkg/controller/user-cluster-controller-manager/node-version-controller/controller.go
@@ -111,7 +111,7 @@ func (r *reconciler) reconcile(ctx context.Context) error {
 		return fmt.Errorf("failed to get cluster %q: %w", r.clusterName, err)
 	}
 
-	if cluster.Status.Versions.OldestNodeVersion != oldestVersion {
+	if oldestKnown := cluster.Status.Versions.OldestNodeVersion; oldestKnown == nil || !oldestKnown.Equal(oldestVersion) {
 		r.log.Infow("Determined new oldest node version", "version", oldestVersion)
 
 		return kubermaticv1helper.UpdateClusterStatus(ctx, r.seedClient, cluster, func(cluster *kubermaticv1.Cluster) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This prevents endless log spam because the code tried to compare 2 semver object pointers.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix usercluster-ctrl-mgr spamming oldest node version in its logs
```

**Documentation**:
```documentation
NONE
```
