### PR TITLE
Add KKP version to Addon status

### DIFF
--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -127,4 +127,6 @@ type AddonCondition struct {
 	// Last time the condition transitioned from one status to another.
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	// KubermaticVersion current KKP version.
+	KubermaticVersion string `json:"kubermaticVersion,omitempty"`
 }

--- a/pkg/apis/kubermatic/v1/addon.go
+++ b/pkg/apis/kubermatic/v1/addon.go
@@ -98,7 +98,7 @@ type AddonList struct {
 // +kubebuilder:validation:Enum=New;Healthy;Unhealthy
 type AddonPhase string
 
-// These are the valid phases of a project.
+// These are the valid phases of an addon.
 const (
 	AddonNew       AddonPhase = "New"
 	AddonHealthy   AddonPhase = "Healthy"
@@ -127,6 +127,7 @@ type AddonCondition struct {
 	// Last time the condition transitioned from one status to another.
 	// +optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
-	// KubermaticVersion current KKP version.
+	// KubermaticVersion is the version of KKP that last _successfully_ reconciled this
+	// addon.
 	KubermaticVersion string `json:"kubermaticVersion,omitempty"`
 }

--- a/pkg/controller/seed-controller-manager/addon/addon_controller.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"slices"
 	"strings"
 	"time"
 
@@ -92,7 +93,7 @@ type Reconciler struct {
 	addonVariables       map[string]interface{}
 	overwriteRegistry    string
 	recorder             record.EventRecorder
-	KubeconfigProvider   KubeconfigProvider
+	kubeconfigProvider   KubeconfigProvider
 	versions             kubermatic.Versions
 	addons               map[string]*addon.Addon
 }
@@ -120,7 +121,7 @@ func Add(
 		log:                  log,
 		addonVariables:       addonCtxVariables,
 		addonEnforceInterval: addonEnforceInterval,
-		KubeconfigProvider:   kubeconfigProvider,
+		kubeconfigProvider:   kubeconfigProvider,
 		workerName:           workerName,
 		recorder:             mgr.GetEventRecorderFor(ControllerName),
 		overwriteRegistry:    overwriteRegistry,
@@ -401,7 +402,7 @@ func (r *Reconciler) getAddonManifests(ctx context.Context, log *zap.SugaredLogg
 		dnsResolverIP = resources.NodeLocalDNSCacheAddress
 	}
 
-	kubeconfig, err := r.KubeconfigProvider.GetAdminKubeconfig(ctx, cluster)
+	kubeconfig, err := r.kubeconfigProvider.GetAdminKubeconfig(ctx, cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -531,7 +532,7 @@ func (r *Reconciler) writeCombinedManifest(log *zap.SugaredLogger, manifest *byt
 
 func (r *Reconciler) writeAdminKubeconfig(ctx context.Context, log *zap.SugaredLogger, addon *kubermaticv1.Addon, cluster *kubermaticv1.Cluster) (string, fileHandlingDone, error) {
 	// Write kubeconfig to disk
-	kubeconfig, err := r.KubeconfigProvider.GetAdminKubeconfig(ctx, cluster)
+	kubeconfig, err := r.kubeconfigProvider.GetAdminKubeconfig(ctx, cluster)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get admin kubeconfig for cluster %s: %w", cluster.Name, err)
 	}
@@ -600,7 +601,7 @@ func (r *Reconciler) getApplyCommand(ctx context.Context, kubeconfigFilename, ma
 // as a result, the CSDriver resource has to be redeployed
 // https://github.com/kubermatic/kubermatic/issues/12429
 func (r *Reconciler) migrateHetznerCSIDriver(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+	cl, err := r.kubeconfigProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get kube client: %w", err)
 	}
@@ -627,7 +628,7 @@ func (r *Reconciler) migrateHetznerCSIDriver(ctx context.Context, log *zap.Sugar
 // https://github.com/kubermatic/kubermatic/issues/12801
 // https://github.com/kubermatic/kubermatic/pull/12936
 func (r *Reconciler) migrateVsphereCSIDriver(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+	cl, err := r.kubeconfigProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get kube client: %w", err)
 	}
@@ -660,7 +661,7 @@ func (r *Reconciler) migrateVsphereCSIDriver(ctx context.Context, log *zap.Sugar
 
 // Between v2.24 and v2.25, the roleRef in a ClusterRoleBinding for the Azure CSI changed.
 func (r *Reconciler) migrateAzureCSIRBAC(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+	cl, err := r.kubeconfigProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get kube client: %w", err)
 	}
@@ -747,7 +748,7 @@ func (r *Reconciler) ensureIsInstalled(ctx context.Context, log *zap.SugaredLogg
 	}
 
 	if addon.Name == csiAddonName {
-		err := r.csiAddonInUseStatus(ctx, log, cluster)
+		err := r.csiAddonInUseStatus(ctx, cluster)
 		if err != nil {
 			return fmt.Errorf("failed to update %s addon status: %w", csiAddonName, err)
 		}
@@ -815,7 +816,7 @@ func (r *Reconciler) ensureRequiredResourceTypesExist(ctx context.Context, log *
 		// Avoid constructing a client we don't need and just return early
 		return nil, nil
 	}
-	userClusterClient, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+	userClusterClient, err := r.kubeconfigProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get client for usercluster: %w", err)
 	}
@@ -874,8 +875,8 @@ func hasEnsureResourcesLabel(addon *kubermaticv1.Addon) bool {
 	return addon.Labels[addonEnsureLabelKey] == "true"
 }
 
-func (r *Reconciler) csiAddonInUseStatus(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) error {
-	status, reason := r.checkCSIAddonInUse(ctx, log, cluster)
+func (r *Reconciler) csiAddonInUseStatus(ctx context.Context, cluster *kubermaticv1.Cluster) error {
+	status, reason := r.checkCSIAddonInUse(ctx, cluster)
 	csiAddonInUse := kubermaticv1.ClusterCondition{
 		Status:            status,
 		KubermaticVersion: r.versions.Kubermatic,
@@ -888,11 +889,12 @@ func (r *Reconciler) csiAddonInUseStatus(ctx context.Context, log *zap.SugaredLo
 	return err
 }
 
-func (r *Reconciler) checkCSIAddonInUse(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster) (corev1.ConditionStatus, string) {
-	userClusterClient, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+func (r *Reconciler) checkCSIAddonInUse(ctx context.Context, cluster *kubermaticv1.Cluster) (corev1.ConditionStatus, string) {
+	userClusterClient, err := r.kubeconfigProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return corev1.ConditionUnknown, fmt.Sprintf("failed to get client for usercluster: %v", err)
 	}
+
 	csiDriverList := &storagev1.CSIDriverList{}
 	csiDriverListOption := &ctrlruntimeclient.ListOptions{
 		Raw: &metav1.ListOptions{
@@ -902,114 +904,91 @@ func (r *Reconciler) checkCSIAddonInUse(ctx context.Context, log *zap.SugaredLog
 
 	// Get CSI drivers created by the csi addon
 	if err := userClusterClient.List(ctx, csiDriverList, csiDriverListOption); err != nil {
-		return corev1.ConditionUnknown, fmt.Sprintf("failed to list csi drivers with %v label: %v", csiAddonStorageClassLabel, err)
+		return corev1.ConditionUnknown, fmt.Sprintf("failed to list CSI drivers with %v label: %v", csiAddonStorageClassLabel, err)
 	}
-	// map to hold csi drivers to storage classes list
-	csiToSC := make(map[string][]string)
-	csiToPV := make(map[string][]string)
-	errMsg := []string{}
-	for i := 0; i < len(csiDriverList.Items); i++ {
-		if !strings.Contains(csiDriverList.Items[i].Name, "csi") {
-			continue
-		}
-		// get all the storage classes that are using the csi driver created by csi addon as provisioner
-		storageCLassList, err := r.storageClassesForProvisioner(ctx, cluster, csiDriverList.Items[i].Name)
-		if err != nil {
-			return corev1.ConditionUnknown, fmt.Sprintf("failed to get the list of storage classes using %v provisioner: %v", csiDriverList.Items[i].Name, err)
-		}
-		for j := 0; j < len(storageCLassList); j++ {
-			pvcList, err := r.pvcsForStorageClass(ctx, cluster, storageCLassList[j])
-			if err != nil {
-				return corev1.ConditionUnknown, fmt.Sprintf("failed to get the list of PVCs referring the %v storage class: %v", storageCLassList[j], err)
+
+	// list all PVCs (cannot filter them by field selectors anyway)
+	pvcList := &corev1.PersistentVolumeClaimList{}
+	if err := userClusterClient.List(ctx, pvcList); err != nil {
+		return corev1.ConditionUnknown, fmt.Sprintf("failed to list PVCs: %v", err)
+	}
+
+	// same for the PVs
+	pvList := &corev1.PersistentVolumeList{}
+	if err := userClusterClient.List(ctx, pvList); err != nil {
+		return corev1.ConditionUnknown, fmt.Sprintf("failed to list PVs: %v", err)
+	}
+
+	// and the same for storage classes
+	storageClassList := &storagev1.StorageClassList{}
+	if err := userClusterClient.List(ctx, storageClassList); err != nil {
+		return corev1.ConditionUnknown, fmt.Sprintf("failed to get storage classes: %v", err)
+	}
+
+	errorMessages := []string{}
+
+	for _, csiDriver := range csiDriverList.Items {
+		// get all the storage classes that are using this driver as provisioner
+		storageClasses := filterStorageClassesByProvisioner(storageClassList.Items, csiDriver.Name)
+
+		// remove all unused storage classes
+		storageClasses = slices.DeleteFunc(storageClasses, func(scName string) bool {
+			for _, pvc := range pvcList.Items {
+				if pvc.Spec.StorageClassName != nil && *pvc.Spec.StorageClassName == scName {
+					return false
+				}
 			}
-			if len(pvcList) > 0 {
-				csiToSC[csiDriverList.Items[i].Name] = append(csiToSC[csiDriverList.Items[i].Name], storageCLassList[j])
-			}
-		}
-		if len(csiToSC[csiDriverList.Items[i].Name]) != 0 {
-			errMsg = append(errMsg, fmt.Sprintf("csidriver %s is being used by storage classes %s", csiDriverList.Items[i].Name, csiToSC[csiDriverList.Items[i].Name]))
+
+			return true
+		})
+
+		if len(storageClasses) > 0 {
+			errorMessages = append(errorMessages, fmt.Sprintf("CSI driver %s is being used by storage classes %s", csiDriver.Name, storageClasses))
 		} else {
 			// Check for the corner case where admin removes the SC without removing the PVs & tries to disable CSI drivers used by them.
-			pvList, err := r.pvsForProvisioner(ctx, cluster, csiDriverList.Items[i].Name)
-			if err != nil {
-				return corev1.ConditionUnknown, fmt.Sprintf("failed to get the list of PVs having %v as provisioner : %v", csiDriverList.Items[i].Name, err)
-			}
-			if len(pvList) > 0 {
-				csiToPV[csiDriverList.Items[i].Name] = append(csiToPV[csiDriverList.Items[i].Name], pvList[0])
-				errMsg = append(errMsg, fmt.Sprintf("csidriver %s is being used by PV %s & %d other PVs", csiDriverList.Items[i].Name, pvList[0], (len(pvList)-1)))
+			if orphanedPVs := filterPVsByProvisioner(pvList.Items, csiDriver.Name); len(orphanedPVs) > 0 {
+				errorMessages = append(errorMessages, fmt.Sprintf("CSI driver %s is being used by PV %s & %d other PVs", csiDriver.Name, orphanedPVs[0], len(orphanedPVs)-1))
 			}
 		}
 	}
-	if len(csiToSC) == 0 && len(csiToPV) == 0 {
+
+	if len(errorMessages) == 0 {
 		return corev1.ConditionFalse, ""
 	}
 
-	return corev1.ConditionTrue, fmt.Sprintf("%v", errMsg)
+	return corev1.ConditionTrue, fmt.Sprintf("%v", errorMessages)
 }
 
-func (r *Reconciler) storageClassesForProvisioner(ctx context.Context, cluster *kubermaticv1.Cluster, provisionerName string) ([]string, error) {
-	storageCLassesForProvisioner := []string{}
-	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
-	if err != nil {
-		return storageCLassesForProvisioner, fmt.Errorf("failed to get client for usercluster: %w", err)
-	}
-	storageCLassList := &storagev1.StorageClassList{}
-	if err := cl.List(ctx, storageCLassList); err != nil {
-		return storageCLassesForProvisioner, fmt.Errorf("failed to get storage classes using provisioner %v: %w", provisionerName, err)
-	}
-	for i := 0; i < len(storageCLassList.Items); i++ {
-		if storageCLassList.Items[i].Provisioner == provisionerName {
-			storageCLassesForProvisioner = append(storageCLassesForProvisioner, storageCLassList.Items[i].Name)
+func filterStorageClassesByProvisioner(classes []storagev1.StorageClass, provisionerName string) []string {
+	classNames := []string{}
+	for _, sc := range classes {
+		if sc.Provisioner == provisionerName {
+			classNames = append(classNames, sc.Name)
 		}
 	}
-	return storageCLassesForProvisioner, nil
+
+	return classNames
 }
 
-func (r *Reconciler) pvcsForStorageClass(ctx context.Context, cluster *kubermaticv1.Cluster, storageClassName string) ([]string, error) {
-	pvcsForStorageClass := []string{}
-	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
-	if err != nil {
-		return pvcsForStorageClass, fmt.Errorf("failed to get client for usercluster: %w", err)
-	}
-	pvcList := &corev1.PersistentVolumeClaimList{}
-	if err := cl.List(ctx, pvcList); err != nil {
-		return pvcsForStorageClass, fmt.Errorf("failed to get the list of PVCs referring the %v storage class: %w", storageClassName, err)
-	}
-
-	for _, item := range pvcList.Items {
-		if item.Spec.StorageClassName != nil && *item.Spec.StorageClassName == storageClassName {
-			pvcsForStorageClass = append(pvcsForStorageClass, item.Name)
-		}
-	}
-	return pvcsForStorageClass, nil
-}
-
-func (r *Reconciler) pvsForProvisioner(ctx context.Context, cluster *kubermaticv1.Cluster, provisionerName string) ([]string, error) {
-	pvsForProvisioner := []string{}
-	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
-	if err != nil {
-		return pvsForProvisioner, fmt.Errorf("failed to get client for usercluster: %w", err)
-	}
-	pvList := &corev1.PersistentVolumeList{}
-	if err := cl.List(ctx, pvList); err != nil {
-		return pvsForProvisioner, fmt.Errorf("failed to get the list of PVs having %v as provisioner : %w", provisionerName, err)
-	}
-	for i := 0; i < len(pvList.Items); i++ {
-		if pvList.Items[i].Spec.CSI != nil {
-			if pvList.Items[i].Spec.CSI.Driver == provisionerName {
-				pvsForProvisioner = append(pvsForProvisioner, pvList.Items[i].Name)
+func filterPVsByProvisioner(pvs []corev1.PersistentVolume, provisionerName string) []string {
+	pvNames := []string{}
+	for _, pv := range pvs {
+		if pv.Spec.CSI != nil {
+			if pv.Spec.CSI.Driver == provisionerName {
+				pvNames = append(pvNames, pv.Name)
 			}
 		} else {
-			if pvList.Items[i].ObjectMeta.Annotations[pvMigrationAnnotation] == provisionerName {
-				pvsForProvisioner = append(pvsForProvisioner, pvList.Items[i].Name)
+			if pv.ObjectMeta.Annotations[pvMigrationAnnotation] == provisionerName {
+				pvNames = append(pvNames, pv.Name)
 			}
 		}
 	}
-	return pvsForProvisioner, nil
+
+	return pvNames
 }
 
 func (r *Reconciler) cleanupDefaultStorageClassAddon(ctx context.Context, cluster *kubermaticv1.Cluster, addon *kubermaticv1.Addon) error {
-	cl, err := r.KubeconfigProvider.GetClient(ctx, cluster)
+	cl, err := r.kubeconfigProvider.GetClient(ctx, cluster)
 	if err != nil {
 		return fmt.Errorf("failed to get client for usercluster: %w", err)
 	}

--- a/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
+++ b/pkg/controller/seed-controller-manager/addon/addon_controller_test.go
@@ -230,7 +230,7 @@ func TestController_getAddonKubeDNStManifests(t *testing.T) {
 	ctx := context.Background()
 
 	controller := &Reconciler{
-		KubeconfigProvider: &fakeKubeconfigProvider{},
+		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(ctx, log, testAddon, cluster, addonObj)
 	if err != nil {
@@ -290,7 +290,7 @@ func TestController_getAddonDeploymentManifests(t *testing.T) {
 
 	controller := &Reconciler{
 		overwriteRegistry:  "bar.io",
-		KubeconfigProvider: &fakeKubeconfigProvider{},
+		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(context.Background(), log, testAddon, cluster, addonObj)
 	if err != nil {
@@ -333,7 +333,7 @@ func TestController_getAddonDeploymentManifestsDefault(t *testing.T) {
 	log := kubermaticlog.New(true, kubermaticlog.FormatConsole).Sugar()
 
 	controller := &Reconciler{
-		KubeconfigProvider: &fakeKubeconfigProvider{},
+		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(context.Background(), log, testAddon, cluster, addonObj)
 	if err != nil {
@@ -382,7 +382,7 @@ func TestController_getAddonManifests(t *testing.T) {
 	}
 
 	controller := &Reconciler{
-		KubeconfigProvider: &fakeKubeconfigProvider{},
+		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 	manifests, err := controller.getAddonManifests(context.Background(), log, testAddon, cluster, addonObj)
 	if err != nil {
@@ -408,7 +408,7 @@ func TestController_getAddonManifests(t *testing.T) {
 
 func TestController_ensureAddonLabelOnManifests(t *testing.T) {
 	controller := &Reconciler{
-		KubeconfigProvider: &fakeKubeconfigProvider{},
+		kubeconfigProvider: &fakeKubeconfigProvider{},
 	}
 
 	manifest := runtime.RawExtension{}
@@ -470,7 +470,7 @@ func TestHugeManifest(t *testing.T) {
 	}
 
 	r := &Reconciler{
-		KubeconfigProvider: &fakeKubeconfigProvider{},
+		kubeconfigProvider: &fakeKubeconfigProvider{},
 		addons:             allAddons,
 	}
 	if _, _, _, err := r.setupManifestInteraction(context.Background(), log, testAddon, cluster); err != nil {

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -139,7 +139,9 @@ spec:
                   additionalProperties:
                     properties:
                       kubermaticVersion:
-                        description: KubermaticVersion current KKP version.
+                        description: |-
+                          KubermaticVersion is the version of KKP that last _successfully_ reconciled this
+                          addon.
                         type: string
                       lastHeartbeatTime:
                         description: Last time we got an update on a given condition.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_addons.yaml
@@ -138,6 +138,9 @@ spec:
                 conditions:
                   additionalProperties:
                     properties:
+                      kubermaticVersion:
+                        description: KubermaticVersion current KKP version.
+                        type: string
                       lastHeartbeatTime:
                         description: Last time we got an update on a given condition.
                         format: date-time


### PR DESCRIPTION
**What this PR does / why we need it**:
For Clusters we remember the KKP version that last successfully reconciled the cluster object, per Condition. For addons we originally did not do this (even though Addons to have Conditions), but later we introduced custom hacky annotations on the Cluster (!) object to remember basically the same information: when we last ran a piece of migration code successfully against a cluster.

This PR cleans it up and adds a KKP version field to AddonConditions. This allows us to easily store whether/when an addon was successfully reconciled (incl. migrations, if necessary). Then we do not need custom annotations anymore.

I have not yet planned any cleanup code to remove the old annotations; we could do this in a future KKP release, it's not critical and doing both cleanup and new code in this PR seemed a bit much.

**NB:** Yes, we do save the KKP version, _but_ we do not do version comparisons when deciding if a migration should run. Migration code does feature detection, i.e. it actually fetches the relevant Kubernetes objects from the usercluster and inspects them to make the ultimate decision. We store the KKP version simply so we can skip this migration step for subsequent reconciliations _with the same KKP version_. This means that yes, once you updated KKP, the migration code for each addon is run for each user cluster again (but should of course not do anything anymore). This is seemingly "too much work", but simply a side effect from the feature-based detection. Some thing had to give, and this is what we decided on. :grin: 

Another reason for not doing a version comparison is that on dev, we do not have nice semver versions, but only Git SHA-1 hashes.

Additionally I cleaned up the CSI-addon check code a bit. It now does fewer Kubernetes queries to achieve the same result, hopefully :grin: 

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Addon conditions now contain the KKP version that has last successfully reconciled the addon (similar to the Cluster conditions).
```

**Documentation**:
```documentation
NONE
```
