### PR TITLE
allow specifying extra containerports exposure for thanos query

### DIFF
--- a/charts/monitoring/prometheus/templates/service.yaml
+++ b/charts/monitoring/prometheus/templates/service.yaml
@@ -23,8 +23,8 @@ spec:
   - name: web
     port: 9090
     targetPort: web
-  {{- if .Values.prometheus.extraPorts }}
-    {{- toYaml .Values.prometheus.extraPorts | nindent 2 }}
+  {{- with .Values.prometheus.extraPorts }}
+  {{- toYaml . | nindent 2 }}
   {{- end }}
   selector:
     app: '{{ template "name" . }}'

--- a/charts/monitoring/prometheus/templates/service.yaml
+++ b/charts/monitoring/prometheus/templates/service.yaml
@@ -23,5 +23,8 @@ spec:
   - name: web
     port: 9090
     targetPort: web
+  {{- if .Values.prometheus.extraPorts }}
+    {{- toYaml .Values.prometheus.extraPorts | nindent 2 }}
+  {{- end }}
   selector:
     app: '{{ template "name" . }}'

--- a/charts/monitoring/prometheus/values.yaml
+++ b/charts/monitoring/prometheus/values.yaml
@@ -154,7 +154,14 @@ prometheus:
   #   sidecarContainers:
   #     - thanos:
   #         image: quay.io/thanos/thanos:v0.31.0
-  sidecarContainers: {}
+  sidecarContainers: []
+
+  ## expose additional ports for sidecar containers e.g. when using thanos-sidecar
+  # extraPorts:
+  # - name: grpc
+  #   port: 10901
+  #   targetPort: grpc
+  extraPorts: []
 
   containers:
     prometheus:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, thanos query component cannot request current metrics data from thanos sidecar - which could be added to Prometheus via sidecar.

This PR provides an optional way to expose the needed ports in prometheus service so that thanos query can request latest data from thanos side, if present.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
NA

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind feature
/kind chore


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allows KKP administrator to interface thanos query with thanos-sidecar to get full benefit of using thanos.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
