### PR TITLE
Update vSphere CCM to 1.30.1

### DIFF
--- a/pkg/resources/cloudcontroller/vsphere.go
+++ b/pkg/resources/cloudcontroller/vsphere.go
@@ -124,10 +124,10 @@ func VSphereCCMVersion(version semver.Semver) string {
 	case v128:
 		return "1.28.0"
 	case v129:
-		fallthrough
+		return "1.29.0"
 	case v130:
 		fallthrough
 	default:
-		return "1.29.0"
+		return "1.30.1"
 	}
 }

--- a/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
+++ b/pkg/resources/test/fixtures/deployment-vsphere-1.30.0-vsphere-cloud-controller-manager-externalCloudProvider.yaml
@@ -42,7 +42,7 @@ spec:
         env:
         - name: SSL_CERT_FILE
           value: /etc/kubermatic/certs/ca-bundle.pem
-        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.29.0
+        image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.30.1
         name: cloud-controller-manager
         resources:
           limits:


### PR DESCRIPTION
**What this PR does / why we need it**:
Adding official support for Kubernetes 1.30.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update vSphere CCM to 1.30.1
```

**Documentation**:
```documentation
NONE
```
