### PR TITLE
Fix minor issues with Velero KKP chart

### DIFF
--- a/charts/backup/velero/templates/daemonset.yaml
+++ b/charts/backup/velero/templates/daemonset.yaml
@@ -31,7 +31,8 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: node-agent
-        # This is label is required for successfull volume backup. Velero uses it to check if the nodeAgent pod is running on the specifc node where the volume is attached or not.
+        # This is label is required for successful volume backup.
+        # Velero uses it to check if the nodeAgent pod is running on the specific node where the volume is attached or not.
         # https://github.com/vmware-tanzu/velero/blob/21beda3c2a87af0b967fea487c735140c765de7d/pkg/nodeagent/node_agent.go#L92
         name: node-agent
       annotations:

--- a/charts/backup/velero/templates/daemonset.yaml
+++ b/charts/backup/velero/templates/daemonset.yaml
@@ -31,6 +31,9 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: node-agent
+        # This is label is required for successfull volume backup. Velero uses it to check if the nodeAgent pod is running on the specifc node where the volume is attached or not.
+        # https://github.com/vmware-tanzu/velero/blob/21beda3c2a87af0b967fea487c735140c765de7d/pkg/nodeagent/node_agent.go#L92
+        name: node-agent
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: scratch
     spec:

--- a/charts/backup/velero/templates/secrets.yaml
+++ b/charts/backup/velero/templates/secrets.yaml
@@ -22,7 +22,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: velero-restic-credentials
+  name: velero-repo-credentials
 type: Opaque
 data:
   repository-password: {{ . | b64enc | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a couple of issues in the KKP Velero Chart:
- Adds [required](https://github.com/vmware-tanzu/velero/blob/21beda3c2a87af0b967fea487c735140c765de7d/pkg/nodeagent/node_agent.go#L92) label to the `nodeAgent` daemonset to avoid partial backup failures when doing volume filesystem backup.
- Applies a secret rename the was introduced in Velero [v1.10.0](https://github.com/vmware-tanzu/velero/blob/55e027897c7cdab0b3d0d32b8706757da7267d95/changelogs/CHANGELOG-1.10.md?plain=1#L69).
**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->
/kind bug
**Special notes for your reviewer**:

This should be backported to release/2.25 and release/2.24.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Adds the label `name: nodeAgent` to the Velero daemon set pods.
- The secret `velero-restic-credentials` is renamed to `velero-repo-credentials`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
