### PR TITLE
Disable default storage addon if csi addon is disabled

### DIFF
--- a/addons/default-storage-class/snapshot-class.yaml
+++ b/addons/default-storage-class/snapshot-class.yaml
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{ if not .Cluster.DisableCSIDriver }}
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
 apiVersion: snapshot.storage.k8s.io/v1
@@ -64,4 +65,5 @@ metadata:
     snapshot.storage.kubernetes.io/is-default-class: "true"
 driver: dobs.csi.digitalocean.com
 deletionPolicy: Delete
+{{ end }}
 {{ end }}

--- a/addons/default-storage-class/storage-class.yaml
+++ b/addons/default-storage-class/storage-class.yaml
@@ -15,6 +15,7 @@
 {{/* Template must only emit data in case its valid for a given provider. That way we can ensure we don't install it when not needed */}}
 {{ if eq .Cluster.CloudProviderName "azure" }}
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if not .Cluster.DisableCSIDriver }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -30,6 +31,7 @@ parameters:
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
+{{ end }}
 {{ else }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -48,6 +50,7 @@ parameters:
 
 {{ if eq .Cluster.CloudProviderName "aws" }}
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if not .Cluster.DisableCSIDriver }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -60,6 +63,7 @@ provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
 volumeBindingMode: WaitForFirstConsumer
+{{ end }}
 {{ else }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -78,6 +82,7 @@ volumeBindingMode: WaitForFirstConsumer
 
 {{ if eq .Cluster.CloudProviderName "vsphere" }}
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if not .Cluster.DisableCSIDriver }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -90,6 +95,7 @@ provisioner: csi.vsphere.vmware.com
 {{ if .Cluster.CSI.StoragePolicy }}
 parameters:
   storagepolicyname: {{ .Cluster.CSI.StoragePolicy }}
+{{ end }}
 {{ end }}
 {{ else }}
 apiVersion: storage.k8s.io/v1
@@ -108,6 +114,7 @@ parameters:
 
 {{ if eq .Cluster.CloudProviderName "openstack" }}
 {{ if .Cluster.Features.Has "externalCloudProvider" }}
+{{ if not .Cluster.DisableCSIDriver }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -119,6 +126,7 @@ metadata:
 provisioner: cinder.csi.openstack.org
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
+{{ end }}
 {{ else }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
@@ -133,6 +141,7 @@ provisioner: kubernetes.io/cinder
 {{ end }}
 
 {{ if eq .Cluster.CloudProviderName "gcp" }}
+{{ if not .Cluster.DisableCSIDriver }}
 # CSI Driver-enabled StorageClass is based on
 # https://github.com/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/tree/31a8f87f161e4e22908703cd47b911c6afa29dcc/examples/kubernetes
 apiVersion: storage.k8s.io/v1
@@ -148,8 +157,10 @@ parameters:
   type: pd-ssd
 volumeBindingMode: WaitForFirstConsumer
 {{ end }}
+{{ end }}
 
 {{ if eq .Cluster.CloudProviderName "hetzner" }}
+{{ if not .Cluster.DisableCSIDriver }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -160,8 +171,10 @@ provisioner: csi.hetzner.cloud
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 {{ end }}
+{{ end }}
 
 {{ if eq .Cluster.CloudProviderName "nutanix" }}
+{{ if not .Cluster.DisableCSIDriver }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -183,8 +196,10 @@ parameters:
 allowVolumeExpansion: true
 reclaimPolicy: Delete
 {{ end }}
+{{ end }}
 
 {{ if eq .Cluster.CloudProviderName "vmwareclouddirector" }}
+{{ if not .Cluster.DisableCSIDriver }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -197,8 +212,10 @@ parameters:
   storageProfile: {{ .Cluster.CSI.StorageProfile | quote }}
   filesystem: {{ default "ext4" .Cluster.CSI.Filesystem | quote }}
 {{ end }}
+{{ end }}
 
 {{ if eq .Cluster.CloudProviderName "digitalocean" }}
+{{ if not .Cluster.DisableCSIDriver }}
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
@@ -234,4 +251,5 @@ parameters:
   fstype: xfs
 reclaimPolicy: Retain
 allowVolumeExpansion: true
+{{ end }}
 {{ end }}

--- a/docs/zz_generated.addondata.go.txt
+++ b/docs/zz_generated.addondata.go.txt
@@ -61,6 +61,8 @@ type ClusterData struct {
 	// KubeVirtInfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
 	KubeVirtInfraStorageClasses []kubermaticv1.KubeVirtInfraStorageClass
+	// DisableCSIDriver indicates if csi drivers (csi addon) is disabled for the user cluster or not.
+	DisableCSIDriver bool
 }
 
 // ClusterAddress stores access and address information of a cluster.

--- a/pkg/addon/types.go
+++ b/pkg/addon/types.go
@@ -166,6 +166,7 @@ func NewTemplateData(
 			},
 			CSIMigration:                csiMigration,
 			KubeVirtInfraStorageClasses: kubeVirtStorageClasses,
+			DisableCSIDriver:            cluster.Spec.DisableCSIDriver,
 		},
 	}, nil
 }
@@ -224,6 +225,8 @@ type ClusterData struct {
 	// KubeVirtInfraStorageClasses is a list of storage classes from KubeVirt infra cluster that are used for
 	// initialization of user cluster storage classes by the CSI driver kubevirt (hot pluggable disks)
 	KubeVirtInfraStorageClasses []kubermaticv1.KubeVirtInfraStorageClass
+	// DisableCSIDriver indicates if csi drivers (csi addon) is disabled for the user cluster or not.
+	DisableCSIDriver bool
 }
 
 type ClusterNetwork struct {

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -69,15 +69,16 @@ import (
 const (
 	ControllerName = "kkp-addon-controller"
 
-	addonLabelKey             = "kubermatic-addon"
-	cleanupFinalizerName      = "cleanup-manifests"
-	addonEnsureLabelKey       = "addons.kubermatic.io/ensure"
-	migratedHetznerCSIAddon   = "kubermatic.k8c.io/migrated-hetzner-csi-addon"
-	migratedVsphereCSIAddon   = "kubermatic.k8c.io/migrated-vsphere-csi-addon"
-	migratedAzureCSIAddon     = "kubermatic.k8c.io/migrated-azure-csi-addon"
-	csiAddonStorageClassLabel = "kubermatic-addon=csi"
-	CSIAddonName              = "csi"
-	pvMigrationAnnotation     = "pv.kubernetes.io/migrated-to"
+	addonLabelKey                = "kubermatic-addon"
+	cleanupFinalizerName         = "cleanup-manifests"
+	addonEnsureLabelKey          = "addons.kubermatic.io/ensure"
+	migratedHetznerCSIAddon      = "kubermatic.k8c.io/migrated-hetzner-csi-addon"
+	migratedVsphereCSIAddon      = "kubermatic.k8c.io/migrated-vsphere-csi-addon"
+	migratedAzureCSIAddon        = "kubermatic.k8c.io/migrated-azure-csi-addon"
+	csiAddonStorageClassLabel    = "kubermatic-addon=csi"
+	CSIAddonName                 = "csi"
+	pvMigrationAnnotation        = "pv.kubernetes.io/migrated-to"
+	defaultStorageClassAddonName = "default-storage-class"
 )
 
 // KubeconfigProvider provides functionality to get a clusters admin kubeconfig.
@@ -702,6 +703,14 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 	sd := strings.TrimSpace(string(d))
 	if len(sd) == 0 {
 		log.Debug("Skipping addon installation as the manifest is empty after parsing")
+		// default-storage-class addon's manifests becomes empty once csi drivers are disabled for a cluster.
+		// we remove the resources created by the addon
+		if addon.Name == defaultStorageClassAddonName {
+			err := r.cleanupDefaultStorageClassAddon(ctx, cluster, addon)
+			if err != nil {
+				return fmt.Errorf("failed to cleanup default storageclass addon: %w", err)
+			}
+		}
 		return nil
 	}
 
@@ -1016,4 +1025,20 @@ func (r *Reconciler) pvsForProvisioner(ctx context.Context, cluster *kubermaticv
 		}
 	}
 	return pvsForProvisioner, nil
+}
+
+func (r *Reconciler) cleanupDefaultStorageClassAddon(ctx context.Context, cluster *kubermaticv1.Cluster, addon *kubermaticv1.Addon) error {
+	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+	if err != nil {
+		return fmt.Errorf("failed to get client for usercluster: %w", err)
+	}
+	// delete storageclass created by "default-storage-class" addon
+	sc := &storagev1.StorageClass{}
+	err = cl.DeleteAllOf(ctx, sc, ctrlruntimeclient.MatchingLabels{
+		addonLabelKey: addon.Spec.Name,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to cleanup resources of default-storage-class addon: %w", err)
+	}
+	return nil
 }

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -52,10 +52,9 @@ const (
 	ControllerName  = "kkp-addoninstaller-controller"
 	addonDefaultKey = ".spec.isDefault"
 
-	kubeProxyAddonName           = "kube-proxy"
-	openVPNAddonName             = "openvpn"
-	CSIAddonName                 = "csi"
-	defaultStorageClassAddonName = "default-storage-class"
+	kubeProxyAddonName = "kube-proxy"
+	openVPNAddonName   = "openvpn"
+	CSIAddonName       = "csi"
 )
 
 type Reconciler struct {
@@ -319,17 +318,6 @@ func skipAddonInstallation(addon kubermaticv1.Addon, cluster *kubermaticv1.Clust
 	}
 	if addon.Name == CSIAddonName && cluster.Spec.DisableCSIDriver {
 		return true // skip csi driver installation if DisableCSIDriver is true
-	}
-
-	// skip default storageclass addon if csi addon is disabled.
-	if addon.Name == defaultStorageClassAddonName && cluster.Spec.DisableCSIDriver {
-		csiAddonCondition, ok := cluster.Status.Conditions[kubermaticv1.ClusterConditionCSIAddonInUse]
-		if ok {
-			if csiAddonCondition.Status == corev1.ConditionFalse {
-				return true
-			}
-		}
-		return true
 	}
 
 	return false

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -319,6 +319,5 @@ func skipAddonInstallation(addon kubermaticv1.Addon, cluster *kubermaticv1.Clust
 	if addon.Name == CSIAddonName && cluster.Spec.DisableCSIDriver {
 		return true // skip csi driver installation if DisableCSIDriver is true
 	}
-
 	return false
 }

--- a/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
+++ b/pkg/controller/seed-controller-manager/addoninstaller/addoninstaller_controller.go
@@ -52,9 +52,10 @@ const (
 	ControllerName  = "kkp-addoninstaller-controller"
 	addonDefaultKey = ".spec.isDefault"
 
-	kubeProxyAddonName = "kube-proxy"
-	openVPNAddonName   = "openvpn"
-	CSIAddonName       = "csi"
+	kubeProxyAddonName           = "kube-proxy"
+	openVPNAddonName             = "openvpn"
+	CSIAddonName                 = "csi"
+	defaultStorageClassAddonName = "default-storage-class"
 )
 
 type Reconciler struct {
@@ -319,5 +320,17 @@ func skipAddonInstallation(addon kubermaticv1.Addon, cluster *kubermaticv1.Clust
 	if addon.Name == CSIAddonName && cluster.Spec.DisableCSIDriver {
 		return true // skip csi driver installation if DisableCSIDriver is true
 	}
+
+	// skip default storageclass addon if csi addon is disabled.
+	if addon.Name == defaultStorageClassAddonName && cluster.Spec.DisableCSIDriver {
+		csiAddonCondition, ok := cluster.Status.Conditions[kubermaticv1.ClusterConditionCSIAddonInUse]
+		if ok {
+			if csiAddonCondition.Status == corev1.ConditionFalse {
+				return true
+			}
+		}
+		return true
+	}
+
 	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable the default storage class addon when the csi addon (csi drivers) are disabled for user clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind bug


**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default storage class addon will be removed if the CSI driver (csi addon) is disabled for user cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
