### PR TITLE
Allow eBPF proxy mode when cni is none

### DIFF
--- a/pkg/validation/cluster.go
+++ b/pkg/validation/cluster.go
@@ -453,9 +453,9 @@ func validateProxyMode(n *kubermaticv1.ClusterNetworkingConfig, cni *kubermaticv
 			[]string{resources.IPVSProxyMode, resources.IPTablesProxyMode, resources.EBPFProxyMode}))
 	}
 
-	if n.ProxyMode == resources.EBPFProxyMode && (cni == nil || cni.Type != kubermaticv1.CNIPluginTypeCilium) {
+	if n.ProxyMode == resources.EBPFProxyMode && (cni == nil || cni.Type == kubermaticv1.CNIPluginTypeCanal) {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("proxyMode"), n.ProxyMode,
-			fmt.Sprintf("%s proxy mode is valid only for %s CNI", resources.EBPFProxyMode, kubermaticv1.CNIPluginTypeCilium)))
+			fmt.Sprintf("%s proxy mode is not valid for %s CNI", resources.EBPFProxyMode, kubermaticv1.CNIPluginTypeCanal)))
 	}
 
 	if n.ProxyMode == resources.EBPFProxyMode && (n.KonnectivityEnabled == nil || !*n.KonnectivityEnabled) { //nolint:staticcheck


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the validation logic to ensure that `EBPFProxyMode` is allowed when the cni plugin is none.

**Which issue(s) this PR fixes**:
ref #https://github.com/kubermatic/dashboard/issues/6755

**What type of PR is this?**
/kind feature

```release-note
NONE
```

```documentation
NONE
```
