### PR TITLE
Bump latest k8s patch versions

### DIFF
--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -571,8 +571,6 @@ spec:
       - v1.29.4
       - v1.29.6
       - v1.29.7
-      - v1.30.0
-      - v1.30.2
       - v1.30.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:

--- a/docs/zz_generated.kubermaticConfiguration.ce.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ce.yaml
@@ -460,7 +460,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.29.6
+    default: v1.29.7
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -564,13 +564,16 @@ spec:
       - v1.28.7
       - v1.28.9
       - v1.28.11
+      - v1.28.12
       - v1.29.0
       - v1.29.1
       - v1.29.2
       - v1.29.4
       - v1.29.6
+      - v1.29.7
       - v1.30.0
       - v1.30.2
+      - v1.30.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -571,8 +571,6 @@ spec:
       - v1.29.4
       - v1.29.6
       - v1.29.7
-      - v1.30.0
-      - v1.30.2
       - v1.30.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:

--- a/docs/zz_generated.kubermaticConfiguration.ee.yaml
+++ b/docs/zz_generated.kubermaticConfiguration.ee.yaml
@@ -460,7 +460,7 @@ spec:
   # Versions configures the available and default Kubernetes versions and updates.
   versions:
     # Default is the default version to offer users.
-    default: v1.29.6
+    default: v1.29.7
     # ExternalClusters contains the available and default Kubernetes versions and updates for ExternalClusters.
     externalClusters:
       aks:
@@ -564,13 +564,16 @@ spec:
       - v1.28.7
       - v1.28.9
       - v1.28.11
+      - v1.28.12
       - v1.29.0
       - v1.29.1
       - v1.29.2
       - v1.29.4
       - v1.29.6
+      - v1.29.7
       - v1.30.0
       - v1.30.2
+      - v1.30.3
   # VerticalPodAutoscaler configures the Kubernetes VPA integration.
   verticalPodAutoscaler:
     admissionController:

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -248,8 +248,6 @@ var (
 			newSemver("v1.29.6"),
 			newSemver("v1.29.7"),
 			// Kubernetes 1.30
-			newSemver("v1.30.0"),
-			newSemver("v1.30.2"),
 			newSemver("v1.30.3"),
 		},
 		Updates: []kubermaticv1.Update{

--- a/pkg/defaulting/configuration.go
+++ b/pkg/defaulting/configuration.go
@@ -216,7 +216,7 @@ var (
 	}
 
 	DefaultKubernetesVersioning = kubermaticv1.KubermaticVersioningConfiguration{
-		Default: semver.NewSemverOrDie("v1.29.6"),
+		Default: semver.NewSemverOrDie("v1.29.7"),
 		// NB: We keep all patch releases that we supported, even if there's
 		// an auto-upgrade rule in place. That's because removing a patch
 		// release from this slice can break reconciliation loop for clusters
@@ -239,15 +239,18 @@ var (
 			newSemver("v1.28.7"),
 			newSemver("v1.28.9"),
 			newSemver("v1.28.11"),
+			newSemver("v1.28.12"),
 			// Kubernetes 1.29
 			newSemver("v1.29.0"),
 			newSemver("v1.29.1"),
 			newSemver("v1.29.2"),
 			newSemver("v1.29.4"),
 			newSemver("v1.29.6"),
+			newSemver("v1.29.7"),
 			// Kubernetes 1.30
 			newSemver("v1.30.0"),
 			newSemver("v1.30.2"),
+			newSemver("v1.30.3"),
 		},
 		Updates: []kubermaticv1.Update{
 			// ======= 1.27 =======


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to add the support for the latest k8s patch versions (1.30.3/1.29.7/1.28.12).

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->
Fixes #

**What type of PR is this?**
/kind chore

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add 1.30.3/1.29.7/1.28.12 to the list of supported Kubernetes releases.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
