### PR TITLE
Restart cluster control plane after etcd restore

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -332,7 +332,8 @@ func GatewayDeploymentReconciler(data *resources.TemplateData, settings *kuberma
 
 			kubernetes.EnsureLabels(&d.Spec.Template, d.Spec.Selector.MatchLabels)
 			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
-				configHashAnnotation: fmt.Sprintf("%x", configHash.Sum(nil)),
+				configHashAnnotation:                   fmt.Sprintf("%x", configHash.Sum(nil)),
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "tmp,docker-entrypoint-d-override",
 			})

--- a/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/deployment.go
@@ -27,6 +27,7 @@ package userclusterresources
 import (
 	"fmt"
 
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
@@ -43,6 +44,7 @@ const (
 )
 
 type templateData interface {
+	Cluster() *kubermaticv1.Cluster
 	RewriteImage(image string) (string, error)
 }
 
@@ -65,9 +67,10 @@ func DeploymentReconciler(data templateData) reconciling.NamedDeploymentReconcil
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, baseLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/path":   "/metrics",
-				"prometheus.io/port":   "8085",
-				"prometheus.io/scrape": "true",
+				"prometheus.io/path":                                    "/metrics",
+				"prometheus.io/port":                                    "8085",
+				"prometheus.io/scrape":                                  "true",
+				resources.ClusterLastRestartAnnotation:                  data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "plugins,scratch",
 			})
 

--- a/pkg/resources/apiserver/deployment.go
+++ b/pkg/resources/apiserver/deployment.go
@@ -106,6 +106,7 @@ func DeploymentReconciler(data *resources.TemplateData, enableOIDCAuthentication
 				"prometheus.io/scrape_with_kube_cert":                   "true",
 				"prometheus.io/path":                                    "/metrics",
 				"prometheus.io/port":                                    fmt.Sprint(address.Port),
+				resources.ClusterLastRestartAnnotation:                  data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: strings.Join(safeToEvictVolumes, ","),
 			})
 

--- a/pkg/resources/cloudcontroller/deployment.go
+++ b/pkg/resources/cloudcontroller/deployment.go
@@ -99,6 +99,9 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 
 				baseLabels := resources.BaseAppLabels(name, nil)
 				kubernetes.EnsureLabels(modified, baseLabels)
+				kubernetes.EnsureAnnotations(&modified.Spec.Template, map[string]string{
+					resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
+				})
 
 				modified.Spec.Selector = &metav1.LabelSelector{
 					MatchLabels: baseLabels,

--- a/pkg/resources/controllermanager/deployment.go
+++ b/pkg/resources/controllermanager/deployment.go
@@ -105,9 +105,10 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/path":                  "/metrics",
-				"prometheus.io/scrape_with_kube_cert": "true",
-				"prometheus.io/port":                  "10257",
+				"prometheus.io/path":                   "/metrics",
+				"prometheus.io/scrape_with_kube_cert":  "true",
+				"prometheus.io/port":                   "10257",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 			})
 
 			dep.Spec.Template.Spec.DNSPolicy, dep.Spec.Template.Spec.DNSConfig, err = resources.UserClusterDNSPolicyAndConfig(data)

--- a/pkg/resources/csi/kubevirt/deployment.go
+++ b/pkg/resources/csi/kubevirt/deployment.go
@@ -90,6 +90,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 
 			kubernetes.EnsureLabels(&d.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "socket-dir",
 			})

--- a/pkg/resources/csi/vmwareclouddirector/deployment.go
+++ b/pkg/resources/csi/vmwareclouddirector/deployment.go
@@ -119,6 +119,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "socket-dir",
 			})

--- a/pkg/resources/dns/dns.go
+++ b/pkg/resources/dns/dns.go
@@ -114,9 +114,10 @@ func DeploymentReconciler(data deploymentReconcilerData) reconciling.NamedDeploy
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/path":   "/metrics",
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "9253",
+				"prometheus.io/path":                   "/metrics",
+				"prometheus.io/scrape":                 "true",
+				"prometheus.io/port":                   "9253",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 			})
 
 			dep.Spec.Template.Spec.Containers = []corev1.Container{

--- a/pkg/resources/etcd/statefulset.go
+++ b/pkg/resources/etcd/statefulset.go
@@ -116,6 +116,10 @@ func StatefulSetReconciler(data etcdStatefulSetReconcilerData, enableDataCorrupt
 
 			kubernetes.EnsureLabels(&set.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&set.Spec.Template, map[string]string{
+				// NB: We purposefully do not want to use the cluster-last-restart annotation here to
+				// restart etcd, as that would lead to multiple complete restarts during an etcd restore.
+				// resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
+
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "launcher",
 			})

--- a/pkg/resources/kubernetes-dashboard/deployment.go
+++ b/pkg/resources/kubernetes-dashboard/deployment.go
@@ -92,6 +92,7 @@ func DeploymentReconciler(data kubernetesDashboardData) reconciling.NamedDeploym
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: tmpVolumeName,
 			})

--- a/pkg/resources/kubestatemetrics/deployment.go
+++ b/pkg/resources/kubestatemetrics/deployment.go
@@ -77,7 +77,8 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
 				// do not specify a port so that Prometheus automatically
 				// scrapes both the metrics and the telemetry endpoints
-				"prometheus.io/scrape": "true",
+				"prometheus.io/scrape":                                         "true",
+				resources.ClusterLastRestartAnnotation:                         data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				"cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes": tmpVolume,
 			})
 

--- a/pkg/resources/machinecontroller/deployment.go
+++ b/pkg/resources/machinecontroller/deployment.go
@@ -124,9 +124,10 @@ func DeploymentReconcilerWithoutInitWrapper(data machinecontrollerData) reconcil
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/path":   "/metrics",
-				"prometheus.io/port":   "8080",
+				"prometheus.io/scrape":                 "true",
+				"prometheus.io/path":                   "/metrics",
+				"prometheus.io/port":                   "8080",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "temp",
 			})

--- a/pkg/resources/machinecontroller/webhook.go
+++ b/pkg/resources/machinecontroller/webhook.go
@@ -98,6 +98,9 @@ func WebhookDeploymentReconciler(data machinecontrollerData) reconciling.NamedDe
 			}
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
+			})
 
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 

--- a/pkg/resources/metrics-server/deployment.go
+++ b/pkg/resources/metrics-server/deployment.go
@@ -105,6 +105,9 @@ func DeploymentReconciler(data metricsServerData) reconciling.NamedDeploymentRec
 			}
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
+			})
 
 			dep.Spec.Template.Spec.Volumes = volumes
 

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -214,6 +214,7 @@ func DeploymentEnvoyReconciler(data nodePortProxyData, versions kubermatic.Versi
 
 			kubernetes.EnsureLabels(&d.Spec.Template, baseLabels)
 			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: volumeMountNameEnvoyConfig,
 			})

--- a/pkg/resources/openvpn/deployment.go
+++ b/pkg/resources/openvpn/deployment.go
@@ -109,9 +109,10 @@ func DeploymentReconciler(data openVPNDeploymentReconcilerData) reconciling.Name
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/path":   "/metrics",
-				"prometheus.io/port":   fmt.Sprintf("%d", exporterPort),
-				"prometheus.io/scrape": "true",
+				"prometheus.io/path":                   "/metrics",
+				"prometheus.io/port":                   fmt.Sprintf("%d", exporterPort),
+				"prometheus.io/scrape":                 "true",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "openvpn-status",
 			})

--- a/pkg/resources/operatingsystemmanager/deployment.go
+++ b/pkg/resources/operatingsystemmanager/deployment.go
@@ -119,9 +119,10 @@ func DeploymentReconcilerWithoutInitWrapper(data operatingSystemManagerData) rec
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/path":   "/metrics",
-				"prometheus.io/port":   "8080",
+				"prometheus.io/scrape":                 "true",
+				"prometheus.io/path":                   "/metrics",
+				"prometheus.io/port":                   "8080",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 			})
 
 			clusterDNSIP := resources.NodeLocalDNSCacheAddress

--- a/pkg/resources/operatingsystemmanager/webhook.go
+++ b/pkg/resources/operatingsystemmanager/webhook.go
@@ -80,6 +80,9 @@ func WebhookDeploymentReconciler(data operatingSystemManagerData) reconciling.Na
 			}
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
+			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
+			})
 
 			dep.Spec.Template.Spec.InitContainers = []corev1.Container{}
 

--- a/pkg/resources/prometheus/statefulset.go
+++ b/pkg/resources/prometheus/statefulset.go
@@ -84,6 +84,7 @@ func StatefulSetReconciler(data *resources.TemplateData) reconciling.NamedStatef
 
 			kubernetes.EnsureLabels(&set.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&set.Spec.Template, map[string]string{
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: volumeDataName,
 			})

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -530,6 +530,11 @@ const (
 	VMwareCloudDirectorCSIKubeconfigSecretName = "vcloud-csi-kubeconfig"
 	// DefaultNodePortRange is a Kubernetes cluster's default nodeport range.
 	DefaultNodePortRange = "30000-32767"
+
+	// ClusterLastRestartAnnotation is an optional annotation on Cluster objects that is meant to contain
+	// a UNIX timestamp (or similar) value to trigger cluster control plane restarts. The value of this
+	// annotation is copied into control plane components.
+	ClusterLastRestartAnnotation = "kubermatic.k8c.io/last-restart"
 )
 
 const (

--- a/pkg/resources/scheduler/deployment.go
+++ b/pkg/resources/scheduler/deployment.go
@@ -103,9 +103,10 @@ func DeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploym
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/path":                  "/metrics",
-				"prometheus.io/scrape_with_kube_cert": "true",
-				"prometheus.io/port":                  "10259",
+				"prometheus.io/path":                   "/metrics",
+				"prometheus.io/scrape_with_kube_cert":  "true",
+				"prometheus.io/port":                   "10259",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 			})
 
 			dep.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: resources.ImagePullSecretName}}

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: aws-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: aws-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: aws-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-aws-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-aws-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: aws-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-aws-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: azure-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: azure-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: azure-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: azure-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-baremetal-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-bringyourown-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: digitalocean-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: digitalocean-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: digitalocean-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-digitalocean-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: digitalocean-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-digitalocean-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-edge-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-edge-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,scratch
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: gcp-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,scratch
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: gcp-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,scratch
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: gcp-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-gcp-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,scratch
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: gcp-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-gcp-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: openstack-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: openstack-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: openstack-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-openstack-cloud-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: openstack-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-openstack-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-csi-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: csi-controller

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-csi-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: csi-controller

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-csi-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: csi-controller

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-csi-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-csi-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: socket-dir
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: csi-controller

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vcd-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vcd-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.27.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: vsphere-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.28.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: vsphere-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.29.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: vsphere-cloud-controller-manager

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-apiserver.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: audit-log,konnectivity-uds
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "30000"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-controller-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-controller-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-controller-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10257"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kube-state-metrics.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/scrape: "true"
       creationTimestamp: null
       labels:

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kubernetes-dashboard-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kubernetes-dashboard.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-kubernetes-dashboard.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,tmp-volume
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: kubernetes-dashboard

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: machine-controller-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-machine-controller.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-nodeport-proxy-envoy-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-nodeport-proxy-envoy.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-nodeport-proxy-envoy.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: envoy-config
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: nodeport-proxy-envoy

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager-webhook.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: operating-system-manager-webhook

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-operating-system-manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-scheduler-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-scheduler-externalCloudProvider.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-scheduler.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-scheduler.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "10259"
         prometheus.io/scrape_with_kube_cert: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-controller-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-controller-externalCloudProvider.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-controller.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-controller.yaml
@@ -20,6 +20,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: applications-cache,http-prober-bin,temp
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/path: /metrics
         prometheus.io/port: "8085"
         prometheus.io/scrape: "true"

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-webhook-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-webhook-externalCloudProvider.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-webhook.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-usercluster-webhook.yaml
@@ -17,6 +17,7 @@ spec:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
         fluentbit.io/parser: json_iso
+        kubermatic.k8c.io/last-restart: ""
         prometheus.io/port: "8080"
         prometheus.io/scrape: "true"
       creationTimestamp: null

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -15,6 +15,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: http-prober-bin
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         app: vsphere-cloud-controller-manager

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.30.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-aws-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-aws-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.30.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-azure-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-azure-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-baremetal-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-baremetal-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-bringyourown-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-bringyourown-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-digitalocean-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-edge-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-edge-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-gcp-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-openstack-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vcd-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vcd-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.27.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.28.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.29.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-prometheus-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-prometheus-externalCloudProvider.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-prometheus.yaml
+++ b/pkg/resources/test/fixtures/statefulset-vsphere-1.30.0-prometheus.yaml
@@ -18,6 +18,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: data
+        kubermatic.k8c.io/last-restart: ""
       creationTimestamp: null
       labels:
         apiserver-etcd-client-certificate-secret-revision: "123456"

--- a/pkg/resources/usercluster-webhook/deployment.go
+++ b/pkg/resources/usercluster-webhook/deployment.go
@@ -79,9 +79,10 @@ func DeploymentReconciler(data webhookData) reconciling.NamedDeploymentReconcile
 
 			kubernetes.EnsureLabels(&d.Spec.Template, baseLabels)
 			kubernetes.EnsureAnnotations(&d.Spec.Template, map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/port":   "8080",
-				"fluentbit.io/parser":  "json_iso",
+				"prometheus.io/scrape":                 "true",
+				"prometheus.io/port":                   "8080",
+				"fluentbit.io/parser":                  "json_iso",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 			})
 
 			projectID, ok := data.Cluster().Labels[kubermaticv1.ProjectIDLabelKey]

--- a/pkg/resources/usercluster/deployment.go
+++ b/pkg/resources/usercluster/deployment.go
@@ -120,9 +120,10 @@ func DeploymentReconciler(data userclusterControllerData) reconciling.NamedDeplo
 
 			kubernetes.EnsureLabels(&dep.Spec.Template, podLabels)
 			kubernetes.EnsureAnnotations(&dep.Spec.Template, map[string]string{
-				"prometheus.io/scrape": "true",
-				"prometheus.io/path":   "/metrics",
-				"prometheus.io/port":   "8085",
+				"prometheus.io/scrape":                 "true",
+				"prometheus.io/path":                   "/metrics",
+				"prometheus.io/port":                   "8085",
+				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
 				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: strings.Join([]string{resources.ApplicationCacheVolumeName, "temp"}, ","),
 			})


### PR DESCRIPTION
**What this PR does / why we need it**:
To prevent stale caches, we should restart each control plane component once an etcd restore has completed. Similar to how we restart MachineDeployments, this PR introduces a new annotation on Cluster objects. This new annotation can technically be any value whatsoever, as long as it _changes_ when KKP intends to restart everything in the cluster namespace.

The current implementation in this PR would also duplicate an empty annotation, which I am not sure is a problem? Is it ugly? Otherwise we might need a little bit more code in each reconciler. No strong feelings on my end. WDYT?

**Which issue(s) this PR fixes**:
Fixes #12718

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix stale caches: After an etcd restore, all control plane components of a usercluster are now automatically restarted. A new annotation `kubermatic.k8c.io/last-restart` on Cluster objects can be used to trigger a full rolllout of a usercluster's control plane.
```

**Documentation**:
```documentation
NONE
```
