### PR TITLE
feat: add Labels to ServiceTypeLoadBalancer

### DIFF
--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -368,6 +368,9 @@ type EnvoyLoadBalancerService struct {
 	// Annotations are used to further tweak the LoadBalancer integration with the
 	// cloud provider.
 	Annotations map[string]string `json:"annotations,omitempty"`
+	// Labels are used to further tweak the LoadBalancer integration with the
+	// cloud provider.
+	Labels map[string]string `json:"labels,omitempty"`
 	// SourceRanges will restrict loadbalancer service to IP ranges specified using CIDR notation like 172.25.0.0/16.
 	// This field will be ignored if the cloud-provider does not support the feature.
 	// More info: https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/

--- a/pkg/resources/nodeportproxy/nodeportproxy.go
+++ b/pkg/resources/nodeportproxy/nodeportproxy.go
@@ -432,6 +432,13 @@ func FrontLoadBalancerServiceReconciler(data *resources.TemplateData) reconcilin
 				}
 			}
 
+			// Copy custom labels specified for the loadBalancer Service.
+			if seed.Spec.NodeportProxy.Envoy.LoadBalancerService.Labels != nil {
+				for k, v := range seed.Spec.NodeportProxy.Envoy.LoadBalancerService.Labels {
+					s.Labels[k] = v
+				}
+			}
+
 			// set of Source IP ranges
 			sourceIPList := sets.Set[string]{}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
add possible to set labels for the envoy service. Many CNIs depending on Labels (like Cilium)

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind/feature
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `.spec.nodeportProxy.envoy.loadBalancerService.labels` to make labels on LoadBalancers created for expose strategies configurable
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
