### PR TITLE
bump Azure CCM / cloud node manager

### DIFF
--- a/addons/azure-cloud-node-manager/cloud-node-manager.yaml
+++ b/addons/azure-cloud-node-manager/cloud-node-manager.yaml
@@ -21,16 +21,16 @@
 {{ $version = "v1.26.19" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.27" }}
-{{ $version = "v1.27.13" }}
+{{ $version = "v1.27.18" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.28" }}
-{{ $version = "v1.28.5" }}
+{{ $version = "v1.28.10" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.29" }}
-{{ $version = "v1.29.3" }}
+{{ $version = "v1.29.8" }}
 {{ end }}
 {{ if eq .Cluster.MajorMinorVersion "1.30" }}
-{{ $version = "v1.29.3" }}
+{{ $version = "v1.30.4" }}
 {{ end }}
 {{ if not (eq $version "UNSUPPORTED") }}
 apiVersion: v1

--- a/pkg/resources/cloudcontroller/azure.go
+++ b/pkg/resources/cloudcontroller/azure.go
@@ -122,15 +122,15 @@ func AzureCCMVersion(version semver.Semver) (string, error) {
 	case v126:
 		return "1.26.19", nil
 	case v127:
-		return "1.27.16", nil
+		return "1.27.18", nil
 	case v128:
-		return "1.28.8", nil
+		return "1.28.10", nil
 	case v129:
-		fallthrough
+		return "1.29.8", nil
 	case v130:
 		fallthrough
 	default:
-		return "1.29.3", nil
+		return "1.30.4", nil
 	}
 }
 

--- a/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.27.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.27.16
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.27.18
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.28.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.8
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.28.10
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.29.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.29.3
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.29.8
         livenessProbe:
           failureThreshold: 3
           httpGet:

--- a/pkg/resources/test/fixtures/deployment-azure-1.30.0-azure-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-azure-1.30.0-azure-cloud-controller-manager-externalCloudProvider.yaml
@@ -41,7 +41,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.29.3
+        image: mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager:v1.30.4
         livenessProbe:
           failureThreshold: 3
           httpGet:


### PR DESCRIPTION
**What this PR does / why we need it**:
Finally we can use a 1.30 CCM for 1.30 clusters.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Azure CCM / cloud node manager to 1.27.18, 1.28.10, 1.29.8, 1.30.4
```

**Documentation**:
```documentation
NONE
```
