### PR TITLE
add 1.30 to EKS/AKS versions, bump Kube patch versions

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -460,32 +460,31 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.29.4
+    default: v1.29.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.29
+        default: v1.30
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.30
           - v1.29
           - v1.28
           - v1.27
       eks:
         # Default is the default version to offer users.
-        default: v1.29
+        default: v1.30
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.30
           - v1.29
           - v1.28
           - v1.27
-          - v1.26
-          - v1.25
-          - v1.24
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version
@@ -558,16 +557,20 @@ spec:
       - v1.27.10
       - v1.27.11
       - v1.27.13
+      - v1.27.14
       - v1.28.2
       - v1.28.5
       - v1.28.6
       - v1.28.7
       - v1.28.9
+      - v1.28.11
       - v1.29.0
       - v1.29.1
       - v1.29.2
       - v1.29.4
+      - v1.29.6
       - v1.30.0
+      - v1.30.2
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -460,32 +460,31 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.29.4
+    default: v1.29.6
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
         # Default is the default version to offer users.
-        default: v1.29
+        default: v1.30
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.30
           - v1.29
           - v1.28
           - v1.27
       eks:
         # Default is the default version to offer users.
-        default: v1.29
+        default: v1.30
         # Updates is a list of available upgrades.
         updates: null
         # Versions lists the available versions.
         versions:
+          - v1.30
           - v1.29
           - v1.28
           - v1.27
-          - v1.26
-          - v1.25
-          - v1.24
     # ProviderIncompatibilities lists all the Kubernetes version incompatibilities
     providerIncompatibilities:
       - # Condition is the cluster or datacenter condition that must be met to block a specific version
@@ -558,16 +557,20 @@ spec:
       - v1.27.10
       - v1.27.11
       - v1.27.13
+      - v1.27.14
       - v1.28.2
       - v1.28.5
       - v1.28.6
       - v1.28.7
       - v1.28.9
+      - v1.28.11
       - v1.29.0
       - v1.29.1
       - v1.29.2
       - v1.29.4
+      - v1.29.6
       - v1.30.0
+      - v1.30.2
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.29.4"),
+		Default: semver.NewSemverOrDie("v1.29.6"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -231,19 +231,23 @@ var (
 			newSemver("v1.27.10"),
 			newSemver("v1.27.11"),
 			newSemver("v1.27.13"),
+			newSemver("v1.27.14"),
 			// Kubernetes 1.28
 			newSemver("v1.28.2"),
 			newSemver("v1.28.5"),
 			newSemver("v1.28.6"),
 			newSemver("v1.28.7"),
 			newSemver("v1.28.9"),
+			newSemver("v1.28.11"),
 			// Kubernetes 1.29
 			newSemver("v1.29.0"),
 			newSemver("v1.29.1"),
 			newSemver("v1.29.2"),
 			newSemver("v1.29.4"),
+			newSemver("v1.29.6"),
 			// Kubernetes 1.30
 			newSemver("v1.30.0"),
+			newSemver("v1.30.2"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.27 =======
@@ -338,22 +342,21 @@ var (
 	eksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-		Default: semver.NewSemverOrDie("v1.29"),
+		Default: semver.NewSemverOrDie("v1.30"),
 		Versions: []semver.Semver{
+			newSemver("v1.30"),
 			newSemver("v1.29"),
 			newSemver("v1.28"),
 			newSemver("v1.27"),
-			newSemver("v1.26"),
-			newSemver("v1.25"),
-			newSemver("v1.24"),
 		},
 	}
 
 	aksProviderVersioningConfiguration = kubermaticv1.ExternalClusterProviderVersioningConfiguration{
 		// List of Supported versions
 		// https://docs.microsoft.com/en-us/azure/aks/supported-kubernetes-versions
-		Default: semver.NewSemverOrDie("v1.29"),
+		Default: semver.NewSemverOrDie("v1.30"),
 		Versions: []semver.Semver{
+			newSemver("v1.30"),
 			newSemver("v1.29"),
 			newSemver("v1.28"),
 			newSemver("v1.27"),


### PR DESCRIPTION
**What this PR does / why we need it**:
1.30 is GA on EKS and will be GA on AKS in July. 1.24 to 1.26 are long gone from AKS.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Add Kubernetes 1.30 to EKS/AKS versions, remove 1.24, 1.25 and 1.26 from AKS.
```

**Documentation**:
```documentation
NONE
```
