### PR TITLE
[EE] create ConfigMap for Velero to use custom restore helper image

### DIFF
--- a/pkg/ee/cluster-backup/controller.go
+++ b/pkg/ee/cluster-backup/controller.go
@@ -238,6 +238,13 @@ func (r *reconciler) ensureUserClusterResources(ctx context.Context, cluster *ku
 		return fmt.Errorf("failed to reconcile Velero Namespace: %w", err)
 	}
 
+	cmReconcilers := []reconciling.NamedConfigMapReconcilerFactory{
+		userclusterresources.CustomizationConfigMapReconciler(data.RewriteImage),
+	}
+	if err := reconciling.ReconcileConfigMaps(ctx, cmReconcilers, resources.ClusterBackupNamespaceName, userClusterClient, addManagedByLabel); err != nil {
+		return fmt.Errorf("failed to reconcile Velero ConfigMaps: %w", err)
+	}
+
 	saReconcilers := []reconciling.NamedServiceAccountReconcilerFactory{
 		userclusterresources.ServiceAccountReconciler(),
 	}
@@ -248,16 +255,14 @@ func (r *reconciler) ensureUserClusterResources(ctx context.Context, cluster *ku
 	clusterRoleBindingReconciler := []reconciling.NamedClusterRoleBindingReconcilerFactory{
 		userclusterresources.ClusterRoleBindingReconciler(),
 	}
-
 	if err := reconciling.ReconcileClusterRoleBindings(ctx, clusterRoleBindingReconciler, "", userClusterClient, addManagedByLabel); err != nil {
 		return fmt.Errorf("failed to reconcile Velero ClusterRoleBinding: %w", err)
 	}
 
+	// Create kubeconfig secret in the user cluster namespace.
 	secretReconcilers := []reconciling.NamedSecretReconcilerFactory{
 		userclusterresources.SecretReconciler(ctx, r.Client, cluster, cbsl),
 	}
-
-	// Create kubeconfig secret in the user cluster namespace.
 	if err := reconciling.ReconcileSecrets(ctx, secretReconcilers, resources.ClusterBackupNamespaceName, userClusterClient, addManagedByLabel); err != nil {
 		return fmt.Errorf("failed to reconcile cluster backup kubeconfig Secret: %w", err)
 	}
@@ -268,10 +273,10 @@ func (r *reconciler) ensureUserClusterResources(ctx context.Context, cluster *ku
 	if err := reconciling.ReconcileDeployments(ctx, deploymentReconcilers, resources.ClusterBackupNamespaceName, userClusterClient, addManagedByLabel); err != nil {
 		return fmt.Errorf("failed to reconcile the cluster backup Deployment: %w", err)
 	}
+
 	dsReconcilers := []reconciling.NamedDaemonSetReconcilerFactory{
 		userclusterresources.DaemonSetReconciler(data),
 	}
-
 	if err := reconciling.ReconcileDaemonSets(ctx, dsReconcilers, resources.ClusterBackupNamespaceName, userClusterClient, addManagedByLabel); err != nil {
 		return fmt.Errorf("failed to reconcile Velero node-agent DaemonSet: %w", err)
 	}
@@ -285,15 +290,13 @@ func (r *reconciler) ensureUserClusterResources(ctx context.Context, cluster *ku
 	for i := range clusterBackupCRDs {
 		creators = append(creators, userclusterresources.CRDReconciler(clusterBackupCRDs[i]))
 	}
-
 	if err = kkpreconciling.ReconcileCustomResourceDefinitions(ctx, creators, "", userClusterClient, addManagedByLabel); err != nil {
 		return fmt.Errorf("failed to reconcile Velero CRDs: %w", err)
 	}
 
 	bslReconcilers := []kkpreconciling.NamedBackupStorageLocationReconcilerFactory{
-		userclusterresources.BSLReconciler(ctx, cluster, cbsl),
+		userclusterresources.BSLReconciler(cluster, cbsl),
 	}
-
 	if err := kkpreconciling.ReconcileBackupStorageLocations(ctx, bslReconcilers, resources.ClusterBackupNamespaceName, userClusterClient, addManagedByLabel); err != nil {
 		return fmt.Errorf("failed to reconcile Velero BSL: %w", err)
 	}

--- a/pkg/ee/cluster-backup/resources/user-cluster/cluster_backup.go
+++ b/pkg/ee/cluster-backup/resources/user-cluster/cluster_backup.go
@@ -25,7 +25,6 @@
 package userclusterresources
 
 import (
-	"context"
 	"fmt"
 
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
@@ -34,6 +33,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	kkpreconciling "k8c.io/kubermatic/v2/pkg/resources/reconciling"
+	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
 
 	corev1 "k8s.io/api/core/v1"
@@ -41,9 +41,10 @@ import (
 )
 
 const (
-	ClusterRoleBindingName = "velero"
-	clusterBackupAppName   = "velero"
-	DefaultBSLName         = "default-cluster-backup-bsl"
+	ClusterRoleBindingName     = "velero"
+	clusterBackupAppName       = "velero"
+	DefaultBSLName             = "default-cluster-backup-bsl"
+	customizationConfigMapName = "fs-restore-action-config"
 
 	CloudCredentialsSecretName           = "velero-cloud-credentials"
 	defaultCloudCredentialsSecretKeyName = "cloud"
@@ -105,7 +106,7 @@ func ClusterRoleBindingReconciler() reconciling.NamedClusterRoleBindingReconcile
 }
 
 // BSLReconciler creates the default BackupStorage location is created for velero.
-func BSLReconciler(ctx context.Context, cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBackupStorageLocation) kkpreconciling.NamedBackupStorageLocationReconcilerFactory {
+func BSLReconciler(cluster *kubermaticv1.Cluster, cbsl *kubermaticv1.ClusterBackupStorageLocation) kkpreconciling.NamedBackupStorageLocationReconcilerFactory {
 	return func() (string, kkpreconciling.BackupStorageLocationReconciler) {
 		return DefaultBSLName, func(bsl *velerov1.BackupStorageLocation) (*velerov1.BackupStorageLocation, error) {
 			kubernetes.EnsureLabels(bsl, resources.BaseAppLabels(clusterBackupAppName, nil))
@@ -121,6 +122,34 @@ func BSLReconciler(ctx context.Context, cluster *kubermaticv1.Cluster, cbsl *kub
 			// add bucket prefix using projectID/clusterID to avoid collision.
 			bsl.Spec.ObjectStorage.Prefix = fmt.Sprintf("%s/%s", projectID, cluster.Name)
 			return bsl, nil
+		}
+	}
+}
+
+// CustomizationConfigMapReconciler reconciles a ConfigMap to configure the velero restore helper,
+// see https://velero.io/docs/v1.12/file-system-backup/#customize-restore-helper-container.
+func CustomizationConfigMapReconciler(rewriter registry.ImageRewriter) reconciling.NamedConfigMapReconcilerFactory {
+	return func() (string, reconciling.ConfigMapReconciler) {
+		return customizationConfigMapName, func(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			// ensure Velero can find this ConfigMap
+			kubernetes.EnsureLabels(cm, map[string]string{
+				"velero.io/plugin-config":      "",
+				"velero.io/pod-volume-restore": "RestoreItemAction",
+			})
+
+			if cm.Data == nil {
+				cm.Data = map[string]string{}
+			}
+
+			// all we want to set is the custom restore helper image
+			rewritten, err := rewriter("docker.io/velero/velero-restore-helper")
+			if err != nil {
+				return nil, fmt.Errorf("failed to rewrite image: %w", err)
+			}
+
+			cm.Data["image"] = rewritten
+
+			return cm, nil
 		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR creates a new ConfigMap in the Velero namespace, solely to configure a custom restore helper.

**Which issue(s) this PR fixes**:
Fixes #13453

**What type of PR is this?**
/kind bug
/kind feature

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
When the cluster-backup feature is enabled, KKP will now reconcile a ConfigMap in the `velero` namespace in user clusters. This ConfigMap is used to configure the restore helper image in order to apply KKP's image rewriting mechanism.
```

**Documentation**:
```documentation
NONE
```
