### PR TITLE
use Release.Last instead of 0 index

### DIFF
--- a/pkg/applications/helmclient/client.go
+++ b/pkg/applications/helmclient/client.go
@@ -334,7 +334,7 @@ func (h HelmClient) GetMetadata(releaseName string) (*release.Release, error) {
 		return nil, err
 	}
 
-	rel, err := h.actionConfig.Releases.Get(releaseName, 0)
+	rel, err := h.actionConfig.Releases.Last(releaseName)
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve metadata for release %q: %w", releaseName, err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue that exists exclusively on our release branches for 2.25 and 2.24 which have our own implementation of helms GetMetadata. Currently these are unable to find the release and will return a `release: not found` error, because .Get(...,0) searches for a release with the revision 0 and not for the last release. Down below is some code to confirm this.

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/bugfix

**Special notes for your reviewer**:

This can be reproduced by doing the following:

```shell
helm install some-release-name oci://registry-1.docker.io/bitnamicharts/nginx
```

And then running the following code. Running the `.Get(...,0` version will return "could not fetch release release: not found", while using the `.Last` version will work.

```Go
package main

import (
	"fmt"
	"log/slog"
	"os"

	"helm.sh/helm/v3/pkg/action"
	"k8s.io/cli-runtime/pkg/genericclioptions"
)

func main() {
	if err := Run(); err != nil {
		fmt.Println(err)
		os.Exit(1)
	}
}

const releaseName = "some-release-name"
const namespace = "default"

func Run() error {
	kubecfg := os.Getenv("KUBECONFIG")

	opts := &genericclioptions.ConfigFlags{
		KubeConfig: &kubecfg,
	}

	actionConfig := action.Configuration{}
	if err := actionConfig.Init(opts, namespace, "secret", slog.Info); err != nil {
		return err
	}

	// this will return "release not found"
	// rel, err := actionConfig.Releases.Get(releaseName, 0)
	// this will work
	rel, err := actionConfig.Releases.Last(releaseName)

	if err != nil {
		return fmt.Errorf("could not fetch release %w", err)
	}

	fmt.Println(rel)

	return nil
}
```

---

This is also the case in helm's official implementation of the GetMetadata (which we are using on main), where it uses the private func `releaseContent`, which actually also specifically differentiates betweeng `.Get` and `.Last`

https://github.com/helm/helm/blob/a2a324e51165388448be8caaf8737b7fd2f1a19a/pkg/action/action.go#L310-L314

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes a critical regression in Application with helm sources, which resulted in "release: not found" errors
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
