### PR TITLE
Update Hetzner CCM to 1.20.0

### DIFF
--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -73,7 +73,8 @@ func hetznerDeploymentReconciler(data *resources.TemplateData) reconciling.Named
 				{
 					Name:  ccmContainerName,
 					Image: registry.Must(data.RewriteImage(resources.RegistryDocker + "/hetznercloud/hcloud-cloud-controller-manager:" + hetznerCCMVersion)),
-					Args: []string{
+					Command: []string{
+						"/bin/hcloud-cloud-controller-manager",
 						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 						"--cloud-provider=hcloud",
 						"--allow-untagged-cloud",

--- a/pkg/resources/cloudcontroller/hetzner.go
+++ b/pkg/resources/cloudcontroller/hetzner.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	HetznerCCMDeploymentName = "hcloud-cloud-controller-manager"
-	hetznerCCMVersion        = "v1.19.0" // https://github.com/hetznercloud/hcloud-cloud-controller-manager#versioning-policy
+	hetznerCCMVersion        = "v1.20.0" // https://github.com/hetznercloud/hcloud-cloud-controller-manager#versioning-policy
 )
 
 var (
@@ -73,8 +73,7 @@ func hetznerDeploymentReconciler(data *resources.TemplateData) reconciling.Named
 				{
 					Name:  ccmContainerName,
 					Image: registry.Must(data.RewriteImage(resources.RegistryDocker + "/hetznercloud/hcloud-cloud-controller-manager:" + hetznerCCMVersion)),
-					Command: []string{
-						"/bin/hcloud-cloud-controller-manager",
+					Args: []string{
 						"--kubeconfig=/etc/kubernetes/kubeconfig/kubeconfig",
 						"--cloud-provider=hcloud",
 						"--allow-untagged-cloud",


### PR DESCRIPTION
**What this PR does / why we need it**:
This brings official support for 1.29 and 1.30. I included the upstream change hetznercloud/hcloud-cloud-controller-manager#691.

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Update Hetzner CCM to 1.20.0
```

**Documentation**:
```documentation
NONE
```
