### PR TITLE
bump integration-tests image to Go 1.22.4 / Kube 1.30

### DIFF
--- a/hack/images/integration-tests/Dockerfile
+++ b/hack/images/integration-tests/Dockerfile
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-9
+FROM quay.io/kubermatic/build:go-1.22-node-20-kind-0.23-10
 LABEL org.opencontainers.image.source="https://github.com/kubermatic/kubermatic/blob/main/hack/images/integration-tests/Dockerfile"
 LABEL org.opencontainers.image.vendor="Kubermatic"
 LABEL org.opencontainers.image.authors="support@kubermatic.com"
 
 # envtest binaries are not available for all k8s patch releases, so beware when updating
-ENV KUBE_VERSION=1.29.1
+ENV KUBE_VERSION=1.30.0
 
 RUN os=$(go env GOOS) && \
     arch=$(go env GOARCH) && \

--- a/hack/images/integration-tests/settings.sh
+++ b/hack/images/integration-tests/settings.sh
@@ -1,1 +1,1 @@
-TAG=k8s-1.29.1-rev0
+TAG=k8s-1.30.0-rev0


### PR DESCRIPTION
**What this PR does / why we need it**:
This is so that when we bump Go dependencies and get a newer `go.mod`, the integration tests continue to work.

1.30.1 and 1.30.2 do not have kubebuilder binaries available.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
