### PR TITLE
cluster-template: add custom cluster annotations

### DIFF
--- a/pkg/apis/kubermatic/v1/cluster_templates.go
+++ b/pkg/apis/kubermatic/v1/cluster_templates.go
@@ -57,6 +57,7 @@ type ClusterTemplate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	ClusterAnnotations     map[string]string `json:"clusterAnnotations,omitempty"`
 	ClusterLabels          map[string]string `json:"clusterLabels,omitempty"`
 	InheritedClusterLabels map[string]string `json:"inheritedClusterLabels,omitempty"`
 	Credential             string            `json:"credential"`

--- a/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/kubermatic/v1/zz_generated.deepcopy.go
@@ -1455,6 +1455,13 @@ func (in *ClusterTemplate) DeepCopyInto(out *ClusterTemplate) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
+	if in.ClusterAnnotations != nil {
+		in, out := &in.ClusterAnnotations, &out.ClusterAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.ClusterLabels != nil {
 		in, out := &in.ClusterLabels, &out.ClusterLabels
 		*out = make(map[string]string, len(*in))

--- a/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
+++ b/pkg/controller/master-controller-manager/cluster-template-synchronizer/controller.go
@@ -181,6 +181,7 @@ func clusterTemplateReconcilerFactory(template *kubermaticv1.ClusterTemplate) re
 			c.Spec = template.Spec
 			c.Labels = template.Labels
 			c.Annotations = template.Annotations
+			c.ClusterAnnotations = template.ClusterAnnotations
 			c.InheritedClusterLabels = template.InheritedClusterLabels
 			c.Credential = template.Credential
 			return c, nil

--- a/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
+++ b/pkg/controller/seed-controller-manager/cluster-template-controller/controller.go
@@ -242,11 +242,19 @@ func (r *reconciler) assignSSHKeyToCluster(ctx context.Context, clusterID string
 func genNewCluster(template *kubermaticv1.ClusterTemplate, instance *kubermaticv1.ClusterTemplateInstance, workerName string) *kubermaticv1.Cluster {
 	name := utilcluster.MakeClusterName()
 
+	annotations := make(map[string]string)
+	for key, val := range template.ClusterAnnotations {
+		annotations[key] = val
+	}
+	for key, val := range template.Annotations {
+		annotations[key] = val
+	}
+
 	newCluster := &kubermaticv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Labels:      template.ClusterLabels,
-			Annotations: template.Annotations,
+			Annotations: annotations,
 		},
 	}
 

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_clustertemplates.yaml
@@ -40,6 +40,10 @@ spec:
                 may reject unrecognized values.
                 More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
+            clusterAnnotations:
+              additionalProperties:
+                type: string
+              type: object
             clusterLabels:
               additionalProperties:
                 type: string

--- a/pkg/test/generator/objects.go
+++ b/pkg/test/generator/objects.go
@@ -616,6 +616,7 @@ func GenClusterTemplate(name, id, projectID, scope, userEmail string) *kubermati
 			Labels:      map[string]string{kubermaticv1.ClusterTemplateScopeLabelKey: scope, kubermaticv1.ProjectIDLabelKey: projectID, kubermaticv1.ClusterTemplateHumanReadableNameLabelKey: name},
 			Annotations: map[string]string{kubermaticv1.ClusterTemplateUserAnnotationKey: userEmail},
 		},
+		ClusterAnnotations:     nil,
 		ClusterLabels:          nil,
 		InheritedClusterLabels: nil,
 		Credential:             "",


### PR DESCRIPTION
**What this PR does / why we need it**:
adds `ClusterAnnotation` to `ClusterTemplate` for adding custom annotations to user clusters.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #11569

**What type of PR is this?**
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
yes, users should be able to add custom annotations to their clusters.
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
