### PR TITLE
Add single namespace mode for KubeVirt provider

### DIFF
--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -183,6 +183,8 @@ spec:
               # storageclass.kubernetes.io/is-default-class : false
               isDefaultClass: true
               name: rook-ceph-block
+          # SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+          singleNamespaceMode: false
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:
           # Include VMs with GPU

--- a/docs/zz_generated.seed.ce.yaml
+++ b/docs/zz_generated.seed.ce.yaml
@@ -183,8 +183,8 @@ spec:
               # storageclass.kubernetes.io/is-default-class : false
               isDefaultClass: true
               name: rook-ceph-block
-          # SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
-          singleNamespaceMode: false
+          # NamespacedMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+          namespacedMode: false
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:
           # Include VMs with GPU

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -186,8 +186,8 @@ spec:
               # storageclass.kubernetes.io/is-default-class : false
               isDefaultClass: true
               name: rook-ceph-block
-          # SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
-          singleNamespaceMode: false
+          # NamespacedMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+          namespacedMode: false
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:
           # Include VMs with GPU

--- a/docs/zz_generated.seed.ee.yaml
+++ b/docs/zz_generated.seed.ee.yaml
@@ -186,6 +186,8 @@ spec:
               # storageclass.kubernetes.io/is-default-class : false
               isDefaultClass: true
               name: rook-ceph-block
+          # SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+          singleNamespaceMode: false
         # Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.
         machineFlavorFilter:
           # Include VMs with GPU

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -748,8 +748,8 @@ type DatacenterSpecFake struct {
 
 // DatacenterSpecKubevirt describes a kubevirt datacenter.
 type DatacenterSpecKubevirt struct {
-	// SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
-	SingleNamespaceMode bool `json:"singleNamespaceMode,omitempty"`
+	// NamespacedMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+	NamespacedMode bool `json:"namespacedMode,omitempty"`
 
 	// +kubebuilder:validation:Enum=ClusterFirstWithHostNet;ClusterFirst;Default;None
 	// +kubebuilder:default=ClusterFirst

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -748,12 +748,11 @@ type DatacenterSpecFake struct {
 
 // DatacenterSpecKubevirt describes a kubevirt datacenter.
 type DatacenterSpecKubevirt struct {
-	// +kubebuilder:validation:Enum=ClusterFirstWithHostNet;ClusterFirst;Default;None
-	// +kubebuilder:default=ClusterFirst
-
 	// SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
 	SingleNamespaceMode bool `json:"singleNamespaceMode,omitempty"`
 
+	// +kubebuilder:validation:Enum=ClusterFirstWithHostNet;ClusterFirst;Default;None
+	// +kubebuilder:default=ClusterFirst
 	// DNSPolicy represents the dns policy for the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
 	// 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the
 	// policy selected with DNSPolicy.

--- a/pkg/apis/kubermatic/v1/datacenter.go
+++ b/pkg/apis/kubermatic/v1/datacenter.go
@@ -751,6 +751,9 @@ type DatacenterSpecKubevirt struct {
 	// +kubebuilder:validation:Enum=ClusterFirstWithHostNet;ClusterFirst;Default;None
 	// +kubebuilder:default=ClusterFirst
 
+	// SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+	SingleNamespaceMode bool `json:"singleNamespaceMode,omitempty"`
+
 	// DNSPolicy represents the dns policy for the pod. Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst',
 	// 'Default' or 'None'. Defaults to "ClusterFirst". DNS parameters given in DNSConfig will be merged with the
 	// policy selected with DNSPolicy.

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -923,8 +923,8 @@ spec:
                                     - name
                                   type: object
                                 type: array
-                              singleNamespaceMode:
-                                description: SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+                              namespacedMode:
+                                description: NamespacedMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
                                 type: boolean
                             type: object
                           machineFlavorFilter:

--- a/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
+++ b/pkg/crd/k8c.io/kubermatic.k8c.io_seeds.yaml
@@ -923,6 +923,9 @@ spec:
                                     - name
                                   type: object
                                 type: array
+                              singleNamespaceMode:
+                                description: SingleNamespaceMode enables the single namespace mode for all user-clusters in the KubeVirt datacenter.
+                                type: boolean
                             type: object
                           machineFlavorFilter:
                             description: 'Optional: MachineFlavorFilter is used to filter out allowed machine flavors based on the specified resource limits like CPU, Memory, and GPU etc.'

--- a/pkg/machine/provider/kubevirt.go
+++ b/pkg/machine/provider/kubevirt.go
@@ -25,6 +25,7 @@ import (
 	kubevirt "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/kubevirt/types"
 	"github.com/kubermatic/machine-controller/pkg/providerconfig/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
+	kkpkubevirt "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 )
 
 type kubevirtConfig struct {
@@ -94,8 +95,12 @@ func CompleteKubevirtProviderSpec(config *kubevirt.RawConfig, cluster *kubermati
 	}
 
 	if cluster != nil {
+		kubevirtInfraNamespace := cluster.Status.NamespaceName
+		if datacenter.NamespacedMode {
+			kubevirtInfraNamespace = kkpkubevirt.DefaultNamespaceName
+		}
 		config.ClusterName = types.ConfigVarString{Value: cluster.Name}
-		config.VirtualMachine.Template.PrimaryDisk.OsImage.Value = extractKubeVirtOsImageURLOrDataVolumeNsName(cluster.Status.NamespaceName, config.VirtualMachine.Template.PrimaryDisk.OsImage.Value)
+		config.VirtualMachine.Template.PrimaryDisk.OsImage.Value = extractKubeVirtOsImageURLOrDataVolumeNsName(kubevirtInfraNamespace, config.VirtualMachine.Template.PrimaryDisk.OsImage.Value)
 	}
 
 	return config, nil

--- a/pkg/provider/cloud/kubevirt/network_policy.go
+++ b/pkg/provider/cloud/kubevirt/network_policy.go
@@ -162,7 +162,7 @@ func customNetworkPolicyReconciler(existing kubermaticv1.CustomNetworkPolicy) re
 	}
 }
 
-func reconcileClusterIsolationNetworkPolicy(ctx context.Context, cluster *kubermaticv1.Cluster, dc *kubermaticv1.DatacenterSpecKubevirt, client ctrlruntimeclient.Client) error {
+func reconcileClusterIsolationNetworkPolicy(ctx context.Context, cluster *kubermaticv1.Cluster, dc *kubermaticv1.DatacenterSpecKubevirt, client ctrlruntimeclient.Client, namespace string) error {
 	var nameservers []string
 	if dc.DNSConfig != nil {
 		nameservers = dc.DNSConfig.Nameservers
@@ -172,18 +172,18 @@ func reconcileClusterIsolationNetworkPolicy(ctx context.Context, cluster *kuberm
 		clusterIsolationNetworkPolicyReconciler(cluster.Status.Address.IP, nameservers),
 		clusterImporterNetworkPolicyReconciler(),
 	}
-	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, cluster.Status.NamespaceName, client); err != nil {
+	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, namespace, client); err != nil {
 		return fmt.Errorf("failed to ensure Network Policies: %w", err)
 	}
 	return nil
 }
 
-func reconcileCustomNetworkPolicies(ctx context.Context, cluster *kubermaticv1.Cluster, dc *kubermaticv1.DatacenterSpecKubevirt, client ctrlruntimeclient.Client) error {
+func reconcileCustomNetworkPolicies(ctx context.Context, cluster *kubermaticv1.Cluster, dc *kubermaticv1.DatacenterSpecKubevirt, client ctrlruntimeclient.Client, namespace string) error {
 	namedNetworkPolicyReconcilerFactories := make([]reconciling.NamedNetworkPolicyReconcilerFactory, 0)
 	for _, netpol := range dc.CustomNetworkPolicies {
 		namedNetworkPolicyReconcilerFactories = append(namedNetworkPolicyReconcilerFactories, customNetworkPolicyReconciler(netpol))
 	}
-	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, cluster.Status.NamespaceName, client); err != nil {
+	if err := reconciling.ReconcileNetworkPolicies(ctx, namedNetworkPolicyReconcilerFactories, namespace, client); err != nil {
 		return fmt.Errorf("failed to ensure Custom Network Policies: %w", err)
 	}
 	return nil

--- a/pkg/provider/cloud/kubevirt/provider.go
+++ b/pkg/provider/cloud/kubevirt/provider.go
@@ -157,7 +157,7 @@ func (k *kubevirt) reconcileCluster(ctx context.Context, cluster *kubermaticv1.C
 	if k.dc.EnableDefaultNetworkPolicies != nil {
 		enableDefaultNetworkPolices = *k.dc.EnableDefaultNetworkPolicies
 	}
-	if enableDefaultNetworkPolices {
+	if enableDefaultNetworkPolices && !k.dc.NamespacedMode {
 		err = reconcileClusterIsolationNetworkPolicy(ctx, cluster, k.dc, client, kubevirtNamespace)
 		if err != nil {
 			return cluster, err

--- a/pkg/resources/cloudconfig/cloudconfig.go
+++ b/pkg/resources/cloudconfig/cloudconfig.go
@@ -30,6 +30,7 @@ import (
 	vsphere "github.com/kubermatic/machine-controller/pkg/cloudprovider/provider/vsphere/types"
 	kubermaticv1 "k8c.io/kubermatic/v2/pkg/apis/kubermatic/v1"
 	"k8c.io/kubermatic/v2/pkg/provider/cloud/gcp"
+	kkpkubevirt "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 	openstackprovider "k8c.io/kubermatic/v2/pkg/provider/cloud/openstack"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/cloudconfig/openstack"
@@ -226,9 +227,13 @@ func CloudConfig(
 		}
 
 	case cloud.Kubevirt != nil:
+		kubevirtInfraNamespace := cluster.Status.NamespaceName
+		if dc.Spec.Kubevirt != nil && dc.Spec.Kubevirt.NamespacedMode {
+			kubevirtInfraNamespace = kkpkubevirt.DefaultNamespaceName
+		}
 		cc := kubevirt.CloudConfig{
 			Kubeconfig: "/etc/kubernetes/cloud/infra-kubeconfig",
-			Namespace:  cluster.Status.NamespaceName,
+			Namespace:  kubevirtInfraNamespace,
 		}
 		return cc.String()
 	}

--- a/pkg/resources/csi/kubevirt/configmap.go
+++ b/pkg/resources/csi/kubevirt/configmap.go
@@ -19,6 +19,7 @@ package kubevirt
 import (
 	"fmt"
 
+	kubevirt "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/reconciler/pkg/reconciling"
 
@@ -41,7 +42,11 @@ func ControllerConfigMapReconciler(data *resources.TemplateData) reconciling.Nam
 				cm.Data = map[string]string{}
 			}
 			cm.Labels = resources.BaseAppLabels(resources.KubeVirtCSIConfigMapName, nil)
-			cm.Data[resources.KubeVirtCSINamespaceKey] = data.Cluster().Status.NamespaceName
+			kubevirtInfraNamespace := data.Cluster().Status.NamespaceName
+			if data.DC().Spec.Kubevirt != nil && data.DC().Spec.Kubevirt.NamespacedMode {
+				kubevirtInfraNamespace = kubevirt.DefaultNamespaceName
+			}
+			cm.Data[resources.KubeVirtCSINamespaceKey] = kubevirtInfraNamespace
 			cm.Data[resources.KubeVirtCSIClusterLabelKey] = fmt.Sprintf("cluster-name=%s", data.Cluster().Name)
 			return cm, nil
 		}

--- a/pkg/resources/csi/kubevirt/deployment.go
+++ b/pkg/resources/csi/kubevirt/deployment.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
+	kubevirt "k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 	"k8c.io/kubermatic/v2/pkg/resources"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/reconciler/pkg/reconciling"
@@ -47,6 +48,10 @@ func DeploymentsReconcilers(data *resources.TemplateData) []reconciling.NamedDep
 func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.NamedDeploymentReconcilerFactory {
 	return func() (name string, create reconciling.DeploymentReconciler) {
 		return resources.KubeVirtCSIControllerName, func(d *appsv1.Deployment) (*appsv1.Deployment, error) {
+			kubevirtInfraNamespace := data.Cluster().Status.NamespaceName
+			if data.DC().Spec.Kubevirt != nil && data.DC().Spec.Kubevirt.NamespacedMode {
+				kubevirtInfraNamespace = kubevirt.DefaultNamespaceName
+			}
 			version := data.Cluster().Status.Versions.ControllerManager.Semver()
 			volumes := []corev1.Volume{
 				{
@@ -107,7 +112,7 @@ func ControllerDeploymentReconciler(data *resources.TemplateData) reconciling.Na
 					Image:           registry.Must(data.RewriteImage("quay.io/kubermatic/kubevirt-csi-driver:" + csiVersion)),
 					Args: []string{
 						"--endpoint=$(CSI_ENDPOINT)",
-						fmt.Sprintf("--infra-cluster-namespace=%s", data.Cluster().Status.NamespaceName),
+						fmt.Sprintf("--infra-cluster-namespace=%s", kubevirtInfraNamespace),
 						fmt.Sprintf("--infra-cluster-labels=%s", fmt.Sprintf("cluster-name=%s", data.Cluster().Name)),
 						"--infra-cluster-kubeconfig=/var/run/secrets/infracluster/kubeconfig",
 						"--tenant-cluster-kubeconfig=/var/run/secrets/tenantcluster/kubeconfig",

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -36,6 +36,7 @@ import (
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
+	"k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -833,7 +834,11 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 	vars = append(vars, GetHTTPProxyEnvVarsFromSeed(data.Seed(), cluster.Status.Address.InternalName)...)
 
 	vars = SanitizeEnvVars(vars)
-	vars = append(vars, corev1.EnvVar{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}})
+	if cluster.Spec.Cloud.Kubevirt != nil && dc.Spec.Kubevirt != nil && dc.Spec.Kubevirt.NamespacedMode {
+		vars = append(vars, corev1.EnvVar{Name: "POD_NAMESPACE", Value: kubevirt.DefaultNamespaceName})
+	} else {
+		vars = append(vars, corev1.EnvVar{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}})
+	}
 
 	return vars, nil
 }

--- a/pkg/resources/data.go
+++ b/pkg/resources/data.go
@@ -36,7 +36,6 @@ import (
 	"k8c.io/kubermatic/v2/pkg/kubernetes"
 	kubermaticlog "k8c.io/kubermatic/v2/pkg/log"
 	"k8c.io/kubermatic/v2/pkg/provider"
-	"k8c.io/kubermatic/v2/pkg/provider/cloud/kubevirt"
 	"k8c.io/kubermatic/v2/pkg/resources/certificates/triple"
 	"k8c.io/kubermatic/v2/pkg/resources/registry"
 	"k8c.io/kubermatic/v2/pkg/version/kubermatic"
@@ -835,7 +834,7 @@ func (data *TemplateData) GetEnvVars() ([]corev1.EnvVar, error) {
 
 	vars = SanitizeEnvVars(vars)
 	if cluster.Spec.Cloud.Kubevirt != nil && dc.Spec.Kubevirt != nil && dc.Spec.Kubevirt.NamespacedMode {
-		vars = append(vars, corev1.EnvVar{Name: "POD_NAMESPACE", Value: kubevirt.DefaultNamespaceName})
+		vars = append(vars, corev1.EnvVar{Name: "POD_NAMESPACE", Value: KubeVirtDefaultSingleNamespace})
 	} else {
 		vars = append(vars, corev1.EnvVar{Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.namespace"}}})
 	}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -704,7 +704,8 @@ const (
 	PacketAPIKey    = "apiKey"
 	PacketProjectID = "projectID"
 
-	KubeVirtKubeconfig = "kubeConfig"
+	KubeVirtKubeconfig             = "kubeConfig"
+	KubeVirtDefaultSingleNamespace = "kubevirt-workload"
 
 	VsphereUsername                    = "username"
 	VspherePassword                    = "password"


### PR DESCRIPTION
**What this PR does / why we need it**:
Part of customer request:
- setup flag in the datacenter spec: namespacedMode
- enable creating Kubevirt cluster in the same namespace on infrastructure cluster.

**Which issue(s) this PR fixes**:
<!--optional, in `fixes #<issue number>` format, will close the issue(s) when PR gets merged-->

**What type of PR is this?**
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
/kind chore
-->

/kind feature

**Special notes for your reviewer**:

This change will only be used by customers with multiple KKP deployments, running KubeVirt infrastructure independently and wanting workload to be placed within a single namespace.

**Does this PR introduce a user-facing change? Then add your Release Note here**:
<!--
Write your release note. Release notes are being used to generate the changelog:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow the deployment of Kubevirt user clusters in the single namespace of the infrastructure cluster.
```

**Documentation**:
<!--
Please do one of the following options:
- Add a link to the existing documentation
- Add a link to the kubermatic/docs pull request
- If no documentation change is applicable then add:
  - TBD (documentation will be added later)
  - NONE (no documentation needed for this PR)
-->
```documentation
NONE
```
