### PR TITLE
make mla-gateway Pod auto-reload nginx when certificates are renewed

### DIFF
--- a/pkg/controller/seed-controller-manager/mla/resources.go
+++ b/pkg/controller/seed-controller-manager/mla/resources.go
@@ -303,6 +303,28 @@ func GatewayExternalServiceReconciler(c *kubermaticv1.Cluster) reconciling.Named
 const (
 	image   = "nginxinc/nginx-unprivileged"
 	version = "1.20.1-alpine"
+
+	nginxScript = `
+set -e
+
+calc_state() {
+  find /etc/ssl -type f -exec cat {} + | sha1sum -
+}
+
+state=$(calc_state)
+
+nginx &
+
+# watch for changes (i.e. renewed certificates), then reload nginx
+while true; do
+  newState=$(calc_state)
+  if [ "$newState" != "$state" ]; then
+    nginx -s reload
+  fi
+  state=$newState
+  sleep 60
+done
+`
 )
 
 func GatewayDeploymentReconciler(data *resources.TemplateData, settings *kubermaticv1.MLAAdminSetting) reconciling.NamedDeploymentReconcilerFactory {
@@ -335,13 +357,18 @@ func GatewayDeploymentReconciler(data *resources.TemplateData, settings *kuberma
 				configHashAnnotation:                   fmt.Sprintf("%x", configHash.Sum(nil)),
 				resources.ClusterLastRestartAnnotation: data.Cluster().Annotations[resources.ClusterLastRestartAnnotation],
 				// these volumes should not block the autoscaler from evicting the pod
-				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "tmp,docker-entrypoint-d-override",
+				resources.ClusterAutoscalerSafeToEvictVolumesAnnotation: "tmp",
 			})
 
 			d.Spec.Template.Spec.Containers = []corev1.Container{
 				{
-					Name:            "nginx",
-					Image:           registry.Must(data.RewriteImage(resources.RegistryDocker + "/" + image + ":" + version)),
+					Name:  "nginx",
+					Image: registry.Must(data.RewriteImage(resources.RegistryDocker + "/" + image + ":" + version)),
+					Command: []string{
+						"/bin/sh",
+						"-c",
+						strings.TrimSpace(nginxScript),
+					},
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Ports: []corev1.ContainerPort{
 						{
@@ -393,10 +420,6 @@ func GatewayDeploymentReconciler(data *resources.TemplateData, settings *kuberma
 							Name:      "tmp",
 							MountPath: "/tmp",
 						},
-						{
-							Name:      "docker-entrypoint-d-override",
-							MountPath: "/docker-entrypoint.d",
-						},
 					},
 				},
 			}
@@ -437,12 +460,10 @@ func GatewayDeploymentReconciler(data *resources.TemplateData, settings *kuberma
 				},
 				{
 					Name:         "tmp",
-					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
-				{
-					Name:         "docker-entrypoint-d-override",
 					VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 				},
 			}
+
 			return d, nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
The normal nginx-ingress-controller pods are smart enough to  react to changed certificates, but a plain nginx container is not. Since nginx offers no HTTP API to reload it, and configmap-reloader cannot send signals, we had more or less 2 options:

1. Solve it during reconciling: Put the resourceVersion of the Cert Secret onto the nginx Deployment to auto-rollout when the Cert is changed. But this would mean we have to rely on KKP doing things.
2. Integrate a simple file watcher loop into the nginx container.

I went with option 2. I played around with this in nginx and everytime I changed a file, nginx was happily reloaded.

**Which issue(s) this PR fixes**:
Fixes #13408

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix mla-gateway Pods not reacting to renewed certificates.
```

**Documentation**:
```documentation
NONE
```
