### PR TITLE
update cert-manager Helm chart to 1.15.1

### DIFF
--- a/charts/cert-manager/Chart.lock
+++ b/charts/cert-manager/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: cert-manager
   repository: https://charts.jetstack.io
-  version: v1.14.4
-digest: sha256:7049711d49ea4fe7bd356459f6c38154f8175d768d08ff601f89f32a91dcb7f1
-generated: "2024-04-11T14:32:24.781613111+02:00"
+  version: v1.15.1
+digest: sha256:e95448cd03fa7c6913abcb1b3d9b9776eb3093e8b3c09bd8e33e10232d2b45d9
+generated: "2024-07-10T13:31:33.605951106+02:00"

--- a/charts/cert-manager/Chart.yaml
+++ b/charts/cert-manager/Chart.yaml
@@ -15,7 +15,7 @@
 apiVersion: v2
 name: cert-manager
 version: 9.9.9-dev
-appVersion: v1.14.4
+appVersion: v1.15.1
 description: A Helm chart for cert-manager
 keywords:
   - kubermatic
@@ -31,4 +31,4 @@ maintainers:
 dependencies:
   - repository: https://charts.jetstack.io
     name: cert-manager
-    version: 1.14.4
+    version: 1.15.1

--- a/charts/cert-manager/test/default.yaml.out
+++ b/charts/cert-manager/test/default.yaml.out
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,9 +27,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -43,9 +43,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,9 +57,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -91,9 +91,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -119,9 +119,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -147,9 +147,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -184,9 +184,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -224,9 +224,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -286,9 +286,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -325,9 +325,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -344,9 +344,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -369,9 +369,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -396,14 +396,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
     verbs: ["approve"]
-    resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+    resourceNames:
+    - "issuers.cert-manager.io/*"
+    - "clusterissuers.cert-manager.io/*"
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # Permission to:
@@ -418,9 +420,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -446,9 +448,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -464,9 +466,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -486,9 +488,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -508,9 +510,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -530,9 +532,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -552,9 +554,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -574,9 +576,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -596,9 +598,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -618,9 +620,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -640,9 +642,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -662,9 +664,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -687,9 +689,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -715,9 +717,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -738,9 +740,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -765,9 +767,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -790,9 +792,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -814,9 +816,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -838,9 +840,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   type: ClusterIP
   ports:
@@ -864,9 +866,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   type: ClusterIP
   ports:
@@ -890,9 +892,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   replicas: 1
   selector:
@@ -907,9 +909,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.14.4"
+        app.kubernetes.io/version: "v1.15.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.14.4
+        helm.sh/chart: cert-manager-v1.15.1
     spec:
       serviceAccountName: release-name-cert-manager-cainjector
       enableServiceLinks: false
@@ -919,7 +921,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.14.4"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.15.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -949,9 +951,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   replicas: 1
   selector:
@@ -966,9 +968,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.14.4"
+        app.kubernetes.io/version: "v1.15.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.14.4
+        helm.sh/chart: cert-manager-v1.15.1
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -982,13 +984,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.14.4"
+          image: "quay.io/jetstack/cert-manager-controller:v1.15.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.14.4
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.1
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -1035,9 +1037,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   replicas: 1
   selector:
@@ -1052,9 +1054,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.14.4"
+        app.kubernetes.io/version: "v1.15.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.14.4
+        helm.sh/chart: cert-manager-v1.15.1
     spec:
       serviceAccountName: release-name-cert-manager-webhook
       enableServiceLinks: false
@@ -1064,7 +1066,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.14.4"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.15.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1116,6 +1118,25 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
 ---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+#
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
 # Source: cert-manager/charts/cert-manager/templates/webhook-mutating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -1126,9 +1147,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1167,9 +1188,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/release-name-cert-manager-webhook-ca"
 webhooks:
@@ -1221,9 +1242,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/startupapicheck-rbac.yaml
 # create certificate role
@@ -1237,9 +1258,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1260,9 +1281,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1287,9 +1308,9 @@ metadata:
     app.kubernetes.io/name: startupapicheck
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "startupapicheck"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
   annotations:
     helm.sh/hook: post-install
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
@@ -1303,9 +1324,9 @@ spec:
         app.kubernetes.io/name: startupapicheck
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "startupapicheck"
-        app.kubernetes.io/version: "v1.14.4"
+        app.kubernetes.io/version: "v1.15.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.14.4
+        helm.sh/chart: cert-manager-v1.15.1
     spec:
       restartPolicy: OnFailure
       serviceAccountName: release-name-cert-manager-startupapicheck
@@ -1316,7 +1337,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-startupapicheck
-          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.14.4"
+          image: "quay.io/jetstack/cert-manager-startupapicheck:v1.15.1"
           imagePullPolicy: IfNotPresent
           args:
           - check

--- a/charts/cert-manager/test/override-controller-test.yaml.out
+++ b/charts/cert-manager/test/override-controller-test.yaml.out
@@ -11,9 +11,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/serviceaccount.yaml
 apiVersion: v1
@@ -27,9 +27,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/webhook-serviceaccount.yaml
 apiVersion: v1
@@ -43,9 +43,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 ---
 # Source: cert-manager/charts/cert-manager/templates/cainjector-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -57,9 +57,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -91,9 +91,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -119,9 +119,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -147,9 +147,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -184,9 +184,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -224,9 +224,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -286,9 +286,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -325,9 +325,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -344,9 +344,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -369,9 +369,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -396,14 +396,16 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
     verbs: ["approve"]
-    resourceNames: ["issuers.cert-manager.io/*", "clusterissuers.cert-manager.io/*"]
+    resourceNames:
+    - "issuers.cert-manager.io/*"
+    - "clusterissuers.cert-manager.io/*"
 ---
 # Source: cert-manager/charts/cert-manager/templates/rbac.yaml
 # Permission to:
@@ -418,9 +420,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -446,9 +448,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
 - apiGroups: ["authorization.k8s.io"]
   resources: ["subjectaccessreviews"]
@@ -464,9 +466,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -486,9 +488,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -508,9 +510,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -530,9 +532,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -552,9 +554,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -574,9 +576,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -596,9 +598,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -618,9 +620,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -640,9 +642,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -662,9 +664,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -687,9 +689,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   # Used for leader election by the controller
   # cert-manager-cainjector-leader-election is used by the CertificateBased injector controller
@@ -715,9 +717,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -738,9 +740,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 rules:
 - apiGroups: [""]
   resources: ["secrets"]
@@ -765,9 +767,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -790,9 +792,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -814,9 +816,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -838,9 +840,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   type: ClusterIP
   ports:
@@ -864,9 +866,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   type: ClusterIP
   ports:
@@ -890,9 +892,9 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   replicas: 1
   selector:
@@ -907,9 +909,9 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.14.4"
+        app.kubernetes.io/version: "v1.15.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.14.4
+        helm.sh/chart: cert-manager-v1.15.1
     spec:
       serviceAccountName: cert-manager-cainjector
       enableServiceLinks: false
@@ -919,7 +921,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.14.4"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.15.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -956,9 +958,9 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   replicas: 1
   selector:
@@ -973,9 +975,9 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.14.4"
+        app.kubernetes.io/version: "v1.15.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.14.4
+        helm.sh/chart: cert-manager-v1.15.1
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -989,13 +991,13 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.14.4"
+          image: "quay.io/jetstack/cert-manager-controller:v1.15.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=kube-system
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.14.4
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.15.1
           - --max-concurrent-challenges=60
           ports:
           - containerPort: 9402
@@ -1048,9 +1050,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
 spec:
   replicas: 1
   selector:
@@ -1065,9 +1067,9 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: release-name
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.14.4"
+        app.kubernetes.io/version: "v1.15.1"
         app.kubernetes.io/managed-by: Helm
-        helm.sh/chart: cert-manager-v1.14.4
+        helm.sh/chart: cert-manager-v1.15.1
     spec:
       serviceAccountName: cert-manager-webhook
       enableServiceLinks: false
@@ -1077,7 +1079,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.14.4"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.15.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -1135,6 +1137,25 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
 ---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+#
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
+# Source: cert-manager/charts/cert-manager/templates/crds.yaml
+# START crd
+---
 # Source: cert-manager/charts/cert-manager/templates/webhook-mutating-webhook.yaml
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
@@ -1145,9 +1166,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/cert-manager-webhook-ca"
 webhooks:
@@ -1186,9 +1207,9 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: release-name
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.14.4"
+    app.kubernetes.io/version: "v1.15.1"
     app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: cert-manager-v1.14.4
+    helm.sh/chart: cert-manager-v1.15.1
   annotations:
     cert-manager.io/inject-ca-from-secret: "default/cert-manager-webhook-ca"
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:
The upgrade notes for 1.15 contain nothing relevant for us: https://cert-manager.io/docs/releases/upgrading/upgrading-1.14-1.15 -- so I think this should be a safe upgrade.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
update cert-manager Helm chart to 1.15.1
```

**Documentation**:
```documentation
NONE
```
