### PR TITLE
[release/v2.24] fix(metrics-server): correct networkpolicy port for secure metrics-server port (#13438)

### DIFF
--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/deployment.go
@@ -53,6 +53,8 @@ const (
 
 	imageName = "metrics-server/metrics-server"
 	imageTag  = "v0.6.4"
+
+	servingPort = 10250
 )
 
 // TLSServingCertSecretReconciler returns a function to manage the TLS serving cert for the metrics server.
@@ -96,7 +98,7 @@ func DeploymentReconciler(imageRewriter registry.ImageRewriter) reconciling.Name
 					Args: []string{
 						"--kubelet-insecure-tls",
 						"--kubelet-use-node-status-port",
-						"--secure-port", "4443",
+						"--secure-port", fmt.Sprintf("%d", servingPort),
 						"--metric-resolution", "15s",
 						"--kubelet-preferred-address-types", "InternalIP,ExternalIP,Hostname",
 						"--v", "1",
@@ -105,7 +107,7 @@ func DeploymentReconciler(imageRewriter registry.ImageRewriter) reconciling.Name
 					},
 					Ports: []corev1.ContainerPort{
 						{
-							ContainerPort: 4443,
+							ContainerPort: servingPort,
 							Name:          "https",
 							Protocol:      corev1.ProtocolTCP,
 						},

--- a/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
+++ b/pkg/controller/user-cluster-controller-manager/resources/resources/metrics-server/networkpolicy.go
@@ -32,7 +32,7 @@ func NetworkPolicyReconciler() reconciling.NamedNetworkPolicyReconcilerFactory {
 	return func() (string, reconciling.NetworkPolicyReconciler) {
 		return "metrics-server", func(np *networkingv1.NetworkPolicy) (*networkingv1.NetworkPolicy, error) {
 			metricsPort := intstr.FromInt(9153)
-			httpsPort := intstr.FromInt(443)
+			httpsPort := intstr.FromInt(servingPort)
 			protoTcp := corev1.ProtocolTCP
 
 			np.Spec = networkingv1.NetworkPolicySpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #13438.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
fix(metrics-server): correct networkpolicy port for metrics-server
```

**Documentation**:
```documentation
NONE
```
