### PR TITLE
[release/v2.25] fix links in changelog

### DIFF
--- a/docs/changelogs/CHANGELOG-2.23.md
+++ b/docs/changelogs/CHANGELOG-2.23.md
@@ -18,9 +18,9 @@
 - [v2.23.15](#v22315)
 - [v2.23.16](#v22316)
 
-## 2.23.16
+## v2.23.16
 
-**GitHub release: [2.23.16](https://github.com/kubermatic/kubermatic/releases/tag/2.23.16)**
+**GitHub release: [v2.23.16](https://github.com/kubermatic/kubermatic/releases/tag/v2.23.16)**
 
 ### Bugfixes
 

--- a/docs/changelogs/CHANGELOG-2.24.md
+++ b/docs/changelogs/CHANGELOG-2.24.md
@@ -11,9 +11,9 @@
 - [v2.24.8](#v2248)
 - [v2.24.9](#v2249)
 
-## 2.24.9
+## v2.24.9
 
-**GitHub release: [2.24.9](https://github.com/kubermatic/kubermatic/releases/tag/2.24.9)**
+**GitHub release: [v2.24.9](https://github.com/kubermatic/kubermatic/releases/tag/v2.24.9)**
 
 ### New Features
 

--- a/docs/changelogs/CHANGELOG-2.25.md
+++ b/docs/changelogs/CHANGELOG-2.25.md
@@ -7,9 +7,9 @@
 - [v2.25.4](#v2254)
 - [v2.25.5](#v2255)
 
-## 2.25.5
+## v2.25.5
 
-**GitHub release: [2.25.5](https://github.com/kubermatic/kubermatic/releases/tag/2.25.5)**
+**GitHub release: [v2.25.5](https://github.com/kubermatic/kubermatic/releases/tag/v2.25.5)**
 
 ### New Features
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The new gchl didn't normalize version flags yet.

/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
