### PR TITLE
[release/v2.23] Fix minor issues with Velero KKP chart (#13516)

### DIFF
--- a/charts/backup/velero/templates/daemonset.yaml
+++ b/charts/backup/velero/templates/daemonset.yaml
@@ -31,6 +31,12 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: node-agent
+        # This is label is required for successful volume backup.
+        # Velero uses it to check if the nodeAgent pod is running on the specific node where the volume is attached or not.
+        # https://github.com/vmware-tanzu/velero/blob/21beda3c2a87af0b967fea487c735140c765de7d/pkg/nodeagent/node_agent.go#L92
+        name: node-agent
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict-local-volumes: scratch
     spec:
       containers:
       - name: node-agent

--- a/charts/backup/velero/templates/secrets.yaml
+++ b/charts/backup/velero/templates/secrets.yaml
@@ -22,7 +22,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: velero-restic-credentials
+  name: velero-repo-credentials
 type: Opaque
 data:
   repository-password: {{ . | b64enc | quote }}

--- a/charts/cert-manager/test/test-certmanager.sh
+++ b/charts/cert-manager/test/test-certmanager.sh
@@ -35,12 +35,12 @@ helm upgrade \
 
 if ! which cmctl; then
   echodate "Downloading cmctl..."
-  OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sLo cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/latest/download/cmctl-$OS-$ARCH.tar.gz
-  tar xzf cmctl.tar.gz
+  OS=$(go env GOOS); ARCH=$(go env GOARCH); curl -sLo cmctl https://github.com/cert-manager/cmctl/releases/download/v2.1.0/cmctl_${OS}_${ARCH}
+  chmod +x cmctl
 
   function cmctl_cleanup {
     echodate "Cleaning up..."
-    rm cmctl cmctl.tar.gz
+    rm cmctl
   }
   appendTrap cmctl_cleanup EXIT
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a manual backport of #13516.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
- Adds the label `name: nodeAgent` to the Velero daemon set pods.
- The secret `velero-restic-credentials` is renamed to `velero-repo-credentials`
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
