### PR TITLE
Fix backup deployment panic

### DIFF
--- a/pkg/ee/cluster-backup/controller.go
+++ b/pkg/ee/cluster-backup/controller.go
@@ -224,6 +224,7 @@ func (r *reconciler) ensureUserClusterResources(ctx context.Context, cluster *ku
 	}
 
 	data := resources.NewTemplateDataBuilder().
+		WithCluster(cluster).
 		WithOverwriteRegistry(r.overwriteRegistry).
 		Build()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a small panic when creating Velero deployment in user cluster:
```
{"level":"info","time":"2024-06-28T12:04:39.252Z","caller":"runtime/panic.go:770","msg":"Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference","controller":"cluster-backup-controller","controllerGroup":"kubermatic.k8c.io","controllerKind":"Cluster","Cluster":{"name":"mkmjb6hchg"},"namespace":"","name":"mkmjb6hchg","reconcileID":"0a5db48e-c306-48ff-9cd6-6605c57a5666"}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xb8 pc=0x3fbc088]

goroutine 898 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	sigs.k8s.io/controller-runtime@v0.18.2/pkg/internal/controller/controller.go:111 +0x1e5
panic({0x4617540?, 0x7fe85b0?})
	runtime/panic.go:770 +0x132
k8c.io/kubermatic/v2/pkg/ee/cluster-backup.(*reconciler).ensureUserClusterResources.DeploymentReconciler.func6.1(0xc003243908)
	k8c.io/kubermatic/v2/pkg/ee/cluster-backup/resources/user-cluster/deployment.go:73 +0x348
k8c.io/reconciler/pkg/reconciling.ReconcileDeployments.DefaultDeployment.func1(0xc003243908)
	k8c.io/reconciler@v0.5.0/pkg/reconciling/defaults.go:110 +0x53
```

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
