### PR TITLE
Refactor addon migrations

### DIFF
--- a/pkg/controller/seed-controller-manager/addon/migrations/csi-azure.go
+++ b/pkg/controller/seed-controller-manager/addon/migrations/csi-azure.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Between v2.24 and v2.25, the roleRef in a ClusterRoleBinding for the Azure CSI changed.
+type azureCsiMigration struct {
+	nopMigration
+}
+
+func (m *azureCsiMigration) Targets(cluster *kubermaticv1.Cluster, addonName string) bool {
+	return addonName == "csi" && cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] && cluster.Spec.Cloud.Azure != nil
+}
+
+func (m *azureCsiMigration) PreApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	crb := &rbacv1.ClusterRoleBinding{}
+	if err := userclusterClient.Get(ctx, types.NamespacedName{Name: "csi-azuredisk-node-secret-binding"}, crb); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get ClusterRoleBinding: %w", err)
+	}
+
+	if crb.RoleRef.Name != "csi-azuredisk-node-role" {
+		log.Infof("Deleting Azure ClusterRoleBinding %s to allow upgrade", crb.Name)
+		if err := userclusterClient.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete ClusterRoleBinding: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/seed-controller-manager/addon/migrations/csi-hetzner.go
+++ b/pkg/controller/seed-controller-manager/addon/migrations/csi-hetzner.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Between v2.22 and v2.23, there was a change to hetzner CSI driver immutable field fsGroupPolicy
+// as a result, the CSDriver resource has to be redeployed
+// https://github.com/kubermatic/kubermatic/issues/12429
+type hetznerCsiMigration struct {
+	nopMigration
+}
+
+func (m *hetznerCsiMigration) Targets(cluster *kubermaticv1.Cluster, addonName string) bool {
+	return addonName == "csi" && cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] && cluster.Spec.Cloud.Hetzner != nil
+}
+
+func (m *hetznerCsiMigration) PreApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	driver := &storagev1.CSIDriver{}
+	if err := userclusterClient.Get(ctx, types.NamespacedName{Name: "csi.hetzner.cloud"}, driver); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get CSIDriver: %w", err)
+	}
+
+	if driver.Spec.FSGroupPolicy == nil || *driver.Spec.FSGroupPolicy != storagev1.FileFSGroupPolicy {
+		log.Info("Deleting Hetzner CSIDriver to allow upgrade")
+		if err := userclusterClient.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete old CSIDriver: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/seed-controller-manager/addon/migrations/csi-vsphere.go
+++ b/pkg/controller/seed-controller-manager/addon/migrations/csi-vsphere.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	storagev1 "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Between v2.23 and v2.24, there was a change to the vSphere CSI driver immutable field volumeLifecycleModes
+// as a result, the CSDriver resource has to be redeployed; there was another change between 2.24 and 2.25 that
+// also requires a recreation of the CSIDriver.
+// https://github.com/kubermatic/kubermatic/issues/12801
+// https://github.com/kubermatic/kubermatic/pull/12936
+type vsphereCsiMigration struct {
+	nopMigration
+}
+
+func (m *vsphereCsiMigration) Targets(cluster *kubermaticv1.Cluster, addonName string) bool {
+	return addonName == "csi" && cluster.Spec.Features[kubermaticv1.ClusterFeatureExternalCloudProvider] && cluster.Spec.Cloud.VSphere != nil
+}
+
+func (m *vsphereCsiMigration) PreApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	driver := &storagev1.CSIDriver{}
+	if err := userclusterClient.Get(ctx, types.NamespacedName{Name: "csi.vsphere.vmware.com"}, driver); apierrors.IsNotFound(err) {
+		return nil
+	} else if err != nil {
+		return fmt.Errorf("failed to get CSIDriver: %w", err)
+	}
+
+	recreate := false
+	if len(driver.Spec.VolumeLifecycleModes) > 1 || (len(driver.Spec.VolumeLifecycleModes) == 1 && driver.Spec.VolumeLifecycleModes[0] != storagev1.VolumeLifecyclePersistent) {
+		recreate = true
+	}
+
+	if driver.Spec.PodInfoOnMount == nil || *driver.Spec.PodInfoOnMount {
+		recreate = true
+	}
+
+	if recreate {
+		log.Info("Deleting vSphere CSIDriver to allow upgrade")
+		if err := userclusterClient.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete old CSIDriver: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/controller/seed-controller-manager/addon/migrations/migrations.go
+++ b/pkg/controller/seed-controller-manager/addon/migrations/migrations.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2020 The Kubermatic Kubernetes Platform contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrations
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+
+	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type AddonMigration interface {
+	// Targets determines whether a given migration is applicable/relevant to a
+	// given addon+cluster combination.
+	Targets(cluster *kubermaticv1.Cluster, addonName string) bool
+	// PreApply is called before an addon's rendered manifest is applied in a usercluster.
+	// It's possible for this to be the initial installation, or any subsequent updates.
+	// This function should ensure that the addon can be cleanly applied.
+	PreApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error
+	// PostApply is called right after an addon manifest was applied in a usercluster and
+	// can be used to update the Cluster object with new status information or similar.
+	PostApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error
+	// PreRemove is called before an addon is removed from a usercluster.
+	PreRemove(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error
+	// PostRemove is called right after an addon was either removed (i.e. its manifest was
+	// also already removed) or if an addon manifest renders into a empty string (e.g. the
+	// csi addon, when CSIDrivers are disabled). This function should clean up what
+	// `kubectl apply --prune` would not remove.
+	PostRemove(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error
+}
+
+var allMigrations = []AddonMigration{
+	&hetznerCsiMigration{},
+	&vsphereCsiMigration{},
+	&azureCsiMigration{},
+}
+
+func RelevantMigrations(cluster *kubermaticv1.Cluster, addonName string) AddonMigration {
+	result := &aggregatedMigration{}
+
+	for i, m := range allMigrations {
+		if m.Targets(cluster, addonName) {
+			result.children = append(result.children, allMigrations[i])
+		}
+	}
+
+	return result
+}
+
+type nopMigration struct{}
+
+var _ AddonMigration = &nopMigration{}
+
+func (nopMigration) Targets(cluster *kubermaticv1.Cluster, addonName string) bool {
+	panic("Implement this when embedding the nop migration in your code.")
+}
+
+func (nopMigration) PreApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	return nil
+}
+
+func (nopMigration) PostApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	return nil
+}
+
+func (nopMigration) PreRemove(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	return nil
+}
+
+func (nopMigration) PostRemove(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	return nil
+}
+
+type aggregatedMigration struct {
+	children []AddonMigration
+}
+
+var _ AddonMigration = &aggregatedMigration{}
+
+func (aggregatedMigration) Targets(cluster *kubermaticv1.Cluster, addonName string) bool {
+	return true
+}
+
+func (m aggregatedMigration) PreApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	for _, child := range m.children {
+		if err := child.PreApply(ctx, log, cluster, seedClient, userclusterClient); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m aggregatedMigration) PostApply(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	for _, child := range m.children {
+		if err := child.PostApply(ctx, log, cluster, seedClient, userclusterClient); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m aggregatedMigration) PreRemove(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	for _, child := range m.children {
+		if err := child.PreRemove(ctx, log, cluster, seedClient, userclusterClient); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m aggregatedMigration) PostRemove(ctx context.Context, log *zap.SugaredLogger, cluster *kubermaticv1.Cluster, seedClient ctrlruntimeclient.Client, userclusterClient ctrlruntimeclient.Client) error {
+	for _, child := range m.children {
+		if err := child.PostRemove(ctx, log, cluster, seedClient, userclusterClient); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/test/addon/setup_test.go
+++ b/pkg/test/addon/setup_test.go
@@ -22,19 +22,19 @@ import (
 	"context"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"k8c.io/kubermatic/v2/pkg/addon"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	"k8c.io/kubermatic/v2/pkg/controller/seed-controller-manager/addon/migrations"
 
-	rbacv1 "k8s.io/api/rbac/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func installAddon(t *testing.T, client ctrlruntimeclient.Client, provider kubermaticv1.ProviderType, addonName string, allAddons map[string]*addon.Addon) *kubermaticv1.Cluster {
+func installAddon(ctx context.Context, t *testing.T, client ctrlruntimeclient.Client, provider kubermaticv1.ProviderType, addonName string, allAddons map[string]*addon.Addon) *kubermaticv1.Cluster {
 	for _, required := range RequiredAddons[addonName] {
 		t.Logf("Installing required %s addon…", required)
-		installAddon(t, client, provider, required, allAddons)
+		installAddon(ctx, t, client, provider, required, allAddons)
 	}
 
 	cluster := loadCluster(t, provider)
@@ -52,47 +52,22 @@ func installAddon(t *testing.T, client ctrlruntimeclient.Client, provider kuberm
 		t.Fatalf("Failed to render addon %s: %v", addonName, err)
 	}
 
-	setupEnvForAddon(t, client, provider, addonName, allAddons)
+	migration := migrations.RelevantMigrations(cluster, addonName)
+	log := zap.NewNop().Sugar()
+
+	if err := migration.PreApply(ctx, log, cluster, nil, client); err != nil {
+		t.Fatalf("Failed to run preApply migrations: %v", err)
+	}
+
 	applyManifests(t, client, manifests)
+
+	if err := migration.PostApply(ctx, log, cluster, nil, client); err != nil {
+		t.Fatalf("Failed to run preApply migrations: %v", err)
+	}
 
 	return cluster
 }
 
-func setupEnvForAddon(t *testing.T, client ctrlruntimeclient.Client, provider kubermaticv1.ProviderType, addonName string, allAddons map[string]*addon.Addon) {
-	// NOP
-}
-
 func setupClusterForAddon(t *testing.T, cluster *kubermaticv1.Cluster, addonName string) {
 	// NOP
-}
-
-// setupEnvForUpgrade simulates the migration steps the KKP installer or addon controller
-// might perform between KKP releases. Re-implementing those steps in a cheap way here is
-// easier than turning this test case into a full-blown e2e test.
-func setupEnvForUpgrade(t *testing.T, client ctrlruntimeclient.Client, provider kubermaticv1.ProviderType, cluster *kubermaticv1.Cluster, addonName string) {
-	ctx := context.Background()
-
-	for _, required := range RequiredAddons[addonName] {
-		setupEnvForUpgrade(t, client, provider, cluster, required)
-	}
-
-	// failed to update object: CSIDriver.storage.k8s.io "csi.vsphere.vmware.com" is invalid: spec.podInfoOnMount: Invalid value: false: field is immutable
-	// https://github.com/kubermatic/kubermatic/pull/12936
-	if addonName == "csi" && provider == kubermaticv1.VSphereCloudProvider {
-		driver := &storagev1.CSIDriver{}
-		driver.Name = "csi.vsphere.vmware.com"
-		if err := client.Delete(ctx, driver); err != nil && !apierrors.IsNotFound(err) {
-			t.Fatalf("Failed to delete VSphere CSI Driver: %v", err)
-		}
-	}
-
-	// ClusterRoleBinding for Azure's CSI was changed.
-	// https://github.com/kubermatic/kubermatic/pull/13250
-	if addonName == "csi" && provider == kubermaticv1.AzureCloudProvider {
-		crb := &rbacv1.ClusterRoleBinding{}
-		crb.Name = "csi-azuredisk-node-secret-binding"
-		if err := client.Delete(ctx, crb); err != nil && !apierrors.IsNotFound(err) {
-			t.Fatalf("Failed to delete Azure CSI ClusterRoleBinding: %v", err)
-		}
-	}
 }

--- a/pkg/test/addon/upgrade_test.go
+++ b/pkg/test/addon/upgrade_test.go
@@ -100,7 +100,9 @@ func testAddonsCanBeApplied(t *testing.T, addons map[string]*addon.Addon) {
 func testAddonCanBeApplied(t *testing.T, addonName string, provider kubermaticv1.ProviderType, allAddons map[string]*addon.Addon) {
 	t.Parallel()
 	_, client := createTestEnv(t)
-	installAddon(t, client, provider, addonName, allAddons)
+	ctx := context.Background()
+
+	installAddon(ctx, t, client, provider, addonName, allAddons)
 }
 
 func testAddonsCanBeUpgraded(t *testing.T, previousAddons, currentAddons map[string]*addon.Addon) {
@@ -140,14 +142,14 @@ func testAddonCanBeUpgraded(t *testing.T, addonName string, provider kubermaticv
 	t.Parallel()
 
 	_, client := createTestEnv(t)
+	ctx := context.Background()
 
 	t.Log("Applying previous manifests…")
-	cluster := installAddon(t, client, provider, addonName, previousAddons)
+	installAddon(ctx, t, client, provider, addonName, previousAddons)
 
 	if _, ok := currentAddons[addonName]; ok {
 		t.Log("Applying current manifests…")
-		setupEnvForUpgrade(t, client, provider, cluster, addonName)
-		installAddon(t, client, provider, addonName, currentAddons)
+		installAddon(ctx, t, client, provider, addonName, currentAddons)
 	} else {
 		t.Log("Addon was deleted, no upgrade possible.")
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
With current efforts to use more upstream Helm charts as sources for our addons, migrations will become more important in the near future. #13508 will change the label selectors in the Azure CSI components.

Up until now we had migrations as functions in the addon controller, and then in the addon upgrade tests we simulated (i.e. reimplemented, see `setupEnvForUpgrade`) the necessary migration steps. This doesn't scale well.

This PR therefore extracts the migration code into a standalone package and then re-uses the actual migration code in the integration tests. New migrations can be a new Go file, plus registering the new type in the `allMigrations` slice.

As before, migrations are meant to be feature-based, not version-based. This is because feature detection is more stable and because on dev we do not have simple semver version jumps, but update from Git hash to hash, making sane comparisons in the code extra hard. So migration code should continue to be feature-based and idempotent.

I tried to define a pretty basic interface for migrations:

* preApply
* postApply
* preRemove
* postRemove

This should hopefully cover all cases and be generic enough to remain stable.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
```documentation
NONE
```
