### PR TITLE
replace kubernetes.io/ingress.class annotation with ingressClassName spec field

### DIFF
--- a/charts/iap/templates/ingresses.yaml
+++ b/charts/iap/templates/ingresses.yaml
@@ -22,7 +22,6 @@ metadata:
     app: iap
     target: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     {{- if not (.ingress.tlsSecretName) }}
     {{- with $.Values.iap.certIssuer }}
     {{- if eq .kind "ClusterIssuer" }}
@@ -36,6 +35,7 @@ metadata:
 {{ toYaml .ingress.annotations | indent 4 }}
 {{- end }}
 spec:
+  ingressClassName: nginx
   tls:
   {{- if .ingress.tlsSecretName }}
   - secretName: {{ .ingress.tlsSecretName }}

--- a/charts/iap/test/values.custom-tls-secret.yaml.out
+++ b/charts/iap/test/values.custom-tls-secret.yaml.out
@@ -165,8 +165,8 @@ metadata:
     app: iap
     target: grafana
   annotations:
-    kubernetes.io/ingress.class: "nginx"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: custom-tls
     hosts:

--- a/charts/iap/test/values.example.yaml.out
+++ b/charts/iap/test/values.example.yaml.out
@@ -323,9 +323,9 @@ metadata:
     app: iap
     target: alertmanager
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: alertmanager-tls
     hosts:
@@ -356,9 +356,9 @@ metadata:
     app: iap
     target: grafana
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: nginx
   tls:
   - secretName: grafana-tls
     hosts:

--- a/charts/minio/templates/ingress.yaml
+++ b/charts/minio/templates/ingress.yaml
@@ -19,7 +19,6 @@ kind: Ingress
 metadata:
   name: minio
   annotations:
-    kubernetes.io/ingress.class: "{{ .Values.minio.ingress.class }}"
     {{- with .Values.minio.certIssuer }}
     {{- if eq .kind "ClusterIssuer" }}
     cert-manager.io/cluster-issuer: {{ .name | quote }}
@@ -28,6 +27,7 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+  ingressClassName: "{{ .Values.minio.ingress.class }}"
   tls:
     - secretName: minio-tls
       hosts:
@@ -52,7 +52,6 @@ kind: Ingress
 metadata:
   name: minio-console
   annotations:
-    kubernetes.io/ingress.class: "{{ .Values.minio.ingress.class }}"
     {{- with .Values.minio.certIssuer }}
     {{- if eq .kind "ClusterIssuer" }}
     cert-manager.io/cluster-issuer: {{ .name | quote }}
@@ -61,6 +60,7 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+  ingressClassName: "{{ .Values.minio.ingress.class }}"
   tls:
     - secretName: minio-console-tls
       hosts:

--- a/charts/minio/test/enable-ingress.yaml.out
+++ b/charts/minio/test/enable-ingress.yaml.out
@@ -249,9 +249,9 @@ kind: Ingress
 metadata:
   name: minio
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: "nginx"
   tls:
     - secretName: minio-tls
       hosts:
@@ -274,9 +274,9 @@ kind: Ingress
 metadata:
   name: minio-console
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: "nginx"
   tls:
     - secretName: minio-console-tls
       hosts:

--- a/charts/mla/grafana/README.md
+++ b/charts/mla/grafana/README.md
@@ -443,8 +443,8 @@ In order to serve Grafana with a prefix (e.g., <http://example.com/grafana>), ad
 ```yaml
 ingress:
   enabled: true
+  ingressClassName: nginx
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
     nginx.ingress.kubernetes.io/use-regex: "true"
 

--- a/charts/mla/minio/values.yaml
+++ b/charts/mla/minio/values.yaml
@@ -151,11 +151,11 @@ minio:
 
   ingress:
     enabled: false
+    ingressClassName: nginx
     labels: {}
     # node-role.kubernetes.io/ingress: platform
 
     annotations: {}
-    # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
     # kubernetes.io/ingress.allow-http: "false"
     # kubernetes.io/ingress.global-static-ip-name: ""

--- a/charts/oauth/templates/ingress.yaml
+++ b/charts/oauth/templates/ingress.yaml
@@ -21,7 +21,6 @@ metadata:
     {{- range $key, $value := .Values.dex.ingress.annotations }}
     {{ $key }}: {{ tpl ($value | toString) $ | quote }}
     {{- end }}
-    kubernetes.io/ingress.class: "{{ .Values.dex.ingress.class }}"
     {{- with .Values.dex.certIssuer }}
     {{- if eq .kind "ClusterIssuer" }}
     cert-manager.io/cluster-issuer: {{ .name | quote }}
@@ -30,6 +29,7 @@ metadata:
     {{- end }}
     {{- end }}
 spec:
+  ingressClassName: "{{ .Values.dex.ingress.class }}"
 {{- if eq .Values.dex.ingress.scheme "https" }}
   tls:
   - secretName: dex-tls

--- a/charts/oauth/test/default.yaml.out
+++ b/charts/oauth/test/default.yaml.out
@@ -340,9 +340,9 @@ kind: Ingress
 metadata:
   name: dex
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: "nginx"
   tls:
   - secretName: dex-tls
     hosts:

--- a/charts/oauth/test/image-pull-secret.yaml.out
+++ b/charts/oauth/test/image-pull-secret.yaml.out
@@ -342,9 +342,9 @@ kind: Ingress
 metadata:
   name: dex
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: "nginx"
   tls:
   - secretName: dex-tls
     hosts:

--- a/charts/oauth/test/ingress-annotations.yaml.out
+++ b/charts/oauth/test/ingress-annotations.yaml.out
@@ -342,9 +342,9 @@ metadata:
   annotations:
     nginx.ingress.kubernetes.io/proxy-buffering: "on"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: "nginx"
   tls:
   - secretName: dex-tls
     hosts:

--- a/charts/oauth/test/theme-with-overwrites.yaml.out
+++ b/charts/oauth/test/theme-with-overwrites.yaml.out
@@ -341,9 +341,9 @@ kind: Ingress
 metadata:
   name: dex
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
 spec:
+  ingressClassName: "nginx"
   tls:
   - secretName: dex-tls
     hosts:

--- a/charts/oauth/test/values.example.ce.yaml.out
+++ b/charts/oauth/test/values.example.ce.yaml.out
@@ -364,9 +364,9 @@ kind: Ingress
 metadata:
   name: dex
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-staging"
 spec:
+  ingressClassName: "nginx"
   tls:
   - secretName: dex-tls
     hosts:

--- a/charts/oauth/test/values.example.ee.yaml.out
+++ b/charts/oauth/test/values.example.ee.yaml.out
@@ -364,9 +364,9 @@ kind: Ingress
 metadata:
   name: dex
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-staging"
 spec:
+  ingressClassName: "nginx"
   tls:
   - secretName: dex-tls
     hosts:

--- a/pkg/controller/operator/master/resources/kubermatic/common.go
+++ b/pkg/controller/operator/master/resources/kubermatic/common.go
@@ -94,10 +94,11 @@ func ClusterRoleBindingReconciler(cfg *kubermaticv1.KubermaticConfiguration) rec
 func IngressReconciler(cfg *kubermaticv1.KubermaticConfiguration) reconciling.NamedIngressReconcilerFactory {
 	return func() (string, reconciling.IngressReconciler) {
 		return ingressName, func(i *networkingv1.Ingress) (*networkingv1.Ingress, error) {
+			i.Spec.IngressClassName = &cfg.Spec.Ingress.ClassName
+
 			if i.Annotations == nil {
 				i.Annotations = make(map[string]string)
 			}
-			i.Annotations["kubernetes.io/ingress.class"] = cfg.Spec.Ingress.ClassName
 
 			// NGINX ingress annotations to avoid timeout of websocket connections after 1 minute.
 			// Needed for Web Terminal feature, for example.


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of using the annotation, we're now using the intended field in the spec. `spec.ingressClassName` was added in Kubernetes 1.18 (https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation), so it's a safe bet that all ingress controllers out there will (have to) support it nowadays.

**Which issue(s) this PR fixes**:
Fixes #13513

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change? Then add your Release Note here**:
```release-note
Replace kubernetes.io/ingress.class annotation with ingressClassName spec field
```

**Documentation**:
```documentation
NONE
```
