### PR TITLE
fix kind setup for non-e2e tests, do not compile clusterexposer anymore

### DIFF
--- a/hack/ci/setup-kind-cluster.sh
+++ b/hack/ci/setup-kind-cluster.sh
@@ -140,7 +140,7 @@ fi
 # there are no cloud providers in that preloaded image.
 # As a solution, we remove the preloaded image after starting the kind
 # cluster, which will force KKP to pull the correct image.
-docker exec "kubermatic-control-plane" bash -c "crictl images | grep kube-controller-manager | awk '{print \$2}' | xargs -I{} crictl rmi registry.k8s.io/kube-controller-manager:{}" || true
+docker exec "$KIND_CLUSTER_NAME-control-plane" bash -c "crictl images | grep kube-controller-manager | awk '{print \$2}' | xargs -I{} crictl rmi registry.k8s.io/kube-controller-manager:{}" || true
 
 helm repo add cilium https://helm.cilium.io/
 helm install cilium cilium/cilium \
@@ -155,8 +155,8 @@ if [ -z "${DISABLE_CLUSTER_EXPOSER:-}" ]; then
   # a NodePort service on the host
   echodate "Starting cluster exposer"
 
-  CGO_ENABLED=0 go build --tags "$KUBERMATIC_EDITION" -v -o /tmp/clusterexposer ./pkg/test/clusterexposer/cmd
-  /tmp/clusterexposer \
+  # this is already built and added to the build image, no need to compile it again
+  clusterexposer \
     --kubeconfig-inner "$KUBECONFIG" \
     --kubeconfig-outer "/etc/kubeconfig/kubeconfig" \
     --build-id "$PROW_JOB_ID" &> /var/log/clusterexposer.log &


### PR DESCRIPTION
**What this PR does / why we need it**:
In https://public-prow.loodse.com/view/gs/prow-dev-public-data/pr-logs/pull/kubermatic_kubermatic/13537/pre-kubermatic-test-helm-charts/1816783696548597760 I noticed

> Error response from daemon: No such container: kubermatic-control-plane

I also try to save some CPU time by not compiling the clusterexposer anymore. We haven't touched it in ages and I think the chances of anyone significantly working on it and not getting their changes tested is rather small, but I'm open to contradicting opinions :grin: 

**What type of PR is this?**
/kind chore

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
NONE
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
