### PR TITLE
fix VPA admission-controller PDB blocking evictions

### DIFF
--- a/pkg/controller/operator/common/vpa/admissionctrl.go
+++ b/pkg/controller/operator/common/vpa/admissionctrl.go
@@ -146,10 +146,11 @@ func AdmissionControllerDeploymentReconciler(cfg *kubermaticv1.KubermaticConfigu
 }
 
 func AdmissionControllerPDBReconciler() reconciling.NamedPodDisruptionBudgetReconcilerFactory {
-	minAvailable := intstr.FromInt(1)
+	maxUnavailable := intstr.FromInt(1)
 	return func() (string, reconciling.PodDisruptionBudgetReconciler) {
 		return AdmissionControllerName, func(pdb *policyv1.PodDisruptionBudget) (*policyv1.PodDisruptionBudget, error) {
-			pdb.Spec.MinAvailable = &minAvailable
+			pdb.Spec.MinAvailable = nil // reset a value previously set by KKP <2.25.7
+			pdb.Spec.MaxUnavailable = &maxUnavailable
 			pdb.Spec.Selector = &metav1.LabelSelector{
 				MatchLabels: appPodLabels(AdmissionControllerName),
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:
In #13180 I introduced PDBs for the VPA, because its Pods live in the kube-system namespace and therefore need a PDB in order for the cluster-autoscaler to consider them evictable.

However in that PR I chose maxUnavailable for recommender/updater, yet chose minAvailable for the admission-controller, even though all 3 Deployments have 1 replica and work identically. So I presume this was simply an oversight, and since now the PDB for the admission-controller is causing node rollout issues, I guess it makes sense to also allow evictions for it the same way we do for the other components.

**What type of PR is this?**
/kind bug

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Fix VPA admission-controller PDB blocking evictions
```

**Documentation**:
```documentation
NONE
```
